### PR TITLE
feat: add sitemap generation for documentation pages

### DIFF
--- a/apps/routecraft.dev/src/app/sitemap.ts
+++ b/apps/routecraft.dev/src/app/sitemap.ts
@@ -1,0 +1,94 @@
+import fs from 'fs'
+import path from 'path'
+import type { MetadataRoute } from 'next'
+
+export const dynamic = 'force-static'
+
+export const baseUrl =
+  process.env.NEXT_PUBLIC_BASE_URL || 'https://routecraft.dev'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const routes: MetadataRoute.Sitemap = []
+
+  // Add home page
+  routes.push({
+    url: `${baseUrl}/`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly',
+    priority: 1.0,
+  })
+
+  // Helper to recursively collect all page.md files from docs
+  function collectDocPages(
+    baseDir: string,
+    urlPrefix: string = '',
+  ): Array<{ url: string; mtime: Date }> {
+    const pages: Array<{ url: string; mtime: Date }> = []
+
+    try {
+      const entries = fs.readdirSync(baseDir, { withFileTypes: true })
+
+      for (const entry of entries) {
+        const fullPath = path.join(baseDir, entry.name)
+
+        if (entry.isDirectory()) {
+          // Check if this directory has a page.md
+          const pagePath = path.join(fullPath, 'page.md')
+          if (fs.existsSync(pagePath)) {
+            const stat = fs.statSync(pagePath)
+            const url = `${urlPrefix}/${entry.name}/`
+            pages.push({
+              url,
+              mtime: stat.mtime,
+            })
+          }
+
+          // Recursively collect pages from subdirectories
+          const subPages = collectDocPages(
+            fullPath,
+            `${urlPrefix}/${entry.name}`,
+          )
+          pages.push(...subPages)
+        }
+      }
+    } catch (error) {
+      console.warn(`Could not read directory ${baseDir}:`, error)
+    }
+
+    return pages
+  }
+
+  // Collect all documentation pages
+  const docsBaseDir = path.join(process.cwd(), 'src', 'app', 'docs')
+  const docPages = collectDocPages(docsBaseDir, '/docs')
+
+  // Add docs landing page if it exists
+  const docsLandingPage = path.join(
+    process.cwd(),
+    'src',
+    'app',
+    'docs',
+    'page.md',
+  )
+  if (fs.existsSync(docsLandingPage)) {
+    const stat = fs.statSync(docsLandingPage)
+    routes.push({
+      url: `${baseUrl}/docs/`,
+      lastModified: stat.mtime,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    })
+  }
+
+  // Add all collected doc pages
+  for (const { url, mtime } of docPages) {
+    routes.push({
+      url: `${baseUrl}${url}`,
+      lastModified: mtime,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    })
+  }
+
+  return routes
+}


### PR DESCRIPTION
- Introduced a new sitemap.ts file to generate a sitemap for the application.
- Implemented functionality to collect and list documentation pages from the 'docs' directory.
- Added home and documentation landing page entries with appropriate metadata for SEO.
- Ensured the sitemap is dynamically generated based on the existing documentation structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a Next.js sitemap that scans `src/app/docs/**` for `page.md` and includes home and docs landing with appropriate metadata.
> 
> - **Sitemap Generation** (`apps/routecraft.dev/src/app/sitemap.ts`):
>   - Creates a static sitemap (`dynamic = 'force-static'`) using `NEXT_PUBLIC_BASE_URL` fallbacking to `https://routecraft.dev`.
>   - Adds routes for home (`/`), docs landing (`/docs/` if present), and recursively discovered docs pages from `src/app/docs/**/page.md`.
>   - Populates `lastModified` from file `mtime` and sets `changeFrequency`/`priority` for entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5394fe419c67557ca5edfdd83867ae508bed9717. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->