### PR TITLE
feat: add CodeSandbox link for online play example in installation documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,15 @@ on:
   push:
     branches: ["main"]
     paths-ignore:
-      - "**.md"
-      - "docs/**"
+      - "**/README.md"
       - ".github/ISSUE_TEMPLATE/**"
+      - ".cursor/**"
   pull_request_target:
     branches: ["main"]
     paths-ignore:
-      - "**.md"
-      - "docs/**"
+      - "**/README.md"
       - ".github/ISSUE_TEMPLATE/**"
+      - ".cursor/**"
   release:
     types: [created]
 
@@ -332,7 +332,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy-pages:
-    name: Deploy docs site to Pages
     needs: [build, cli-test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/apps/routecraft.dev/src/app/docs/introduction/installation/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/installation/page.md
@@ -4,15 +4,15 @@ title: Installation
 
 Install via the CLI or manually add packages. {% .lead %}
 
-<!-- ## Play Online
+## Play Online
 
 If you want to try RouteCraft in your browser without installing anything, open our examples:
 
 {% quick-links %}
 
-{% quick-link title="Open on CodeSandbox" icon="installation" href="https://codesandbox.io/p/sandbox/github/routecraftjs/routecraft?file=/examples" description="Play around with RouteCraft in your browser." /%}
+{% quick-link title="Open on CodeSandbox" icon="installation" href="https://codesandbox.io/p/sandbox/github/routecraftjs/craft-playground?file=%2Froutes%2Fhello-world.route.ts" description="Play around with RouteCraft in your browser." /%}
 
-{% /quick-links %} -->
+{% /quick-links %}
 
 ## System requirements
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables the Play Online section with a new CodeSandbox link in installation docs and updates CI to refine ignored paths and adjust Pages deployment config.
> 
> - **Docs**:
>   - Enable the "Play Online" section in `apps/routecraft.dev/src/app/docs/introduction/installation/page.md`.
>   - Update quick link to CodeSandbox: `routecraftjs/craft-playground` with `routes/hello-world.route.ts`.
> - **CI**:
>   - Refine `paths-ignore` for `push` and `pull_request_target`: ignore `**/README.md` and `.cursor/**` (instead of all `**.md` and `docs/**`).
>   - Tweak `deploy-pages` job config (remove custom name; use artifact-based Pages deployment with explicit permissions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc9b49f957f2883b656da91ffbc73adf815c40a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->