### PR TITLE
feat(eslint): add batch-before-from rule to enforce route-level batch positioning

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -215,6 +215,36 @@ Make HTTP requests. Can be used as an enricher with `.enrich()` or destination w
 }))
 ```
 
+// Direct the fetch result into a specific field (custom aggregator)
+```ts
+.enrich(
+  fetch({
+    url: 'https://api.example.com/items'
+  }),
+  (original, enrichment) => ({
+    ...original,
+    body: {
+      ...original.body,
+      api: enrichment // place the full FetchResult on a field
+    }
+  })
+)
+
+// Or only keep the response body
+.enrich(
+  fetch({
+    url: (exchange) => `https://api.example.com/users/${exchange.body.userId}`
+  }),
+  (original, enrichment) => ({
+    ...original,
+    body: {
+      ...original.body,
+      userData: enrichment.body
+    }
+  })
+)
+```
+
 Options:
 
 | Field | Type | Default | Required | Description |

--- a/apps/routecraft.dev/src/app/docs/reference/linting/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/linting/page.md
@@ -93,6 +93,33 @@ export default craft()
   .from(timer({ intervalMs: 5000 }))
 ```
 
+#### batch-before-from
+
+- **Action**: Warn (default)
+- **Description**: `batch()` is a route-level operation and must be configured before `.from()`. Using `batch()` after `.from()` is ambiguous and won’t affect the current route.
+- **Options**: None
+- **Autofix**: None
+
+Examples:
+
+```ts
+// ✅ Good: batch before from
+craft()
+  .id('bulk')
+  .batch({ size: 50, flushIntervalMs: 5000 })
+  .from(timer({ intervalMs: 1000 }))
+  .to(database({ operation: 'bulkInsert' }))
+```
+
+```ts
+// ❌ Bad: batch after from (will be staged for the next route, not this one)
+craft()
+  .id('bulk')
+  .from(timer({ intervalMs: 1000 }))
+  .batch({ size: 50 })
+  .to(database({ operation: 'bulkInsert' }))
+```
+
 ### Customizing Rule Severity
 
 You can change the severity or disable rules in your ESLint config:
@@ -107,6 +134,8 @@ export default [
     rules: {
       // Warn instead of error
       '@routecraft/routecraft/require-named-route': 'warn',
+      // Elevate to error
+      '@routecraft/routecraft/batch-before-from': 'error',
     },
   },
 ]
@@ -121,6 +150,7 @@ export default [
     plugins: { '@routecraft/routecraft': routecraftPlugin },
     rules: {
       '@routecraft/routecraft/require-named-route': 'off',
+      '@routecraft/routecraft/batch-before-from': 'off',
     },
   },
 ]
@@ -133,5 +163,9 @@ The plugin provides two pre-configured rule sets:
 - `routecraftPlugin.configs.recommended` - Recommended rules for all RouteCraft projects
 - `routecraftPlugin.configs.all` - All available rules enabled
 
-Both configs currently enable `require-named-route` as an error. More rules will be added in future releases.
+The recommended config enables:
+- `require-named-route` as error
+- `batch-before-from` as warn
+
+The all config enables both rules as errors.
 

--- a/packages/eslint-plugin-routecraft/README.md
+++ b/packages/eslint-plugin-routecraft/README.md
@@ -33,6 +33,7 @@ export default [
     },
     rules: {
       'routecraft/require-named-route': 'error',
+      'routecraft/batch-before-from': 'warn',
     },
   },
 ];
@@ -40,7 +41,34 @@ export default [
 
 ## Rules
 
-- [`routecraft/require-named-route`](https://routecraft.dev/docs/reference/eslint-rules#require-named-route) - Enforces that all routes have a `.routeId()` for better debuggability
+- `routecraft/require-named-route` — Enforce `.id(<non-empty string>)` before `.from()` in a `craft()` chain
+- `routecraft/batch-before-from` — Enforce `batch()` is used as a route-level operation before `.from()`
+
+### routecraft/require-named-route
+
+```ts
+// ✅ Good
+craft().id('user-processor').from(source).to(dest)
+
+// ❌ Bad
+craft().from(source).to(dest)
+```
+
+### routecraft/batch-before-from
+
+```ts
+// ✅ Good: batch() before from()
+craft()
+  .batch({ size: 50 })
+  .from(source)
+  .to(dest)
+
+// ❌ Bad: batch() after from()
+craft()
+  .from(source)
+  .batch({ size: 50 })
+  .to(dest)
+```
 
 ## Recommended Configuration
 
@@ -52,6 +80,7 @@ export default [
     },
     rules: {
       'routecraft/require-named-route': 'warn',
+      'routecraft/batch-before-from': 'warn',
     },
   },
 ];

--- a/packages/eslint-plugin-routecraft/src/index.ts
+++ b/packages/eslint-plugin-routecraft/src/index.ts
@@ -1,19 +1,23 @@
 import type { Rule } from "eslint";
 import requireNamedRouteRule from "./rules/require-named-route.ts";
+import batchBeforeFromRule from "./rules/batch-before-from.ts";
 
 export const rules: Record<string, Rule.RuleModule> = {
   "require-named-route": requireNamedRouteRule,
+  "batch-before-from": batchBeforeFromRule,
 };
 
 export const configs = {
   all: {
     rules: {
       "@routecraft/routecraft/require-named-route": "error",
+      "@routecraft/routecraft/batch-before-from": "error",
     },
   },
   recommended: {
     rules: {
       "@routecraft/routecraft/require-named-route": "error",
+      "@routecraft/routecraft/batch-before-from": "warn",
     },
   },
 };

--- a/packages/eslint-plugin-routecraft/src/rules/batch-before-from.ts
+++ b/packages/eslint-plugin-routecraft/src/rules/batch-before-from.ts
@@ -1,0 +1,227 @@
+import type { Rule } from "eslint";
+
+// Type Guards
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isIdentifier(
+  node: unknown,
+): node is { type: "Identifier"; name: string } {
+  return (
+    isObject(node) &&
+    node["type"] === "Identifier" &&
+    typeof node["name"] === "string"
+  );
+}
+
+function isMemberExpression(node: unknown): node is {
+  type: "MemberExpression";
+  computed: boolean;
+  object: unknown;
+  property: unknown;
+} {
+  return (
+    isObject(node) &&
+    node["type"] === "MemberExpression" &&
+    typeof node["computed"] === "boolean" &&
+    "object" in node &&
+    "property" in node
+  );
+}
+
+function isCallExpression(
+  node: unknown,
+): node is { type: "CallExpression"; callee: unknown; arguments: unknown[] } {
+  return (
+    isObject(node) &&
+    node["type"] === "CallExpression" &&
+    Array.isArray(node["arguments"]) &&
+    "callee" in node
+  );
+}
+
+// Utility Functions
+
+/**
+ * Get the method name from a CallExpression (e.g., "batch" from craft().batch())
+ * Returns undefined if it's not a member call expression
+ */
+function getMemberCallName(node: unknown): string | undefined {
+  if (!isCallExpression(node)) return undefined;
+
+  const callee = (node as Record<string, unknown>)["callee"] as unknown;
+
+  if (isMemberExpression(callee) && !callee.computed) {
+    if (isIdentifier(callee["property"])) {
+      return (callee["property"] as { name: string }).name;
+    }
+  } else if (isIdentifier(callee)) {
+    return callee.name;
+  }
+
+  return undefined;
+}
+
+/**
+ * Check if a call expression chain originates from craft()
+ * Walks back through the chain to find the root call
+ */
+function originatesFromCraft(call: unknown): boolean {
+  let current: unknown = call;
+
+  while (isCallExpression(current)) {
+    const callee = (current as Record<string, unknown>)["callee"] as unknown;
+
+    if (isIdentifier(callee) && callee.name === "craft") {
+      return true;
+    }
+
+    if (isMemberExpression(callee)) {
+      current = callee["object"] as unknown;
+      continue;
+    }
+
+    break;
+  }
+
+  return false;
+}
+
+/**
+ * Collect the chain of call expressions from node backwards to craft()
+ * Returns the chain in left-to-right order (craft() to node)
+ */
+function collectChainBackwards(node: unknown): unknown[] {
+  const callsInReverse: unknown[] = [];
+  let current: unknown = node;
+
+  while (isCallExpression(current)) {
+    callsInReverse.push(current);
+    const callee = (current as Record<string, unknown>)["callee"] as unknown;
+
+    if (isMemberExpression(callee)) {
+      current = callee["object"] as unknown;
+    } else {
+      break;
+    }
+  }
+
+  return callsInReverse.reverse();
+}
+
+/**
+ * Find the index of the most recent from() call before the given index
+ * Returns -1 if no from() is found
+ */
+function findLastFromIndex(chain: unknown[], beforeIndex: number): number {
+  for (let i = beforeIndex - 1; i >= 0; i--) {
+    const call = chain[i];
+    if (isCallExpression(call) && getMemberCallName(call) === "from") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Check if there's a from() call after the given batch() node by walking up the AST
+ * This determines if batch() is starting a new route in a multi-route chain
+ */
+function hasFromAfterBatch(batchNode: unknown): boolean {
+  let current: unknown = batchNode;
+
+  while (isObject(current) && "parent" in current) {
+    const parent = current["parent"] as unknown;
+
+    // If parent is a MemberExpression where current is the object
+    if (
+      isObject(parent) &&
+      parent["type"] === "MemberExpression" &&
+      (parent as Record<string, unknown>)["object"] === current
+    ) {
+      const property = (parent as Record<string, unknown>)["property"];
+
+      // Check if the property is "from"
+      if (isIdentifier(property) && property.name === "from") {
+        return true;
+      }
+
+      // Move to the parent's parent (the CallExpression)
+      if ("parent" in parent) {
+        current = parent["parent"] as unknown;
+        continue;
+      }
+    }
+    break;
+  }
+
+  return false;
+}
+
+/**
+ * Validate that a chain starts with craft() and ends with batch()
+ */
+function isValidCraftChain(chain: unknown[], expectedEndCall: string): boolean {
+  if (chain.length === 0) return false;
+
+  const firstCall = chain[0];
+  const lastCall = chain[chain.length - 1];
+
+  return (
+    isCallExpression(firstCall) &&
+    getMemberCallName(firstCall) === "craft" &&
+    isCallExpression(lastCall) &&
+    getMemberCallName(lastCall) === expectedEndCall
+  );
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Ensure batch() is used as a route-level operation (before from()).",
+      recommended: false,
+    },
+    messages: {
+      batchAfterFrom:
+        "batch-before-from: batch() must be configured before from(); it is a route-level operation.",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        // Only process batch() calls from craft() chains
+        if (getMemberCallName(node) !== "batch") return;
+        if (!originatesFromCraft(node)) return;
+
+        // Collect and validate the chain
+        const chain = collectChainBackwards(node);
+        if (!isValidCraftChain(chain, "batch")) return;
+
+        // Check if there's a from() before this batch()
+        const batchIndex = chain.length - 1;
+        const lastFromIndex = findLastFromIndex(chain, batchIndex);
+
+        // If no from() before batch(), it's valid (route-level batch)
+        if (lastFromIndex === -1) return;
+
+        // If there's a from() before batch(), it's only valid if batch() starts a new route
+        // (indicated by a from() call after it)
+        const startsNewRoute = hasFromAfterBatch(node);
+        if (startsNewRoute) return;
+
+        // Report error: batch() is in the middle of a route
+        context.report({
+          node: node as Rule.Node,
+          messageId: "batchAfterFrom",
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-routecraft/test/batch-before-from.test.ts
+++ b/packages/eslint-plugin-routecraft/test/batch-before-from.test.ts
@@ -1,0 +1,127 @@
+import { describe, test } from "vitest";
+import { RuleTester } from "eslint";
+import batchBeforeFromRule from "../src/rules/batch-before-from";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+describe("batch-before-from", () => {
+  /**
+   * @case Verifies that valid cases pass (batch before from, no batch, etc.)
+   * @preconditions Routes with batch() before from(), routes without batch(), or non-craft chains
+   * @expectedResult No errors should be reported
+   */
+  test("valid cases pass", () => {
+    ruleTester.run("batch-before-from", batchBeforeFromRule, {
+      valid: [
+        // batch before from
+        {
+          code: `
+            import { craft, simple, log } from "@routecraft/routecraft";
+            craft()
+              .batch({ size: 10 })
+              .from(simple(['a', 'b']))
+              .to(log());
+          `,
+        },
+        // with id and other ops
+        {
+          code: `
+            craft()
+              .id('r')
+              .batch({ size: 10, flushIntervalMs: 1000 })
+              .from(simple([1,2,3]))
+              .transform(x => x)
+              .to(log());
+          `,
+        },
+        // no batch usage
+        {
+          code: `
+            craft().id('r').from(simple(1)).to(log());
+          `,
+        },
+        // multiple routes staged: batch before each from
+        {
+          code: `
+            craft()
+              .batch()
+              .from(simple(1))
+              .to(log())
+              .batch({ size: 5 })
+              .from(simple(2))
+              .to(log());
+          `,
+        },
+        // Non-craft chains are ignored
+        {
+          code: `
+            api().from(x).batch().to(y);
+          `,
+        },
+      ],
+      invalid: [],
+    });
+  });
+
+  /**
+   * @case Verifies that invalid cases are reported (batch after from)
+   * @preconditions Routes that call batch() after from() in the same chain
+   * @expectedResult Errors should be reported for each violation
+   */
+  test("invalid cases are reported", () => {
+    ruleTester.run("batch-before-from", batchBeforeFromRule, {
+      valid: [],
+      invalid: [
+        // batch after from
+        {
+          code: `
+            import { craft, simple } from "@routecraft/routecraft";
+            craft()
+              .from(simple([1,2,3]))
+              .batch({ size: 10 })
+              .to(dest);
+          `,
+          errors: [{ messageId: "batchAfterFrom" }],
+        },
+        // appears later in chain without a new from
+        {
+          code: `
+            craft()
+              .batch()
+              .from(simple([1,2,3]))
+              .to(dest)
+              .batch({ size: 2 });
+          `,
+          errors: [{ messageId: "batchAfterFrom" }],
+        },
+        // id then from then batch
+        {
+          code: `
+            craft()
+              .id('r')
+              .from(simple(1))
+              .batch();
+          `,
+          errors: [{ messageId: "batchAfterFrom" }],
+        },
+        // multiple routes, second route has late batch
+        {
+          code: `
+            craft()
+              .batch()
+              .from(simple(1))
+              .to(dest)
+              .from(simple(2))
+              .batch();
+          `,
+          errors: [{ messageId: "batchAfterFrom" }],
+        },
+      ],
+    });
+  });
+});

--- a/packages/routecraft/src/adapters/fetch.ts
+++ b/packages/routecraft/src/adapters/fetch.ts
@@ -39,15 +39,15 @@ export type FetchResult<T = string | unknown> = {
  * - send: performs request as side effect (ignores body)
  */
 export class FetchAdapter<T = unknown, R = FetchResult>
-  implements Enricher<T, R>, Destination<T>
+  implements Enricher<T, FetchResult<R>>, Destination<T>
 {
   readonly adapterId = "routecraft.adapter.fetch";
 
   constructor(private readonly options: FetchOptions<T>) {}
 
-  async enrich(exchange: Exchange<T>): Promise<R> {
+  async enrich(exchange: Exchange<T>): Promise<FetchResult<R>> {
     const result = await this.performFetch(exchange);
-    return result as unknown as R;
+    return result as FetchResult<R>;
   }
 
   async send(exchange: Exchange<T>): Promise<void> {

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -646,15 +646,20 @@ export class RouteBuilder<Current = unknown> {
   /**
    * Filter data based on a predicate function.
    * Exchanges that don't match the predicate will be dropped.
+   * The predicate receives the full Exchange object, allowing filtering based on
+   * headers, body, or other exchange properties.
    *
-   * @param filter A function that returns true to keep the exchange, false to drop it
+   * @param filter A function that receives the Exchange and returns true to keep it, false to drop it
    * @returns A RouteBuilder with the same type
    * @example
-   * // Keep only numbers greater than 10
-   * .filter((num) => num > 10)
+   * // Filter based on body value
+   * .filter((exchange) => exchange.body > 10)
    *
-   * // Filter based on a complex condition
-   * .filter((user) => user.age >= 18 && user.status === 'active')
+   * // Filter based on body properties
+   * .filter((exchange) => exchange.body.age >= 18 && exchange.body.status === 'active')
+   *
+   * // Filter based on headers
+   * .filter((exchange) => exchange.headers['x-priority'] === 'high')
    */
   filter(
     filter: Filter<Current> | CallableFilter<Current>,

--- a/packages/routecraft/src/operations/filter.ts
+++ b/packages/routecraft/src/operations/filter.ts
@@ -2,6 +2,11 @@ import { type Adapter, type Step } from "../types.ts";
 import { type Exchange, OperationType } from "../exchange.ts";
 import { error as rcError } from "../error.ts";
 
+/**
+ * Function that evaluates a predicate against the entire Exchange.
+ * Returns true to keep the exchange, false to filter it out.
+ * Can evaluate headers, body, and other exchange properties.
+ */
 export type CallableFilter<T = unknown> = (
   exchange: Exchange<T>,
 ) => Promise<boolean> | boolean;
@@ -10,6 +15,14 @@ export interface Filter<T = unknown> extends Adapter {
   filter: CallableFilter<T>;
 }
 
+/**
+ * Filter: evaluate predicate against the entire Exchange.
+ * - Receives full Exchange (allows filtering on headers, body, and other properties)
+ * - Returns true to continue, false to reject the exchange
+ * - Aligns with Apache Camel Filter EIP behavior
+ * - Use when you need to filter based on headers or other exchange metadata
+ * - For body-only transformations, use `.transform` instead
+ */
 export class FilterStep<T = unknown> implements Step<Filter<T>> {
   operation: OperationType = OperationType.FILTER;
   adapter: Filter<T>;


### PR DESCRIPTION
Add a new ESLint rule that ensures batch() is configured before .from() in
route chains, as batch() is a route-level operation that must be positioned
before the route source adapter.

Changes:
- Add batch-before-from rule implementation with AST analysis
- Add comprehensive test suite for the new rule
- Update ESLint plugin configs (recommended: warn, all: error)
- Document the rule in linting reference and README
- Add callout in operations docs linking to linting rule

Documentation improvements:
- Add fetch adapter enrichment examples with custom aggregators
- Clarify filter() receives full Exchange object (not just body)
- Add callout explaining filter vs transform distinction
- Update filter operation docs with Exchange-based examples

Code improvements:
- Fix fetch adapter type signature for enrichment return type
- Enhance filter operation and builder docs with Exchange examples
- Improve hello-world test with proper mocking and assertions

BREAKING CHANGE: None (new rule defaults to warn severity)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new ESLint rule to enforce placing `batch()` before `.from()`, updates plugin configs and docs, refines filter and fetch typings/docs, and improves an example test with mocking/assertions.
> 
> - **ESLint plugin**
>   - Add rule `@routecraft/routecraft/batch-before-from` with AST implementation and tests.
>   - Update `src/index.ts` configs: `recommended` (warn) and `all` (error).
>   - Update README with rule usage and recommended config.
> - **Docs**
>   - Linting reference: add `batch-before-from` rule section and config examples.
>   - Operations: add callout linking the rule under `batch()`; expand `filter()` description/examples to use full `Exchange`.
>   - Adapters: add `fetch` enrichment examples with custom aggregators.
> - **Core library**
>   - `fetch` adapter: fix `Enricher` return type to `FetchResult<R>`.
>   - Clarify `filter()` API and JSDoc in `builder.ts` and `operations/filter.ts` (full `Exchange` predicate).
> - **Examples**
>   - Revamp `examples/hello-world.test.ts` with `fetch` mocking, console spy, and assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1a453fcd0055f675c88c43c03a8e45a924efc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->