### PR TITLE
feat(aggregate): enhance default aggregator to flatten arrays and combine scalars

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -451,13 +451,21 @@ aggregate<R>(fn?: Aggregator<Current, R> | CallableAggregator<Current, R>): Rout
 
 Combine multiple exchanges into a single result. Useful after `split` to recombine processed items.
 
-If no aggregator is provided, exchange bodies are automatically collected into an array.
+If no aggregator is provided, exchange bodies are automatically collected into an array. **If any body is an array, all arrays are flattened and combined with scalar values into a single flattened array.**
 
 ```ts
 // Automatically collect bodies into an array
 .split()
 .process((exchange) => ({ ...exchange, body: exchange.body * 2 }))
-.aggregate() // Returns array of processed items
+.aggregate() // Returns array of processed items: [2, 4, 6]
+
+// Arrays are automatically flattened
+// Input: [1, [2, 3], 4, [5, 6]]
+// Output: [1, 2, 3, 4, 5, 6] (flattened)
+
+// Mixed arrays and scalars are combined
+// Input: [[1, 2], 3, [4, 5]]
+// Output: [1, 2, 3, 4, 5] (arrays flattened, scalars added)
 
 // Custom aggregation logic
 .aggregate((items) => ({


### PR DESCRIPTION
- Updated the default aggregator to flatten arrays when any body is an array, ensuring mixed arrays and scalar values are combined into a single flattened array.
- Enhanced documentation to clarify the new behavior of the aggregator.
- Added comprehensive tests to validate the new aggregation logic, including cases for mixed arrays and scalars.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default aggregator now flattens array bodies one level and combines with scalars; docs clarified and tests added to cover new behavior.
> 
> - **Core (`packages/routecraft/src/operations/aggregate.ts`)**
>   - Update `defaultAggregate` to flatten array bodies one level when any body is an array, combining with scalar values; preserves first-exchange metadata.
>   - Add helper types `ExtractArrayElement` and `FlattenedAggregateResult`; adjust function return typing and casts.
> - **Docs (`apps/routecraft.dev/src/app/docs/reference/operations/page.md`)**
>   - Clarify `aggregate` default behavior and add examples showing one-level flattening and mixed arrays/scalars outputs.
> - **Tests (`packages/routecraft/test/route.test.ts`)**
>   - Add tests for `defaultAggregate` covering mixed arrays + scalars, multiple arrays, and single array with scalars.
>   - Import `defaultAggregate`, `DefaultExchange`, and `Exchange` for direct aggregator testing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 173b3a9672810abc9082c1986cbd1cfbc4c91a93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->