### PR TITLE
chore: update package versions to 0.3.0 across all modules

### DIFF
--- a/apps/routecraft.dev/package.json
+++ b/apps/routecraft.dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "routecraft.dev",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/routecraft.dev/src/components/VersionSelector.tsx
+++ b/apps/routecraft.dev/src/components/VersionSelector.tsx
@@ -8,7 +8,7 @@ import {
 } from '@headlessui/react'
 import clsx from 'clsx'
 
-const versions = [{ label: 'v0.1.1', value: 'v0.1.1' }]
+const versions = [{ label: 'v0.2.0', value: 'v0.2.0' }]
 
 function ChevronDownIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   return (

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -8,12 +8,12 @@
     "test:coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@routecraft/ai": "workspace:^0.2.0",
-    "@routecraft/routecraft": "workspace:^0.2.0",
+    "@routecraft/ai": "workspace:^0.3.0",
+    "@routecraft/routecraft": "workspace:^0.3.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@routecraft/cli": "workspace:^0.2.0",
+    "@routecraft/cli": "workspace:^0.3.0",
     "tsx": "^4.21.0",
     "vitest": "^4.0.18"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/workspace",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.28.2",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/ai",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "AI and MCP integrations for RouteCraft",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -24,14 +24,14 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@routecraft/routecraft": "workspace:^0.2.0"
+    "@routecraft/routecraft": "workspace:^0.3.0"
   },
   "devDependencies": {
     "vitest": "^4.0.18",
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "@routecraft/routecraft": ">=0.2.0"
+    "@routecraft/routecraft": "*"
   },
   "keywords": [
     "routecraft",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI for running RouteCraft routes",
   "private": false,
   "type": "module",
@@ -22,7 +22,7 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "@routecraft/routecraft": "workspace:^0.2.0",
+    "@routecraft/routecraft": "workspace:^0.3.0",
     "commander": "^14.0.3",
     "dotenv": "^17.3.1"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,7 +30,7 @@ const program = new Command();
 program
   .name("craft")
   .description("A modern routing framework for TypeScript")
-  .version("0.2.0")
+  .version("0.3.0")
   .option(
     "--log-level <level>",
     "Log level (e.g. info, warn, error, silent to disable)",

--- a/packages/create-routecraft/package.json
+++ b/packages/create-routecraft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-routecraft",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Create a new RouteCraft project",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create-routecraft/src/index.ts
+++ b/packages/create-routecraft/src/index.ts
@@ -73,7 +73,7 @@ const NODE_TEMPLATE = {
       JSON.stringify(
         {
           name: projectName,
-          version: "0.1.0",
+          version: "0.2.0",
           private: true,
           type: "module",
           scripts: {

--- a/packages/eslint-plugin-routecraft/package.json
+++ b/packages/eslint-plugin-routecraft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/eslint-plugin-routecraft",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/routecraft/package.json
+++ b/packages/routecraft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/routecraft",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Type-safe integration and automation framework for TypeScript/Node.js",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,17 +176,17 @@ importers:
   examples:
     dependencies:
       '@routecraft/ai':
-        specifier: workspace:^0.2.0
+        specifier: workspace:^0.3.0
         version: link:../packages/ai
       '@routecraft/routecraft':
-        specifier: workspace:^0.2.0
+        specifier: workspace:^0.3.0
         version: link:../packages/routecraft
       zod:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@routecraft/cli':
-        specifier: workspace:^0.2.0
+        specifier: workspace:^0.3.0
         version: link:../packages/cli
       tsx:
         specifier: ^4.21.0
@@ -201,7 +201,7 @@ importers:
         specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
       '@routecraft/routecraft':
-        specifier: workspace:^0.2.0
+        specifier: workspace:^0.3.0
         version: link:../routecraft
     devDependencies:
       vitest:
@@ -214,7 +214,7 @@ importers:
   packages/cli:
     dependencies:
       '@routecraft/routecraft':
-        specifier: workspace:^0.2.0
+        specifier: workspace:^0.3.0
         version: link:../routecraft
       commander:
         specifier: ^14.0.3
@@ -2867,8 +2867,8 @@ packages:
   highlight-words-core@1.2.3:
     resolution: {integrity: sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==}
 
-  hono@4.11.10:
-    resolution: {integrity: sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==}
+  hono@4.12.0:
+    resolution: {integrity: sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -4899,9 +4899,9 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
-  '@hono/node-server@1.19.9(hono@4.11.10)':
+  '@hono/node-server@1.19.9(hono@4.12.0)':
     dependencies:
-      hono: 4.11.10
+      hono: 4.12.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -5164,7 +5164,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.10)
+      '@hono/node-server': 1.19.9(hono@4.12.0)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -5174,7 +5174,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.11.10
+      hono: 4.12.0
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6665,8 +6665,8 @@ snapshots:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
@@ -6689,7 +6689,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6700,22 +6700,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6726,7 +6726,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7244,7 +7244,7 @@ snapshots:
 
   highlight-words-core@1.2.3: {}
 
-  hono@4.11.10: {}
+  hono@4.12.0: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
- Bumped version numbers in package.json files for @routecraft/workspace, @routecraft/ai, @routecraft/cli, routecraft.dev, examples, and other related packages to 0.3.0.
- Updated workspace references in pnpm-lock.yaml to reflect the new versioning.
- Adjusted version labels in the VersionSelector component to match the new versioning scheme.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.0 with updated package versions and synchronized dependency references across the monorepo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->