### PR TITLE
fix(logger)!: default destination to stdout instead of stderr

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -163,6 +163,13 @@ export default config
 | `restartBackoffMultiplier` | `number` | `2` | Multiplier applied to delay on each successive restart |
 | `toolRefreshIntervalMs` | `number` | `60000` | Polling interval for HTTP client tool lists (0 = no polling) |
 
+**Logging when `transport` is `'stdio'`:**
+
+The stdio transport uses stdout as the protocol channel. Routecraft's logger defaults to stdout, so logs will corrupt the protocol stream unless you redirect them. When running an MCP server over stdio, always pass one of:
+
+- `--log-file <path>` -- write logs to a file
+- `--log-level silent` -- disable logging entirely
+
 **HTTP server auth (`McpHttpAuthOptions`):**
 
 When `auth` is set and `transport` is `'http'`, every request to `/mcp` must include a valid `Authorization: Bearer <token>` header. The `auth` object requires a `validator` function that receives the raw bearer token and returns an `AuthPrincipal` on success or `null` to reject. The principal is made available on exchange headers so routes can read the caller's identity.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -76,10 +76,7 @@ program
     "--log-level <level>",
     "Log level (e.g. info, warn, error, silent to disable)",
   )
-  .option(
-    "--log-file <path>",
-    "Write logs to a file (keeps stdout clear for MCP stdio)",
-  )
+  .option("--log-file <path>", "Write logs to a file instead of stdout")
   .showSuggestionAfterError()
   .showHelpAfterError()
   .exitOverride((err) => {

--- a/packages/routecraft/src/logger.ts
+++ b/packages/routecraft/src/logger.ts
@@ -71,7 +71,10 @@ function getDestination(fileConfig?: string): NodeJS.WritableStream {
         const fd = openSync(pathToUse, "a");
         return pinoDest.destination(fd);
       } catch {
-        return pinoDest.destination(1);
+        // User asked for "not stdout" via --log-file; honour that even when
+        // both file paths fail. Fall back to stderr rather than violating the
+        // flag's contract (e.g. corrupting an MCP stdio protocol stream).
+        return pinoDest.destination(2);
       }
     }
   }

--- a/packages/routecraft/src/logger.ts
+++ b/packages/routecraft/src/logger.ts
@@ -47,8 +47,9 @@ function loadConfigFile(): PinoOptionsLike {
 }
 
 /**
- * Resolve destination stream. ENV wins, then config file, then stderr.
- * Default is stderr so stdout stays clear for MCP/stdio and logs are conventional diagnostics.
+ * Resolve destination stream. ENV wins, then config file, then stdout.
+ * Aligns with pino's default and 12-factor. Adapters that own stdout
+ * (e.g. MCP stdio) must redirect logs via --log-file or --log-level silent.
  */
 function getDestination(fileConfig?: string): NodeJS.WritableStream {
   const pinoDest = pino as unknown as {
@@ -70,18 +71,18 @@ function getDestination(fileConfig?: string): NodeJS.WritableStream {
         const fd = openSync(pathToUse, "a");
         return pinoDest.destination(fd);
       } catch {
-        return pinoDest.destination(2);
+        return pinoDest.destination(1);
       }
     }
   }
-  return pinoDest.destination(2);
+  return pinoDest.destination(1);
 }
 
 /** Options object accepted by pino() */
 type PinoOptions = Parameters<typeof pino>[0];
 
 /**
- * Use pretty (pino-pretty) when NODE_ENV is not production and we're writing to stderr.
+ * Use pretty (pino-pretty) when NODE_ENV is not production and we're writing to stdout.
  * Override with PINO_PRETTY=1 to force pretty; set LOG_FILE to get JSON (e.g. for MCP).
  */
 function usePrettyOutput(filePath?: string): boolean {


### PR DESCRIPTION
Closes #207

## Summary

- Framework logger now defaults to **stdout** (fd 1), matching pino's own default and 12-factor conventions.
- Stops penalising the 99% of users who are not running stdio MCP servers.
- stdio MCP users opt out manually via \`--log-file <path>\` or \`--log-level silent\`. No adapter-side magic.
- Updated the \`--log-file\` CLI help text and added a stdio logging note to the MCP plugin docs.

## Why

The previous stderr default existed solely to protect stdio MCP adapters from protocol corruption. That is a niche case; defaulting for it forced every other user to know logs land on stderr. See #207 for the full rationale.

## Breaking change

Anyone currently parsing stderr for routecraft logs must switch to stdout or pass \`--log-file <path>\`. When running MCP over stdio transport, set \`--log-file\` or \`--log-level silent\` to avoid protocol corruption.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (72 files, 747 passed)
- [ ] Manual: run \`craft run ./examples/dist/hello-world.js\` and confirm logs land on stdout
- [ ] Manual: run an MCP stdio server with \`--log-file /tmp/mcp.log\` and confirm the protocol channel stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the framework logger to stdout (fd 1) instead of stderr, matching `pino` and 12‑factor conventions. This is a breaking change; CLI help and docs were updated.

- **Bug Fixes**
  - When `--log-file` and the tmpdir fallback both fail to open, fall back to stderr to honor the flag and avoid corrupting MCP stdio.

- **Migration**
  - If you read logs from stderr, switch to stdout or pass `--log-file <path>`.
  - For MCP over stdio, use `--log-file <path>` or `--log-level silent` to avoid protocol corruption.

<sup>Written for commit 9d9d9360e89ce0ce0b157a481a363576fcc01d6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

