### PR TITLE
fix(routecraft): attach DSL sugar and auth header types to public package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: "**/dist"
-          key: build-${{ github.sha }}
+          key: build-${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Upload docs export artifact
         if: github.event_name == 'release'
@@ -273,7 +273,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: "**/dist"
-          key: build-${{ github.sha }}
+          key: build-${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Fetch tags
         run: git fetch --force --tags
@@ -341,7 +341,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: "**/dist"
-          key: build-${{ github.sha }}
+          key: build-${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Determine canary version
         id: canary_version
@@ -463,7 +463,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: "**/dist"
-          key: build-${{ github.sha }}
+          key: build-${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Update package versions
         run: |

--- a/.standards/type-safety-and-schemas.md
+++ b/.standards/type-safety-and-schemas.md
@@ -84,6 +84,46 @@ Routes **never** spawn processes. Stdio MCP clients are registered in `mcpPlugin
 
 ---
 
+## Module Augmentation
+
+Every `declare module` block inside `packages/*/src/**` must target the published package specifier, never a relative path.
+
+```ts
+// Good
+declare module "@routecraft/routecraft" {
+  interface RouteBuilder<Current> {
+    myMethod(...): RouteBuilder<Current>;
+  }
+}
+
+// Bad -- relative specifier
+declare module "./builder.ts" { ... }
+declare module "../exchange.ts" { ... }
+```
+
+### Why
+
+`tsup` bundles per-package declarations into a single `dist/index.d.ts`. Relative specifiers survive verbatim into that bundle and no longer resolve in a consumer's module graph. TypeScript then silently drops the augmentation, so the added methods and header keys vanish from the public types. Our own unit tests still compile (they import from `../src/`, where relative specifiers resolve at source-compile time), so the regression is invisible until a real consumer hits it.
+
+Using the package specifier attaches the augmentation to the same `RouteBuilder` / `RoutecraftHeaders` / `StoreRegistry` that is re-exported from the entry point, so it merges correctly in both source compilation and the bundled `.d.ts`.
+
+### Guard
+
+`packages/create-routecraft/test/integration.test.ts` scaffolds a real project, installs `@routecraft/routecraft` via `file:` protocol, and runs `tsc --noEmit`. That typecheck resolves types through `dist/index.d.ts`, so any `declare module` with a relative specifier in the published bundle fails the test at a consumer boundary.
+
+### Scope
+
+This rule applies to every augmentation block, including:
+
+- `RouteBuilder` sugar (`.log`, `.debug`, `.map`, `.schema`) in `packages/routecraft/src/dsl.ts`
+- `RoutecraftHeaders` entries in `packages/routecraft/src/auth/types.ts` and per-adapter shared files
+- `StoreRegistry` entries in per-adapter shared files (cron, direct, mail, split, etc.)
+- Any future augmentation of a type exported from `@routecraft/routecraft`
+
+A lint rule covering this in `@routecraft/eslint-plugin-routecraft` would be the right final state; until that lands, the integration test is the guard.
+
+---
+
 ## References
 
 - Standard Schema: [standardschema.dev](https://standardschema.dev)

--- a/packages/create-routecraft/templates/examples/hello-world/capabilities/hello-world.ts
+++ b/packages/create-routecraft/templates/examples/hello-world/capabilities/hello-world.ts
@@ -20,6 +20,8 @@ const greetRoute = craft()
     }),
   )
   .transform((result) => `Hello, ${result.body.name}!`)
+  // `.log()` is sugar for `.tap(log())`: a type-preserving log tap.
+  .log()
   .to(log());
 
 // "hello-world" caller: dispatches a user id to the greet service.

--- a/packages/create-routecraft/templates/examples/hello-world/capabilities/hello-world.ts
+++ b/packages/create-routecraft/templates/examples/hello-world/capabilities/hello-world.ts
@@ -20,7 +20,6 @@ const greetRoute = craft()
     }),
   )
   .transform((result) => `Hello, ${result.body.name}!`)
-  // `.log()` is sugar for `.tap(log())`: a type-preserving log tap.
   .log()
   .to(log());
 

--- a/packages/create-routecraft/test/integration.test.ts
+++ b/packages/create-routecraft/test/integration.test.ts
@@ -3,7 +3,7 @@ import { mkdir, rm, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
-import { exec, spawn, type ExecOptions } from "node:child_process";
+import { exec, execSync, spawn, type ExecOptions } from "node:child_process";
 import { promisify } from "node:util";
 import { generateProjectStructure, type InitOptions } from "../src/lib.js";
 
@@ -213,6 +213,18 @@ const packagesBuilt = existsSync(
   join(MONOREPO_ROOT, "packages/routecraft/dist/index.d.ts"),
 );
 const integrationTest = packagesBuilt ? test : test.skip;
+
+// Rebuild the routecraft package so its dist/ matches the checked-out
+// source. On local runs this catches stale dist after editing source without
+// running `pnpm build`. On CI it is a belt-and-suspenders against cache
+// issues on the `pull_request_target` workflow (see cache key scoping in
+// ci.yml). Cheap — one tsup run on a single package.
+if (packagesBuilt) {
+  execSync("pnpm --filter @routecraft/routecraft build", {
+    cwd: MONOREPO_ROOT,
+    stdio: "inherit",
+  });
+}
 
 /**
  * Patch the scaffolded package.json to use local file: references

--- a/packages/routecraft/src/adapters/mail/client-manager.ts
+++ b/packages/routecraft/src/adapters/mail/client-manager.ts
@@ -311,6 +311,7 @@ export class MailClientManager {
       result.pollIntervalMs = overrides.pollIntervalMs;
     if (overrides.includeHeaders !== undefined)
       result.includeHeaders = overrides.includeHeaders;
+    if (overrides.verify !== undefined) result.verify = overrides.verify;
 
     // Pass through search filters
     if (overrides.from !== undefined) result.from = overrides.from;

--- a/packages/routecraft/src/auth/types.ts
+++ b/packages/routecraft/src/auth/types.ts
@@ -144,7 +144,10 @@ export interface OAuthValidatorAuthOptions {
   validator: OAuthTokenVerifier;
 }
 
-declare module "../exchange.ts" {
+// Must target the published package specifier; a relative path would survive
+// into the bundled `dist/index.d.ts` where it no longer resolves, and the
+// augmentation would be silently dropped by the consumer's TypeScript.
+declare module "@routecraft/routecraft" {
   interface RoutecraftHeaders {
     /** Authenticated subject (from Principal). */
     "routecraft.auth.subject"?: string;

--- a/packages/routecraft/src/auth/types.ts
+++ b/packages/routecraft/src/auth/types.ts
@@ -144,9 +144,8 @@ export interface OAuthValidatorAuthOptions {
   validator: OAuthTokenVerifier;
 }
 
-// Must target the published package specifier; a relative path would survive
-// into the bundled `dist/index.d.ts` where it no longer resolves, and the
-// augmentation would be silently dropped by the consumer's TypeScript.
+// See .standards/type-safety-and-schemas.md#module-augmentation for why this
+// targets the package specifier and not a relative path.
 declare module "@routecraft/routecraft" {
   interface RoutecraftHeaders {
     /** Authenticated subject (from Principal). */

--- a/packages/routecraft/src/dsl.ts
+++ b/packages/routecraft/src/dsl.ts
@@ -139,13 +139,8 @@ registerDsl("schema", {
 // Module augmentation: TypeScript types for built-in sugar
 // ---------------------------------------------------------------------------
 
-// Must target the published package specifier, not `"./builder.ts"`. After
-// tsup bundles the declarations into a single `dist/index.d.ts`, a relative
-// path no longer resolves in the consumer's module graph and TypeScript
-// silently drops the augmentation, causing `.log` / `.debug` / `.map` /
-// `.schema` to disappear from the public `RouteBuilder`. Using the package
-// name keeps the augmentation attached to the same `RouteBuilder` that is
-// re-exported from the entry point.
+// See .standards/type-safety-and-schemas.md#module-augmentation for why this
+// targets the package specifier and not a relative path.
 declare module "@routecraft/routecraft" {
   interface RouteBuilder<Current> {
     /**

--- a/packages/routecraft/src/dsl.ts
+++ b/packages/routecraft/src/dsl.ts
@@ -139,7 +139,14 @@ registerDsl("schema", {
 // Module augmentation: TypeScript types for built-in sugar
 // ---------------------------------------------------------------------------
 
-declare module "./builder.ts" {
+// Must target the published package specifier, not `"./builder.ts"`. After
+// tsup bundles the declarations into a single `dist/index.d.ts`, a relative
+// path no longer resolves in the consumer's module graph and TypeScript
+// silently drops the augmentation, causing `.log` / `.debug` / `.map` /
+// `.schema` to disappear from the public `RouteBuilder`. Using the package
+// name keeps the augmentation attached to the same `RouteBuilder` that is
+// re-exported from the entry point.
+declare module "@routecraft/routecraft" {
   interface RouteBuilder<Current> {
     /**
      * Log the current exchange at info level. Type-preserving tap.


### PR DESCRIPTION
Two `declare module` blocks targeted relative source paths:
`declare module "./builder.ts"` in `dsl.ts`, and
`declare module "../exchange.ts"` in `auth/types.ts`. tsup bundles the
package declarations into a single `dist/index.d.ts`, and those
relative specifiers survive verbatim into the published file where
they no longer resolve in a consumer's module graph. TypeScript
silently drops the augmentations and the methods / header keys vanish
from the public `@routecraft/routecraft` types.

Concretely this made `.log`, `.debug`, `.map`, and `.schema` disappear
from the published `RouteBuilder` type, and the `routecraft.auth.*`
keys disappear from `RoutecraftHeaders`. The augmentations worked in
our own test suite only because those tests import from `../src/`,
which lets the relative specifier resolve during source compilation.

Retarget both augmentations to `"@routecraft/routecraft"`, matching
the pattern used by every other augmentation in the codebase
(`cron/source.ts`, `mail/shared.ts`, `direct/shared.ts`, `split.ts`,
etc). The same interface-merging rules apply because `RouteBuilder` is
exported as a class (which produces a merge-compatible interface
symbol) and `RoutecraftHeaders` is already an interface.

Regression test
- New `examples/test/dsl-sugar.test.ts` imports from
  `@routecraft/routecraft` (not `../src/`) and exercises `.log`,
  `.debug`, `.map`, `.schema` via `expectTypeOf`. The examples
  workspace links against the built package through pnpm, so if any of
  these augmentations detaches from the public entry again, both
  `pnpm test` and `pnpm build` fail on type-check.

Verified against the built `dist/index.d.ts`: all nine
`declare module` blocks now target `"@routecraft/routecraft"`.

Co-authored-by: Claude <claude@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost type augmentations in `@routecraft/routecraft` so consumers see DSL sugar (`.log`, `.debug`, `.map`, `.schema`) and auth header types again, and tightens CI to avoid stale `dist/` in PRs.

- **Bug Fixes**
  - Retargeted augmentation `declare module` blocks in `dsl.ts` and `auth/types.ts` to `@routecraft/routecraft`; documented the rule in `.standards/type-safety-and-schemas.md`; added `.log()` in the `hello-world` template to assert the public types.
  - Mail: `resolveImapOptions` now forwards `verify` for named accounts.
  - CI/tests: scope `**/dist` cache keys to the PR head SHA; rebuild `@routecraft/routecraft` at the start of integration tests.

<sup>Written for commit 1b8d95ddf3bd2caea3a76993b8e4aa8d2b91b62b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

