### PR TITLE
fix(mail): make IMAP source reliable for poll and re-evaluation workloads

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -1160,6 +1160,29 @@ craft()
   .to(log())
 ```
 
+**Source delivery modes:** the source runs in one of two modes.
+
+- **IDLE (default):** the server pushes notifications when new mail arrives. The `\Seen` flag is the cross-cycle dedupe state, so each message is delivered exactly once per subscription. IDLE is the right default for "process each new email once" workloads. If the IMAP connection drops mid-subscription the source reconnects automatically with exponential backoff; auth failures stop the subscription immediately.
+- **Poll (opt-in):** set `pollIntervalMs` to fetch on a cadence instead of IDLE. Required whenever you opt out of the `\Seen` dedupe model (`markSeen: false` or `unseen: false`), for example to re-evaluate the inbox on every cycle and rely on a folder move as the done-signal. IDLE has no cycle boundary, so combining it with those overrides would refetch the entire folder on every inbound message; the source throws `RC5003` at startup to prevent this footgun.
+
+```ts
+// Re-evaluate the inbox every minute; archive a message to mark it done.
+// If you later extend `matchesCriteria`, previously-unmatched mail that is
+// still in INBOX is picked up on the next cycle.
+craft()
+  .id('inbox-processor')
+  .from(mail('INBOX', {
+    pollIntervalMs: 60_000,
+    markSeen: false,
+    unseen: false,
+  }))
+  .filter(matchesCriteria)
+  .process(processMessage)
+  .to(mail({ action: 'move', folder: 'Archive' }))
+```
+
+The `\Seen` flag is written per-message **after** the handler resolves successfully, so a downstream failure leaves the message un-Seen and it is retried on the next cycle. `limit` combined with IDLE is a latency trap (backlog beyond the limit only drains when new mail arrives) and emits a warning at subscribe time.
+
 **Fetch destination (IMAP pull):** Pass a folder string or server options to fetch messages. Use with `.enrich()` to pull mail on demand.
 
 ```ts

--- a/packages/routecraft/src/adapters/mail/fetch-destination.ts
+++ b/packages/routecraft/src/adapters/mail/fetch-destination.ts
@@ -6,6 +6,7 @@ import {
   getClientManager,
   createImapClient,
   fetchMessages,
+  markMessagesSeen,
   throwMailConnectionError,
   type MailFetchLogger,
 } from "./shared.ts";
@@ -84,6 +85,18 @@ export class MailFetchDestinationAdapter implements Destination<
           }
         : undefined;
       const messages = await fetchMessages(client, resolved, folder, logger);
+
+      // Destination has no post-commit hook, so mark Seen here. Best-effort:
+      // a flag failure must not fail the enrichment since messages have
+      // already been fetched.
+      if (resolved.markSeen !== false && messages.length > 0) {
+        await markMessagesSeen(
+          client,
+          messages.map((m) => m.uid),
+          logger,
+        );
+      }
+
       return messages;
     } finally {
       if (usePool) {

--- a/packages/routecraft/src/adapters/mail/shared.ts
+++ b/packages/routecraft/src/adapters/mail/shared.ts
@@ -693,18 +693,6 @@ export async function fetchMessages(
         break;
       }
     }
-
-    // Mark messages as seen after successful fetch
-    if (options.markSeen !== false && messages.length > 0) {
-      const uids = messages.map((m) => m.uid);
-      try {
-        await client.messageFlagsAdd(uids.join(","), ["\\Seen"], {
-          uid: true,
-        });
-      } catch {
-        // Non-fatal: log but do not throw if flagging fails
-      }
-    }
   } catch (error) {
     throw rcError("RC5001", error instanceof Error ? error : undefined, {
       message: `Failed to fetch messages from IMAP: ${error instanceof Error ? error.message : String(error)}`,
@@ -712,4 +700,37 @@ export async function fetchMessages(
   }
 
   return messages;
+}
+
+/**
+ * Mark one or more messages as \Seen on an open IMAP mailbox.
+ *
+ * Never throws: flagging failure degrades correctness (a message may be
+ * redelivered) but must not tear down the fetch cycle or source subscription.
+ * Callers that care about the failure should pass a logger.
+ *
+ * @param client - Connected ImapFlow client with the target mailbox open
+ * @param uids - UIDs to flag. May be a single uid or an array. Empty arrays are a no-op.
+ * @param logger - Optional logger for flagging diagnostics
+ */
+export async function markMessagesSeen(
+  client: InstanceType<typeof import("imapflow").ImapFlow>,
+  uids: number | number[],
+  logger?: MailFetchLogger,
+): Promise<void> {
+  const list = Array.isArray(uids) ? uids : [uids];
+  if (list.length === 0) return;
+  try {
+    await client.messageFlagsAdd(list.join(","), ["\\Seen"], {
+      uid: true,
+    });
+  } catch (error) {
+    logger?.warn(
+      {
+        err: error instanceof Error ? error : new Error(String(error)),
+        uids: list,
+      },
+      "mail adapter failed to mark messages as seen",
+    );
+  }
 }

--- a/packages/routecraft/src/adapters/mail/source.ts
+++ b/packages/routecraft/src/adapters/mail/source.ts
@@ -1,16 +1,29 @@
 import type { CraftContext } from "../../context.ts";
 import type { Source } from "../../operations/from.ts";
 import type { Exchange, ExchangeHeaders } from "../../exchange.ts";
+import { rcError } from "../../error.ts";
 import type { MailMessage, MailServerOptions } from "./types.ts";
+import type { MailClientManager } from "./client-manager.ts";
 import {
   getClientManager,
   createImapClient,
   fetchMessages,
+  markMessagesSeen,
+  isMailAuthError,
   throwMailConnectionError,
   HEADER_MAIL_UID,
   HEADER_MAIL_FOLDER,
   type MailFetchLogger,
 } from "./shared.ts";
+
+type ImapClient = InstanceType<typeof import("imapflow").ImapFlow>;
+
+/** Cap reconnect attempts so an unrecoverable server fault does not loop forever. */
+const IDLE_RECONNECT_MAX_ATTEMPTS = 30;
+/** Initial backoff between IDLE reconnect attempts. */
+const IDLE_RECONNECT_BASE_MS = 1_000;
+/** Cap for exponential backoff. */
+const IDLE_RECONNECT_MAX_MS = 60_000;
 
 /**
  * Source adapter that receives email messages from IMAP using IDLE or polling.
@@ -23,11 +36,36 @@ import {
  * exchange so downstream operations can resolve the target message even after
  * body transforms.
  *
+ * ## IDLE vs poll
+ *
+ * - Default mode is IDLE: the server pushes new-arrival notifications and the
+ *   \Seen flag is the cross-cycle dedupe state. This is the right model when
+ *   each message should be delivered to the handler exactly once.
+ * - Set `pollIntervalMs` to run in poll mode. Poll mode is required whenever
+ *   you opt out of the \Seen-flag model by setting `markSeen: false` or
+ *   `unseen: false` (for example, to re-evaluate the inbox on every cycle and
+ *   rely on a folder move as the done-signal). IDLE cannot bound re-delivery
+ *   cycles, so combining it with those overrides would flood the handler on
+ *   every inbound message.
+ * - `limit` combined with IDLE is a latency trap: backlog beyond `limit` only
+ *   drains when new mail arrives. A warning is logged at subscribe time.
+ *
  * @example
  * ```typescript
+ * // Default: IDLE, \Seen-based dedupe, exactly-once-ish delivery.
  * craft()
- *   .from(mail('INBOX', { markSeen: true }))
+ *   .from(mail('INBOX', {}))
  *   .to(processMessage())
+ *
+ * // Re-evaluate the inbox on a cadence, move-to-archive as the done signal.
+ * craft()
+ *   .from(mail('INBOX', {
+ *     markSeen: false,
+ *     unseen: false,
+ *     pollIntervalMs: 60_000,
+ *   }))
+ *   .filter(matchesCriteria)
+ *   .to(mail({ action: 'move', folder: 'Archive' }))
  * ```
  *
  * @experimental
@@ -54,7 +92,6 @@ export class MailSourceAdapter implements Source<MailMessage> {
     const manager = getClientManager(context);
     const account = this.adapterOptions.account;
 
-    // Resolve options
     const resolved: MailServerOptions = manager
       ? manager.resolveImapOptions(account, {
           ...this.adapterOptions,
@@ -63,9 +100,6 @@ export class MailSourceAdapter implements Source<MailMessage> {
       : ({ ...this.adapterOptions, folder: this.folder } as MailServerOptions);
 
     const folder = resolved.folder ?? this.folder;
-
-    // Acquire client: pooled or standalone
-    let client: InstanceType<typeof import("imapflow").ImapFlow>;
     const hasConnectionOverride =
       this.adapterOptions.host !== undefined ||
       this.adapterOptions.port !== undefined ||
@@ -73,6 +107,95 @@ export class MailSourceAdapter implements Source<MailMessage> {
       this.adapterOptions.auth !== undefined;
     const usePool = !!manager && !hasConnectionOverride;
 
+    const logger: MailFetchLogger | undefined = context.logger
+      ? {
+          debug: (obj, msg) => context.logger.debug(obj, msg),
+          warn: (obj, msg) => context.logger.warn(obj, msg),
+        }
+      : undefined;
+
+    validateSourceOptions(resolved, logger);
+
+    const markSeenEnabled = resolved.markSeen !== false;
+
+    // Mutable ref so the idle loop can swap the client on reconnect while
+    // the abort handler still releases whatever connection is current.
+    const clientRef: { current: ImapClient | null } = { current: null };
+    clientRef.current = await this.acquireAndOpen(
+      manager,
+      account,
+      resolved,
+      folder,
+      usePool,
+    );
+
+    let released = false;
+    const releaseClient = () => {
+      if (released) return;
+      released = true;
+      const c = clientRef.current;
+      if (!c) return;
+      clientRef.current = null;
+      if (usePool) {
+        manager!.releaseImap(account, c);
+      } else {
+        c.logout().catch(() => {});
+      }
+    };
+
+    const onAbort = () => releaseClient();
+    abortController.signal.addEventListener("abort", onAbort, { once: true });
+
+    const handlerWithHeaders = (message: MailMessage) => {
+      const headers: ExchangeHeaders = {
+        [HEADER_MAIL_UID]: message.uid,
+        [HEADER_MAIL_FOLDER]: message.folder,
+      };
+      return handler(message, headers);
+    };
+
+    try {
+      if (onReady) onReady();
+
+      if (resolved.pollIntervalMs) {
+        await this.pollLoop(
+          clientRef,
+          resolved,
+          folder,
+          markSeenEnabled,
+          handlerWithHeaders,
+          abortController,
+          logger,
+        );
+      } else {
+        await this.idleLoop(
+          clientRef,
+          manager,
+          account,
+          resolved,
+          folder,
+          usePool,
+          markSeenEnabled,
+          handlerWithHeaders,
+          abortController,
+          logger,
+        );
+      }
+    } finally {
+      abortController.signal.removeEventListener("abort", onAbort);
+      releaseClient();
+    }
+  }
+
+  /** Acquire an IMAP client (pool or standalone) and open the mailbox. */
+  private async acquireAndOpen(
+    manager: MailClientManager | null,
+    account: string | undefined,
+    resolved: MailServerOptions,
+    folder: string,
+    usePool: boolean,
+  ): Promise<ImapClient> {
+    let client: ImapClient;
     if (usePool) {
       client = await manager!.acquireImap(account, folder);
     } else {
@@ -88,161 +211,288 @@ export class MailSourceAdapter implements Source<MailMessage> {
         throwMailConnectionError(error, "IMAP");
       }
     }
-
-    // Guard against double-release of the IMAP client
-    let released = false;
-    const releaseClient = () => {
-      if (released) return;
-      released = true;
-      if (usePool) {
-        manager!.releaseImap(account, client);
-      } else {
-        client.logout().catch(() => {});
-      }
-    };
-
-    const onAbort = () => releaseClient();
-    abortController.signal.addEventListener("abort", onAbort, { once: true });
-
     try {
       await client.mailboxOpen(folder);
       if (usePool) manager!.trackMailbox(account, client, folder);
-
-      if (onReady) {
-        onReady();
-      }
-
-      const handlerWithHeaders = (message: MailMessage) => {
-        const headers: ExchangeHeaders = {
-          [HEADER_MAIL_UID]: message.uid,
-          [HEADER_MAIL_FOLDER]: message.folder,
-        };
-        return handler(message, headers);
-      };
-
-      const logger: MailFetchLogger | undefined = context.logger
-        ? {
-            debug: (obj, msg) => context.logger.debug(obj, msg),
-            warn: (obj, msg) => context.logger.warn(obj, msg),
-          }
-        : undefined;
-
-      if (resolved.pollIntervalMs) {
-        await this.pollLoop(
-          client,
-          resolved,
-          folder,
-          handlerWithHeaders,
-          abortController,
-          logger,
-        );
+      return client;
+    } catch (error) {
+      if (usePool) {
+        manager!.releaseImap(account, client);
       } else {
-        await this.idleLoop(
-          client,
-          resolved,
-          folder,
-          handlerWithHeaders,
-          abortController,
-          logger,
-        );
+        await client.logout().catch(() => {});
       }
-    } finally {
-      abortController.signal.removeEventListener("abort", onAbort);
-      releaseClient();
+      throw error;
     }
   }
 
   private async pollLoop(
-    client: Awaited<ReturnType<typeof createImapClient>>,
+    clientRef: { current: ImapClient | null },
     options: MailServerOptions,
     folder: string,
+    markSeenEnabled: boolean,
     handler: (message: MailMessage) => Promise<Exchange>,
     abortController: AbortController,
     logger?: MailFetchLogger,
   ): Promise<void> {
-    const processedUids = new Set<number>();
-
     while (!abortController.signal.aborted) {
+      const client = clientRef.current;
+      if (!client) return;
+
       const messages = await fetchMessages(client, options, folder, logger);
 
       for (const message of messages) {
         if (abortController.signal.aborted) break;
-        if (processedUids.has(message.uid)) continue;
         try {
           await handler(message);
-          processedUids.add(message.uid);
+          if (markSeenEnabled) {
+            await markMessagesSeen(client, message.uid, logger);
+          }
         } catch {
-          // Exchange error already logged by the route pipeline.
-          // UID is NOT marked processed so it will be retried on the next poll.
+          // Handler error already logged by the route pipeline. Leave the
+          // message un-Seen so the next poll cycle retries it.
         }
       }
 
       if (abortController.signal.aborted) break;
 
-      // Wait for the poll interval, cleaning up the abort listener on timeout
-      await new Promise<void>((resolve) => {
-        const timeout = setTimeout(() => {
-          abortController.signal.removeEventListener("abort", onAbort);
-          resolve();
-        }, options.pollIntervalMs);
-        const onAbort = () => {
-          clearTimeout(timeout);
-          resolve();
-        };
-        abortController.signal.addEventListener("abort", onAbort, {
-          once: true,
-        });
-      });
+      await waitWithAbort(options.pollIntervalMs ?? 0, abortController);
     }
   }
 
   private async idleLoop(
-    client: Awaited<ReturnType<typeof createImapClient>>,
+    clientRef: { current: ImapClient | null },
+    manager: MailClientManager | null,
+    account: string | undefined,
     options: MailServerOptions,
     folder: string,
+    usePool: boolean,
+    markSeenEnabled: boolean,
     handler: (message: MailMessage) => Promise<Exchange>,
     abortController: AbortController,
     logger?: MailFetchLogger,
   ): Promise<void> {
-    const processedUids = new Set<number>();
+    // Drain whatever matches on startup, then transition into IDLE.
+    await this.drainOnce(
+      clientRef,
+      options,
+      folder,
+      markSeenEnabled,
+      handler,
+      abortController,
+      logger,
+    );
 
-    // Fetch existing messages first
-    const existing = await fetchMessages(client, options, folder, logger);
-    for (const message of existing) {
-      if (abortController.signal.aborted) return;
-      if (processedUids.has(message.uid)) continue;
-      try {
-        await handler(message);
-        processedUids.add(message.uid);
-      } catch {
-        // Exchange error already logged by the route pipeline.
-        // UID is NOT marked processed so it will be retried on the next idle cycle.
-      }
-    }
-
-    // Listen for new messages via IDLE
     while (!abortController.signal.aborted) {
+      const client = clientRef.current;
+      if (!client) return;
+
       try {
         await client.idle();
       } catch (error) {
         if (abortController.signal.aborted) return;
-        throwMailConnectionError(error, "IMAP");
+        if (isMailAuthError(error)) {
+          // Auth failures will not recover on reconnect; surface clearly and stop.
+          throwMailConnectionError(error, "IMAP");
+        }
+        logger?.warn(
+          {
+            err: error instanceof Error ? error : new Error(String(error)),
+            folder,
+          },
+          "mail adapter IDLE connection dropped; attempting reconnect",
+        );
+        await this.reconnectWithBackoff(
+          clientRef,
+          manager,
+          account,
+          options,
+          folder,
+          usePool,
+          abortController,
+          logger,
+        );
+        if (abortController.signal.aborted) return;
+        continue;
       }
 
       if (abortController.signal.aborted) return;
 
-      const newMessages = await fetchMessages(client, options, folder, logger);
-      for (const message of newMessages) {
-        if (abortController.signal.aborted) return;
-        if (processedUids.has(message.uid)) continue;
-        try {
-          await handler(message);
-          processedUids.add(message.uid);
-        } catch {
-          // Exchange error already logged by the route pipeline.
-          // UID is NOT marked processed so it will be retried on the next idle cycle.
+      await this.drainOnce(
+        clientRef,
+        options,
+        folder,
+        markSeenEnabled,
+        handler,
+        abortController,
+        logger,
+      );
+    }
+  }
+
+  /**
+   * Fetch matching messages once and deliver each to the handler.
+   * Marks each message Seen only after the handler resolves successfully,
+   * so a handler failure leaves the message in the pool for retry.
+   */
+  private async drainOnce(
+    clientRef: { current: ImapClient | null },
+    options: MailServerOptions,
+    folder: string,
+    markSeenEnabled: boolean,
+    handler: (message: MailMessage) => Promise<Exchange>,
+    abortController: AbortController,
+    logger?: MailFetchLogger,
+  ): Promise<void> {
+    const client = clientRef.current;
+    if (!client) return;
+
+    const messages = await fetchMessages(client, options, folder, logger);
+    for (const message of messages) {
+      if (abortController.signal.aborted) return;
+      try {
+        await handler(message);
+        if (markSeenEnabled) {
+          await markMessagesSeen(client, message.uid, logger);
         }
+      } catch {
+        // Handler error already logged by the route pipeline. Leave un-Seen
+        // so the next drain cycle (next IDLE wake or next poll tick) retries.
       }
     }
   }
+
+  /**
+   * Replace a dead IMAP client after an IDLE failure. Exponential backoff
+   * with jitter, capped total attempts. Releases the current client on the
+   * first attempt so the pool slot is freed for the new connection.
+   */
+  private async reconnectWithBackoff(
+    clientRef: { current: ImapClient | null },
+    manager: MailClientManager | null,
+    account: string | undefined,
+    options: MailServerOptions,
+    folder: string,
+    usePool: boolean,
+    abortController: AbortController,
+    logger?: MailFetchLogger,
+  ): Promise<void> {
+    const dead = clientRef.current;
+    clientRef.current = null;
+    if (dead) {
+      if (usePool) {
+        try {
+          manager!.releaseImap(account, dead);
+        } catch {
+          // Ignore release errors on a client we know is broken
+        }
+      } else {
+        await dead.logout().catch(() => {});
+      }
+    }
+
+    for (let attempt = 1; attempt <= IDLE_RECONNECT_MAX_ATTEMPTS; attempt++) {
+      if (abortController.signal.aborted) return;
+
+      const base = Math.min(
+        IDLE_RECONNECT_BASE_MS * 2 ** (attempt - 1),
+        IDLE_RECONNECT_MAX_MS,
+      );
+      // Full jitter: pick uniformly in [0, base] so retries don't thunder.
+      const delay = Math.floor(Math.random() * base);
+      await waitWithAbort(delay, abortController);
+      if (abortController.signal.aborted) return;
+
+      try {
+        const fresh = await this.acquireAndOpen(
+          manager,
+          account,
+          options,
+          folder,
+          usePool,
+        );
+        clientRef.current = fresh;
+        logger?.debug(
+          { folder, attempt },
+          "mail adapter IDLE reconnect succeeded",
+        );
+        return;
+      } catch (error) {
+        if (isMailAuthError(error)) {
+          throwMailConnectionError(error, "IMAP");
+        }
+        logger?.warn(
+          {
+            err: error instanceof Error ? error : new Error(String(error)),
+            folder,
+            attempt,
+          },
+          "mail adapter IDLE reconnect attempt failed",
+        );
+      }
+    }
+
+    throw rcError("RC5010", undefined, {
+      message: `Mail adapter IDLE reconnect gave up after ${IDLE_RECONNECT_MAX_ATTEMPTS} attempts on folder "${folder}".`,
+    });
+  }
+}
+
+/**
+ * Subscribe-time validation.
+ *
+ * Re-evaluation mode (`markSeen: false` or `unseen: false`) requires an
+ * explicit poll cadence: IDLE has no cycle boundary so it would re-fetch the
+ * entire folder on every inbound message, flooding the handler.
+ * `limit` without a poll interval is a latency trap but not dangerous, so it
+ * only warns.
+ */
+function validateSourceOptions(
+  options: MailServerOptions,
+  logger?: MailFetchLogger,
+): void {
+  const disabledSeen = options.markSeen === false;
+  const disabledUnseen = options.unseen === false;
+  const hasPoll =
+    typeof options.pollIntervalMs === "number" && options.pollIntervalMs > 0;
+
+  if ((disabledSeen || disabledUnseen) && !hasPoll) {
+    const which = disabledSeen ? "markSeen: false" : "unseen: false";
+    throw rcError("RC5003", undefined, {
+      message:
+        `Mail source configured with ${which} requires pollIntervalMs. ` +
+        "IDLE mode cannot bound re-delivery cycles and would refetch the " +
+        "entire folder on every incoming message. Set pollIntervalMs to " +
+        "poll on a cadence, or remove the markSeen/unseen override.",
+    });
+  }
+
+  if (typeof options.limit === "number" && !hasPoll) {
+    logger?.warn(
+      { limit: options.limit, folder: options.folder },
+      "mail source `limit` with IDLE: backlog beyond the limit will only " +
+        "drain when new mail arrives. Use pollIntervalMs for predictable drain.",
+    );
+  }
+}
+
+/**
+ * Sleep for `ms` milliseconds, resolving early if the abort signal fires.
+ * `ms <= 0` resolves immediately (still observing abort synchronously).
+ */
+function waitWithAbort(
+  ms: number,
+  abortController: AbortController,
+): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      abortController.signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    abortController.signal.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/packages/routecraft/test/mail.test.ts
+++ b/packages/routecraft/test/mail.test.ts
@@ -1160,6 +1160,352 @@ describe("Mail Adapter", () => {
       // Verify the pool connection was released (logout is called on drain)
       expect(mockLogout).toHaveBeenCalled();
     });
+
+    /**
+     * @case markSeen happens per-message AFTER the handler resolves successfully
+     * @preconditions Poll source with default markSeen, one message fetched, downstream step throws
+     * @expectedResult messageFlagsAdd is NOT called for the failed UID; no silent message loss
+     */
+    test("does not mark Seen when handler fails", async () => {
+      let pollCount = 0;
+      mockFetch.mockImplementation(() => ({
+        async *[Symbol.asyncIterator]() {
+          if (pollCount === 0) {
+            pollCount++;
+            yield {
+              uid: 77,
+              flags: new Set([]),
+              envelope: {
+                messageId: "<fail@test.com>",
+                from: [{ address: "a@b.com" }],
+                to: [{ address: "c@d.com" }],
+                subject: "Handler will throw",
+                date: new Date("2026-04-22"),
+              },
+              source: Buffer.from("content"),
+            };
+          }
+        },
+      }));
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("test-handler-fail")
+            .from(
+              mail("INBOX", {
+                pollIntervalMs: 5,
+                // markSeen left at default (true) to exercise the post-handler path
+              }),
+            )
+            .process(() => {
+              throw new Error("downstream boom");
+            }),
+        )
+        .build();
+
+      const startPromise = t.ctx.start();
+      await new Promise((r) => setTimeout(r, 20));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(mockMessageFlagsAdd).not.toHaveBeenCalled();
+    });
+
+    /**
+     * @case markSeen is called per-message AFTER the handler resolves
+     * @preconditions Poll source with default markSeen, one message fetched, route has no throwing steps
+     * @expectedResult messageFlagsAdd called with the single uid (not a batched string)
+     */
+    test("marks Seen per-message after handler success", async () => {
+      let pollCount = 0;
+      mockFetch.mockImplementation(() => ({
+        async *[Symbol.asyncIterator]() {
+          if (pollCount === 0) {
+            pollCount++;
+            yield {
+              uid: 11,
+              flags: new Set([]),
+              envelope: {
+                messageId: "<ok@test.com>",
+                from: [{ address: "a@b.com" }],
+                to: [{ address: "c@d.com" }],
+                subject: "Handler succeeds",
+                date: new Date("2026-04-22"),
+              },
+              source: Buffer.from("content"),
+            };
+          }
+        },
+      }));
+
+      const s = spy();
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("test-handler-ok")
+            .from(
+              mail("INBOX", {
+                pollIntervalMs: 5,
+              }),
+            )
+            .to(s),
+        )
+        .build();
+
+      const startPromise = t.ctx.start();
+      await new Promise((r) => setTimeout(r, 20));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(s.received.length).toBeGreaterThanOrEqual(1);
+      expect(mockMessageFlagsAdd).toHaveBeenCalledWith("11", ["\\Seen"], {
+        uid: true,
+      });
+    });
+
+    /**
+     * @case Re-delivery across poll cycles when opting out of \Seen dedupe
+     * @preconditions unseen: false, markSeen: false, same UID returned on multiple polls
+     * @expectedResult Handler is invoked more than once for the same UID across cycles
+     */
+    test("redelivers the same UID across polls when Seen dedupe is disabled", async () => {
+      mockFetch.mockImplementation(() => ({
+        async *[Symbol.asyncIterator]() {
+          yield {
+            uid: 5,
+            flags: new Set([]),
+            envelope: {
+              messageId: "<rebill@test.com>",
+              from: [{ address: "a@b.com" }],
+              to: [{ address: "c@d.com" }],
+              subject: "Redelivered",
+              date: new Date("2026-04-22"),
+            },
+            source: Buffer.from("content"),
+          };
+        },
+      }));
+
+      const s = spy();
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("test-redelivery")
+            .from(
+              mail("INBOX", {
+                pollIntervalMs: 1,
+                markSeen: false,
+                unseen: false,
+              }),
+            )
+            .to(s),
+        )
+        .build();
+
+      const startPromise = t.ctx.start();
+      // Give the poll loop enough time to complete at least two cycles.
+      await new Promise((r) => setTimeout(r, 40));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(s.received.length).toBeGreaterThanOrEqual(2);
+      expect(mockMessageFlagsAdd).not.toHaveBeenCalled();
+    });
+
+    /**
+     * @case IDLE reconnects after a non-auth error
+     * @preconditions First idle() rejects with a transient error, second hangs until abort
+     * @expectedResult mailboxOpen is called more than once (initial + reconnect)
+     */
+    test("IDLE reconnects after a transient connection drop", async () => {
+      // Zero jitter so the reconnect backoff collapses to 0ms in the test.
+      vi.spyOn(Math, "random").mockReturnValue(0);
+
+      mockFetch.mockImplementation(() => ({
+        async *[Symbol.asyncIterator]() {},
+      }));
+
+      let idleCalls = 0;
+      mockIdle.mockImplementation(async () => {
+        idleCalls++;
+        if (idleCalls === 1) {
+          throw new Error("ECONNRESET");
+        }
+        // Resolve promptly on subsequent calls so the abort check between
+        // idle() and drainOnce can exit the loop cleanly.
+        await new Promise((r) => setTimeout(r, 2));
+      });
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft().id("test-idle-reconnect").from(mail("INBOX", {})).to(spy()),
+        )
+        .build();
+
+      const startPromise = t.ctx.start();
+      await new Promise((r) => setTimeout(r, 50));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(idleCalls).toBeGreaterThanOrEqual(2);
+      // Initial open + reconnect open
+      expect(mockMailboxOpen.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    /**
+     * @case Auth errors during IDLE do not trigger reconnect
+     * @preconditions idle() rejects with an auth error on the first call
+     * @expectedResult Subscription fails with RC5012 (no reconnect attempts)
+     */
+    test("IDLE auth failure stops the subscription without reconnect", async () => {
+      mockFetch.mockImplementation(() => ({
+        async *[Symbol.asyncIterator]() {},
+      }));
+
+      let idleCalls = 0;
+      mockIdle.mockImplementation(async () => {
+        idleCalls++;
+        throw new Error("AUTHENTICATIONFAILED");
+      });
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "wrong" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft().id("test-idle-auth-fail").from(mail("INBOX", {})).to(spy()),
+        )
+        .build();
+
+      const startPromise = t.ctx.start();
+      await new Promise((r) => setTimeout(r, 30));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(idleCalls).toBe(1);
+      // No reconnect: mailboxOpen called once at initial subscribe
+      expect(mockMailboxOpen.mock.calls.length).toBe(1);
+    });
+
+    /**
+     * @case Throws RC5003 at subscribe when markSeen is false without pollIntervalMs
+     * @preconditions markSeen: false with no pollIntervalMs (IDLE flood footgun)
+     * @expectedResult t.test() rejects with RC5003
+     */
+    test("throws when markSeen: false without pollIntervalMs", async () => {
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("test-guard-markseen")
+            .from(mail("INBOX", { markSeen: false }))
+            .to(spy()),
+        )
+        .build();
+
+      await expect(t.test()).rejects.toMatchObject({ rc: "RC5003" });
+    });
+
+    /**
+     * @case Throws RC5003 at subscribe when unseen is false without pollIntervalMs
+     * @preconditions unseen: false with no pollIntervalMs
+     * @expectedResult t.test() rejects with RC5003
+     */
+    test("throws when unseen: false without pollIntervalMs", async () => {
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("test-guard-unseen")
+            .from(mail("INBOX", { unseen: false }))
+            .to(spy()),
+        )
+        .build();
+
+      await expect(t.test()).rejects.toMatchObject({ rc: "RC5003" });
+    });
   });
 
   describe("buildSearchCriteriaSets", () => {


### PR DESCRIPTION
## Summary

Fixes three correctness bugs in the mail Source that made it unreliable for any inbox-processing workload, and adds subscribe-time guards to prevent the worst misconfiguration.

### Bugs fixed (all with regression tests)

1. **`\Seen` was marked before the handler ran.** `fetchMessages` batched `messageFlagsAdd` inside the fetch call, then the source iterated and called the handler on each message. A handler failure left the message marked Seen, and the default `unseen: true` then filtered it out of every future fetch → silent message loss on any downstream error. Fix: moved `markSeen` out of `fetchMessages`. The source marks each UID Seen **after** the handler resolves successfully. The fetch destination still marks pre-return (no post-commit hook available on `.enrich()`).
2. **No IDLE reconnect.** The previous code did `await client.idle()` and rethrew on any error, leaving the subscription dead until someone restarted the process. Fix: exponential backoff with full jitter, capped at 30 attempts. Auth errors bypass reconnect and surface immediately.
3. **`processedUids` set fought the re-evaluation pattern.** An in-memory `Set<number>` in both loops prevented a delivered UID from being re-delivered in the same process lifetime. Broken across restarts, and also broken whenever the caller opts out of the `\Seen` dedupe model. Fix: removed. When `markSeen: false` and `unseen: false` are set together, the inbox location is now the single source of truth and messages are redelivered every cycle until archived elsewhere.

### Safety guards added

- Throw `RC5003` at subscribe when `markSeen: false` or `unseen: false` is set without `pollIntervalMs`. IDLE has no cycle boundary, so combining those overrides would refetch the entire folder on every inbound message. Loud failure > silent flood.
- Warn when `limit` is set without `pollIntervalMs`. Limit + IDLE is a latency trap (backlog beyond the limit only drains on new-mail events) but not destructive.

### Docs

Adds a "Source delivery modes" section to the mail adapter reference explaining IDLE vs poll semantics, the re-evaluation pattern, and both guard behaviors.

## Test plan

- [x] 7 new regression tests covering: handler-fail-skips-Seen, per-message Seen on success, cross-cycle redelivery with Seen dedupe disabled, IDLE reconnect after transient drop, IDLE no-reconnect on auth failure, guard throws for `markSeen: false` and `unseen: false` without `pollIntervalMs`
- [x] All 788 existing tests still pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format` clean
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves IMAP mail source reliability for IDLE and poll. Messages are only marked \Seen after successful handling, IDLE reconnects automatically, and re-evaluation workloads redeliver as expected.

- **Bug Fixes**
  - Mark \Seen per message only after the handler succeeds; avoids silent loss on handler errors.
  - Remove in-memory UID dedupe so `markSeen: false`/`unseen: false` can redeliver each cycle; inbox state is the single source of truth.
  - Add IDLE reconnect with exponential backoff and jitter (max 30 attempts); auth errors fail fast without reconnect.
  - Move Seen marking out of `fetchMessages`; source marks after success, while the fetch destination marks best-effort on fetch.

- **Migration**
  - Set `pollIntervalMs` when using `markSeen: false` or `unseen: false` (throws `RC5003` if missing).
  - Using `limit` without `pollIntervalMs` now logs a warning in IDLE mode.

<sup>Written for commit b73e82aa2440f1d0c7d655463b8b3dadf53989da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

