### PR TITLE
Add transform() support to choice branch builder

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -714,7 +714,7 @@ Matched branches inline their steps before the remaining main-pipeline steps, so
   c
     .when(
       (ex) => ex.body.priority === "urgent",
-      (b) => b.to(urgentQueue),
+      (b) => b.transform(prioritize).to(urgentQueue),
     )
     .when(
       (ex) => ex.body.amount > 1000,
@@ -725,14 +725,14 @@ Matched branches inline their steps before the remaining main-pipeline steps, so
 .to(audit); // runs for urgent and review; skipped for otherwise (halted)
 ```
 
-Phase 1 branches support `to()` and `halt()`. Pipeline operations like `transform`, `enrich`, and `filter` will be added to branches in later phases.
+Branches currently support `to()`, `transform()`, and `halt()`. Additional pipeline operations (`enrich`, `filter`, `header`, `validate`) will be added in subsequent phases. Branches that change body type via `transform()` must converge on the same `Out` type; the callback return type enforces this at compile time.
 
 **Events:**
 
 - `route:<id>:operation:choice:matched` -- `{ branchIndex, branchLabel: "when" | "otherwise" }`
 - `route:<id>:operation:choice:unmatched` -- fires when no branch matched and the exchange is dropped.
 
-**Known limitations (phase 1):**
+**Known limitations:**
 
 - Nested `.choice()` inside a branch is not supported.
 - Predicates must be synchronous.

--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -725,7 +725,9 @@ Matched branches inline their steps before the remaining main-pipeline steps, so
 .to(audit); // runs for urgent and review; skipped for otherwise (halted)
 ```
 
-Branches currently support `to()`, `transform()`, and `halt()`. Additional pipeline operations (`enrich`, `filter`, `header`, `validate`) will be added in subsequent phases. Branches that change body type via `transform()` must converge on the same `Out` type; the callback return type enforces this at compile time.
+Branches currently support `to()`, `transform()`, and `halt()`. Additional pipeline operations (`enrich`, `filter`, `header`, `validate`) will be added in subsequent phases.
+
+Branches that change body type via `transform()` must converge on the same `Out` type; the callback return type enforces this at compile time.
 
 **Events:**
 

--- a/packages/routecraft/src/operations/choice.ts
+++ b/packages/routecraft/src/operations/choice.ts
@@ -9,6 +9,11 @@ import {
 import { rcError } from "../error.ts";
 import { COLLECT_STEPS } from "../dsl-symbol.ts";
 import { type Destination, type CallableDestination, ToStep } from "./to.ts";
+import {
+  type Transformer,
+  type CallableTransformer,
+  TransformStep,
+} from "./transform.ts";
 
 /**
  * Predicate that decides whether a choice branch matches an exchange.
@@ -84,10 +89,10 @@ export class HaltStep implements Step<HaltAdapter> {
  * Sub-builder that defines the step pipeline for a single choice branch.
  *
  * Exposed to the user as the `b` parameter inside `when(pred, b => ...)` and
- * `otherwise(b => ...)` callbacks. Intentionally narrow: phase 1 only exposes
- * `.to()` and `.halt()`. Other pipeline operations (`transform`, `enrich`,
- * `filter`, ...) will be added in subsequent phases by delegating to the
- * shared step-adding logic.
+ * `otherwise(b => ...)` callbacks. Grown additively: phase 1 shipped `.to()`
+ * and `.halt()`; phase 2 adds `.transform()`. Remaining pipeline operations
+ * (`enrich`, `filter`, `header`, `validate`, ...) will follow the same
+ * pattern in subsequent phases.
  *
  * @template Current - Body type entering this branch
  * @experimental
@@ -109,6 +114,29 @@ export class BranchBuilder<Current = unknown> {
   ): BranchBuilder<R extends void ? Current : R> {
     this.steps.push(new ToStep<Current, R>(destination));
     return this as unknown as BranchBuilder<R extends void ? Current : R>;
+  }
+
+  /**
+   * Transform the exchange body inside this branch. Mirrors the semantics of
+   * `RouteBuilder.transform`: the transformer receives the current body and
+   * returns the replacement body. Headers and exchange identity are
+   * preserved.
+   *
+   * Useful for branches that shape the body before the choice converges back
+   * into the main pipeline, e.g.
+   * `.when(isUrgent, b => b.transform(prioritize))`.
+   *
+   * @param transformer - Adapter or callable that maps the body to a new value
+   * @returns This builder, re-typed to the transformer's output
+   * @template Return - Result body type
+   */
+  transform<Return>(
+    transformer:
+      | Transformer<Current, Return>
+      | CallableTransformer<Current, Return>,
+  ): BranchBuilder<Return> {
+    this.steps.push(new TransformStep<Current, Return>(transformer));
+    return this as unknown as BranchBuilder<Return>;
   }
 
   /**

--- a/packages/routecraft/src/operations/choice.ts
+++ b/packages/routecraft/src/operations/choice.ts
@@ -108,6 +108,7 @@ export class BranchBuilder<Current = unknown> {
    * @param destination - Adapter or callable that processes the exchange
    * @returns This builder, re-typed to the destination's output
    * @template R - Result body type; defaults to `void` (body unchanged)
+   * @see RouteBuilder.to
    */
   to<R = void>(
     destination: Destination<Current, R> | CallableDestination<Current, R>,
@@ -129,6 +130,7 @@ export class BranchBuilder<Current = unknown> {
    * @param transformer - Adapter or callable that maps the body to a new value
    * @returns This builder, re-typed to the transformer's output
    * @template Return - Result body type
+   * @see RouteBuilder.transform
    */
   transform<Return>(
     transformer:

--- a/packages/routecraft/test/choice.test.ts
+++ b/packages/routecraft/test/choice.test.ts
@@ -286,4 +286,115 @@ describe("choice operation", () => {
     expect(whenSink.received).toHaveLength(1);
     expect(otherwiseSink.received).toHaveLength(0);
   });
+
+  /**
+   * @case transform() inside a branch rewrites the body before the choice converges
+   * @preconditions Two branches each transforming the body differently; shared downstream .to()
+   * @expectedResult Downstream destination sees the per-branch transformed body for each exchange
+   */
+  test("transform() inside a branch rewrites the body before convergence", async () => {
+    const shared = spy<Order>();
+
+    const inputs: Order[] = [
+      { priority: "urgent", amount: 10 },
+      { priority: "normal", amount: 50 },
+    ];
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-transform-converge")
+          .from(items(inputs))
+          .choice((c) =>
+            c
+              .when(
+                (ex) => ex.body.priority === "urgent",
+                (b) => b.transform((body) => ({ ...body, amount: 999 })),
+              )
+              .otherwise((b) =>
+                b.transform((body) => ({ ...body, amount: 0 })),
+              ),
+          )
+          .to(shared),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(shared.receivedBodies()).toEqual([
+      { priority: "urgent", amount: 999 },
+      { priority: "normal", amount: 0 },
+    ]);
+  });
+
+  /**
+   * @case transform() can chain with .to() and .halt() inside the same branch
+   * @preconditions Branch transforms body, sends to a sink, then halts
+   * @expectedResult Sink sees the transformed body; downstream .to() is skipped due to halt
+   */
+  test("transform() chains with to() and halt() inside a branch", async () => {
+    const sink = spy<Order>();
+    const downstream = spy<Order>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-transform-chain")
+          .from(items<Order>([{ priority: "normal", amount: 1 }]))
+          .choice((c) =>
+            c.otherwise((b) =>
+              b
+                .transform((body) => ({ ...body, amount: body.amount + 100 }))
+                .to(sink)
+                .halt(),
+            ),
+          )
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(sink.received).toHaveLength(1);
+    expect(sink.received[0].body).toEqual({ priority: "normal", amount: 101 });
+    expect(downstream.received).toHaveLength(0);
+  });
+
+  /**
+   * @case transform() changes the body type inside a branch; both branches must converge to the same Out
+   * @preconditions Both branches call .transform to a string; downstream .to() receives strings
+   * @expectedResult Downstream receives the per-branch string value; type flows through
+   */
+  test("transform() can change body type; branches must converge", async () => {
+    const downstream = spy<string>();
+
+    const inputs: Order[] = [
+      { priority: "urgent", amount: 3 },
+      { priority: "normal", amount: 4 },
+    ];
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-transform-type-change")
+          .from(items(inputs))
+          .choice<string>((c) =>
+            c
+              .when(
+                (ex) => ex.body.priority === "urgent",
+                (b) => b.transform((body) => `URGENT:${body.amount}`),
+              )
+              .otherwise((b) => b.transform((body) => `normal:${body.amount}`)),
+          )
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(downstream.receivedBodies()).toEqual(["URGENT:3", "normal:4"]);
+  });
 });

--- a/packages/routecraft/test/choice.test.ts
+++ b/packages/routecraft/test/choice.test.ts
@@ -1,6 +1,11 @@
-import { describe, test, expect, afterEach } from "vitest";
+import { describe, test, expect, expectTypeOf, afterEach } from "vitest";
 import { testContext, spy, type TestContext } from "@routecraft/testing";
-import { craft, type Source, type EventName } from "@routecraft/routecraft";
+import {
+  craft,
+  BranchBuilder,
+  type Source,
+  type EventName,
+} from "@routecraft/routecraft";
 
 type Order = { priority: "urgent" | "normal"; amount: number };
 
@@ -396,5 +401,96 @@ describe("choice operation", () => {
     await t.drain();
 
     expect(downstream.receivedBodies()).toEqual(["URGENT:3", "normal:4"]);
+  });
+
+  /**
+   * @case transform() inside a branch awaits async (Promise-returning) transformers
+   * @preconditions Branch uses an async transformer that resolves after a tick
+   * @expectedResult Downstream sink sees the resolved body, proving the await is honoured inside inlined branch steps
+   */
+  test("transform() inside a branch awaits async transformers", async () => {
+    const sink = spy<Order>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-transform-async")
+          .from(items<Order>([{ priority: "normal", amount: 1 }]))
+          .choice((c) =>
+            c.otherwise((b) =>
+              b
+                .transform(async (body) => {
+                  await new Promise((r) => setTimeout(r, 1));
+                  return { ...body, amount: body.amount + 1 };
+                })
+                .to(sink),
+            ),
+          ),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(sink.received).toHaveLength(1);
+    expect(sink.received[0].body).toEqual({ priority: "normal", amount: 2 });
+  });
+
+  /**
+   * @case A transformer throwing inside a branch propagates as a step failure
+   * @preconditions Branch transformer throws; no route-level error handler
+   * @expectedResult step:error, route:error, context:error, and exchange:failed all fire; downstream .to() does not receive the exchange
+   */
+  test("transform() throwing inside a branch propagates as a step failure", async () => {
+    const downstream = spy<Order>();
+    const events: string[] = [];
+
+    t = await testContext()
+      .on("route:*:step:*:error" as const, () => {
+        events.push("step:error");
+      })
+      .on("route:*:error" as const, () => {
+        events.push("route:error");
+      })
+      .on("context:error", () => {
+        events.push("context:error");
+      })
+      .on("route:*:exchange:failed" as const, () => {
+        events.push("exchange:failed");
+      })
+      .routes(
+        craft()
+          .id("choice-transform-throws")
+          .from(items<Order>([{ priority: "normal", amount: 1 }]))
+          .choice((c) =>
+            c.otherwise((b) =>
+              b.transform(() => {
+                throw new Error("branch transform blew up");
+              }),
+            ),
+          )
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(events).toContain("step:error");
+    expect(events).toContain("route:error");
+    expect(events).toContain("context:error");
+    expect(events).toContain("exchange:failed");
+    expect(downstream.received).toHaveLength(0);
+  });
+
+  /**
+   * @case Type-level: BranchBuilder.transform propagates the Return generic to the next builder stage
+   * @preconditions A BranchBuilder<number> transforms numbers into strings
+   * @expectedResult The resulting builder is exactly BranchBuilder<string>; subsequent .to() narrows the exchange body
+   */
+  test("type-level: BranchBuilder.transform propagates body type", () => {
+    const b = new BranchBuilder<number>();
+    const b2 = b.transform((n) => n.toString());
+    expectTypeOf(b2).toEqualTypeOf<BranchBuilder<string>>();
   });
 });


### PR DESCRIPTION
## Summary
Extends the `BranchBuilder` class to support the `.transform()` operation, allowing branches within a `choice()` to rewrite the exchange body before convergence. This completes phase 2 of branch capability expansion.

## Key Changes
- **BranchBuilder.transform()**: New method that accepts a `Transformer` or `CallableTransformer`, mirrors `RouteBuilder.transform()` semantics, and properly re-types the builder to the transformer's output type
- **Type safety**: Branches that change body type via `transform()` must converge on the same `Out` type, enforced at compile time via generic constraints
- **Step integration**: Reuses existing `TransformStep` infrastructure, ensuring consistent async/error handling behavior across the codebase
- **Comprehensive test coverage**: Added 6 new test cases covering:
  - Body transformation before choice convergence
  - Chaining with `.to()` and `.halt()` in the same branch
  - Type changes across branches with convergence
  - Async transformer support
  - Error propagation from throwing transformers
  - Type-level verification of generic propagation

## Implementation Details
- The `transform()` method delegates to the existing `TransformStep` class, maintaining consistency with the main pipeline
- Branches can now chain operations: `.transform(...).to(...).halt()`
- Async transformers are properly awaited within branch execution
- Errors thrown in branch transformers propagate as step failures, triggering standard error events
- Documentation updated to reflect phase 2 capabilities and clarify that additional operations will follow the same pattern

https://claude.ai/code/session_014REeethnLykENzXhWPL8Jg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.transform()` to choice branch `BranchBuilder`, so branches can rewrite the body before the choice converges. This lets you shape data per-branch without extra routes, with compile-time type safety.

- **New Features**
  - `BranchBuilder.transform()` in `when`/`otherwise`, mirroring `RouteBuilder.transform()`; builder re-typed to the transformer’s output.
  - Compile-time check that all branches converge to the same output type when using `transform()`.
  - Reuses `TransformStep` for consistent async/await and error events; chains with `.to()` and `.halt()`.
  - Docs updated; tests cover per-branch rewrite before convergence, chaining, async transformers, thrown errors, and generic propagation.

<sup>Written for commit 45a9c9b25d7b8a088ab038a92767a916b0118774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

