### PR TITLE
feat(routecraft): add enrich() to choice BranchBuilder (phase 3)

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -725,7 +725,7 @@ Matched branches inline their steps before the remaining main-pipeline steps, so
 .to(audit); // runs for urgent and review; skipped for otherwise (halted)
 ```
 
-Branches currently support `to()`, `transform()`, and `halt()`. Additional pipeline operations (`enrich`, `filter`, `header`, `validate`) will be added in subsequent phases.
+Branches currently support `to()`, `transform()`, `enrich()`, and `halt()`. Additional pipeline operations (`filter`, `header`, `validate`) will be added in subsequent phases.
 
 Branches that change body type via `transform()` must converge on the same `Out` type; the callback return type enforces this at compile time.
 

--- a/packages/routecraft/src/operations/choice.ts
+++ b/packages/routecraft/src/operations/choice.ts
@@ -7,6 +7,7 @@ import {
   getExchangeRoute,
 } from "../exchange.ts";
 import { rcError } from "../error.ts";
+import { ENRICH_MERGE_TYPE } from "../brand.ts";
 import { COLLECT_STEPS } from "../dsl-symbol.ts";
 import { type Destination, type CallableDestination, ToStep } from "./to.ts";
 import {
@@ -14,6 +15,12 @@ import {
   type CallableTransformer,
   TransformStep,
 } from "./transform.ts";
+import {
+  EnrichStep,
+  type DestinationAggregator,
+  type EnrichMergeShape,
+  type EnrichAggregatorOption,
+} from "./enrich.ts";
 
 /**
  * Predicate that decides whether a choice branch matches an exchange.
@@ -90,9 +97,9 @@ export class HaltStep implements Step<HaltAdapter> {
  *
  * Exposed to the user as the `b` parameter inside `when(pred, b => ...)` and
  * `otherwise(b => ...)` callbacks. Grown additively: phase 1 shipped `.to()`
- * and `.halt()`; phase 2 adds `.transform()`. Remaining pipeline operations
- * (`enrich`, `filter`, `header`, `validate`, ...) will follow the same
- * pattern in subsequent phases.
+ * and `.halt()`; phase 2 added `.transform()`; phase 3 adds `.enrich()`.
+ * Remaining pipeline operations (`filter`, `header`, `validate`, ...) will
+ * follow the same pattern in subsequent phases.
  *
  * @template Current - Body type entering this branch
  * @experimental
@@ -139,6 +146,47 @@ export class BranchBuilder<Current = unknown> {
   ): BranchBuilder<Return> {
     this.steps.push(new TransformStep<Current, Return>(transformer));
     return this as unknown as BranchBuilder<Return>;
+  }
+
+  /**
+   * Enrich the exchange body with data from a destination inside this branch.
+   * Mirrors the semantics of `RouteBuilder.enrich`: the destination fetches
+   * data, which the optional aggregator merges into the body (default
+   * aggregator spreads the result onto the body object).
+   *
+   * Useful when a branch needs to fetch per-case enrichment data, e.g.
+   * `.when(isReview, b => b.enrich(http({ url: reviewApi })).to(reviewQueue))`.
+   *
+   * @param destination - Adapter or callable that returns enrichment data
+   * @param aggregator - Optional merge strategy; defaults to spreading result onto body
+   * @returns This builder, re-typed with the merged body shape
+   * @template R - Body type returned by the destination
+   * @template A - Aggregator type (drives body shape inference)
+   * @see RouteBuilder.enrich
+   */
+  enrich<
+    R,
+    A extends
+      | DestinationAggregator<Current, R>
+      | (DestinationAggregator<unknown, unknown> & {
+          [ENRICH_MERGE_TYPE]?: EnrichMergeShape;
+        })
+      | undefined = undefined,
+  >(
+    destination: Destination<Current, R> | CallableDestination<Current, R>,
+    aggregator?: A,
+  ): BranchBuilder<
+    A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
+  > {
+    this.steps.push(
+      new EnrichStep<Current, R>(
+        destination,
+        aggregator as EnrichAggregatorOption<Current, R> | undefined,
+      ),
+    );
+    return this as unknown as BranchBuilder<
+      A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
+    >;
   }
 
   /**

--- a/packages/routecraft/test/choice.test.ts
+++ b/packages/routecraft/test/choice.test.ts
@@ -493,4 +493,134 @@ describe("choice operation", () => {
     const b2 = b.transform((n) => n.toString());
     expectTypeOf(b2).toEqualTypeOf<BranchBuilder<string>>();
   });
+
+  /**
+   * @case enrich() inside a branch merges destination result into the body before convergence
+   * @preconditions Branch uses enrich() with a destination that returns an object; default aggregator spreads result onto body
+   * @expectedResult Downstream sink sees the body with the enrichment merged in
+   */
+  test("enrich() inside a branch merges result into the body", async () => {
+    const shared = spy<Order & { reviewReason: string }>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-enrich-merge")
+          .from(items<Order>([{ priority: "normal", amount: 5000 }]))
+          .choice((c) =>
+            c.otherwise((b) =>
+              b.enrich(() => ({ reviewReason: "high-value" })),
+            ),
+          )
+          .to(shared),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(shared.received).toHaveLength(1);
+    expect(shared.received[0].body).toEqual({
+      priority: "normal",
+      amount: 5000,
+      reviewReason: "high-value",
+    });
+  });
+
+  /**
+   * @case enrich() inside a branch awaits async destinations
+   * @preconditions Branch uses enrich() with an async destination that resolves after a tick
+   * @expectedResult Downstream sink sees the merged body, proving the await is honoured inside inlined branch steps
+   */
+  test("enrich() inside a branch awaits async destinations", async () => {
+    const sink = spy<Order & { fetched: number }>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-enrich-async")
+          .from(items<Order>([{ priority: "urgent", amount: 1 }]))
+          .choice((c) =>
+            c.otherwise((b) =>
+              b
+                .enrich(async () => {
+                  await new Promise((r) => setTimeout(r, 1));
+                  return { fetched: 42 };
+                })
+                .to(sink),
+            ),
+          ),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(sink.received).toHaveLength(1);
+    expect(sink.received[0].body).toEqual({
+      priority: "urgent",
+      amount: 1,
+      fetched: 42,
+    });
+  });
+
+  /**
+   * @case enrich() destination throwing inside a branch propagates as a step failure
+   * @preconditions Branch enrich destination throws; no route-level error handler
+   * @expectedResult step:error, route:error, context:error, and exchange:failed all fire; downstream .to() does not receive the exchange
+   */
+  test("enrich() destination throwing inside a branch propagates as a step failure", async () => {
+    const downstream = spy<Order>();
+    const events: string[] = [];
+
+    t = await testContext()
+      .on("route:*:step:*:error" as const, () => {
+        events.push("step:error");
+      })
+      .on("route:*:error" as const, () => {
+        events.push("route:error");
+      })
+      .on("context:error", () => {
+        events.push("context:error");
+      })
+      .on("route:*:exchange:failed" as const, () => {
+        events.push("exchange:failed");
+      })
+      .routes(
+        craft()
+          .id("choice-enrich-throws")
+          .from(items<Order>([{ priority: "normal", amount: 1 }]))
+          .choice((c) =>
+            c.otherwise((b) =>
+              b.enrich(() => {
+                throw new Error("enrich fetch blew up");
+              }),
+            ),
+          )
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(events).toContain("step:error");
+    expect(events).toContain("route:error");
+    expect(events).toContain("context:error");
+    expect(events).toContain("exchange:failed");
+    expect(downstream.received).toHaveLength(0);
+  });
+
+  /**
+   * @case Type-level: BranchBuilder.enrich propagates merged body type (Current & R) to the next builder stage
+   * @preconditions A BranchBuilder<{ a: number }> enriches with a destination returning { b: string }
+   * @expectedResult The resulting builder is BranchBuilder<{ a: number } & { b: string }>
+   */
+  test("type-level: BranchBuilder.enrich propagates merged body type", () => {
+    const b = new BranchBuilder<{ a: number }>();
+    const b2 = b.enrich(() => ({ b: "x" }));
+    expectTypeOf(b2).toEqualTypeOf<
+      BranchBuilder<{ a: number } & { b: string }>
+    >();
+  });
 });


### PR DESCRIPTION
Follow-up to #244 and #245. Adds .enrich() to the branch sub-builder so branches can fetch per-case enrichment data and merge it into the body before the choice converges back into the main pipeline. Mirrors RouteBuilder.enrich semantics including aggregator-driven body type inference via the ENRICH_MERGE_TYPE brand.

Four new tests cover: default-aggregator merge of a synchronous enrichment, async enrichment awaited inside an inlined branch step, enrich destination throwing (asserts step:error, route:error, context:error, exchange:failed, and downstream .to() skipped), plus a type-level expectTypeOf assertion on the merged body shape.

Docs updated: branches now list enrich() among supported ops; filter, header, and validate remain as the deferred surface.

With three pipeline ops on BranchBuilder (to, transform, enrich) plus halt, the phase-5 StepBuilderBase extraction is now the next natural refactor to stop RouteBuilder and BranchBuilder from drifting.

https://claude.ai/code/session_014REeethnLykENzXhWPL8Jg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `enrich()` to the choice branch builder so branches can fetch per-branch data and merge it into the body before converging back to the main pipeline. Mirrors `RouteBuilder.enrich`, including aggregator-driven body type inference via the `ENRICH_MERGE_TYPE` brand.

- **New Features**
  - `BranchBuilder.enrich(destination, aggregator?)`: merges destination result into the body; default spread merge; awaits async; on error, emits step/route/context errors and skips downstream steps.
  - Type inference: aggregator or destination result drives merged body type (`Current & R`), with branded aggregators via `ENRICH_MERGE_TYPE`.
  - Docs: branch ops now list `enrich()`; `filter`, `header`, `validate` remain deferred.

<sup>Written for commit 37ad695915ebb20f261fa42c5778d1d31c583278. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

