### PR TITLE
Extract shared pipeline operations into StepBuilderBase

### DIFF
--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { BRAND, ENRICH_MERGE_TYPE, isRouteBuilder, setBrand } from "./brand.ts";
+import { BRAND, isRouteBuilder, setBrand } from "./brand.ts";
+import { StepBuilderBase } from "./step-builder-base.ts";
 import { type RouteDefinition, type ErrorHandler } from "./route.ts";
 import {
   CraftContext,
@@ -32,11 +33,7 @@ import {
   type CallableProcessor,
   ProcessStep,
 } from "./operations/process.ts";
-import {
-  type Destination,
-  type CallableDestination,
-  ToStep,
-} from "./operations/to.ts";
+import { type Destination, type CallableDestination } from "./operations/to.ts";
 import {
   type Splitter,
   type CallableSplitter,
@@ -48,11 +45,6 @@ import {
   AggregateStep,
   defaultAggregate,
 } from "./operations/aggregate.ts";
-import {
-  type Transformer,
-  type CallableTransformer,
-  TransformStep,
-} from "./operations/transform.ts";
 import { TapStep } from "./operations/tap.ts";
 import {
   type CallableFilter,
@@ -64,12 +56,6 @@ import {
   type CallableValidator,
   ValidateStep,
 } from "./operations/validate.ts";
-import {
-  EnrichStep,
-  type DestinationAggregator,
-  type EnrichMergeShape,
-  type EnrichAggregatorOption,
-} from "./operations/enrich.ts";
 import { HeaderStep } from "./operations/header.ts";
 import { type HeaderValue } from "./exchange.ts";
 import { PUSH_STEP, COLLECT_STEPS } from "./dsl-symbol.ts";
@@ -368,7 +354,7 @@ export type RouteOptions = Partial<Pick<RouteDefinition, "consumer">> & {
  *   .to(log())
  * ```
  */
-export class RouteBuilder<Current = unknown> {
+export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   protected currentRoute?: RouteDefinition;
   protected routes: RouteDefinition[] = [];
 
@@ -385,6 +371,7 @@ export class RouteBuilder<Current = unknown> {
     | undefined;
 
   constructor() {
+    super();
     setBrand(this, BRAND.RouteBuilder);
   }
 
@@ -539,30 +526,30 @@ export class RouteBuilder<Current = unknown> {
   }
 
   /**
-   * Internal method to add a step to the current route.
-   * This is used by the public methods to build up the route definition.
+   * Append a step to the current route. Implements the abstract hook from
+   * {@link StepBuilderBase} for inherited pipeline operations (`to`,
+   * `transform`, `enrich`), and is also called by the route-specific
+   * operations below (`process`, `split`, `aggregate`, `tap`, `filter`,
+   * `validate`, `header`, `choice`).
    *
-   * @template T The type of adapter used by the step
-   * @param step The step definition to add
-   * @returns The current RouteBuilder instance
-   * @private
+   * @param step - The step to append
+   * @throws {RoutecraftError} RC2002 if `.from()` has not been called yet
    */
-  private addStep<T extends Adapter>(step: Step<T>): RouteBuilder<Current> {
+  protected override pushStep<T extends Adapter>(step: Step<T>): void {
     const route = this.requireSource();
     logger.trace(
       { operation: step.operation, route: route.id },
       "Adding step to route",
     );
     route.steps.push(step);
-    return this.withType<Current>();
   }
 
   /**
    * Symbol-keyed method for registerDsl to add steps without exposing
-   * addStep as public API. Not visible in autocomplete.
+   * pushStep as public API. Not visible in autocomplete.
    */
   [PUSH_STEP]<T extends Adapter>(step: Step<T>): this {
-    this.addStep(step);
+    this.pushStep(step);
     return this;
   }
 
@@ -581,35 +568,8 @@ export class RouteBuilder<Current = unknown> {
   process<Return = Current>(
     processor: Processor<Current, Return> | CallableProcessor<Current, Return>,
   ): RouteBuilder<Return> {
-    this.addStep(new ProcessStep<Current, Return>(processor));
+    this.pushStep(new ProcessStep<Current, Return>(processor));
     return this.withType<Return>();
-  }
-
-  /**
-   * Send the processed data to a destination.
-   * If the destination returns undefined, the exchange continues unchanged.
-   * If the destination returns a value, the exchange body is replaced with that value.
-   *
-   * @template R The result type returned by the destination
-   * @param destination A function or adapter that sends the data
-   * @returns A RouteBuilder with the result type
-   * @example
-   * // Send to a destination that returns void (no body change)
-   * .to(async ({ body }) => {
-   *   await db.users.insert(body);
-   * })
-   *
-   * // Send and replace body with result
-   * .to(http({ url: 'https://api.example.com/transform' }))
-   * // Body becomes HttpResult
-   */
-  to<R = void>(
-    destination: Destination<Current, R> | CallableDestination<Current, R>,
-  ): RouteBuilder<R extends void ? Current : R> {
-    const route = this.requireSource();
-    logger.trace({ route: route.id }, "Adding destination step to route");
-    route.steps.push(new ToStep<Current, R>(destination));
-    return this.withType<R extends void ? Current : R>();
   }
 
   /**
@@ -706,35 +666,15 @@ export class RouteBuilder<Current = unknown> {
   ): RouteBuilder<ResultType> {
     if (!aggregator) {
       // Use default aggregator which collects bodies into an array
-      this.addStep(
+      this.pushStep(
         new AggregateStep<Current, ResultType>(
           defaultAggregate as CallableAggregator<Current, ResultType>,
         ),
       );
     } else {
-      this.addStep(new AggregateStep<Current, ResultType>(aggregator));
+      this.pushStep(new AggregateStep<Current, ResultType>(aggregator));
     }
     return this.withType<ResultType>();
-  }
-
-  /**
-   * Transform the current data to a new type using a transformer function.
-   * Unlike process, this operates only on the body of the exchange, not the entire exchange.
-   *
-   * @template Return The resulting type after transformation
-   * @param transformer A function that transforms the current body to a new body of type Return
-   * @returns A RouteBuilder with the new type Return
-   * @example
-   * // Transform a string to an object
-   * .transform<{ value: string }>((str) => ({ value: str }))
-   */
-  transform<Return>(
-    transformer:
-      | Transformer<Current, Return>
-      | CallableTransformer<Current, Return>,
-  ): RouteBuilder<Return> {
-    this.addStep(new TransformStep<Current, Return>(transformer));
-    return this.withType<Return>();
   }
 
   /**
@@ -760,7 +700,7 @@ export class RouteBuilder<Current = unknown> {
       | HeaderValue
       | ((exchange: Exchange<Current>) => HeaderValue | Promise<HeaderValue>),
   ): RouteBuilder<Current> {
-    this.addStep(new HeaderStep<Current>(key, valueOrFn));
+    this.pushStep(new HeaderStep<Current>(key, valueOrFn));
     return this.withType<Current>();
   }
 
@@ -787,7 +727,7 @@ export class RouteBuilder<Current = unknown> {
       | Destination<Current, unknown>
       | CallableDestination<Current, unknown>,
   ): RouteBuilder<Current> {
-    this.addStep(new TapStep<Current>(destination));
+    this.pushStep(new TapStep<Current>(destination));
     return this.withType<Current>();
   }
 
@@ -820,7 +760,7 @@ export class RouteBuilder<Current = unknown> {
   filter(
     filter: Filter<Current> | CallableFilter<Current>,
   ): RouteBuilder<Current> {
-    this.addStep(new FilterStep<Current>(filter));
+    this.pushStep(new FilterStep<Current>(filter));
     return this.withType<Current>();
   }
 
@@ -851,57 +791,8 @@ export class RouteBuilder<Current = unknown> {
   validate<R = Current>(
     validator: Validator<Current, R> | CallableValidator<Current, R>,
   ): RouteBuilder<R> {
-    this.addStep(new ValidateStep<Current, R>(validator));
+    this.pushStep(new ValidateStep<Current, R>(validator));
     return this.withType<R>();
-  }
-
-  /**
-   * Enrich the current data with additional information from a destination.
-   * By default, the result is merged into the exchange body.
-   * Uses the same Destination adapters as .to() but with a merge-by-default aggregator.
-   *
-   * @template R The resulting type after enrichment (defaults to Current if not specified)
-   * @param destination A destination adapter or function that returns enrichment data
-   * @param aggregator Optional function to control how data is combined
-   * @returns A RouteBuilder with the combined type
-   * @example
-   * // Add user details from an API (default merge behavior)
-   * .enrich(http({
-   *   url: (ex) => `https://api.example.com/users/${ex.body.userId}`
-   * }))
-   *
-   * // Custom aggregation strategy
-   * .enrich(
-   *   http({ url: 'https://api.example.com/data' }),
-   *   (original, result) => ({
-   *     ...original,
-   *     body: { ...original.body, fetchedData: result.body }
-   *   })
-   * )
-   */
-  enrich<
-    R,
-    A extends
-      | DestinationAggregator<Current, R>
-      | (DestinationAggregator<unknown, unknown> & {
-          [ENRICH_MERGE_TYPE]?: EnrichMergeShape;
-        })
-      | undefined = undefined,
-  >(
-    destination: Destination<Current, R> | CallableDestination<Current, R>,
-    aggregator?: A,
-  ): RouteBuilder<
-    A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
-  > {
-    this.addStep(
-      new EnrichStep<Current, R>(
-        destination,
-        aggregator as EnrichAggregatorOption<Current, R> | undefined,
-      ),
-    );
-    return this.withType<
-      A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
-    >();
   }
 
   /**
@@ -944,7 +835,7 @@ export class RouteBuilder<Current = unknown> {
   ): RouteBuilder<Out> {
     const sub = new ChoiceSubBuilder<Current, Out>();
     fn(sub);
-    this.addStep(new ChoiceStep<Current>(sub[COLLECT_STEPS]()));
+    this.pushStep(new ChoiceStep<Current>(sub[COLLECT_STEPS]()));
     return this.withType<Out>();
   }
 

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -376,18 +376,6 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   }
 
   /**
-   * Safe identity cast: same instance, type parameter updated for the next step.
-   * Used to propagate body/result type through the method chain.
-   *
-   * @template T - The body type for the next step
-   * @returns This builder typed as RouteBuilder<T>
-   * @private
-   */
-  private withType<T>(): RouteBuilder<T> {
-    return this as unknown as RouteBuilder<T>;
-  }
-
-  /**
    * Set the route id for the next route to be created.
    * Stages the id; does not affect the current route if one already exists.
    *
@@ -507,7 +495,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     this.pendingOptions = undefined;
 
     this.routes.push(this.currentRoute);
-    return this.withType<T>();
+    return this.retype<T>();
   }
 
   /**
@@ -569,7 +557,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     processor: Processor<Current, Return> | CallableProcessor<Current, Return>,
   ): RouteBuilder<Return> {
     this.pushStep(new ProcessStep<Current, Return>(processor));
-    return this.withType<Return>();
+    return this.retype<Return>();
   }
 
   /**
@@ -633,7 +621,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       this.pushStep(new SplitStep<Current, ItemType>(splitter));
     }
 
-    return this.withType<ItemType>();
+    return this.retype<ItemType>();
   }
 
   /**
@@ -671,7 +659,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     } else {
       this.pushStep(new AggregateStep<Current, ResultType>(aggregator));
     }
-    return this.withType<ResultType>();
+    return this.retype<ResultType>();
   }
 
   /**
@@ -698,7 +686,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       | ((exchange: Exchange<Current>) => HeaderValue | Promise<HeaderValue>),
   ): RouteBuilder<Current> {
     this.pushStep(new HeaderStep<Current>(key, valueOrFn));
-    return this.withType<Current>();
+    return this.retype<Current>();
   }
 
   /**
@@ -725,7 +713,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       | CallableDestination<Current, unknown>,
   ): RouteBuilder<Current> {
     this.pushStep(new TapStep<Current>(destination));
-    return this.withType<Current>();
+    return this.retype<Current>();
   }
 
   /**
@@ -758,7 +746,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     filter: Filter<Current> | CallableFilter<Current>,
   ): RouteBuilder<Current> {
     this.pushStep(new FilterStep<Current>(filter));
-    return this.withType<Current>();
+    return this.retype<Current>();
   }
 
   /**
@@ -789,7 +777,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     validator: Validator<Current, R> | CallableValidator<Current, R>,
   ): RouteBuilder<R> {
     this.pushStep(new ValidateStep<Current, R>(validator));
-    return this.withType<R>();
+    return this.retype<R>();
   }
 
   /**
@@ -833,7 +821,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     const sub = new ChoiceSubBuilder<Current, Out>();
     fn(sub);
     this.pushStep(new ChoiceStep<Current>(sub[COLLECT_STEPS]()));
-    return this.withType<Out>();
+    return this.retype<Out>();
   }
 
   /**

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -599,9 +599,6 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       | Splitter<Current, ItemType>
       | CallableSplitter<Current, ItemType>,
   ): RouteBuilder<ItemType> {
-    const route = this.requireSource();
-    logger.trace({ route: route.id }, "Adding split step to route");
-
     // If no splitter is provided, use default splitter: arrays are split, non-arrays as single item
     if (!splitter) {
       const defaultSplitter: CallableSplitter<Current, ItemType> = (
@@ -631,9 +628,9 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
         ];
       };
 
-      route.steps.push(new SplitStep<Current, ItemType>(defaultSplitter));
+      this.pushStep(new SplitStep<Current, ItemType>(defaultSplitter));
     } else {
-      route.steps.push(new SplitStep<Current, ItemType>(splitter));
+      this.pushStep(new SplitStep<Current, ItemType>(splitter));
     }
 
     return this.withType<ItemType>();

--- a/packages/routecraft/src/operations/choice.ts
+++ b/packages/routecraft/src/operations/choice.ts
@@ -7,20 +7,8 @@ import {
   getExchangeRoute,
 } from "../exchange.ts";
 import { rcError } from "../error.ts";
-import { ENRICH_MERGE_TYPE } from "../brand.ts";
 import { COLLECT_STEPS } from "../dsl-symbol.ts";
-import { type Destination, type CallableDestination, ToStep } from "./to.ts";
-import {
-  type Transformer,
-  type CallableTransformer,
-  TransformStep,
-} from "./transform.ts";
-import {
-  EnrichStep,
-  type DestinationAggregator,
-  type EnrichMergeShape,
-  type EnrichAggregatorOption,
-} from "./enrich.ts";
+import { StepBuilderBase } from "../step-builder-base.ts";
 
 /**
  * Predicate that decides whether a choice branch matches an exchange.
@@ -96,97 +84,24 @@ export class HaltStep implements Step<HaltAdapter> {
  * Sub-builder that defines the step pipeline for a single choice branch.
  *
  * Exposed to the user as the `b` parameter inside `when(pred, b => ...)` and
- * `otherwise(b => ...)` callbacks. Grown additively: phase 1 shipped `.to()`
- * and `.halt()`; phase 2 added `.transform()`; phase 3 adds `.enrich()`.
- * Remaining pipeline operations (`filter`, `header`, `validate`, ...) will
- * follow the same pattern in subsequent phases.
+ * `otherwise(b => ...)` callbacks. Pipeline operations (`to`, `transform`,
+ * `enrich`) are inherited from {@link StepBuilderBase} and behave identically
+ * to their counterparts on `RouteBuilder`; the polymorphic return types
+ * ensure a chained call re-types this builder as `BranchBuilder<NewT>`.
+ *
+ * BranchBuilder adds `.halt()` for explicit short-circuit of the enclosing
+ * choice. Branch-unsafe ops like `.split()` / `.aggregate()` / `.from()` are
+ * deliberately absent because they have no coherent meaning inside a
+ * converging branch.
  *
  * @template Current - Body type entering this branch
  * @experimental
  */
-export class BranchBuilder<Current = unknown> {
+export class BranchBuilder<Current = unknown> extends StepBuilderBase<Current> {
   private readonly steps: Step<Adapter>[] = [];
 
-  /**
-   * Send the exchange to a destination inside this branch. Mirrors the
-   * semantics of `RouteBuilder.to`: a destination that returns `undefined`
-   * leaves the body unchanged; a returned value replaces the body.
-   *
-   * @param destination - Adapter or callable that processes the exchange
-   * @returns This builder, re-typed to the destination's output
-   * @template R - Result body type; defaults to `void` (body unchanged)
-   * @see RouteBuilder.to
-   */
-  to<R = void>(
-    destination: Destination<Current, R> | CallableDestination<Current, R>,
-  ): BranchBuilder<R extends void ? Current : R> {
-    this.steps.push(new ToStep<Current, R>(destination));
-    return this as unknown as BranchBuilder<R extends void ? Current : R>;
-  }
-
-  /**
-   * Transform the exchange body inside this branch. Mirrors the semantics of
-   * `RouteBuilder.transform`: the transformer receives the current body and
-   * returns the replacement body. Headers and exchange identity are
-   * preserved.
-   *
-   * Useful for branches that shape the body before the choice converges back
-   * into the main pipeline, e.g.
-   * `.when(isUrgent, b => b.transform(prioritize))`.
-   *
-   * @param transformer - Adapter or callable that maps the body to a new value
-   * @returns This builder, re-typed to the transformer's output
-   * @template Return - Result body type
-   * @see RouteBuilder.transform
-   */
-  transform<Return>(
-    transformer:
-      | Transformer<Current, Return>
-      | CallableTransformer<Current, Return>,
-  ): BranchBuilder<Return> {
-    this.steps.push(new TransformStep<Current, Return>(transformer));
-    return this as unknown as BranchBuilder<Return>;
-  }
-
-  /**
-   * Enrich the exchange body with data from a destination inside this branch.
-   * Mirrors the semantics of `RouteBuilder.enrich`: the destination fetches
-   * data, which the optional aggregator merges into the body (default
-   * aggregator spreads the result onto the body object).
-   *
-   * Useful when a branch needs to fetch per-case enrichment data, e.g.
-   * `.when(isReview, b => b.enrich(http({ url: reviewApi })).to(reviewQueue))`.
-   *
-   * @param destination - Adapter or callable that returns enrichment data
-   * @param aggregator - Optional merge strategy; defaults to spreading result onto body
-   * @returns This builder, re-typed with the merged body shape
-   * @template R - Body type returned by the destination
-   * @template A - Aggregator type (drives body shape inference)
-   * @see RouteBuilder.enrich
-   */
-  enrich<
-    R,
-    A extends
-      | DestinationAggregator<Current, R>
-      | (DestinationAggregator<unknown, unknown> & {
-          [ENRICH_MERGE_TYPE]?: EnrichMergeShape;
-        })
-      | undefined = undefined,
-  >(
-    destination: Destination<Current, R> | CallableDestination<Current, R>,
-    aggregator?: A,
-  ): BranchBuilder<
-    A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
-  > {
-    this.steps.push(
-      new EnrichStep<Current, R>(
-        destination,
-        aggregator as EnrichAggregatorOption<Current, R> | undefined,
-      ),
-    );
-    return this as unknown as BranchBuilder<
-      A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
-    >;
+  protected override pushStep<T extends Adapter>(step: Step<T>): void {
+    this.steps.push(step);
   }
 
   /**

--- a/packages/routecraft/src/operations/choice.ts
+++ b/packages/routecraft/src/operations/choice.ts
@@ -117,7 +117,7 @@ export class BranchBuilder<Current = unknown> extends StepBuilderBase<Current> {
    * @returns This builder (for chaining, though no further steps will execute)
    */
   halt(): BranchBuilder<Current> {
-    this.steps.push(new HaltStep());
+    this.pushStep(new HaltStep());
     return this;
   }
 

--- a/packages/routecraft/src/step-builder-base.ts
+++ b/packages/routecraft/src/step-builder-base.ts
@@ -1,0 +1,148 @@
+import { ENRICH_MERGE_TYPE } from "./brand.ts";
+import { type Adapter, type Step } from "./types.ts";
+import {
+  type Destination,
+  type CallableDestination,
+  ToStep,
+} from "./operations/to.ts";
+import {
+  type Transformer,
+  type CallableTransformer,
+  TransformStep,
+} from "./operations/transform.ts";
+import {
+  EnrichStep,
+  type DestinationAggregator,
+  type EnrichMergeShape,
+  type EnrichAggregatorOption,
+} from "./operations/enrich.ts";
+
+// Type-only imports to avoid a runtime cycle. The `Retyped` conditional below
+// resolves `this` into the concrete subclass typed at `NewT`; the value side
+// of each subclass is defined in its own module and imports StepBuilderBase,
+// not the other way around.
+import type { RouteBuilder } from "./builder.ts";
+import type { BranchBuilder } from "./operations/choice.ts";
+
+/**
+ * Maps the polymorphic `this` type of a `StepBuilderBase` call to the same
+ * concrete subclass re-typed at the new body type `NewT`. Enables methods on
+ * the shared base class to return `RouteBuilder<NewT>` or `BranchBuilder<NewT>`
+ * automatically based on the receiver at the call site, without each subclass
+ * overriding every method to narrow its return.
+ *
+ * Closed-world on purpose: only the framework-owned subclasses participate.
+ * External subclasses fall through to `never`, which is intentional -- the
+ * shared base class is not a public extension point today.
+ *
+ * @template This - The polymorphic `this` type inside a method on StepBuilderBase
+ * @template NewT - The new body type to re-type the subclass at
+ */
+export type Retyped<This, NewT> =
+  This extends RouteBuilder<unknown>
+    ? RouteBuilder<NewT>
+    : This extends BranchBuilder<unknown>
+      ? BranchBuilder<NewT>
+      : never;
+
+/**
+ * Shared abstract base for builders that accumulate pipeline steps.
+ *
+ * Implements the pipeline operations that are identical across
+ * `RouteBuilder` and `BranchBuilder` (`to`, `transform`, `enrich`). Each
+ * subclass provides its own `pushStep` hook describing where steps go --
+ * `RouteBuilder` pushes into the current route definition (and enforces
+ * that `.from()` has been called via `requireSource`), while
+ * `BranchBuilder` pushes into its internal step array.
+ *
+ * Return types thread through the polymorphic `this` via {@link Retyped},
+ * so a `.transform()` call on a `RouteBuilder<A>` returns `RouteBuilder<B>`
+ * and the same call on `BranchBuilder<A>` returns `BranchBuilder<B>`.
+ *
+ * @template Current - Body type entering the next step
+ */
+export abstract class StepBuilderBase<Current = unknown> {
+  /**
+   * Append a step to the builder's pipeline. Implemented by each subclass
+   * to route the step into the right collection (current route definition
+   * vs. branch step array). Subclass-specific validation (e.g.
+   * `RouteBuilder.requireSource`) lives in the implementation.
+   *
+   * @param step - The step to append
+   */
+  protected abstract pushStep<T extends Adapter>(step: Step<T>): void;
+
+  /**
+   * Send the exchange to a destination. A destination that returns
+   * `undefined` leaves the body unchanged; a returned value replaces
+   * the body.
+   *
+   * @param destination - Adapter or callable that processes the exchange
+   * @returns The subclass builder re-typed to the destination's output
+   * @template R - Result body type; defaults to `void` (body unchanged)
+   */
+  to<R = void>(
+    destination: Destination<Current, R> | CallableDestination<Current, R>,
+  ): Retyped<this, R extends void ? Current : R> {
+    this.pushStep(new ToStep<Current, R>(destination));
+    return this as unknown as Retyped<this, R extends void ? Current : R>;
+  }
+
+  /**
+   * Transform the exchange body. The transformer receives the current
+   * body and returns the replacement body. Headers and exchange identity
+   * are preserved. Use `.process()` when the full exchange is needed.
+   *
+   * @param transformer - Adapter or callable that maps the body to a new value
+   * @returns The subclass builder re-typed to the transformer's output
+   * @template Return - Result body type
+   */
+  transform<Return>(
+    transformer:
+      | Transformer<Current, Return>
+      | CallableTransformer<Current, Return>,
+  ): Retyped<this, Return> {
+    this.pushStep(new TransformStep<Current, Return>(transformer));
+    return this as unknown as Retyped<this, Return>;
+  }
+
+  /**
+   * Enrich the exchange with data from a destination (e.g. HTTP lookup).
+   * Uses the same Destination adapters as `.to()` but with a merge-by-default
+   * aggregator. Optional aggregator controls how data is combined; `only(...)`
+   * and similar helpers carry an `ENRICH_MERGE_TYPE` brand that drives the
+   * body-type inference.
+   *
+   * @param destination - Adapter or callable that returns enrichment data
+   * @param aggregator - Optional merge strategy; defaults to spreading result onto body
+   * @returns The subclass builder re-typed with the merged body shape
+   * @template R - Body type returned by the destination
+   * @template A - Aggregator type (drives body shape inference)
+   */
+  enrich<
+    R,
+    A extends
+      | DestinationAggregator<Current, R>
+      | (DestinationAggregator<unknown, unknown> & {
+          [ENRICH_MERGE_TYPE]?: EnrichMergeShape;
+        })
+      | undefined = undefined,
+  >(
+    destination: Destination<Current, R> | CallableDestination<Current, R>,
+    aggregator?: A,
+  ): Retyped<
+    this,
+    A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
+  > {
+    this.pushStep(
+      new EnrichStep<Current, R>(
+        destination,
+        aggregator as EnrichAggregatorOption<Current, R> | undefined,
+      ),
+    );
+    return this as unknown as Retyped<
+      this,
+      A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
+    >;
+  }
+}

--- a/packages/routecraft/src/step-builder-base.ts
+++ b/packages/routecraft/src/step-builder-base.ts
@@ -33,8 +33,11 @@ import type { BranchBuilder } from "./operations/choice.ts";
  *
  * Closed-world on purpose: only the framework-owned subclasses participate.
  * External subclasses fall through to `never`, which is intentional -- the
- * shared base class is not a public extension point today.
+ * shared base class is not a public extension point today. Any future
+ * framework-owned subclass (for example, a `PathBuilder` for multicast) must
+ * be added to the union below.
  *
+ * @internal
  * @template This - The polymorphic `this` type inside a method on StepBuilderBase
  * @template NewT - The new body type to re-type the subclass at
  */
@@ -55,10 +58,17 @@ export type Retyped<This, NewT> =
  * that `.from()` has been called via `requireSource`), while
  * `BranchBuilder` pushes into its internal step array.
  *
- * Return types thread through the polymorphic `this` via {@link Retyped},
- * so a `.transform()` call on a `RouteBuilder<A>` returns `RouteBuilder<B>`
- * and the same call on `BranchBuilder<A>` returns `BranchBuilder<B>`.
+ * Return types are threaded through the polymorphic `this` via
+ * {@link Retyped}, so a `.transform()` call on a `RouteBuilder<A>` returns
+ * `RouteBuilder<B>` and the same call on `BranchBuilder<A>` returns
+ * `BranchBuilder<B>`.
  *
+ * This class is framework-internal. It is not exported from the package
+ * entry point and should not be subclassed outside the framework; the
+ * {@link Retyped} conditional is closed-world and external subclasses
+ * would silently resolve to `never`.
+ *
+ * @internal
  * @template Current - Body type entering the next step
  */
 export abstract class StepBuilderBase<Current = unknown> {
@@ -73,6 +83,22 @@ export abstract class StepBuilderBase<Current = unknown> {
   protected abstract pushStep<T extends Adapter>(step: Step<T>): void;
 
   /**
+   * Return `this` re-typed to the concrete subclass at a new body type.
+   *
+   * The single cast point used by every pipeline method that changes
+   * `Current`. Centralising it means `RouteBuilder` and `BranchBuilder`
+   * do not each need their own `withType<T>()` helper, and the closed-world
+   * {@link Retyped} conditional resolves the return type to the caller's
+   * concrete subclass.
+   *
+   * @template T - New body type
+   * @returns This instance, re-typed
+   */
+  protected retype<T>(): Retyped<this, T> {
+    return this as unknown as Retyped<this, T>;
+  }
+
+  /**
    * Send the exchange to a destination. A destination that returns
    * `undefined` leaves the body unchanged; a returned value replaces
    * the body.
@@ -85,7 +111,7 @@ export abstract class StepBuilderBase<Current = unknown> {
     destination: Destination<Current, R> | CallableDestination<Current, R>,
   ): Retyped<this, R extends void ? Current : R> {
     this.pushStep(new ToStep<Current, R>(destination));
-    return this as unknown as Retyped<this, R extends void ? Current : R>;
+    return this.retype<R extends void ? Current : R>();
   }
 
   /**
@@ -103,7 +129,7 @@ export abstract class StepBuilderBase<Current = unknown> {
       | CallableTransformer<Current, Return>,
   ): Retyped<this, Return> {
     this.pushStep(new TransformStep<Current, Return>(transformer));
-    return this as unknown as Retyped<this, Return>;
+    return this.retype<Return>();
   }
 
   /**
@@ -140,9 +166,8 @@ export abstract class StepBuilderBase<Current = unknown> {
         aggregator as EnrichAggregatorOption<Current, R> | undefined,
       ),
     );
-    return this as unknown as Retyped<
-      this,
+    return this.retype<
       A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
-    >;
+    >();
   }
 }


### PR DESCRIPTION
## Summary
Refactors `RouteBuilder` and `BranchBuilder` to share common pipeline operation implementations (`to`, `transform`, `enrich`) via a new abstract base class `StepBuilderBase`. This eliminates code duplication and establishes a pattern for consistent behavior across builder types.

## Key Changes

- **New `StepBuilderBase` abstract class** (`step-builder-base.ts`):
  - Defines the three shared pipeline operations: `to()`, `transform()`, and `enrich()`
  - Declares abstract `pushStep()` hook for subclasses to implement step collection
  - Introduces `Retyped<This, NewT>` type utility to enable polymorphic return types that automatically re-type the concrete subclass (e.g., `RouteBuilder<A>` → `RouteBuilder<B>`)

- **`RouteBuilder` refactoring**:
  - Now extends `StepBuilderBase<Current>`
  - Removes duplicate implementations of `to()`, `transform()`, and `enrich()`
  - Renames private `addStep()` to protected `pushStep()` and implements the abstract hook
  - Updates all internal step-adding calls to use `pushStep()`
  - Removes unused `ENRICH_MERGE_TYPE` import from builder.ts

- **`BranchBuilder` refactoring**:
  - Now extends `StepBuilderBase<Current>`
  - Removes duplicate implementations of `to()`, `transform()`, and `enrich()`
  - Implements `pushStep()` to append steps to its internal array
  - Updates `halt()` to use `pushStep()` for consistency

## Implementation Details

- The `Retyped` conditional type maps polymorphic `this` to the concrete subclass re-typed at the new body type, enabling shared methods to return the correct builder type without explicit overrides in each subclass
- The type system is intentionally closed-world (only `RouteBuilder` and `BranchBuilder` participate) to keep the base class as an internal framework detail
- All step-adding logic now flows through the `pushStep()` hook, centralizing the pattern and making future extensions more maintainable

https://claude.ai/code/session_014REeethnLykENzXhWPL8Jg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts shared pipeline operations (.to, .transform, .enrich) into a new abstract base to remove duplication and ensure consistent behavior across builders. Adds a single `retype<T>()` helper and internal tags; no API changes.

- **Refactors**
  - Added `StepBuilderBase` with shared `to`/`transform`/`enrich`, `Retyped` utility, and `protected retype<T>()`; subclasses implement `pushStep`.
  - `RouteBuilder` extends the base, implements `pushStep` with the existing `requireSource` check, removes duplicate methods and `withType`, and routes all ops via `pushStep`.
  - `BranchBuilder` extends the base, implements `pushStep`, and updates `halt()` to use it.
  - Centralizes step appends and logging; removes direct `route.steps` writes (e.g., `split`/`choice`) and a stale import.
  - Marks `StepBuilderBase` and `Retyped` as `@internal` to document closed-world typing.

<sup>Written for commit 0b732ce1239473b22db681b861758afb87f4a2d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture by consolidating shared builder functionality to enhance code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->