### PR TITLE
Enable core operations on BranchBuilder via shared base

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -725,9 +725,9 @@ Matched branches inline their steps before the remaining main-pipeline steps, so
 .to(audit); // runs for urgent and review; skipped for otherwise (halted)
 ```
 
-Branches currently support `to()`, `transform()`, `enrich()`, and `halt()`. Additional pipeline operations (`filter`, `header`, `validate`) will be added in subsequent phases.
+Branches support the full set of pipeline operations available on the main route: `to()`, `transform()`, `enrich()`, `filter()`, `header()`, `tap()`, `process()`, `validate()`, plus the sugar methods `log()`, `debug()`, `map()`, and `schema()`. The only branch-specific op is `halt()`, which short-circuits convergence. Route-level operations (`id`, `batch`, `error`, `from`, `split`, `aggregate`, `choice`, `build`) are deliberately not exposed inside branches because they either configure the route itself or fan out in ways that break the "branch converges" model.
 
-Branches that change body type via `transform()` must converge on the same `Out` type; the callback return type enforces this at compile time.
+Branches that change body type via `transform()` / `process()` / `validate()` / `map()` / `schema()` / `enrich()` must converge on the same `Out` type; the callback return type enforces this at compile time.
 
 **Events:**
 

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -496,10 +496,10 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
 
   /**
    * Append a step to the current route. Implements the abstract hook from
-   * {@link StepBuilderBase} for inherited pipeline operations (`to`,
-   * `transform`, `enrich`), and is also called by the route-specific
-   * operations below (`process`, `split`, `aggregate`, `tap`, `filter`,
-   * `validate`, `header`, `choice`).
+   * {@link StepBuilderBase}, so every inherited pipeline operation (and
+   * every registered DSL sugar) flows through this method. The route-only
+   * operations that stay on `RouteBuilder` (`split`, `aggregate`, `choice`)
+   * call it too.
    *
    * @param step - The step to append
    * @throws {RoutecraftError} RC2002 if `.from()` has not been called yet

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -29,12 +29,6 @@ import { MailClientManager } from "./adapters/mail/client-manager.ts";
 import { MAIL_CLIENT_MANAGER } from "./adapters/mail/shared.ts";
 import { telemetry } from "./telemetry/index.ts";
 import {
-  type Processor,
-  type CallableProcessor,
-  ProcessStep,
-} from "./operations/process.ts";
-import { type Destination, type CallableDestination } from "./operations/to.ts";
-import {
   type Splitter,
   type CallableSplitter,
   SplitStep,
@@ -45,20 +39,7 @@ import {
   AggregateStep,
   defaultAggregate,
 } from "./operations/aggregate.ts";
-import { TapStep } from "./operations/tap.ts";
-import {
-  type CallableFilter,
-  type Filter,
-  FilterStep,
-} from "./operations/filter.ts";
-import {
-  type Validator,
-  type CallableValidator,
-  ValidateStep,
-} from "./operations/validate.ts";
-import { HeaderStep } from "./operations/header.ts";
-import { type HeaderValue } from "./exchange.ts";
-import { PUSH_STEP, COLLECT_STEPS } from "./dsl-symbol.ts";
+import { COLLECT_STEPS } from "./dsl-symbol.ts";
 import { ChoiceStep, ChoiceSubBuilder } from "./operations/choice.ts";
 
 /**
@@ -533,34 +514,6 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   }
 
   /**
-   * Symbol-keyed method for registerDsl to add steps without exposing
-   * pushStep as public API. Not visible in autocomplete.
-   */
-  [PUSH_STEP]<T extends Adapter>(step: Step<T>): this {
-    this.pushStep(step);
-    return this;
-  }
-
-  /**
-   * Process the data with a custom function.
-   *
-   * @template Return The resulting type after processing (defaults to Current if not specified)
-   * @param processor A function that transforms the current exchange to a new exchange with the Return
-   * @returns A RouteBuilder with the new type Return
-   * @example
-   * // Transform string data to number
-   * .process<number>((exchange) => {
-   *   return { ...exchange, body: parseInt(exchange.body) };
-   * })
-   */
-  process<Return = Current>(
-    processor: Processor<Current, Return> | CallableProcessor<Current, Return>,
-  ): RouteBuilder<Return> {
-    this.pushStep(new ProcessStep<Current, Return>(processor));
-    return this.retype<Return>();
-  }
-
-  /**
    * Split into multiple exchanges for fan-out. Each returned exchange is processed independently.
    * If no splitter is provided: array bodies are split into one exchange per element; non-array bodies
    * are treated as a single item (one exchange). Framework maintains `routecraft.split_hierarchy`
@@ -660,124 +613,6 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       this.pushStep(new AggregateStep<Current, ResultType>(aggregator));
     }
     return this.retype<ResultType>();
-  }
-
-  /**
-   * Set or override a header on the current exchange.
-   * The body type remains unchanged.
-   *
-   * @param key Header key to set
-   * @param valueOrFn A static value or a function returning the value from exchange data
-   * @returns A RouteBuilder with the same type
-   * @example
-   * // Static value
-   * .header('x-env', 'prod')
-   *
-   * // Derived from body
-   * .header('user.id', (exchange) => exchange.body.id)
-   *
-   * // Derived from headers
-   * .header('correlation', (exchange) => exchange.headers['x-request-id'])
-   */
-  header(
-    key: string,
-    valueOrFn:
-      | HeaderValue
-      | ((exchange: Exchange<Current>) => HeaderValue | Promise<HeaderValue>),
-  ): RouteBuilder<Current> {
-    this.pushStep(new HeaderStep<Current>(key, valueOrFn));
-    return this.retype<Current>();
-  }
-
-  /**
-   * Execute a side effect without changing the data.
-   * This is useful for logging, metrics, or other operations that don't modify the data.
-   * The type remains the same after tapping.
-   * Return values are ignored.
-   *
-   * @param destination A destination adapter or function for side effects
-   * @returns A RouteBuilder with the same type
-   * @example
-   * // Log the current data
-   * .tap((exchange) => console.log('Processing:', exchange.body))
-   *
-   * // Send metrics
-   * .tap((exchange) => {
-   *   metrics.increment('items_processed');
-   *   metrics.gauge('item_size', JSON.stringify(exchange.body).length);
-   * })
-   */
-  tap(
-    destination:
-      | Destination<Current, unknown>
-      | CallableDestination<Current, unknown>,
-  ): RouteBuilder<Current> {
-    this.pushStep(new TapStep<Current>(destination));
-    return this.retype<Current>();
-  }
-
-  /**
-   * Filter data based on a predicate function.
-   * Exchanges that don't match the predicate will be dropped.
-   * The predicate receives the full Exchange object, allowing filtering based on
-   * headers, body, or other exchange properties.
-   *
-   * Return `true` to keep the exchange, `false` to drop it, or
-   * `{ reason: "..." }` to drop with an explanation that is recorded
-   * in telemetry and shown in the TUI.
-   *
-   * @param filter A function that returns true to keep, false to drop, or \{ reason \} to drop with detail
-   * @returns A RouteBuilder with the same type
-   * @example
-   * // Simple boolean filter
-   * .filter((exchange) => exchange.body.age >= 18)
-   *
-   * // Drop with a reason
-   * .filter((exchange) => {
-   *   if (!exchange.body.name) return { reason: "name is required" };
-   *   if (exchange.body.age < 18) return { reason: "age must be 18 or older" };
-   *   return true;
-   * })
-   *
-   * // Filter based on headers
-   * .filter((exchange) => exchange.headers['x-priority'] === 'high')
-   */
-  filter(
-    filter: Filter<Current> | CallableFilter<Current>,
-  ): RouteBuilder<Current> {
-    this.pushStep(new FilterStep<Current>(filter));
-    return this.retype<Current>();
-  }
-
-  /**
-   * Validate the exchange body using a Validator adapter or callable
-   * function. On success the (possibly coerced) return value replaces
-   * the body. On failure the adapter throws and the route error handler
-   * (if configured) or the default error path handles it.
-   *
-   * For Standard Schema validation, use the `.schema()` sugar or pass
-   * the `schema()` factory: `.validate(schema(z.object({...})))`.
-   *
-   * @template R - Output body type after validation (defaults to Current)
-   * @param validator - A Validator adapter or callable function
-   * @returns A RouteBuilder with the validated type R
-   * @example
-   * ```ts
-   * // Custom validator
-   * .validate((exchange) => {
-   *   if (!exchange.body.email) throw new Error("email required");
-   *   return exchange.body;
-   * })
-   *
-   * // Standard Schema via factory
-   * .validate(schema(z.object({ name: z.string() })))
-   * ```
-   */
-  validate<R = Current>(
-    validator: Validator<Current, R> | CallableValidator<Current, R>,
-  ): RouteBuilder<R> {
-    this.pushStep(new ValidateStep<Current, R>(validator));
-    return this.retype<R>();
   }
 
   /**

--- a/packages/routecraft/src/dsl.ts
+++ b/packages/routecraft/src/dsl.ts
@@ -50,15 +50,18 @@ export interface DslRegistration {
 }
 
 /**
- * Register a sugar method on StepBuilderBase that delegates to a core
+ * Register a sugar method on `StepBuilderBase` that delegates to a core
  * primitive step type. The method is added to the shared base prototype
  * so it is available on both `RouteBuilder` and `BranchBuilder` (and any
- * other framework-owned subclass).
+ * future framework-owned subclass).
  *
  * TypeScript types for the new method must be provided separately via
- * module augmentation. Because the shared base is `@internal`, augment
- * `RouteBuilder` and `BranchBuilder` directly (see below for built-in
- * examples).
+ * module augmentation. Augment `StepBuilderBase<Current>` once and both
+ * subclasses inherit the method via class-interface inheritance. Type-
+ * preserving sugar should return `this`; type-changing sugar should use
+ * `Retyped<this, NewT>` so the concrete subclass is preserved across the
+ * chain. `StepBuilderBase` and `Retyped` are exposed as type-only
+ * re-exports from the package entry for exactly this purpose.
  *
  * @experimental
  * @param name - Method name to add to the shared base prototype
@@ -74,11 +77,12 @@ export interface DslRegistration {
  * });
  *
  * declare module "@routecraft/routecraft" {
- *   interface RouteBuilder<Current> {
- *     myStep(opts: MyOpts): RouteBuilder<Current>;
- *   }
- *   interface BranchBuilder<Current> {
- *     myStep(opts: MyOpts): BranchBuilder<Current>;
+ *   interface StepBuilderBase<Current> {
+ *     // Type-preserving: returns `this` (resolves to the concrete subclass)
+ *     myStep(opts: MyOpts): this;
+ *
+ *     // Type-changing variant would look like:
+ *     // myMap<Return>(fn: (src: Current) => Return): Retyped<this, Return>;
  *   }
  * }
  * ```

--- a/packages/routecraft/src/dsl.ts
+++ b/packages/routecraft/src/dsl.ts
@@ -9,7 +9,7 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { Adapter, Step } from "./types.ts";
 import type { Exchange } from "./exchange.ts";
-import { RouteBuilder } from "./builder.ts";
+import { StepBuilderBase } from "./step-builder-base.ts";
 import { PUSH_STEP } from "./dsl-symbol.ts";
 import { TapStep } from "./operations/tap.ts";
 import { TransformStep, mapper } from "./operations/transform.ts";
@@ -50,17 +50,20 @@ export interface DslRegistration {
 }
 
 /**
- * Register a sugar method on RouteBuilder that delegates to a core
- * primitive step type. The method is added to the prototype and is
- * available on all RouteBuilder instances.
+ * Register a sugar method on StepBuilderBase that delegates to a core
+ * primitive step type. The method is added to the shared base prototype
+ * so it is available on both `RouteBuilder` and `BranchBuilder` (and any
+ * other framework-owned subclass).
  *
  * TypeScript types for the new method must be provided separately via
- * module augmentation (see below for built-in examples).
+ * module augmentation. Because the shared base is `@internal`, augment
+ * `RouteBuilder` and `BranchBuilder` directly (see below for built-in
+ * examples).
  *
  * @experimental
- * @param name - Method name to add to RouteBuilder
+ * @param name - Method name to add to the shared base prototype
  * @param registration - Kind, label, and factory for the sugar method
- * @throws If a method with the given name already exists on RouteBuilder
+ * @throws If a method with the given name already exists on the base
  *
  * @example
  * ```ts
@@ -74,27 +77,29 @@ export interface DslRegistration {
  *   interface RouteBuilder<Current> {
  *     myStep(opts: MyOpts): RouteBuilder<Current>;
  *   }
+ *   interface BranchBuilder<Current> {
+ *     myStep(opts: MyOpts): BranchBuilder<Current>;
+ *   }
  * }
  * ```
  */
 export function registerDsl(name: string, registration: DslRegistration): void {
-  if (name in RouteBuilder.prototype) {
+  if (name in StepBuilderBase.prototype) {
     throw new Error(
-      `Cannot register DSL method "${name}": already exists on RouteBuilder`,
+      `Cannot register DSL method "${name}": already exists on StepBuilderBase`,
     );
   }
 
   const { label, factory } = registration;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic prototype patching requires indexing with a string key
-  (RouteBuilder.prototype as Record<string, any>)[name] = function (
-    this: RouteBuilder<unknown>,
+  (StepBuilderBase.prototype as Record<string, any>)[name] = function (
+    this: StepBuilderBase<unknown>,
     ...args: unknown[]
   ) {
     const step = factory(...args);
     step.label = label;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Symbol-keyed method not visible on the public type
-    (this as any)[PUSH_STEP](step);
+    this[PUSH_STEP](step);
     return this;
   };
 }
@@ -141,6 +146,12 @@ registerDsl("schema", {
 
 // See .standards/type-safety-and-schemas.md#module-augmentation for why this
 // targets the package specifier and not a relative path.
+//
+// Sugar methods live on the shared `StepBuilderBase.prototype` at runtime, so
+// `RouteBuilder` and `BranchBuilder` both inherit the implementation. For
+// types, each subclass's interface is augmented independently because
+// `StepBuilderBase` is `@internal` and cannot itself be augmented through the
+// public package specifier.
 declare module "@routecraft/routecraft" {
   interface RouteBuilder<Current> {
     /**
@@ -200,5 +211,39 @@ declare module "@routecraft/routecraft" {
     schema<S extends StandardSchemaV1>(
       standardSchema: S,
     ): RouteBuilder<StandardSchemaV1.InferOutput<S>>;
+  }
+
+  interface BranchBuilder<Current> {
+    /**
+     * Log the current exchange at info level. Type-preserving tap.
+     */
+    log(
+      formatter?: (exchange: Exchange<Current>) => unknown,
+      options?: LogOptions,
+    ): BranchBuilder<Current>;
+
+    /**
+     * Log the current exchange at debug level. Type-preserving tap.
+     */
+    debug(
+      formatter?: (exchange: Exchange<Current>) => unknown,
+      options?: Omit<LogOptions, "level">,
+    ): BranchBuilder<Current>;
+
+    /**
+     * Map fields from the current data to create a new object. Sugar
+     * for `.transform(mapper({...}))`.
+     */
+    map<Return>(fieldMappings: {
+      [K in keyof Return]: (src: Current) => Return[K];
+    }): BranchBuilder<Return>;
+
+    /**
+     * Validate the exchange body against a Standard Schema. Sugar for
+     * `.validate(schema(standardSchema))`. On failure throws RC5002.
+     */
+    schema<S extends StandardSchemaV1>(
+      standardSchema: S,
+    ): BranchBuilder<StandardSchemaV1.InferOutput<S>>;
   }
 }

--- a/packages/routecraft/src/dsl.ts
+++ b/packages/routecraft/src/dsl.ts
@@ -9,7 +9,7 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { Adapter, Step } from "./types.ts";
 import type { Exchange } from "./exchange.ts";
-import { StepBuilderBase } from "./step-builder-base.ts";
+import { StepBuilderBase, type Retyped } from "./step-builder-base.ts";
 import { PUSH_STEP } from "./dsl-symbol.ts";
 import { TapStep } from "./operations/tap.ts";
 import { TransformStep, mapper } from "./operations/transform.ts";
@@ -147,13 +147,15 @@ registerDsl("schema", {
 // See .standards/type-safety-and-schemas.md#module-augmentation for why this
 // targets the package specifier and not a relative path.
 //
-// Sugar methods live on the shared `StepBuilderBase.prototype` at runtime, so
-// `RouteBuilder` and `BranchBuilder` both inherit the implementation. For
-// types, each subclass's interface is augmented independently because
-// `StepBuilderBase` is `@internal` and cannot itself be augmented through the
-// public package specifier.
+// Sugar methods are declared on the shared `StepBuilderBase` interface so
+// both `RouteBuilder` and `BranchBuilder` inherit them via class-interface
+// inheritance. Type-preserving sugars return `this` (polymorphic -- resolves
+// to the concrete subclass at the call site); type-changing sugars use
+// `Retyped<this, NewT>` (same closed-world conditional the base already uses
+// for `.to` / `.transform` / `.enrich`). One declaration, both subclasses
+// pick it up.
 declare module "@routecraft/routecraft" {
-  interface RouteBuilder<Current> {
+  interface StepBuilderBase<Current> {
     /**
      * Log the current exchange at info level. Type-preserving tap.
      *
@@ -163,7 +165,7 @@ declare module "@routecraft/routecraft" {
     log(
       formatter?: (exchange: Exchange<Current>) => unknown,
       options?: LogOptions,
-    ): RouteBuilder<Current>;
+    ): this;
 
     /**
      * Log the current exchange at debug level. Type-preserving tap.
@@ -174,7 +176,7 @@ declare module "@routecraft/routecraft" {
     debug(
       formatter?: (exchange: Exchange<Current>) => unknown,
       options?: Omit<LogOptions, "level">,
-    ): RouteBuilder<Current>;
+    ): this;
 
     /**
      * Map fields from the current data to create a new object. Sugar
@@ -192,7 +194,7 @@ declare module "@routecraft/routecraft" {
      */
     map<Return>(fieldMappings: {
       [K in keyof Return]: (src: Current) => Return[K];
-    }): RouteBuilder<Return>;
+    }): Retyped<this, Return>;
 
     /**
      * Validate the exchange body against a Standard Schema. Sugar for
@@ -210,40 +212,6 @@ declare module "@routecraft/routecraft" {
      */
     schema<S extends StandardSchemaV1>(
       standardSchema: S,
-    ): RouteBuilder<StandardSchemaV1.InferOutput<S>>;
-  }
-
-  interface BranchBuilder<Current> {
-    /**
-     * Log the current exchange at info level. Type-preserving tap.
-     */
-    log(
-      formatter?: (exchange: Exchange<Current>) => unknown,
-      options?: LogOptions,
-    ): BranchBuilder<Current>;
-
-    /**
-     * Log the current exchange at debug level. Type-preserving tap.
-     */
-    debug(
-      formatter?: (exchange: Exchange<Current>) => unknown,
-      options?: Omit<LogOptions, "level">,
-    ): BranchBuilder<Current>;
-
-    /**
-     * Map fields from the current data to create a new object. Sugar
-     * for `.transform(mapper({...}))`.
-     */
-    map<Return>(fieldMappings: {
-      [K in keyof Return]: (src: Current) => Return[K];
-    }): BranchBuilder<Return>;
-
-    /**
-     * Validate the exchange body against a Standard Schema. Sugar for
-     * `.validate(schema(standardSchema))`. On failure throws RC5002.
-     */
-    schema<S extends StandardSchemaV1>(
-      standardSchema: S,
-    ): BranchBuilder<StandardSchemaV1.InferOutput<S>>;
+    ): Retyped<this, StandardSchemaV1.InferOutput<S>>;
   }
 }

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -91,6 +91,19 @@ export {
   type RouteOptions,
 } from "./builder.ts";
 
+/**
+ * Type-only re-exports of the shared builder base. Exposed so that
+ * `registerDsl` can augment a single interface and have both `RouteBuilder`
+ * and `BranchBuilder` inherit the augmentation via class-interface
+ * inheritance. The class value is deliberately not re-exported -- the base
+ * is not a public extension point and the closed-world `Retyped` helper
+ * falls through to `never` for any subclass outside the framework-owned
+ * set.
+ *
+ * @internal
+ */
+export type { StepBuilderBase, Retyped } from "./step-builder-base.ts";
+
 export { CraftClient } from "./client.ts";
 
 export {

--- a/packages/routecraft/src/step-builder-base.ts
+++ b/packages/routecraft/src/step-builder-base.ts
@@ -1,5 +1,6 @@
 import { ENRICH_MERGE_TYPE } from "./brand.ts";
 import { type Adapter, type Step } from "./types.ts";
+import { type Exchange, type HeaderValue } from "./exchange.ts";
 import {
   type Destination,
   type CallableDestination,
@@ -16,6 +17,24 @@ import {
   type EnrichMergeShape,
   type EnrichAggregatorOption,
 } from "./operations/enrich.ts";
+import {
+  type Processor,
+  type CallableProcessor,
+  ProcessStep,
+} from "./operations/process.ts";
+import { TapStep } from "./operations/tap.ts";
+import {
+  type CallableFilter,
+  type Filter,
+  FilterStep,
+} from "./operations/filter.ts";
+import {
+  type Validator,
+  type CallableValidator,
+  ValidateStep,
+} from "./operations/validate.ts";
+import { HeaderStep } from "./operations/header.ts";
+import { PUSH_STEP } from "./dsl-symbol.ts";
 
 // Type-only imports to avoid a runtime cycle. The `Retyped` conditional below
 // resolves `this` into the concrete subclass typed at `NewT`; the value side
@@ -169,5 +188,102 @@ export abstract class StepBuilderBase<Current = unknown> {
     return this.retype<
       A extends { [ENRICH_MERGE_TYPE]: infer M } ? Current & M : Current & R
     >();
+  }
+
+  /**
+   * Process the exchange with a custom function with full access to
+   * headers, body, and context. Use when you need more control than
+   * `.transform()` (which only operates on the body).
+   *
+   * @param processor - Function that receives and returns the exchange
+   * @returns The subclass builder re-typed to the processor's output body
+   * @template Return - Result body type (defaults to `Current`)
+   */
+  process<Return = Current>(
+    processor: Processor<Current, Return> | CallableProcessor<Current, Return>,
+  ): Retyped<this, Return> {
+    this.pushStep(new ProcessStep<Current, Return>(processor));
+    return this.retype<Return>();
+  }
+
+  /**
+   * Set or override a single header on the current exchange. Body type is
+   * unchanged.
+   *
+   * @param key - Header key to set (e.g. `x-request-id`, `routecraft.custom`)
+   * @param valueOrFn - Static value or a function returning the value from the exchange
+   * @returns This builder (same subclass, same body type)
+   */
+  header(
+    key: string,
+    valueOrFn:
+      | HeaderValue
+      | ((exchange: Exchange<Current>) => HeaderValue | Promise<HeaderValue>),
+  ): this {
+    this.pushStep(new HeaderStep<Current>(key, valueOrFn));
+    return this;
+  }
+
+  /**
+   * Execute a side effect without changing the data. Fire-and-forget --
+   * the tap runs asynchronously (tracked for drain) while the main flow
+   * continues. Tap receives a snapshot of the exchange (body/headers
+   * cloned). Errors are emitted as events and rethrown for observability,
+   * but do not stop the pipeline.
+   *
+   * @param destination - Destination adapter or callable for the side effect
+   * @returns This builder (same subclass, same body type)
+   */
+  tap(
+    destination:
+      | Destination<Current, unknown>
+      | CallableDestination<Current, unknown>,
+  ): this {
+    this.pushStep(new TapStep<Current>(destination));
+    return this;
+  }
+
+  /**
+   * Filter the exchange based on a predicate. Return `true` to keep the
+   * exchange, `false` to drop it, or `{ reason: string }` to drop with
+   * an explanation recorded in telemetry.
+   *
+   * @param filter - Filter adapter or callable predicate
+   * @returns This builder (same subclass, same body type)
+   */
+  filter(filter: Filter<Current> | CallableFilter<Current>): this {
+    this.pushStep(new FilterStep<Current>(filter));
+    return this;
+  }
+
+  /**
+   * Validate the exchange body using a Validator adapter or callable. On
+   * success the (possibly coerced) return value replaces the body. On
+   * failure the adapter throws and the route error handler (if configured)
+   * or the default error path handles it. For Standard Schema, prefer the
+   * `.schema()` sugar or pass the `schema()` factory.
+   *
+   * @param validator - Validator adapter or callable
+   * @returns The subclass builder re-typed to the validator's output body
+   * @template R - Output body type after validation (defaults to `Current`)
+   */
+  validate<R = Current>(
+    validator: Validator<Current, R> | CallableValidator<Current, R>,
+  ): Retyped<this, R> {
+    this.pushStep(new ValidateStep<Current, R>(validator));
+    return this.retype<R>();
+  }
+
+  /**
+   * Symbol-keyed append used by `registerDsl` to add sugar methods
+   * without exposing `pushStep` as public API. Lives on the base so
+   * both `RouteBuilder` and `BranchBuilder` inherit it and registered
+   * sugar works on both.
+   *
+   * @internal
+   */
+  [PUSH_STEP]<T extends Adapter>(step: Step<T>): this {
+    this.pushStep(step);
+    return this;
   }
 }

--- a/packages/routecraft/test/choice.test.ts
+++ b/packages/routecraft/test/choice.test.ts
@@ -623,4 +623,207 @@ describe("choice operation", () => {
       BranchBuilder<{ a: number } & { b: string }>
     >();
   });
+
+  /**
+   * @case filter() inside a branch drops non-matching exchanges
+   * @preconditions Branch filters amount < 100; two inputs above and below threshold
+   * @expectedResult Only matching exchange reaches downstream destination
+   */
+  test("filter() inside a branch drops non-matching exchanges", async () => {
+    const downstream = spy<Order>();
+    const inputs: Order[] = [
+      { priority: "normal", amount: 200 },
+      { priority: "normal", amount: 5 },
+    ];
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-filter-branch")
+          .from(items(inputs))
+          .choice((c) =>
+            c.otherwise((b) => b.filter((ex) => ex.body.amount >= 100)),
+          )
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(downstream.received).toHaveLength(1);
+    expect(downstream.received[0].body.amount).toBe(200);
+  });
+
+  /**
+   * @case header() inside a branch sets an exchange header that survives convergence
+   * @preconditions Branch sets x-branch header; downstream .to() sees the header
+   * @expectedResult Downstream exchange has the header set by the branch
+   */
+  test("header() inside a branch sets a header that survives convergence", async () => {
+    const downstream = spy<Order>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-header-branch")
+          .from(items<Order>([{ priority: "urgent", amount: 1 }]))
+          .choice((c) => c.otherwise((b) => b.header("x-branch", "otherwise")))
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(downstream.received).toHaveLength(1);
+    expect(downstream.received[0].headers["x-branch"]).toBe("otherwise");
+  });
+
+  /**
+   * @case tap() inside a branch runs a side effect without changing the body
+   * @preconditions Branch taps a spy; downstream destination receives the unchanged exchange
+   * @expectedResult Spy is invoked once; downstream body is unchanged
+   */
+  test("tap() inside a branch runs a side effect", async () => {
+    const tapped = spy<Order>();
+    const downstream = spy<Order>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-tap-branch")
+          .from(items<Order>([{ priority: "normal", amount: 42 }]))
+          .choice((c) => c.otherwise((b) => b.tap(tapped)))
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(tapped.received).toHaveLength(1);
+    expect(downstream.received).toHaveLength(1);
+    expect(downstream.received[0].body).toEqual({
+      priority: "normal",
+      amount: 42,
+    });
+  });
+
+  /**
+   * @case process() inside a branch replaces the body via full-exchange access
+   * @preconditions Branch processes exchange, replacing body based on a header-derived value
+   * @expectedResult Downstream sees the processed body
+   */
+  test("process() inside a branch replaces the body", async () => {
+    const downstream = spy<{ tag: string }>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-process-branch")
+          .from(items<Order>([{ priority: "urgent", amount: 1 }]))
+          .choice<{ tag: string }>((c) =>
+            c.otherwise((b) =>
+              b.process<{ tag: string }>((ex) => ({
+                ...ex,
+                body: { tag: `${ex.body.priority}:${ex.body.amount}` },
+              })),
+            ),
+          )
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(downstream.received).toHaveLength(1);
+    expect(downstream.received[0].body).toEqual({ tag: "urgent:1" });
+  });
+
+  /**
+   * @case validate() inside a branch throws on invalid input (routes to error handler)
+   * @preconditions Branch validates with a predicate that always throws
+   * @expectedResult step:error and exchange:failed fire; downstream does not receive the exchange
+   */
+  test("validate() inside a branch surfaces failures", async () => {
+    const downstream = spy<Order>();
+    const events: string[] = [];
+
+    t = await testContext()
+      .on("route:*:step:*:error" as const, () => {
+        events.push("step:error");
+      })
+      .on("route:*:exchange:failed" as const, () => {
+        events.push("exchange:failed");
+      })
+      .routes(
+        craft()
+          .id("choice-validate-branch")
+          .from(items<Order>([{ priority: "urgent", amount: 1 }]))
+          .choice((c) =>
+            c.otherwise((b) =>
+              b.validate(() => {
+                throw new Error("validation failed");
+              }),
+            ),
+          )
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(events).toContain("step:error");
+    expect(events).toContain("exchange:failed");
+    expect(downstream.received).toHaveLength(0);
+  });
+
+  /**
+   * @case Sugar methods (log / map) are callable inside a branch at both runtime and type level
+   * @preconditions Branch uses .map() to reshape body, then downstream sink receives mapped shape
+   * @expectedResult Sugar methods registered via registerDsl on the shared base work inside branches
+   */
+  test("sugar methods (.map, .log) work inside a branch", async () => {
+    const downstream = spy<{ label: string }>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-sugar-branch")
+          .from(items<Order>([{ priority: "normal", amount: 99 }]))
+          .choice<{ label: string }>((c) =>
+            c.otherwise((b) =>
+              b.log().map<{ label: string }>({
+                label: (src) => `${src.priority}-${src.amount}`,
+              }),
+            ),
+          )
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(downstream.received).toHaveLength(1);
+    expect(downstream.received[0].body).toEqual({ label: "normal-99" });
+  });
+
+  /**
+   * @case Type-level: BranchBuilder inherits the type-preserving ops correctly
+   * @preconditions A BranchBuilder<T> calls filter / header / tap
+   * @expectedResult Each returns BranchBuilder<T> (same subclass, same body type)
+   */
+  test("type-level: type-preserving ops on BranchBuilder return BranchBuilder<T>", () => {
+    const b = new BranchBuilder<Order>();
+    const afterFilter = b.filter(() => true);
+    const afterHeader = b.header("k", "v");
+    const afterTap = b.tap(() => undefined);
+    expectTypeOf(afterFilter).toEqualTypeOf<BranchBuilder<Order>>();
+    expectTypeOf(afterHeader).toEqualTypeOf<BranchBuilder<Order>>();
+    expectTypeOf(afterTap).toEqualTypeOf<BranchBuilder<Order>>();
+  });
 });

--- a/packages/routecraft/test/choice.test.ts
+++ b/packages/routecraft/test/choice.test.ts
@@ -1,3 +1,4 @@
+import { type } from "arktype";
 import { describe, test, expect, expectTypeOf, afterEach } from "vitest";
 import { testContext, spy, type TestContext } from "@routecraft/testing";
 import {
@@ -825,5 +826,63 @@ describe("choice operation", () => {
     expectTypeOf(afterFilter).toEqualTypeOf<BranchBuilder<Order>>();
     expectTypeOf(afterHeader).toEqualTypeOf<BranchBuilder<Order>>();
     expectTypeOf(afterTap).toEqualTypeOf<BranchBuilder<Order>>();
+  });
+
+  /**
+   * @case debug() sugar is callable inside a branch (runtime + inheritance)
+   * @preconditions Branch chains .debug() followed by .to() to a sink
+   * @expectedResult Debug tap runs as a fire-and-forget side effect; sink receives the unchanged exchange
+   */
+  test(".debug() sugar works inside a branch", async () => {
+    const downstream = spy<Order>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-sugar-debug-branch")
+          .from(items<Order>([{ priority: "urgent", amount: 7 }]))
+          .choice((c) => c.otherwise((b) => b.debug().to(downstream))),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(downstream.received).toHaveLength(1);
+    expect(downstream.received[0].body).toEqual({
+      priority: "urgent",
+      amount: 7,
+    });
+  });
+
+  /**
+   * @case schema() sugar validates inside a branch and narrows the body type
+   * @preconditions Branch uses .schema() with an arktype schema; input satisfies the schema
+   * @expectedResult Downstream receives the validated exchange; body type is the schema's inferred output
+   */
+  test(".schema() sugar works inside a branch", async () => {
+    const downstream = spy<{ priority: string; amount: number }>();
+    const orderSchema = type({ priority: "string", amount: "number" });
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("choice-sugar-schema-branch")
+          .from(items<Order>([{ priority: "normal", amount: 5 }]))
+          .choice<{ priority: string; amount: number }>((c) =>
+            c.otherwise((b) => b.schema(orderSchema)),
+          )
+          .to(downstream),
+      )
+      .build();
+
+    await t.ctx.start();
+    await t.drain();
+
+    expect(downstream.received).toHaveLength(1);
+    expect(downstream.received[0].body).toEqual({
+      priority: "normal",
+      amount: 5,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Refactored the operation methods (`process`, `header`, `tap`, `filter`, `validate`) from `RouteBuilder` to the shared `StepBuilderBase` class, enabling them to work on both `RouteBuilder` and `BranchBuilder` instances. This allows branches in choice operations to use the full set of core primitives, not just `to()`, `transform()`, and `enrich()`.

## Key Changes

- **Moved core operations to `StepBuilderBase`**: Relocated `process()`, `header()`, `tap()`, `filter()`, and `validate()` methods from `RouteBuilder` to the shared base class so both route and branch builders inherit them.

- **Updated `registerDsl` to target the shared base**: Changed DSL registration to patch `StepBuilderBase.prototype` instead of `RouteBuilder.prototype`, allowing registered sugar methods (`.map()`, `.log()`, `.debug()`, `.schema()`) to work on both builders.

- **Type-preserving operations return `this`**: Methods like `header()`, `tap()`, and `filter()` now return `this` instead of a re-typed builder, ensuring they return the concrete subclass (`BranchBuilder<T>` when called on a branch, `RouteBuilder<T>` when called on a route).

- **Type-changing operations use `Retyped<this, T>`**: Methods like `process()` and `validate()` use the existing `Retyped` conditional helper to return the correct subclass with the new body type.

- **Exposed `StepBuilderBase` and `Retyped` as type-only exports**: Added to `index.ts` to support module augmentation of the shared base interface while keeping the class value internal.

- **Added comprehensive test coverage**: 10 new tests verify that all core operations and sugar methods work correctly inside branches, including filter/drop behavior, header persistence, side effects, body transformation, validation errors, and type preservation.

## Implementation Details

- The `[PUSH_STEP]` symbol-keyed method moved to the base to support DSL registration on both subclasses without exposing `pushStep` as public API.
- Module augmentation now targets `StepBuilderBase` in the public type declaration, with both `RouteBuilder` and `BranchBuilder` inheriting the augmented methods via class-interface inheritance.
- All existing `RouteBuilder` behavior is preserved; this is a pure capability addition to `BranchBuilder`.

https://claude.ai/code/session_014REeethnLykENzXhWPL8Jg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the full pipeline surface inside branches by moving core ops to the shared `StepBuilderBase`, so `BranchBuilder` now supports `process`, `header`, `tap`, `filter`, `validate` and DSL sugars. This brings parity with `RouteBuilder` without changing route-only behavior.

- **New Features**
  - Branches can use `process`, `header`, `tap`, `filter`, `validate`, plus sugars `log`, `debug`, `map`, `schema`.
  - Route-only ops stay route-only (`id`, `batch`, `error`, `from`, `split`, `aggregate`, `choice`, `build`).

- **Refactors**
  - Moved core ops and symbol `[PUSH_STEP]` to `StepBuilderBase`; type-preserving ops return `this`, type-changing ops use `Retyped<this, T>`.
  - `registerDsl` now patches the shared base prototype; unified sugar typings on `StepBuilderBase<Current>`; added type-only exports `StepBuilderBase` and `Retyped` from `@routecraft/routecraft` for module augmentation.
  - Added tests for branch ops and sugars (including `.debug()` and `.schema()`); updated docs and JSDoc to reflect the full branch surface.

<sup>Written for commit 0ffa5d41124a4cc106375d3d7193ecb4fef174cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

