### PR TITLE
feat(ai): tools() DSL — registration, selection, resolution (#224 part 1)

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -511,6 +511,84 @@ const out = await testFn(greet, { name: 'alice' })
 
 `testFn` validates the input against the schema, calls the handler with a synthetic `{ logger, abortSignal }` context, and returns the handler's output. Validation failures throw `RC5002`. It works structurally on any `{ schema, handler }` shape, so real `FnOptions` values pass without modification.
 
+### Agent tools (experimental DSL)
+
+> **Status: DSL-only.** The configuration surface below is fully implemented and validated; the agent runtime that actually presents these tools to the LLM and dispatches them lands in a follow-up release. Setting `tools:` on an agent today is a no-op at dispatch time.
+
+Tags, the `tools([...])` selector, the builder helpers, and the context-default tool list register and validate cleanly so user code can be written against the final shape now.
+
+```ts
+import {
+  agentPlugin,
+  agent,
+  defaultFns,
+  directTool,
+  tools,
+} from '@routecraft/ai'
+
+agentPlugin({
+  functions: {
+    ...defaultFns,                                  // currentTime, randomUuid (read-only, idempotent)
+    sendSlack: { description, schema, handler, tags: ['destructive', 'messaging'] },
+    fetchOrder: directTool('fetch-order'),          // wraps a direct route as a fn
+  },
+  agents: {
+    researcher: {
+      description, model, system,
+      tools: tools([
+        'currentTime',                              // bare ref
+        'fetchOrder',
+        'direct_cancel-order',                      // prefix convention
+        { name: 'sendSlack', guard: requireApproval },
+        { tagged: 'read-only' },                    // single tag
+        { tagged: ['read-only', 'idempotent'] },    // OR-of-tags
+      ]),
+    },
+  },
+  tools: tools(['currentTime', { tagged: 'read-only' }]),  // context default
+})
+```
+
+#### `tools(items)`
+
+Flat array of items. Each item is one of:
+
+- **Bare string** — name lookup. Plain ids resolve against the fn registry; `direct_*` falls back to the direct registry via `directTool`. `agent_*` and `mcp_*` are reserved for future stories and currently throw a clear "not yet supported" error.
+- **`{ name, guard? }`** — same name lookup, with an optional guard attached. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct.
+- **`{ tagged, guard? }`** — selects every fn / route whose tags overlap the requested set (single tag or array). Optional guard applies to every match. Tag-zero-match contributes nothing without throwing.
+
+Resolution rules:
+
+- Final list deduplicated by tool name.
+- Explicit refs always win over tag-selector matches, regardless of position in the list.
+- A `directTool(routeId)` fn-registry wrapper supersedes the same direct route surfaced via the prefix convention.
+- Schema, description, and tag overrides at the use site are intentionally not supported. Definition is a registration concern: register a separate fn with `directTool(routeId, { description, schema, tags })` if you need a custom view.
+
+#### Builders
+
+| Builder | Use |
+|---|---|
+| `directTool(routeId, overrides?)` | Adapt a registered direct route as a fn. Pulls description, input schema, and tags from the route's discovery bundle by default; `overrides` can replace any of those. |
+| `agentTool(agentId)` | Reserved for sub-agent tools (follow-up story). Currently a stub that throws a clear "not yet supported" error. |
+| `mcpTool(server, tool)` | Reserved for MCP tools (follow-up story). Currently a stub. |
+| `defaultFns` | A small starter set (`currentTime`, `randomUuid`) tagged `read-only`/`idempotent`. Spread into your `functions:` config. |
+
+#### Tags
+
+Apply with `.tag(value | values[])` on routes and `tags?: Tag[]` on `FnOptions`. Empty strings are rejected; surrounding whitespace is trimmed at storage so exact selectors match.
+
+`KnownTag` (a literal-suggested type) covers the framework's well-known tags:
+
+```ts
+type KnownTag = 'read-only' | 'destructive' | 'idempotent';
+```
+
+Any user string is also accepted; the `KnownTag` literals just power autocomplete.
+
+#### Context-default tool list
+
+`agentPlugin({ tools: tools([...]) })` registers a default tool list for the context. Agents that omit their own `tools:` field inherit it. An agent that sets `tools:` replaces the default entirely (override, not extend). Two installs each supplying a default throw at context init -- combine selectors into a single `tools([...])` call.
+
 ### Typed fn ids (`FnRegistry`)
 
 For compile-time autocomplete of fn ids in the agent `tools: [...]` field (follow-up story), populate the `FnRegistry` marker interface via declaration merging in your project:

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -6,6 +6,7 @@ import {
 } from "@routecraft/routecraft";
 import { parseProviderModel } from "../llm/shared.ts";
 import { AgentDestinationAdapter } from "./destination.ts";
+import { isToolSelection } from "./tools/selection.ts";
 import type { AgentOptions, AgentResult } from "./types.ts";
 
 /**
@@ -35,6 +36,11 @@ export function validateAgentOptions(options: AgentOptions): void {
   ) {
     throw rcError("RC5003", undefined, {
       message: `Agent: "model" must be either a "providerId:modelName" string or an LlmModelConfig object with a "provider" field.`,
+    });
+  }
+  if (options.tools !== undefined && !isToolSelection(options.tools)) {
+    throw rcError("RC5003", undefined, {
+      message: `Agent: "tools" must be the result of tools([...]).`,
     });
   }
 }

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -1,7 +1,7 @@
 export { agent } from "./agent.ts";
 export { AgentDestinationAdapter, type AgentBinding } from "./destination.ts";
 export { agentPlugin, type AgentPluginOptions } from "./plugin.ts";
-export { ADAPTER_AGENT_REGISTRY } from "./store.ts";
+export { ADAPTER_AGENT_REGISTRY, ADAPTER_TOOLS_DEFAULT } from "./store.ts";
 export type {
   AgentOptions,
   AgentRegisteredOptions,

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -4,11 +4,12 @@ import {
   type CraftPlugin,
 } from "@routecraft/routecraft";
 import { validateAgentOptions } from "./agent.ts";
-import { ADAPTER_AGENT_REGISTRY } from "./store.ts";
+import { ADAPTER_AGENT_REGISTRY, ADAPTER_TOOLS_DEFAULT } from "./store.ts";
 import { validateFnOptions } from "../fn/fn.ts";
 import { ADAPTER_FN_REGISTRY } from "../fn/store.ts";
 import type { AgentRegisteredOptions } from "./types.ts";
 import { isDeferredFn, type FnEntry } from "./tools/types.ts";
+import { isToolSelection, type ToolSelection } from "./tools/selection.ts";
 
 export interface AgentPluginOptions {
   /**
@@ -35,6 +36,16 @@ export interface AgentPluginOptions {
    * `@routecraft/testing` rather than dispatching through the plugin.
    */
   functions?: Record<string, FnEntry>;
+
+  /**
+   * Context-default tool list for agents that don't specify their own
+   * `tools:` field. Build via `tools([...])`. An agent that does set
+   * `tools:` replaces this default entirely (override, not extend).
+   *
+   * Multiple `agentPlugin` installs that each provide a default throw
+   * at context init: a context can only have one default tool list.
+   */
+  tools?: ToolSelection;
 }
 
 function validateRegisteredAgent(
@@ -91,6 +102,12 @@ function validateRegisteredAgent(
 export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
   const agents = options.agents ?? {};
   const functions = options.functions ?? {};
+  const defaultTools = options.tools;
+  if (defaultTools !== undefined && !isToolSelection(defaultTools)) {
+    throw rcError("RC5003", undefined, {
+      message: `agentPlugin: "tools" must be the result of tools([...]).`,
+    });
+  }
   return {
     apply(ctx: CraftContext) {
       // Merge into an existing registry when present so multiple
@@ -109,6 +126,11 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
         if (entry === null || typeof entry !== "object") {
           throw rcError("RC5003", undefined, {
             message: `agentPlugin: agent "${id}" entry must be an object with description, model, and system.`,
+          });
+        }
+        if (entry.tools !== undefined && !isToolSelection(entry.tools)) {
+          throw rcError("RC5003", undefined, {
+            message: `agentPlugin: agent "${id}" "tools" must be the result of tools([...]).`,
           });
         }
         validateRegisteredAgent(id, entry);
@@ -155,6 +177,21 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
         ctx.setStore(
           ADAPTER_FN_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
           fnMap,
+        );
+      }
+
+      if (defaultTools !== undefined) {
+        const existingDefault = ctx.getStore(
+          ADAPTER_TOOLS_DEFAULT as keyof import("@routecraft/routecraft").StoreRegistry,
+        );
+        if (existingDefault !== undefined) {
+          throw rcError("RC5003", undefined, {
+            message: `agentPlugin: a default tool list is already set on this context. Combine selectors into a single tools([...]) call.`,
+          });
+        }
+        ctx.setStore(
+          ADAPTER_TOOLS_DEFAULT as keyof import("@routecraft/routecraft").StoreRegistry,
+          defaultTools,
         );
       }
     },

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -7,8 +7,8 @@ import { validateAgentOptions } from "./agent.ts";
 import { ADAPTER_AGENT_REGISTRY } from "./store.ts";
 import { validateFnOptions } from "../fn/fn.ts";
 import { ADAPTER_FN_REGISTRY } from "../fn/store.ts";
-import type { FnOptions } from "../fn/types.ts";
 import type { AgentRegisteredOptions } from "./types.ts";
+import { isDeferredFn, type FnEntry } from "./tools/types.ts";
 
 export interface AgentPluginOptions {
   /**
@@ -21,14 +21,20 @@ export interface AgentPluginOptions {
 
   /**
    * Ad-hoc in-process functions available to agents (via `tools: [...]`
-   * in follow-up stories). Keyed by the fn id; each entry provides
-   * description, Standard Schema, and handler. Duplicate ids across
-   * multiple `agentPlugin` installs throw at context init.
+   * in follow-up stories). Keyed by the fn id; each entry is either an
+   * eagerly-authored `FnOptions` (description, schema, handler) or a
+   * deferred descriptor emitted by a builder helper such as
+   * `directTool(routeId)` / `agentTool(agentId)` / `mcpTool(server, tool)`.
+   * Deferred descriptors resolve at agent dispatch time when all
+   * registries are populated.
+   *
+   * Duplicate ids across multiple `agentPlugin` installs throw at
+   * context init.
    *
    * For tests, exercise registered fn handlers via `testFn` from
    * `@routecraft/testing` rather than dispatching through the plugin.
    */
-  functions?: Record<string, FnOptions>;
+  functions?: Record<string, FnEntry>;
 }
 
 function validateRegisteredAgent(
@@ -122,8 +128,8 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
 
       const existingFns = ctx.getStore(
         ADAPTER_FN_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-      ) as Map<string, FnOptions> | undefined;
-      const fnMap = existingFns ?? new Map<string, FnOptions>();
+      ) as Map<string, FnEntry> | undefined;
+      const fnMap = existingFns ?? new Map<string, FnEntry>();
       for (const [id, entry] of Object.entries(functions)) {
         if (id.trim() === "") {
           throw rcError("RC5003", undefined, {
@@ -135,7 +141,9 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
             message: `agentPlugin: fn "${id}" entry must be an object with description, schema, and handler.`,
           });
         }
-        validateFnOptions(id, entry);
+        if (!isDeferredFn(entry)) {
+          validateFnOptions(id, entry);
+        }
         if (fnMap.has(id)) {
           throw rcError("RC5003", undefined, {
             message: `agentPlugin: duplicate fn id "${id}". Each fn id must be unique within a context.`,

--- a/packages/ai/src/agent/store.ts
+++ b/packages/ai/src/agent/store.ts
@@ -1,4 +1,5 @@
 import type { AgentRegisteredOptions } from "./types.ts";
+import type { ToolSelection } from "./tools/selection.ts";
 
 /**
  * Store key for the registry of agents installed by `agentPlugin`. Resolved
@@ -11,8 +12,20 @@ export const ADAPTER_AGENT_REGISTRY = Symbol.for(
   "routecraft.adapter.agent.registry",
 );
 
+/**
+ * Store key for the context-default tool selection installed via
+ * `agentPlugin({ tools })`. Agents that omit their own `tools:` field
+ * fall back to this list at dispatch time.
+ *
+ * @experimental
+ */
+export const ADAPTER_TOOLS_DEFAULT = Symbol.for(
+  "routecraft.adapter.tools.default",
+);
+
 declare module "@routecraft/routecraft" {
   interface StoreRegistry {
     [ADAPTER_AGENT_REGISTRY]: Map<string, AgentRegisteredOptions>;
+    [ADAPTER_TOOLS_DEFAULT]: ToolSelection;
   }
 }

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -84,6 +84,7 @@ export function directTool<TIn = unknown, TOut = unknown>(
   return {
     [DEFERRED_FN_BRAND]: true,
     kind: "direct",
+    targetId: routeId,
     resolve(ctx, fnId): FnOptions {
       const route = readDirectRoute(ctx, routeId, fnId);
       const description = overrides?.description ?? route.description;
@@ -180,6 +181,7 @@ export function agentTool(
   return {
     [DEFERRED_FN_BRAND]: true,
     kind: "agent",
+    targetId: agentId,
     resolve(_ctx, fnId): FnOptions {
       throw rcError("RC5003", undefined, {
         message: `agentTool("${agentId}") (referenced as fn "${fnId}") is not yet supported. Sub-agent tools land in a follow-up story.`,
@@ -215,6 +217,7 @@ export function mcpTool(
   return {
     [DEFERRED_FN_BRAND]: true,
     kind: "mcp",
+    targetId: `${serverId}:${toolName}`,
     resolve(_ctx, fnId): FnOptions {
       throw rcError("RC5003", undefined, {
         message: `mcpTool("${serverId}", "${toolName}") (referenced as fn "${fnId}") is not yet supported. MCP tools land in a follow-up story.`,

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -106,11 +106,12 @@ export function directTool<TIn = unknown>(
       message: `directTool: routeId must be a non-empty string.`,
     });
   }
+  const overrideTags = normalizeOverrideTags(overrides?.tags, routeId);
   return {
     [DEFERRED_FN_BRAND]: true,
     kind: "direct",
     targetId: routeId,
-    ...(overrides?.tags !== undefined ? { overrideTags: overrides.tags } : {}),
+    ...(overrideTags !== undefined ? { overrideTags } : {}),
     resolve(ctx, fnId): FnOptions {
       const route = readDirectRoute(ctx, routeId, fnId);
       const description = overrides?.description ?? route.description;
@@ -127,17 +128,46 @@ export function directTool<TIn = unknown>(
           message: `directTool: route "${routeId}" has no .input(...) schema and no override was provided (referenced as fn "${fnId}").`,
         });
       }
-      const tags = overrides?.tags ?? route.tags;
+      const tags = overrideTags ?? route.tags;
       const handler = ((input, hctx) =>
         dispatchDirect(hctx, routeId, input)) as FnOptions["handler"];
       return {
         description,
         schema,
-        ...(tags && tags.length > 0 ? { tags } : {}),
+        ...(tags && tags.length > 0 ? { tags: [...tags] } : {}),
         handler,
       } as FnOptions;
     },
   };
+}
+
+/**
+ * Trim and validate user-supplied builder override tags so they match
+ * exact tag selectors and surface clear errors on misuse. Returns
+ * `undefined` when no override was supplied (so the caller can omit
+ * the field entirely on the descriptor).
+ */
+function normalizeOverrideTags(
+  value: Tag[] | undefined,
+  routeId: string,
+): readonly Tag[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw rcError("RC5003", undefined, {
+      message: `directTool("${routeId}"): override "tags" must be an array of non-empty strings.`,
+    });
+  }
+  const out: Tag[] = [];
+  for (const t of value) {
+    if (typeof t !== "string" || t.trim() === "") {
+      throw rcError("RC5003", undefined, {
+        message: `directTool("${routeId}"): override "tags" must contain only non-empty strings.`,
+      });
+    }
+    const trimmed = t.trim();
+    if (!out.includes(trimmed)) out.push(trimmed);
+  }
+  return out;
 }
 
 function readDirectRoute(

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -1,0 +1,256 @@
+import {
+  ADAPTER_DIRECT_REGISTRY,
+  DefaultExchange,
+  getDirectChannel,
+  rcError,
+  type CraftContext,
+  type DirectRouteMetadata,
+  type Exchange,
+  type Tag,
+} from "@routecraft/routecraft";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { z } from "zod";
+import { randomUUID } from "node:crypto";
+import type { FnHandlerContext, FnOptions } from "../../fn/types.ts";
+import { DEFERRED_FN_BRAND, type DeferredFn } from "./types.ts";
+
+/**
+ * Per-call overrides accepted by the builder helpers. Lets the caller
+ * narrow the underlying tool's surface to a specific agent without
+ * touching the underlying registration.
+ *
+ * @experimental
+ */
+export interface ToolBuilderOverrides<TIn = unknown, TOut = unknown> {
+  /** Replace the underlying description shown to the LLM. */
+  description?: string;
+  /**
+   * Replace the underlying input schema. Replaces, does not merge with,
+   * the underlying schema.
+   */
+  schema?: StandardSchemaV1<unknown, TIn>;
+  /**
+   * Replace the underlying tags. Replaces, does not merge with, the
+   * underlying tags.
+   */
+  tags?: Tag[];
+  /**
+   * Optional guard that runs after schema validation but before the
+   * underlying handler. Throwing inside the guard surfaces back to the
+   * LLM as a tool error so the model can self-correct.
+   */
+  guard?: (input: TIn, ctx: FnHandlerContext) => void | Promise<void>;
+  /**
+   * Override the handler return type at the type level. Rarely needed;
+   * provided so callers can narrow `unknown`.
+   */
+  handler?: (input: TIn, ctx: FnHandlerContext) => Promise<TOut> | TOut;
+}
+
+/**
+ * Wrap a registered direct route as a fn-shaped tool. The route's
+ * `.description()`, `.input()` schema, and tags become the fn's
+ * description, schema, and tags by default; pass `overrides` to narrow
+ * any of them for the calling agent.
+ *
+ * Resolution is deferred to agent dispatch time, when the direct
+ * registry is populated. Errors at resolution (unknown route id,
+ * missing description, missing input schema) throw `RC5003`.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * agentPlugin({
+ *   functions: {
+ *     fetchOrder: directTool("fetch-order"),
+ *     safeFetchOrder: directTool("fetch-order", {
+ *       description: "Read-only order fetch.",
+ *       tags: ["read-only"],
+ *     }),
+ *   },
+ * });
+ * ```
+ */
+export function directTool<TIn = unknown, TOut = unknown>(
+  routeId: string,
+  overrides?: ToolBuilderOverrides<TIn, TOut>,
+): DeferredFn {
+  if (typeof routeId !== "string" || routeId.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `directTool: routeId must be a non-empty string.`,
+    });
+  }
+  return {
+    [DEFERRED_FN_BRAND]: true,
+    kind: "direct",
+    resolve(ctx, fnId): FnOptions {
+      const route = readDirectRoute(ctx, routeId, fnId);
+      const description = overrides?.description ?? route.description;
+      if (typeof description !== "string" || description.trim() === "") {
+        throw rcError("RC5003", undefined, {
+          message: `directTool: route "${routeId}" has no .description() and no override was provided (referenced as fn "${fnId}").`,
+        });
+      }
+      const schema =
+        overrides?.schema ??
+        (route.input?.body as StandardSchemaV1<unknown, TIn> | undefined);
+      if (!schema) {
+        throw rcError("RC5003", undefined, {
+          message: `directTool: route "${routeId}" has no .input(...) schema and no override was provided (referenced as fn "${fnId}").`,
+        });
+      }
+      const tags = overrides?.tags ?? route.tags;
+      const handler =
+        overrides?.handler ??
+        (((input, hctx) =>
+          dispatchDirect<TIn, TOut>(hctx, routeId, input)) as FnOptions<
+          TIn,
+          TOut
+        >["handler"]);
+      return {
+        description,
+        schema,
+        ...(tags && tags.length > 0 ? { tags } : {}),
+        handler,
+      } as FnOptions;
+    },
+  };
+}
+
+function readDirectRoute(
+  ctx: CraftContext,
+  routeId: string,
+  fnId: string,
+): DirectRouteMetadata {
+  const registry = ctx.getStore(ADAPTER_DIRECT_REGISTRY) as
+    | Map<string, DirectRouteMetadata>
+    | undefined;
+  const route = registry?.get(routeId);
+  if (!route) {
+    const known = registry ? [...registry.keys()].sort() : [];
+    throw rcError("RC5003", undefined, {
+      message:
+        `directTool: unknown direct route id "${routeId}" (referenced as fn "${fnId}"). ` +
+        (known.length > 0
+          ? `Known route ids: ${known.join(", ")}.`
+          : `No direct routes are registered in this context.`),
+    });
+  }
+  return route;
+}
+
+async function dispatchDirect<TIn, TOut>(
+  hctx: FnHandlerContext,
+  routeId: string,
+  input: TIn,
+): Promise<TOut> {
+  if (!hctx.context) {
+    throw rcError("RC5003", undefined, {
+      message: `directTool: no CraftContext available on the handler context (cannot dispatch to direct route "${routeId}").`,
+    });
+  }
+  const exchange = new DefaultExchange<TIn>(hctx.context, { body: input });
+  const channel = getDirectChannel<TIn>(hctx.context, routeId, {});
+  const result = (await channel.send(
+    routeId,
+    exchange,
+  )) as unknown as Exchange<TOut>;
+  return result.body;
+}
+
+/**
+ * Wrap a registered agent as a fn-shaped tool. Lands in story F (sub-
+ * agents). Available now as a builder so the prefix auto-resolution
+ * path in `tools(...)` can recognise `agent_*` and emit a clear "not
+ * supported yet" error rather than treating the name as an unknown fn.
+ *
+ * @experimental
+ */
+export function agentTool(
+  agentId: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- shape mirrors the future story F signature
+  _overrides?: never,
+): DeferredFn {
+  if (typeof agentId !== "string" || agentId.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `agentTool: agentId must be a non-empty string.`,
+    });
+  }
+  return {
+    [DEFERRED_FN_BRAND]: true,
+    kind: "agent",
+    resolve(_ctx, fnId): FnOptions {
+      throw rcError("RC5003", undefined, {
+        message: `agentTool("${agentId}") (referenced as fn "${fnId}") is not yet supported. Sub-agent tools land in a follow-up story.`,
+      });
+    },
+  };
+}
+
+/**
+ * Wrap an MCP tool as a fn-shaped tool. Lands in story E (MCP tools).
+ * Available now as a builder so the prefix auto-resolution path in
+ * `tools(...)` can recognise `mcp_*` and emit a clear "not supported
+ * yet" error.
+ *
+ * @experimental
+ */
+export function mcpTool(
+  serverId: string,
+  toolName: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- shape mirrors the future story E signature
+  _overrides?: never,
+): DeferredFn {
+  if (typeof serverId !== "string" || serverId.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `mcpTool: serverId must be a non-empty string.`,
+    });
+  }
+  if (typeof toolName !== "string" || toolName.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `mcpTool: toolName must be a non-empty string.`,
+    });
+  }
+  return {
+    [DEFERRED_FN_BRAND]: true,
+    kind: "mcp",
+    resolve(_ctx, fnId): FnOptions {
+      throw rcError("RC5003", undefined, {
+        message: `mcpTool("${serverId}", "${toolName}") (referenced as fn "${fnId}") is not yet supported. MCP tools land in a follow-up story.`,
+      });
+    },
+  };
+}
+
+/**
+ * Small starter set of generic, broadly useful fns. Spread into your
+ * `agentPlugin({ functions: { ... } })` config to give every agent in
+ * the context the basics for free.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * agentPlugin({
+ *   functions: {
+ *     ...defaultFns,
+ *     fetchOrder: directTool("fetch-order"),
+ *   },
+ * });
+ * ```
+ */
+export const defaultFns = {
+  currentTime: {
+    description: "Returns the current UTC timestamp in ISO 8601 format.",
+    schema: z.object({}),
+    handler: () => new Date().toISOString(),
+    tags: ["read-only", "idempotent"],
+  } satisfies FnOptions<Record<string, never>, string>,
+  randomUuid: {
+    description: "Generates a fresh random UUID v4.",
+    schema: z.object({}),
+    handler: () => randomUUID(),
+    tags: ["read-only"],
+  } satisfies FnOptions<Record<string, never>, string>,
+} as const;

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -110,6 +110,7 @@ export function directTool<TIn = unknown>(
     [DEFERRED_FN_BRAND]: true,
     kind: "direct",
     targetId: routeId,
+    ...(overrides?.tags !== undefined ? { overrideTags: overrides.tags } : {}),
     resolve(ctx, fnId): FnOptions {
       const route = readDirectRoute(ctx, routeId, fnId);
       const description = overrides?.description ?? route.description;

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -1,27 +1,63 @@
 import {
   ADAPTER_DIRECT_REGISTRY,
   DefaultExchange,
+  HeadersKeys,
   getDirectChannel,
   rcError,
+  sanitizeEndpoint,
   type CraftContext,
   type DirectRouteMetadata,
   type Exchange,
+  type KnownTag,
   type Tag,
 } from "@routecraft/routecraft";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import type { FnHandlerContext, FnOptions } from "../../fn/types.ts";
 import { DEFERRED_FN_BRAND, type DeferredFn } from "./types.ts";
+
+/**
+ * Standard Schema implementation of an empty input object. Used by the
+ * `defaultFns` so this module stays free of a Zod runtime dependency
+ * (per CLAUDE.md "Use Standard Schema, not Zod/Valibot directly in
+ * shared code").
+ */
+const emptyObjectSchema: StandardSchemaV1<unknown, Record<string, never>> = {
+  "~standard": {
+    version: 1,
+    vendor: "routecraft",
+    validate(value) {
+      if (
+        value === null ||
+        typeof value !== "object" ||
+        Array.isArray(value) ||
+        Object.keys(value as object).length > 0
+      ) {
+        return {
+          issues: [
+            {
+              message: "Expected an empty object {}.",
+            },
+          ],
+        };
+      }
+      return { value: {} as Record<string, never> };
+    },
+  },
+};
 
 /**
  * Per-call overrides accepted by the builder helpers. Lets the caller
  * narrow the underlying tool's surface to a specific agent without
  * touching the underlying registration.
  *
+ * Only the LLM-facing contract (description, schema, tags) can be
+ * overridden here. Guards are policy and live at the consumer:
+ * attach them in `tools([{ name, guard }])` at the agent's call site.
+ *
  * @experimental
  */
-export interface ToolBuilderOverrides<TIn = unknown, TOut = unknown> {
+export interface ToolBuilderOverrides<TIn = unknown> {
   /** Replace the underlying description shown to the LLM. */
   description?: string;
   /**
@@ -34,17 +70,6 @@ export interface ToolBuilderOverrides<TIn = unknown, TOut = unknown> {
    * underlying tags.
    */
   tags?: Tag[];
-  /**
-   * Optional guard that runs after schema validation but before the
-   * underlying handler. Throwing inside the guard surfaces back to the
-   * LLM as a tool error so the model can self-correct.
-   */
-  guard?: (input: TIn, ctx: FnHandlerContext) => void | Promise<void>;
-  /**
-   * Override the handler return type at the type level. Rarely needed;
-   * provided so callers can narrow `unknown`.
-   */
-  handler?: (input: TIn, ctx: FnHandlerContext) => Promise<TOut> | TOut;
 }
 
 /**
@@ -72,9 +97,9 @@ export interface ToolBuilderOverrides<TIn = unknown, TOut = unknown> {
  * });
  * ```
  */
-export function directTool<TIn = unknown, TOut = unknown>(
+export function directTool<TIn = unknown>(
   routeId: string,
-  overrides?: ToolBuilderOverrides<TIn, TOut>,
+  overrides?: ToolBuilderOverrides<TIn>,
 ): DeferredFn {
   if (typeof routeId !== "string" || routeId.trim() === "") {
     throw rcError("RC5003", undefined, {
@@ -102,13 +127,8 @@ export function directTool<TIn = unknown, TOut = unknown>(
         });
       }
       const tags = overrides?.tags ?? route.tags;
-      const handler =
-        overrides?.handler ??
-        (((input, hctx) =>
-          dispatchDirect<TIn, TOut>(hctx, routeId, input)) as FnOptions<
-          TIn,
-          TOut
-        >["handler"]);
+      const handler = ((input, hctx) =>
+        dispatchDirect(hctx, routeId, input)) as FnOptions["handler"];
       return {
         description,
         schema,
@@ -127,7 +147,11 @@ function readDirectRoute(
   const registry = ctx.getStore(ADAPTER_DIRECT_REGISTRY) as
     | Map<string, DirectRouteMetadata>
     | undefined;
-  const route = registry?.get(routeId);
+  // Direct sources register under the sanitised endpoint, so look up
+  // by sanitised key. Reject the raw id in the error message so the
+  // user can see which one they wrote.
+  const endpoint = sanitizeEndpoint(routeId);
+  const route = registry?.get(endpoint);
   if (!route) {
     const known = registry ? [...registry.keys()].sort() : [];
     throw rcError("RC5003", undefined, {
@@ -141,22 +165,26 @@ function readDirectRoute(
   return route;
 }
 
-async function dispatchDirect<TIn, TOut>(
+async function dispatchDirect<TIn>(
   hctx: FnHandlerContext,
   routeId: string,
   input: TIn,
-): Promise<TOut> {
+): Promise<unknown> {
   if (!hctx.context) {
     throw rcError("RC5003", undefined, {
       message: `directTool: no CraftContext available on the handler context (cannot dispatch to direct route "${routeId}").`,
     });
   }
-  const exchange = new DefaultExchange<TIn>(hctx.context, { body: input });
-  const channel = getDirectChannel<TIn>(hctx.context, routeId, {});
-  const result = (await channel.send(
-    routeId,
-    exchange,
-  )) as unknown as Exchange<TOut>;
+  const endpoint = sanitizeEndpoint(routeId);
+  const headers = hctx.correlationId
+    ? { [HeadersKeys.CORRELATION_ID]: hctx.correlationId }
+    : undefined;
+  const exchange = new DefaultExchange<TIn>(hctx.context, {
+    body: input,
+    ...(headers ? { headers } : {}),
+  });
+  const channel = getDirectChannel<TIn>(hctx.context, endpoint, {});
+  const result = (await channel.send(endpoint, exchange)) as Exchange<unknown>;
   return result.body;
 }
 
@@ -246,14 +274,14 @@ export function mcpTool(
 export const defaultFns = {
   currentTime: {
     description: "Returns the current UTC timestamp in ISO 8601 format.",
-    schema: z.object({}),
+    schema: emptyObjectSchema,
     handler: () => new Date().toISOString(),
-    tags: ["read-only", "idempotent"],
+    tags: ["read-only", "idempotent"] satisfies KnownTag[],
   } satisfies FnOptions<Record<string, never>, string>,
   randomUuid: {
     description: "Generates a fresh random UUID v4.",
-    schema: z.object({}),
+    schema: emptyObjectSchema,
     handler: () => randomUUID(),
-    tags: ["read-only"],
+    tags: ["read-only"] satisfies KnownTag[],
   } satisfies FnOptions<Record<string, never>, string>,
-} as const;
+};

--- a/packages/ai/src/agent/tools/index.ts
+++ b/packages/ai/src/agent/tools/index.ts
@@ -12,3 +12,12 @@ export {
   type DeferredFnKind,
   type FnEntry,
 } from "./types.ts";
+export {
+  isToolSelection,
+  TOOL_SELECTION_BRAND,
+  tools,
+  type ResolvedTool,
+  type ToolGuard,
+  type ToolSelection,
+  type ToolsItem,
+} from "./selection.ts";

--- a/packages/ai/src/agent/tools/index.ts
+++ b/packages/ai/src/agent/tools/index.ts
@@ -1,0 +1,14 @@
+export {
+  agentTool,
+  defaultFns,
+  directTool,
+  mcpTool,
+  type ToolBuilderOverrides,
+} from "./builders.ts";
+export {
+  DEFERRED_FN_BRAND,
+  isDeferredFn,
+  type DeferredFn,
+  type DeferredFnKind,
+  type FnEntry,
+} from "./types.ts";

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -1,0 +1,350 @@
+import {
+  ADAPTER_DIRECT_REGISTRY,
+  rcError,
+  type CraftContext,
+  type DirectRouteMetadata,
+  type Tag,
+} from "@routecraft/routecraft";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { ADAPTER_FN_REGISTRY } from "../../fn/store.ts";
+import type { FnHandlerContext, FnOptions } from "../../fn/types.ts";
+import { directTool } from "./builders.ts";
+import { isDeferredFn, type FnEntry } from "./types.ts";
+
+/**
+ * Synchronous or async guard run after schema validation, before the
+ * underlying handler. Throwing surfaces back to the LLM as a tool error
+ * so the model can self-correct.
+ *
+ * @experimental
+ */
+export type ToolGuard = (
+  input: unknown,
+  ctx: FnHandlerContext,
+) => void | Promise<void>;
+
+/**
+ * One entry in the agent's `tools([...])` list.
+ *
+ * - bare string: name lookup. Plain ids resolve against the fn registry;
+ *   `direct_*` falls back to the direct registry via `directTool`.
+ * - `{ name, guard? }`: same lookup, with a guard attached to that tool.
+ * - `{ tagged, guard? }`: select every fn / route whose tags include any
+ *   of the requested tag(s). Optional guard applies to every match.
+ *
+ * @experimental
+ */
+export type ToolsItem =
+  | string
+  | { name: string; guard?: ToolGuard }
+  | { tagged: Tag | Tag[]; guard?: ToolGuard };
+
+/**
+ * Brand for {@link ToolSelection}. Lets the agent runtime detect a
+ * `tools(...)` value vs a plain array.
+ *
+ * @internal
+ */
+export const TOOL_SELECTION_BRAND = Symbol.for("routecraft.ai.tools.selection");
+
+/**
+ * Opaque deferred descriptor returned by `tools(...)`. Resolves at
+ * agent dispatch time, when both the fn registry and the direct route
+ * registry are populated.
+ *
+ * @experimental
+ */
+export interface ToolSelection {
+  readonly [TOOL_SELECTION_BRAND]: true;
+  /**
+   * Resolve the selection against the live context. Throws RC5003 on
+   * any unresolvable explicit reference (unknown name, deferred
+   * resolution failure). Tag selectors that match nothing contribute
+   * zero tools and never throw.
+   */
+  readonly resolve: (ctx: CraftContext) => ResolvedTool[];
+}
+
+/**
+ * A tool ready to be wired into the LLM tool list. Produced by
+ * `ToolSelection.resolve()`.
+ *
+ * @experimental
+ */
+export interface ResolvedTool {
+  /** Tool name presented to the LLM (matches the registered fn id or, for routes referenced by convention, `direct_<routeId>`). */
+  name: string;
+  /** Description shown to the LLM. */
+  description: string;
+  /** Standard Schema validating the LLM-supplied input. */
+  schema: StandardSchemaV1<unknown, unknown>;
+  /** Optional tags inherited from the underlying registration. */
+  tags?: Tag[];
+  /** Optional guard run after validation, before the handler. */
+  guard?: ToolGuard;
+  /** The function the LLM ultimately invokes. */
+  handler: FnOptions["handler"];
+}
+
+/**
+ * Type guard. Returns true when `value` is a tool selection produced
+ * by `tools(...)`.
+ *
+ * @internal
+ */
+export function isToolSelection(value: unknown): value is ToolSelection {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    TOOL_SELECTION_BRAND in value &&
+    (value as { [TOOL_SELECTION_BRAND]: unknown })[TOOL_SELECTION_BRAND] ===
+      true
+  );
+}
+
+/**
+ * Build a tool selection for an agent from a flat list of references.
+ *
+ * Items can be bare strings, `{ name, guard? }`, or `{ tagged, guard? }`.
+ * Resolution happens lazily at agent dispatch time.
+ *
+ * Resolution rules:
+ * - Bare names look up exact matches in the fn registry first; if
+ *   missing AND the name starts with `direct_`, the suffix is treated
+ *   as a direct route id and wrapped via `directTool`. Names starting
+ *   with `agent_` or `mcp_` produce a "not yet supported" error
+ *   (stories E and F).
+ * - Tag selectors walk both the fn registry and the direct route
+ *   registry, including any entry whose tags overlap with the
+ *   requested set. Direct routes not already covered by a fn registry
+ *   entry are surfaced under the `direct_<routeId>` name.
+ * - Final list is deduplicated by tool name. Explicit references win
+ *   over tag-selector matches regardless of position in the list.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * agent({
+ *   tools: tools([
+ *     "currentTime",
+ *     "fetchOrder",
+ *     "direct_cancel-order",
+ *     { name: "sendSlack", guard: confirmGuard },
+ *     { tagged: "read-only" },
+ *   ]),
+ * });
+ * ```
+ */
+export function tools(items: ToolsItem[]): ToolSelection {
+  if (!Array.isArray(items)) {
+    throw rcError("RC5003", undefined, {
+      message: `tools(items): items must be an array.`,
+    });
+  }
+  return {
+    [TOOL_SELECTION_BRAND]: true,
+    resolve(ctx) {
+      const explicit = new Map<string, ResolvedTool>();
+
+      // Phase 1: explicit refs (bare strings + { name, guard }).
+      for (const item of items) {
+        if (typeof item === "string") {
+          const tool = resolveByName(ctx, item, undefined);
+          explicit.set(tool.name, tool);
+          continue;
+        }
+        if (item === null || typeof item !== "object") {
+          throw rcError("RC5003", undefined, {
+            message: `tools(): each item must be a string, { name, guard? }, or { tagged, guard? }.`,
+          });
+        }
+        if ("name" in item) {
+          if (typeof item.name !== "string" || item.name.trim() === "") {
+            throw rcError("RC5003", undefined, {
+              message: `tools(): { name } must be a non-empty string.`,
+            });
+          }
+          const tool = resolveByName(ctx, item.name, item.guard);
+          explicit.set(tool.name, tool);
+        }
+      }
+
+      // Phase 2: tag selectors. Explicit names already in the map win.
+      const out = new Map<string, ResolvedTool>(explicit);
+      for (const item of items) {
+        if (typeof item === "object" && item !== null && "tagged" in item) {
+          const wanted = normalizeTags(item.tagged);
+          if (wanted.length === 0) continue;
+          for (const match of resolveByTags(ctx, wanted, item.guard)) {
+            if (!out.has(match.name)) out.set(match.name, match);
+          }
+        }
+      }
+
+      return [...out.values()];
+    },
+  };
+}
+
+function resolveByName(
+  ctx: CraftContext,
+  name: string,
+  guard: ToolGuard | undefined,
+): ResolvedTool {
+  if (typeof name !== "string" || name.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): tool name must be a non-empty string.`,
+    });
+  }
+  const fnRegistry = ctx.getStore(ADAPTER_FN_REGISTRY) as
+    | Map<string, FnEntry>
+    | undefined;
+  const fnEntry = fnRegistry?.get(name);
+  if (fnEntry) {
+    return resolveFnEntry(ctx, name, fnEntry, guard);
+  }
+
+  if (name.startsWith("agent_")) {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): "${name}" looks like an agent reference. Sub-agent tools land in a follow-up story.`,
+    });
+  }
+  if (name.startsWith("mcp_")) {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): "${name}" looks like an MCP reference. MCP tools land in a follow-up story.`,
+    });
+  }
+  if (name.startsWith("direct_")) {
+    const routeId = name.slice("direct_".length);
+    if (routeId === "") {
+      throw rcError("RC5003", undefined, {
+        message: `tools(): "${name}" has an empty direct route id.`,
+      });
+    }
+    const wrapper = directTool(routeId);
+    const fn = wrapper.resolve(ctx, name);
+    return toResolvedTool(name, fn, guard);
+  }
+
+  const known = listKnownNames(ctx);
+  throw rcError("RC5003", undefined, {
+    message:
+      `tools(): unknown tool "${name}". ` +
+      (known.length > 0
+        ? `Available: ${known.join(", ")}.`
+        : `No fns or direct routes are registered in this context.`),
+  });
+}
+
+function resolveFnEntry(
+  ctx: CraftContext,
+  name: string,
+  entry: FnEntry,
+  guard: ToolGuard | undefined,
+): ResolvedTool {
+  if (isDeferredFn(entry)) {
+    const fn = entry.resolve(ctx, name);
+    return toResolvedTool(name, fn, guard);
+  }
+  return toResolvedTool(name, entry, guard);
+}
+
+function toResolvedTool(
+  name: string,
+  fn: FnOptions,
+  guard: ToolGuard | undefined,
+): ResolvedTool {
+  return {
+    name,
+    description: fn.description,
+    schema: fn.schema as StandardSchemaV1<unknown, unknown>,
+    ...(fn.tags && fn.tags.length > 0 ? { tags: fn.tags } : {}),
+    ...(guard ? { guard } : {}),
+    handler: fn.handler as FnOptions["handler"],
+  };
+}
+
+function resolveByTags(
+  ctx: CraftContext,
+  wanted: Tag[],
+  guard: ToolGuard | undefined,
+): ResolvedTool[] {
+  const wantedSet = new Set(wanted);
+  const out: ResolvedTool[] = [];
+  const seenNames = new Set<string>();
+  const coveredRouteIds = new Set<string>();
+
+  // Walk the fn registry first so explicit fn-side tags (incl. directTool
+  // wrappers) take precedence over a parallel direct-registry walk.
+  const fnRegistry = ctx.getStore(ADAPTER_FN_REGISTRY) as
+    | Map<string, FnEntry>
+    | undefined;
+  if (fnRegistry) {
+    for (const [name, entry] of fnRegistry) {
+      if (isDeferredFn(entry) && entry.kind === "direct") {
+        coveredRouteIds.add(entry.targetId);
+      }
+      const fn = isDeferredFn(entry) ? entry.resolve(ctx, name) : entry;
+      const tags = fn.tags ?? [];
+      if (tags.some((t) => wantedSet.has(t))) {
+        out.push(toResolvedTool(name, fn, guard));
+        seenNames.add(name);
+      }
+    }
+  }
+
+  // Walk the direct registry for routes not already surfaced via a
+  // fn-registry wrapper. Use the prefix-convention name `direct_<id>`.
+  const directRegistry = ctx.getStore(ADAPTER_DIRECT_REGISTRY) as
+    | Map<string, DirectRouteMetadata>
+    | undefined;
+  if (directRegistry) {
+    for (const [routeId, meta] of directRegistry) {
+      if (coveredRouteIds.has(routeId)) continue;
+      const tags = meta.tags ?? [];
+      if (!tags.some((t) => wantedSet.has(t))) continue;
+      const conventionName = `direct_${routeId}`;
+      if (seenNames.has(conventionName)) continue;
+      // Only include if the route is fully tool-shaped (has description
+      // and input schema). Routes that are missing those silently skip
+      // tag-selector inclusion -- explicit refs would still throw.
+      if (
+        typeof meta.description !== "string" ||
+        meta.description.trim() === ""
+      ) {
+        continue;
+      }
+      if (!meta.input?.body) continue;
+      const wrapper = directTool(routeId);
+      const fn = wrapper.resolve(ctx, conventionName);
+      out.push(toResolvedTool(conventionName, fn, guard));
+      seenNames.add(conventionName);
+    }
+  }
+
+  return out;
+}
+
+function normalizeTags(value: Tag | Tag[]): Tag[] {
+  return (Array.isArray(value) ? value : [value]).filter(
+    (t): t is Tag => typeof t === "string" && t.trim() !== "",
+  );
+}
+
+function listKnownNames(ctx: CraftContext): string[] {
+  const fnNames = [
+    ...(
+      (ctx.getStore(ADAPTER_FN_REGISTRY) as Map<string, FnEntry> | undefined) ??
+      new Map()
+    ).keys(),
+  ];
+  const routeNames = [
+    ...(
+      (ctx.getStore(ADAPTER_DIRECT_REGISTRY) as
+        | Map<string, DirectRouteMetadata>
+        | undefined) ?? new Map()
+    ).keys(),
+  ].map((id) => `direct_${id}`);
+  return [...fnNames, ...routeNames].sort();
+}

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -299,11 +299,13 @@ function resolveByTags(
     for (const [name, entry] of fnRegistry) {
       if (isDeferredFn(entry)) {
         if (entry.kind !== "direct") continue;
-        // Peek at the underlying route's tags via the direct registry
-        // first so we don't trigger the wrapper's full resolve unless
-        // it actually matches.
-        const peekedTags = peekDirectTags(ctx, entry.targetId);
-        if (!peekedTags.some((t) => wantedSet.has(t))) continue;
+        // Use the wrapper's explicit `overrides.tags` when present so a
+        // `directTool(routeId, { tags: [...] })` wrapper actually drives
+        // selection. Fall back to peeking the underlying route's tags
+        // when no override was supplied.
+        const candidateTags =
+          entry.overrideTags ?? peekDirectTags(ctx, entry.targetId);
+        if (!candidateTags.some((t) => wantedSet.has(t))) continue;
         const fn = entry.resolve(ctx, name);
         out.push(toResolvedTool(name, fn, guard));
         seenNames.add(name);

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -1,6 +1,7 @@
 import {
   ADAPTER_DIRECT_REGISTRY,
   rcError,
+  sanitizeEndpoint,
   type CraftContext,
   type DirectRouteMetadata,
   type Tag,
@@ -167,6 +168,10 @@ export function tools(items: ToolsItem[]): ToolSelection {
           }
           const tool = resolveByName(ctx, item.name, item.guard);
           explicit.set(tool.name, tool);
+        } else if (!("tagged" in item)) {
+          throw rcError("RC5003", undefined, {
+            message: `tools(): each object item must include "name" or "tagged".`,
+          });
         }
       }
 
@@ -273,22 +278,41 @@ function resolveByTags(
   const wantedSet = new Set(wanted);
   const out: ResolvedTool[] = [];
   const seenNames = new Set<string>();
+  // Track route ids already surfaced via a fn-registry directTool wrapper
+  // **that actually contributed** so the direct-registry walk doesn't
+  // double-include them. Wrappers that didn't match the wanted tag set
+  // are NOT added here -- the underlying route may still match by its
+  // own tags and is allowed to surface under the prefix convention.
   const coveredRouteIds = new Set<string>();
 
   // Walk the fn registry first so explicit fn-side tags (incl. directTool
   // wrappers) take precedence over a parallel direct-registry walk.
+  // Skip non-direct deferred entries entirely: agentTool/mcpTool always
+  // throw on .resolve() by design, and a misconfigured directTool would
+  // throw too -- swallowing failures here would mask real config bugs,
+  // so we don't resolve such entries unless an explicit by-name ref
+  // forces it.
   const fnRegistry = ctx.getStore(ADAPTER_FN_REGISTRY) as
     | Map<string, FnEntry>
     | undefined;
   if (fnRegistry) {
     for (const [name, entry] of fnRegistry) {
-      if (isDeferredFn(entry) && entry.kind === "direct") {
-        coveredRouteIds.add(entry.targetId);
-      }
-      const fn = isDeferredFn(entry) ? entry.resolve(ctx, name) : entry;
-      const tags = fn.tags ?? [];
-      if (tags.some((t) => wantedSet.has(t))) {
+      if (isDeferredFn(entry)) {
+        if (entry.kind !== "direct") continue;
+        // Peek at the underlying route's tags via the direct registry
+        // first so we don't trigger the wrapper's full resolve unless
+        // it actually matches.
+        const peekedTags = peekDirectTags(ctx, entry.targetId);
+        if (!peekedTags.some((t) => wantedSet.has(t))) continue;
+        const fn = entry.resolve(ctx, name);
         out.push(toResolvedTool(name, fn, guard));
+        seenNames.add(name);
+        coveredRouteIds.add(entry.targetId);
+        continue;
+      }
+      const tags = entry.tags ?? [];
+      if (tags.some((t) => wantedSet.has(t))) {
+        out.push(toResolvedTool(name, entry, guard));
         seenNames.add(name);
       }
     }
@@ -324,6 +348,14 @@ function resolveByTags(
   }
 
   return out;
+}
+
+function peekDirectTags(ctx: CraftContext, routeId: string): Tag[] {
+  const directRegistry = ctx.getStore(ADAPTER_DIRECT_REGISTRY) as
+    | Map<string, DirectRouteMetadata>
+    | undefined;
+  // Routes register under the sanitised endpoint; look up the same way.
+  return directRegistry?.get(sanitizeEndpoint(routeId))?.tags ?? [];
 }
 
 function normalizeTags(value: Tag | Tag[]): Tag[] {

--- a/packages/ai/src/agent/tools/types.ts
+++ b/packages/ai/src/agent/tools/types.ts
@@ -1,4 +1,4 @@
-import type { CraftContext } from "@routecraft/routecraft";
+import type { CraftContext, Tag } from "@routecraft/routecraft";
 import type { FnOptions } from "../../fn/types.ts";
 
 /**
@@ -44,6 +44,15 @@ export interface DeferredFn {
    * convention.
    */
   readonly targetId: string;
+  /**
+   * Tags supplied as an explicit override at builder time (e.g.
+   * `directTool(routeId, { tags: [...] })`). When present these take
+   * precedence over the underlying registry's tags for tag-selector
+   * matching, so the user's override actually drives selection.
+   * Undefined when no override was supplied — the resolver then peeks
+   * the underlying registry's tags for the match decision.
+   */
+  readonly overrideTags?: readonly Tag[];
   /**
    * Resolve to a concrete `FnOptions`. Throws `RC5003` with a clear
    * message if the underlying registry entry is missing or incomplete.

--- a/packages/ai/src/agent/tools/types.ts
+++ b/packages/ai/src/agent/tools/types.ts
@@ -1,0 +1,72 @@
+import type { CraftContext } from "@routecraft/routecraft";
+import type { FnOptions } from "../../fn/types.ts";
+
+/**
+ * Discriminator value for {@link DeferredFn}. Plain symbol so a
+ * `typeof entry === "object" && BRAND in entry` check is enough for
+ * runtime detection without leaking implementation details.
+ *
+ * @internal
+ */
+export const DEFERRED_FN_BRAND = Symbol.for("routecraft.ai.fn.deferred");
+
+/**
+ * The kinds of underlying things `tools(...)` can wrap as a fn. Each
+ * builder helper (`directTool`, `agentTool`, `mcpTool`) emits one of
+ * these kinds; the kind is purely informational at runtime (used for
+ * error messages and the prefix-auto-resolution path in `tools()`).
+ *
+ * @experimental
+ */
+export type DeferredFnKind = "direct" | "agent" | "mcp";
+
+/**
+ * A fn that cannot be fully constructed at config-write time because it
+ * depends on registries (direct route metadata, agent registrations,
+ * MCP tool descriptors) that aren't populated until later in the
+ * context lifecycle.
+ *
+ * Created by the builder helpers; the `agentPlugin` stores deferred
+ * entries unmodified, and the agent runtime calls `.resolve(ctx, id)`
+ * just before building the LLM tool list, when all registries are live.
+ *
+ * @experimental
+ */
+export interface DeferredFn {
+  readonly [DEFERRED_FN_BRAND]: true;
+  /** Underlying source kind. Surfaces in error messages. */
+  readonly kind: DeferredFnKind;
+  /**
+   * Resolve to a concrete `FnOptions`. Throws `RC5003` with a clear
+   * message if the underlying registry entry is missing or incomplete.
+   *
+   * @param ctx - Live context (registries populated)
+   * @param fnId - The fn id this descriptor was registered as (used in
+   *   error messages so the user can find the offending config entry)
+   */
+  readonly resolve: (ctx: CraftContext, fnId: string) => FnOptions;
+}
+
+/**
+ * Type guard. Returns true when the value is a deferred fn descriptor
+ * emitted by `directTool` / `agentTool` / `mcpTool`.
+ *
+ * @internal
+ */
+export function isDeferredFn(value: unknown): value is DeferredFn {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    DEFERRED_FN_BRAND in value &&
+    (value as { [DEFERRED_FN_BRAND]: unknown })[DEFERRED_FN_BRAND] === true
+  );
+}
+
+/**
+ * What the fn registry actually holds. Eagerly authored fns are stored
+ * as `FnOptions`; entries from `directTool` / `agentTool` / `mcpTool`
+ * are stored as `DeferredFn` and resolved on first agent dispatch.
+ *
+ * @experimental
+ */
+export type FnEntry = FnOptions | DeferredFn;

--- a/packages/ai/src/agent/tools/types.ts
+++ b/packages/ai/src/agent/tools/types.ts
@@ -37,6 +37,14 @@ export interface DeferredFn {
   /** Underlying source kind. Surfaces in error messages. */
   readonly kind: DeferredFnKind;
   /**
+   * The underlying registered id this wrapper targets (route id for
+   * `direct`, agent id for `agent`, `<server>:<tool>` for `mcp`). Used
+   * by the `tools()` resolver for tag-selector dedup so a fn-registry
+   * wrapper supersedes the same route surfaced via the prefix
+   * convention.
+   */
+  readonly targetId: string;
+  /**
    * Resolve to a concrete `FnOptions`. Throws `RC5003` with a clear
    * message if the underlying registry entry is missing or incomplete.
    *

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -1,5 +1,6 @@
 import type { Exchange } from "@routecraft/routecraft";
 import type { LlmModelConfig, LlmModelId, LlmUsage } from "../llm/types.ts";
+import type { ToolSelection } from "./tools/selection.ts";
 
 /**
  * Resolves a user prompt from an exchange. When omitted, the agent derives
@@ -39,6 +40,17 @@ export interface AgentOptions {
    * exchange. Defaults to the body (string as-is, JSON for objects).
    */
   user?: AgentUserPromptSource;
+
+  /**
+   * Tools the agent is allowed to call. Build via
+   * `tools([...])` from `@routecraft/ai`. Resolved against the live
+   * fn / direct registries at agent dispatch time.
+   *
+   * When omitted, the agent inherits the context-default tool list set
+   * via `agentPlugin({ tools })`. An explicit value here replaces the
+   * default entirely (no extension).
+   */
+  tools?: ToolSelection;
 }
 
 /**

--- a/packages/ai/src/fn/fn.ts
+++ b/packages/ai/src/fn/fn.ts
@@ -45,4 +45,18 @@ export function validateFnOptions(id: string, options: FnOptions): void {
       message: `agentPlugin: fn "${id}" "handler" is required and must be a function.`,
     });
   }
+  if (options.tags !== undefined) {
+    if (!Array.isArray(options.tags)) {
+      throw rcError("RC5003", undefined, {
+        message: `agentPlugin: fn "${id}" "tags" must be an array of non-empty strings.`,
+      });
+    }
+    for (const t of options.tags) {
+      if (typeof t !== "string" || t.trim() === "") {
+        throw rcError("RC5003", undefined, {
+          message: `agentPlugin: fn "${id}" "tags" must contain only non-empty strings.`,
+        });
+      }
+    }
+  }
 }

--- a/packages/ai/src/fn/fn.ts
+++ b/packages/ai/src/fn/fn.ts
@@ -51,12 +51,15 @@ export function validateFnOptions(id: string, options: FnOptions): void {
         message: `agentPlugin: fn "${id}" "tags" must be an array of non-empty strings.`,
       });
     }
-    for (const t of options.tags) {
+    for (let i = 0; i < options.tags.length; i++) {
+      const t = options.tags[i];
       if (typeof t !== "string" || t.trim() === "") {
         throw rcError("RC5003", undefined, {
           message: `agentPlugin: fn "${id}" "tags" must contain only non-empty strings.`,
         });
       }
+      // Normalise: trim surrounding whitespace so exact selectors match.
+      options.tags[i] = t.trim();
     }
   }
 }

--- a/packages/ai/src/fn/index.ts
+++ b/packages/ai/src/fn/index.ts
@@ -1,4 +1,3 @@
-export { validateFnOptions } from "./fn.ts";
 export { ADAPTER_FN_REGISTRY } from "./store.ts";
 export type {
   FnHandlerContext,

--- a/packages/ai/src/fn/store.ts
+++ b/packages/ai/src/fn/store.ts
@@ -1,8 +1,13 @@
-import type { FnOptions } from "./types.ts";
+import type { FnEntry } from "../agent/tools/types.ts";
 
 /**
  * Store key for the registry of fns installed by `agentPlugin`. Read by
  * the agent tool loop at dispatch time (follow-up story).
+ *
+ * Entries are either eagerly authored `FnOptions` or deferred
+ * descriptors emitted by `directTool` / `agentTool` / `mcpTool`. The
+ * agent runtime resolves deferred entries on first dispatch when all
+ * registries are live.
  *
  * @experimental
  */
@@ -10,6 +15,6 @@ export const ADAPTER_FN_REGISTRY = Symbol.for("routecraft.adapter.fn.registry");
 
 declare module "@routecraft/routecraft" {
   interface StoreRegistry {
-    [ADAPTER_FN_REGISTRY]: Map<string, FnOptions>;
+    [ADAPTER_FN_REGISTRY]: Map<string, FnEntry>;
   }
 }

--- a/packages/ai/src/fn/types.ts
+++ b/packages/ai/src/fn/types.ts
@@ -1,6 +1,7 @@
 import type {
   CraftContext,
   ResolveKey,
+  Tag,
   logger as frameworkLogger,
 } from "@routecraft/routecraft";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
@@ -63,6 +64,17 @@ export interface FnOptions<TIn = unknown, TOut = unknown> {
    * input and a minimal handler context.
    */
   handler: (input: TIn, ctx: FnHandlerContext) => Promise<TOut> | TOut;
+
+  /**
+   * Tags used by selectors (e.g. agents whitelisting
+   * `{ tagged: "read-only" }`). Use the `KnownTag` literals where they
+   * fit ("read-only", "destructive", "idempotent") and any string
+   * otherwise.
+   *
+   * Empty/missing means no tags. Empty-string entries throw RC5003 at
+   * context init.
+   */
+  tags?: Tag[];
 }
 
 /**

--- a/packages/ai/src/fn/types.ts
+++ b/packages/ai/src/fn/types.ts
@@ -28,6 +28,14 @@ export interface FnHandlerContext {
    * (e.g. via `testFn` in unit tests).
    */
   readonly context?: CraftContext;
+  /**
+   * Correlation id of the calling exchange, when the fn was invoked
+   * from inside a running route or agent dispatch. Propagated to any
+   * child exchanges (e.g. direct route calls) so traces stay linked.
+   * The agent runtime populates this in a follow-up commit; today only
+   * `directTool`-built handlers consume it.
+   */
+  readonly correlationId?: string;
 }
 
 /**
@@ -71,8 +79,10 @@ export interface FnOptions<TIn = unknown, TOut = unknown> {
    * fit ("read-only", "destructive", "idempotent") and any string
    * otherwise.
    *
-   * Empty/missing means no tags. Empty-string entries throw RC5003 at
-   * context init.
+   * Must be an array (or omitted). Non-array values, non-string
+   * entries, and empty-string entries all throw RC5003 at context
+   * init. Surrounding whitespace is trimmed at storage so selectors
+   * match by exact value.
    */
   tags?: Tag[];
 }

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -117,6 +117,7 @@ export {
   AgentDestinationAdapter,
   agentPlugin,
   ADAPTER_AGENT_REGISTRY,
+  ADAPTER_TOOLS_DEFAULT,
 } from "./agent/index.ts";
 export type {
   AgentBinding,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -140,18 +140,24 @@ export type {
 } from "./fn/index.ts";
 
 // Tool builders: wrap registered routes / agents / MCP tools as
-// fn-shaped entries usable from `agentPlugin({ functions: { ... } })`
-// and selectable via `tools([...])` (follow-up commit).
+// fn-shaped entries usable from `agentPlugin({ functions: { ... } })`,
+// plus the `tools([...])` selector consumed by the agent runtime.
 export {
   agentTool,
   defaultFns,
   directTool,
   mcpTool,
   isDeferredFn,
+  isToolSelection,
+  tools,
   type DeferredFn,
   type DeferredFnKind,
   type FnEntry,
+  type ResolvedTool,
   type ToolBuilderOverrides,
+  type ToolGuard,
+  type ToolSelection,
+  type ToolsItem,
 } from "./agent/tools/index.ts";
 
 // Embedding adapter and plugin

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -139,6 +139,21 @@ export type {
   RegisteredFnId,
 } from "./fn/index.ts";
 
+// Tool builders: wrap registered routes / agents / MCP tools as
+// fn-shaped entries usable from `agentPlugin({ functions: { ... } })`
+// and selectable via `tools([...])` (follow-up commit).
+export {
+  agentTool,
+  defaultFns,
+  directTool,
+  mcpTool,
+  isDeferredFn,
+  type DeferredFn,
+  type DeferredFnKind,
+  type FnEntry,
+  type ToolBuilderOverrides,
+} from "./agent/tools/index.ts";
+
 // Embedding adapter and plugin
 export {
   embedding,

--- a/packages/ai/test/fn.test.ts
+++ b/packages/ai/test/fn.test.ts
@@ -155,6 +155,85 @@ describe("fn registration via agentPlugin", () => {
         .build(),
     ).rejects.toThrow(/id/i);
   });
+
+  /**
+   * @case Fn with tags is registered with tags preserved on the registry entry
+   * @preconditions agentPlugin functions entry with tags: ["read-only", "data"]
+   * @expectedResult Registry entry exposes the same tags array
+   */
+  test("agentPlugin preserves fn tags on the registry entry", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              currentTime: {
+                description: "Current UTC ISO 8601 timestamp.",
+                schema: z.object({}),
+                handler: async () => new Date().toISOString(),
+                tags: ["read-only", "idempotent"],
+              },
+            },
+          }),
+        ],
+      })
+      .build();
+
+    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("currentTime");
+    expect(entry?.tags).toEqual(["read-only", "idempotent"]);
+  });
+
+  /**
+   * @case Fn tags must be a non-empty-string array
+   * @preconditions agentPlugin functions entry with tags: ["read-only", ""]
+   * @expectedResult build() rejects with RC5003 mentioning tags
+   */
+  test("agentPlugin throws when a fn tag is empty", async () => {
+    await expect(
+      new ContextBuilder()
+        .with({
+          plugins: [
+            agentPlugin({
+              functions: {
+                bad: {
+                  description: "x",
+                  schema: z.object({}),
+                  handler: async () => 1,
+                  tags: ["read-only", ""],
+                },
+              },
+            }),
+          ],
+        })
+        .build(),
+    ).rejects.toThrow(/tags/i);
+  });
+
+  /**
+   * @case Fn tags must be an array (not a string)
+   * @preconditions agentPlugin functions entry with tags: "read-only" cast to any
+   * @expectedResult build() rejects with RC5003 mentioning tags
+   */
+  test("agentPlugin throws when fn tags is not an array", async () => {
+    await expect(
+      new ContextBuilder()
+        .with({
+          plugins: [
+            agentPlugin({
+              functions: {
+                bad: {
+                  description: "x",
+                  schema: z.object({}),
+                  handler: async () => 1,
+                  tags: "read-only" as unknown as string[],
+                },
+              },
+            }),
+          ],
+        })
+        .build(),
+    ).rejects.toThrow(/tags/i);
+  });
 });
 
 describe("testFn - exercise fn handlers in isolation", () => {

--- a/packages/ai/test/fn.test.ts
+++ b/packages/ai/test/fn.test.ts
@@ -41,7 +41,7 @@ describe("fn registration via agentPlugin", () => {
     const registry = t.ctx.getStore(ADAPTER_FN_REGISTRY);
     expect(registry).toBeInstanceOf(Map);
     expect(registry?.has("currentTime")).toBe(true);
-    expect(registry?.get("currentTime")?.description).toBe(
+    expect((registry?.get("currentTime") as FnOptions).description).toBe(
       "Current UTC timestamp in ISO 8601",
     );
   });
@@ -179,7 +179,9 @@ describe("fn registration via agentPlugin", () => {
       })
       .build();
 
-    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("currentTime");
+    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("currentTime") as
+      | FnOptions
+      | undefined;
     expect(entry?.tags).toEqual(["read-only", "idempotent"]);
   });
 

--- a/packages/ai/test/tools-builders.test.ts
+++ b/packages/ai/test/tools-builders.test.ts
@@ -219,6 +219,56 @@ describe("tool builders - directTool", () => {
   });
 });
 
+describe("tool builders - directTool dispatch", () => {
+  let t: TestContext | undefined;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case directTool dispatch sanitizes the endpoint when sending into a direct route
+   * @preconditions Direct route id contains characters that `encodeURIComponent` rewrites (e.g. "/")
+   * @expectedResult Handler dispatches into the route via the sanitised endpoint and returns the route body
+   */
+  test("dispatchDirect sanitizes the endpoint before send", async () => {
+    const inputSchema = z.object({ orderId: z.string() });
+    t = await testContext()
+      .routes([
+        craft()
+          .id("orders/fetch")
+          .description("Fetch an order from the orders subsystem.")
+          .input(inputSchema)
+          .from(direct())
+          .process((ex) => ({
+            ...ex,
+            body: {
+              orderId: (ex.body as { orderId: string }).orderId,
+              ok: true,
+            },
+          }))
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const desc = directTool("orders/fetch");
+    const fn = desc.resolve(t.ctx, "ordersFetch");
+    const result = await fn.handler(
+      { orderId: "abc" },
+      {
+        logger: undefined as unknown as Parameters<
+          typeof fn.handler
+        >[1]["logger"],
+        abortSignal: new AbortController().signal,
+        context: t.ctx,
+      },
+    );
+    expect(result).toMatchObject({ orderId: "abc", ok: true });
+  });
+});
+
 describe("tool builders - agentTool stub", () => {
   /**
    * @case agentTool returns a deferred descriptor whose resolve throws

--- a/packages/ai/test/tools-builders.test.ts
+++ b/packages/ai/test/tools-builders.test.ts
@@ -1,0 +1,316 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { z } from "zod";
+import { craft, direct, isRoutecraftError, log } from "@routecraft/routecraft";
+import { testContext, type TestContext } from "@routecraft/testing";
+import {
+  agentPlugin,
+  agentTool,
+  defaultFns,
+  directTool,
+  isDeferredFn,
+  mcpTool,
+  ADAPTER_FN_REGISTRY,
+  type FnEntry,
+  type FnOptions,
+} from "../src/index.ts";
+
+describe("tool builders - directTool", () => {
+  let t: TestContext | undefined;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case directTool returns a deferred descriptor branded as a fn entry
+   * @preconditions directTool("any-route")
+   * @expectedResult isDeferredFn returns true; kind === "direct"
+   */
+  test("directTool returns a deferred descriptor", () => {
+    const desc = directTool("fetch-order");
+    expect(isDeferredFn(desc)).toBe(true);
+    expect(desc.kind).toBe("direct");
+  });
+
+  /**
+   * @case directTool rejects empty/blank routeId
+   * @preconditions directTool("")
+   * @expectedResult RC5003 thrown synchronously at builder call
+   */
+  test("directTool throws on empty routeId", () => {
+    expect(() => directTool("")).toThrow(/routeId/i);
+    expect(() => directTool("   ")).toThrow(/routeId/i);
+  });
+
+  /**
+   * @case directTool resolves at dispatch time using the direct registry
+   * @preconditions Route registered with .description() and .input(); directTool referenced from agentPlugin functions
+   * @expectedResult Resolution returns FnOptions with description, schema, and tags pulled from the route
+   */
+  test("directTool resolves to FnOptions from the direct registry", async () => {
+    const inputSchema = z.object({ orderId: z.string() });
+
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              fetchOrder: directTool("fetch-order"),
+            },
+          }),
+        ],
+      })
+      .routes([
+        craft()
+          .id("fetch-order")
+          .description("Fetch an order by id from the orders DB.")
+          .input(inputSchema)
+          .tag("read-only")
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("fetchOrder") as
+      | FnEntry
+      | undefined;
+    expect(entry).toBeDefined();
+    expect(isDeferredFn(entry!)).toBe(true);
+
+    if (!isDeferredFn(entry!)) throw new Error("expected deferred entry");
+    const resolved = entry.resolve(t.ctx, "fetchOrder");
+    expect(resolved.description).toBe(
+      "Fetch an order by id from the orders DB.",
+    );
+    expect(resolved.schema).toBe(inputSchema);
+    expect(resolved.tags).toEqual(["read-only"]);
+    expect(typeof resolved.handler).toBe("function");
+  });
+
+  /**
+   * @case directTool overrides replace, do not merge
+   * @preconditions directTool("fetch-order", { description, tags }) overrides; route defines its own .description() and .tag()
+   * @expectedResult Resolved FnOptions uses the override values exactly
+   */
+  test("directTool overrides replace route-level values", async () => {
+    const overrideSchema = z.object({ q: z.string() });
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              custom: directTool("fetch-order", {
+                description: "OVERRIDE description.",
+                tags: ["destructive"],
+                schema: overrideSchema,
+              }),
+            },
+          }),
+        ],
+      })
+      .routes([
+        craft()
+          .id("fetch-order")
+          .description("Original description.")
+          .input(z.object({ orderId: z.string() }))
+          .tag("read-only")
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("custom");
+    if (!entry || !isDeferredFn(entry)) throw new Error("expected deferred");
+    const resolved = entry.resolve(t.ctx, "custom");
+    expect(resolved.description).toBe("OVERRIDE description.");
+    expect(resolved.schema).toBe(overrideSchema);
+    expect(resolved.tags).toEqual(["destructive"]);
+  });
+
+  /**
+   * @case directTool throws RC5003 at resolution when the route id is unknown
+   * @preconditions directTool("does-not-exist") with no matching route
+   * @expectedResult resolve() throws RC5003 listing known route ids
+   */
+  test("directTool resolution throws on unknown route id", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: { broken: directTool("does-not-exist") },
+          }),
+        ],
+      })
+      .routes([
+        craft().id("real-route").description("...").from(direct()).to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("broken");
+    if (!entry || !isDeferredFn(entry)) throw new Error("expected deferred");
+    let caught: unknown;
+    try {
+      entry.resolve(t.ctx, "broken");
+    } catch (err) {
+      caught = err;
+    }
+    expect(isRoutecraftError(caught)).toBe(true);
+    expect((caught as { rc?: string }).rc).toBe("RC5003");
+    expect((caught as Error).message).toMatch(/does-not-exist/);
+    expect((caught as Error).message).toMatch(/real-route/);
+  });
+
+  /**
+   * @case directTool resolution throws RC5003 when the underlying route has no description
+   * @preconditions Route lacks .description(); no description override on directTool
+   * @expectedResult resolve() throws RC5003 mentioning the route id
+   */
+  test("directTool resolution throws when route has no description", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: { needsDesc: directTool("no-desc") },
+          }),
+        ],
+      })
+      .routes([
+        craft().id("no-desc").input(z.object({})).from(direct()).to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("needsDesc");
+    if (!entry || !isDeferredFn(entry)) throw new Error("expected deferred");
+    expect(() => entry.resolve(t!.ctx, "needsDesc")).toThrow(/description/i);
+  });
+
+  /**
+   * @case directTool resolution throws RC5003 when the route has no input schema
+   * @preconditions Route has .description() but no .input(); no schema override
+   * @expectedResult resolve() throws RC5003 mentioning input
+   */
+  test("directTool resolution throws when route has no input schema", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: { needsSchema: directTool("no-input") },
+          }),
+        ],
+      })
+      .routes([
+        craft()
+          .id("no-input")
+          .description("Route with no input schema.")
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("needsSchema");
+    if (!entry || !isDeferredFn(entry)) throw new Error("expected deferred");
+    expect(() => entry.resolve(t!.ctx, "needsSchema")).toThrow(/input/i);
+  });
+});
+
+describe("tool builders - agentTool stub", () => {
+  /**
+   * @case agentTool returns a deferred descriptor whose resolve throws
+   * @preconditions agentTool("researcher")
+   * @expectedResult deferred kind === "agent"; resolve throws RC5003 mentioning the story
+   */
+  test("agentTool returns a deferred descriptor that resolves to a not-yet-supported error", () => {
+    const desc = agentTool("researcher");
+    expect(desc.kind).toBe("agent");
+    expect(() => desc.resolve(undefined as never, "research")).toThrow(
+      /not yet supported/i,
+    );
+  });
+
+  /**
+   * @case agentTool throws on empty agentId at build time
+   * @preconditions agentTool("")
+   * @expectedResult RC5003 thrown synchronously
+   */
+  test("agentTool throws on empty agentId", () => {
+    expect(() => agentTool("")).toThrow(/agentId/i);
+  });
+});
+
+describe("tool builders - mcpTool stub", () => {
+  /**
+   * @case mcpTool returns a deferred descriptor whose resolve throws
+   * @preconditions mcpTool("brave", "search")
+   * @expectedResult deferred kind === "mcp"; resolve throws RC5003 mentioning the story
+   */
+  test("mcpTool returns a deferred descriptor that resolves to a not-yet-supported error", () => {
+    const desc = mcpTool("brave", "search");
+    expect(desc.kind).toBe("mcp");
+    expect(() => desc.resolve(undefined as never, "searchWeb")).toThrow(
+      /not yet supported/i,
+    );
+  });
+
+  /**
+   * @case mcpTool throws on empty serverId or toolName
+   * @preconditions mcpTool with blank inputs
+   * @expectedResult RC5003 thrown synchronously
+   */
+  test("mcpTool throws on empty serverId / toolName", () => {
+    expect(() => mcpTool("", "search")).toThrow(/serverId/i);
+    expect(() => mcpTool("brave", "")).toThrow(/toolName/i);
+  });
+});
+
+describe("tool builders - defaultFns", () => {
+  /**
+   * @case defaultFns ships currentTime and randomUuid as eager FnOptions
+   * @preconditions Spread defaultFns into agentPlugin.functions
+   * @expectedResult Both registered, both have description / schema / handler / tags
+   */
+  test("defaultFns provides currentTime and randomUuid as eager fns", () => {
+    expect(defaultFns.currentTime).toBeDefined();
+    expect(isDeferredFn(defaultFns.currentTime!)).toBe(false);
+    const ct = defaultFns.currentTime as FnOptions;
+    expect(typeof ct.description).toBe("string");
+    expect(typeof ct.handler).toBe("function");
+    expect(ct.tags).toContain("read-only");
+
+    expect(defaultFns.randomUuid).toBeDefined();
+    const ru = defaultFns.randomUuid as FnOptions;
+    expect(typeof ru.description).toBe("string");
+    expect(typeof ru.handler).toBe("function");
+  });
+
+  /**
+   * @case currentTime handler returns an ISO 8601 timestamp string
+   * @preconditions Call defaultFns.currentTime.handler({}, ctx)
+   * @expectedResult Returns a parseable ISO string within a second of now
+   */
+  test("currentTime handler returns a fresh ISO timestamp", async () => {
+    const ct = defaultFns.currentTime as FnOptions<
+      Record<string, never>,
+      string
+    >;
+    const before = Date.now();
+    const out = await ct.handler(
+      {},
+      {
+        logger: undefined as unknown as Parameters<
+          typeof ct.handler
+        >[1]["logger"],
+        abortSignal: new AbortController().signal,
+      },
+    );
+    const after = Date.now();
+    const parsed = Date.parse(out);
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(after);
+  });
+});

--- a/packages/ai/test/tools-builders.test.ts
+++ b/packages/ai/test/tools-builders.test.ts
@@ -44,6 +44,31 @@ describe("tool builders - directTool", () => {
   });
 
   /**
+   * @case directTool override tags are trimmed at builder time
+   * @preconditions directTool("x", { tags: ["  read-only  "] })
+   * @expectedResult overrideTags on the descriptor is ["read-only"]
+   */
+  test("directTool trims override tags at builder time", () => {
+    const desc = directTool("x", { tags: ["  read-only  ", "data"] });
+    expect(desc.overrideTags).toEqual(["read-only", "data"]);
+  });
+
+  /**
+   * @case directTool override tags reject non-array and empty/blank entries
+   * @preconditions directTool with malformed tags overrides
+   * @expectedResult RC5003 thrown synchronously at builder call
+   */
+  test("directTool rejects malformed override tags", () => {
+    expect(() =>
+      directTool("x", { tags: "read-only" as unknown as string[] }),
+    ).toThrow(/tags/i);
+    expect(() => directTool("x", { tags: ["read-only", ""] })).toThrow(
+      /non-empty/i,
+    );
+    expect(() => directTool("x", { tags: ["   "] })).toThrow(/non-empty/i);
+  });
+
+  /**
    * @case directTool resolves at dispatch time using the direct registry
    * @preconditions Route registered with .description() and .input(); directTool referenced from agentPlugin functions
    * @expectedResult Resolution returns FnOptions with description, schema, and tags pulled from the route

--- a/packages/ai/test/tools-default.test.ts
+++ b/packages/ai/test/tools-default.test.ts
@@ -1,0 +1,188 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { ContextBuilder } from "@routecraft/routecraft";
+import { testContext, type TestContext } from "@routecraft/testing";
+import {
+  ADAPTER_AGENT_REGISTRY,
+  ADAPTER_TOOLS_DEFAULT,
+  agent,
+  agentPlugin,
+  defaultFns,
+  isToolSelection,
+  tools,
+  type AgentRegisteredOptions,
+} from "../src/index.ts";
+
+describe("agentPlugin context-default tools", () => {
+  let t: TestContext | undefined;
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Context-default tools are stored under ADAPTER_TOOLS_DEFAULT
+   * @preconditions agentPlugin({ tools: tools(["currentTime"]) })
+   * @expectedResult Store contains a ToolSelection at the new symbol
+   */
+  test("agentPlugin stores its tools default in the context store", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: { ...defaultFns },
+            tools: tools(["currentTime"]),
+          }),
+        ],
+      })
+      .build();
+
+    const stored = t.ctx.getStore(ADAPTER_TOOLS_DEFAULT);
+    expect(stored).toBeDefined();
+    expect(isToolSelection(stored!)).toBe(true);
+  });
+
+  /**
+   * @case Without a context default, ADAPTER_TOOLS_DEFAULT is unset
+   * @preconditions agentPlugin without tools field
+   * @expectedResult Store entry is undefined
+   */
+  test("agentPlugin without tools field does not set the default", async () => {
+    t = await testContext()
+      .with({ plugins: [agentPlugin({ functions: { ...defaultFns } })] })
+      .build();
+
+    expect(t.ctx.getStore(ADAPTER_TOOLS_DEFAULT)).toBeUndefined();
+  });
+
+  /**
+   * @case Two installs both supplying a default throw at context init
+   * @preconditions Two agentPlugin entries each with a tools: tools([...])
+   * @expectedResult build() rejects with RC5003 mentioning the conflict
+   */
+  test("two installs each supplying a tools default throws", async () => {
+    await expect(
+      new ContextBuilder()
+        .with({
+          plugins: [
+            agentPlugin({
+              functions: { ...defaultFns },
+              tools: tools(["currentTime"]),
+            }),
+            agentPlugin({
+              tools: tools(["randomUuid"]),
+            }),
+          ],
+        })
+        .build(),
+    ).rejects.toThrow(/default tool list is already set/i);
+  });
+
+  /**
+   * @case agentPlugin rejects a non-ToolSelection passed as tools
+   * @preconditions agentPlugin({ tools: ["currentTime"] as never })
+   * @expectedResult Synchronous RC5003 thrown at plugin construction
+   */
+  test("agentPlugin rejects a non-ToolSelection tools value", () => {
+    expect(() =>
+      agentPlugin({
+        tools: ["currentTime"] as never,
+      }),
+    ).toThrow(/tools\(/);
+  });
+});
+
+describe("agentPlugin per-agent tools field", () => {
+  let t: TestContext | undefined;
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Per-agent tools selection round-trips through the registry
+   * @preconditions agentPlugin agents entry with tools: tools([...])
+   * @expectedResult Registered options contain the same ToolSelection
+   */
+  test("per-agent tools selection is preserved on AgentRegisteredOptions", async () => {
+    const sel = tools(["currentTime"]);
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: { ...defaultFns },
+            agents: {
+              researcher: {
+                description: "Research workflow coordinator.",
+                model: "anthropic:claude-opus-4-7",
+                system: "Be precise.",
+                tools: sel,
+              },
+            },
+          }),
+        ],
+      })
+      .build();
+
+    const entry = t.ctx.getStore(ADAPTER_AGENT_REGISTRY)?.get("researcher") as
+      | AgentRegisteredOptions
+      | undefined;
+    expect(entry?.tools).toBe(sel);
+  });
+
+  /**
+   * @case agentPlugin throws when an agent's tools is not a ToolSelection
+   * @preconditions agents entry with tools: ["currentTime"] cast to never
+   * @expectedResult RC5003 thrown at context init naming the agent
+   */
+  test("agentPlugin throws when agent tools is not a ToolSelection", async () => {
+    await expect(
+      new ContextBuilder()
+        .with({
+          plugins: [
+            agentPlugin({
+              agents: {
+                broken: {
+                  description: "x",
+                  model: "anthropic:claude-opus-4-7",
+                  system: "y",
+                  tools: ["currentTime"] as never,
+                },
+              },
+            }),
+          ],
+        })
+        .build(),
+    ).rejects.toThrow(/agent "broken".*tools/i);
+  });
+});
+
+describe("agent() inline tools validation", () => {
+  /**
+   * @case Inline agent({ tools }) rejects a non-ToolSelection synchronously
+   * @preconditions agent({ ..., tools: ["currentTime"] as never })
+   * @expectedResult RC5003 thrown synchronously by validateAgentOptions
+   */
+  test("inline agent({ tools }) rejects a non-ToolSelection", () => {
+    expect(() =>
+      agent({
+        model: "anthropic:claude-opus-4-7",
+        system: "Be helpful.",
+        tools: ["currentTime"] as never,
+      }),
+    ).toThrow(/tools\(/);
+  });
+
+  /**
+   * @case Inline agent({ tools: tools([...]) }) accepts a ToolSelection
+   * @preconditions agent with tools: tools(["currentTime"])
+   * @expectedResult agent() returns a destination without throwing
+   */
+  test("inline agent({ tools: tools(...) }) accepts a ToolSelection", () => {
+    const dest = agent({
+      model: "anthropic:claude-opus-4-7",
+      system: "Be helpful.",
+      tools: tools(["currentTime"]),
+    });
+    expect(dest).toBeDefined();
+  });
+});

--- a/packages/ai/test/tools-selection.test.ts
+++ b/packages/ai/test/tools-selection.test.ts
@@ -1,0 +1,369 @@
+import { describe, test, expect, afterEach, vi } from "vitest";
+import { z } from "zod";
+import { craft, direct, isRoutecraftError, log } from "@routecraft/routecraft";
+import { testContext, type TestContext } from "@routecraft/testing";
+import {
+  agentPlugin,
+  defaultFns,
+  directTool,
+  isToolSelection,
+  tools,
+} from "../src/index.ts";
+
+async function buildCtx(opts: {
+  functions?: NonNullable<Parameters<typeof agentPlugin>[0]>["functions"];
+}): Promise<TestContext> {
+  return await testContext()
+    .with({
+      plugins: [agentPlugin({ functions: opts.functions ?? {} })],
+    })
+    .build();
+}
+
+describe("tools() resolver - shape", () => {
+  /**
+   * @case tools(items) returns a branded selection descriptor
+   * @preconditions tools(["currentTime"])
+   * @expectedResult isToolSelection returns true; resolve is callable
+   */
+  test("tools() returns a branded selection descriptor", () => {
+    const sel = tools(["currentTime"]);
+    expect(isToolSelection(sel)).toBe(true);
+    expect(typeof sel.resolve).toBe("function");
+  });
+
+  /**
+   * @case tools(items) rejects non-array input
+   * @preconditions tools("currentTime" as never)
+   * @expectedResult RC5003 thrown synchronously
+   */
+  test("tools() rejects non-array input", () => {
+    expect(() => tools("currentTime" as never)).toThrow(/array/i);
+  });
+});
+
+describe("tools() resolver - bare references", () => {
+  let t: TestContext | undefined;
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Bare fn name resolves against the fn registry
+   * @preconditions agentPlugin functions includes currentTime; resolve tools(["currentTime"])
+   * @expectedResult Single ResolvedTool named "currentTime" with description and handler from defaultFns
+   */
+  test("bare fn name resolves to a registered fn", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    const resolved = tools(["currentTime"]).resolve(t.ctx);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].name).toBe("currentTime");
+    expect(resolved[0].description).toMatch(/timestamp/i);
+    expect(typeof resolved[0].handler).toBe("function");
+    expect(resolved[0].tags).toContain("read-only");
+  });
+
+  /**
+   * @case direct_<routeId> bare ref resolves via the direct registry
+   * @preconditions Direct route "fetch-order" registered with description + input
+   * @expectedResult Single ResolvedTool named "direct_fetch-order"
+   */
+  test("direct_<routeId> bare ref resolves via the direct registry", async () => {
+    const inputSchema = z.object({ orderId: z.string() });
+    t = await testContext()
+      .routes([
+        craft()
+          .id("fetch-order")
+          .description("Fetch an order by id.")
+          .input(inputSchema)
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const resolved = tools(["direct_fetch-order"]).resolve(t.ctx);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].name).toBe("direct_fetch-order");
+    expect(resolved[0].description).toBe("Fetch an order by id.");
+    expect(resolved[0].schema).toBe(inputSchema);
+  });
+
+  /**
+   * @case Fn registry entry with id "direct_x" wins over the prefix convention
+   * @preconditions Route "x" registered AND fn registry entry named "direct_x" with explicit description
+   * @expectedResult Resolution returns the fn registry entry (not the route-derived one)
+   */
+  test("explicit fn registry entry wins over the prefix convention", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              direct_x: {
+                description: "Explicit fn registry entry.",
+                schema: z.object({}),
+                handler: () => "explicit",
+                tags: ["read-only"],
+              },
+            },
+          }),
+        ],
+      })
+      .routes([
+        craft()
+          .id("x")
+          .description("Route description.")
+          .input(z.object({}))
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const [resolved] = tools(["direct_x"]).resolve(t.ctx);
+    expect(resolved.description).toBe("Explicit fn registry entry.");
+  });
+
+  /**
+   * @case Unknown bare name throws RC5003
+   * @preconditions agentPlugin without "missing"; resolve tools(["missing"])
+   * @expectedResult RC5003 thrown listing available names
+   */
+  test("unknown bare name throws RC5003", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    let caught: unknown;
+    try {
+      tools(["missing"]).resolve(t.ctx);
+    } catch (err) {
+      caught = err;
+    }
+    expect(isRoutecraftError(caught)).toBe(true);
+    expect((caught as { rc?: string }).rc).toBe("RC5003");
+    expect((caught as Error).message).toMatch(/missing/);
+    expect((caught as Error).message).toMatch(/currentTime|randomUuid/);
+  });
+
+  /**
+   * @case agent_<id> reference surfaces a clear "story F" error
+   * @preconditions resolve tools(["agent_researcher"])
+   * @expectedResult RC5003 thrown mentioning sub-agent / follow-up story
+   */
+  test("agent_<id> bare ref throws not-yet-supported", async () => {
+    t = await buildCtx({});
+    expect(() => tools(["agent_researcher"]).resolve(t!.ctx)).toThrow(
+      /sub-agent|follow-up/i,
+    );
+  });
+
+  /**
+   * @case mcp_<server>_<tool> reference surfaces a clear "story E" error
+   * @preconditions resolve tools(["mcp_brave_search"])
+   * @expectedResult RC5003 thrown mentioning MCP / follow-up story
+   */
+  test("mcp_<...> bare ref throws not-yet-supported", async () => {
+    t = await buildCtx({});
+    expect(() => tools(["mcp_brave_search"]).resolve(t!.ctx)).toThrow(
+      /MCP|follow-up/i,
+    );
+  });
+});
+
+describe("tools() resolver - { name, guard }", () => {
+  let t: TestContext | undefined;
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case { name, guard } attaches the guard to the resolved tool
+   * @preconditions tools([{ name: "currentTime", guard: g }]) with currentTime registered
+   * @expectedResult ResolvedTool.guard is the supplied function
+   */
+  test("{ name, guard } attaches the guard", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    const guard = vi.fn();
+    const [resolved] = tools([{ name: "currentTime", guard }]).resolve(t.ctx);
+    expect(resolved.name).toBe("currentTime");
+    expect(resolved.guard).toBe(guard);
+  });
+
+  /**
+   * @case { name } with empty/blank string throws
+   * @preconditions tools([{ name: "" }])
+   * @expectedResult RC5003 thrown synchronously at resolve
+   */
+  test("{ name } rejects empty string", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    expect(() => tools([{ name: "" }]).resolve(t!.ctx)).toThrow(/non-empty/i);
+  });
+});
+
+describe("tools() resolver - tag selectors", () => {
+  let t: TestContext | undefined;
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Single-tag selector matches eager fn registry entries
+   * @preconditions defaultFns spread (currentTime + randomUuid both tagged "read-only")
+   * @expectedResult { tagged: "read-only" } resolves to both fns
+   */
+  test("{ tagged } matches eager fn registry entries", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name).sort();
+    expect(names).toEqual(["currentTime", "randomUuid"]);
+  });
+
+  /**
+   * @case Tag selector matches direct routes via the direct registry
+   * @preconditions Two direct routes; one tagged "read-only", one untagged
+   * @expectedResult Selector resolves to one ResolvedTool named "direct_<id>"
+   */
+  test("{ tagged } matches direct routes via the direct registry", async () => {
+    t = await testContext()
+      .routes([
+        craft()
+          .id("read-thing")
+          .description("Read a thing.")
+          .input(z.object({}))
+          .tag("read-only")
+          .from(direct())
+          .to(log()),
+        craft()
+          .id("untagged")
+          .description("Other thing.")
+          .input(z.object({}))
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
+    expect(resolved.map((r) => r.name)).toEqual(["direct_read-thing"]);
+  });
+
+  /**
+   * @case OR-of-tags: matches entries with ANY of the requested tags
+   * @preconditions defaultFns (read-only, idempotent for currentTime; read-only for randomUuid) + a fn tagged only "destructive"
+   * @expectedResult { tagged: ["idempotent", "destructive"] } returns currentTime and the destructive fn but not randomUuid
+   */
+  test("{ tagged: [...] } is an OR over the listed tags", async () => {
+    t = await buildCtx({
+      functions: {
+        ...defaultFns,
+        wipe: {
+          description: "Wipe data.",
+          schema: z.object({}),
+          handler: () => "ok",
+          tags: ["destructive"],
+        },
+      },
+    });
+    const resolved = tools([{ tagged: ["idempotent", "destructive"] }]).resolve(
+      t.ctx,
+    );
+    const names = resolved.map((r) => r.name).sort();
+    expect(names).toEqual(["currentTime", "wipe"]);
+  });
+
+  /**
+   * @case Tag-zero-match returns nothing and does not throw
+   * @preconditions No registered entry has tag "ghost"
+   * @expectedResult tools([{ tagged: "ghost" }]).resolve() returns []
+   */
+  test("tag-zero-match returns nothing without throwing", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    const resolved = tools([{ tagged: "ghost" }]).resolve(t.ctx);
+    expect(resolved).toEqual([]);
+  });
+
+  /**
+   * @case Tag selector applies its guard to every matched tool
+   * @preconditions tools([{ tagged: "read-only", guard: g }]); 2 fns matched
+   * @expectedResult Both ResolvedTools have ResolvedTool.guard === g
+   */
+  test("tag selector guard applies to every matched tool", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    const guard = vi.fn();
+    const resolved = tools([{ tagged: "read-only", guard }]).resolve(t.ctx);
+    expect(resolved.length).toBeGreaterThanOrEqual(1);
+    for (const tool of resolved) expect(tool.guard).toBe(guard);
+  });
+
+  /**
+   * @case Explicit refs win over tag-selector matches regardless of order
+   * @preconditions Tag selector matches "currentTime"; later (or earlier) explicit ref overrides with a different guard
+   * @expectedResult Final list contains "currentTime" with the explicit guard
+   */
+  test("explicit refs win over tag-selector matches", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    const explicitGuard = vi.fn();
+    const tagGuard = vi.fn();
+    const resolved = tools([
+      { tagged: "read-only", guard: tagGuard },
+      { name: "currentTime", guard: explicitGuard },
+    ]).resolve(t.ctx);
+    const ct = resolved.find((r) => r.name === "currentTime");
+    expect(ct?.guard).toBe(explicitGuard);
+  });
+});
+
+describe("tools() resolver - dedup and prefix-convention coverage", () => {
+  let t: TestContext | undefined;
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Same tool referenced twice surfaces only once
+   * @preconditions tools(["currentTime", "currentTime"])
+   * @expectedResult Single ResolvedTool
+   */
+  test("duplicate explicit refs are deduplicated", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    const resolved = tools(["currentTime", "currentTime"]).resolve(t.ctx);
+    expect(resolved).toHaveLength(1);
+  });
+
+  /**
+   * @case A directTool wrapper in functions and a direct route under the same name surface once
+   * @preconditions Route "fetch-order" + functions: { fetchOrder: directTool("fetch-order") }; tag "read-only" on both
+   * @expectedResult { tagged: "read-only" } returns one entry per tool name (no double include)
+   */
+  test("directTool fn registry wrapper supersedes the same direct route at tag matching", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              fetchOrder: directTool("fetch-order"),
+            },
+          }),
+        ],
+      })
+      .routes([
+        craft()
+          .id("fetch-order")
+          .description("Fetch an order.")
+          .input(z.object({ orderId: z.string() }))
+          .tag("read-only")
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name);
+    expect(names).toContain("fetchOrder");
+    expect(names).not.toContain("direct_fetch-order");
+  });
+});

--- a/packages/ai/test/tools-selection.test.ts
+++ b/packages/ai/test/tools-selection.test.ts
@@ -315,6 +315,108 @@ describe("tools() resolver - tag selectors", () => {
   });
 });
 
+describe("tools() resolver - regression", () => {
+  let t: TestContext | undefined;
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Tag selectors must NOT resolve agentTool/mcpTool stubs even when those stubs are present in the registry
+   * @preconditions agentPlugin functions has both an `agentTool("x")` and an `mcpTool("a","b")` deferred entry, plus eager fns; query unrelated tag
+   * @expectedResult Resolution returns matching eager fns; the stubs are silently skipped (not thrown)
+   */
+  test("tag walk silently skips non-direct deferred stubs", async () => {
+    const { agentTool, mcpTool } = await import("../src/index.ts");
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              ...defaultFns,
+              futureAgent: agentTool("researcher"),
+              futureMcp: mcpTool("brave", "search"),
+            },
+          }),
+        ],
+      })
+      .build();
+
+    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name).sort();
+    expect(names).toEqual(["currentTime", "randomUuid"]);
+  });
+
+  /**
+   * @case Tag selectors must NOT throw when a misconfigured directTool wrapper is in the registry; only explicit refs throw
+   * @preconditions functions: { broken: directTool("does-not-exist") }; tag selector that matches eager fns
+   * @expectedResult Selector returns the eager match; broken wrapper is silently skipped because its underlying route has no matching tag
+   */
+  test("tag walk silently skips a directTool wrapper when its target route is missing", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              ...defaultFns,
+              broken: directTool("does-not-exist"),
+            },
+          }),
+        ],
+      })
+      .build();
+
+    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name).sort();
+    expect(names).toEqual(["currentTime", "randomUuid"]);
+  });
+
+  /**
+   * @case Tools item that is an object lacking both name and tagged is rejected
+   * @preconditions tools([{ guard: () => {} } as never])
+   * @expectedResult RC5003 thrown when resolve() runs
+   */
+  test("tools() throws on object items lacking both name and tagged", async () => {
+    t = await testContext()
+      .with({
+        plugins: [agentPlugin({ functions: { ...defaultFns } })],
+      })
+      .build();
+
+    expect(() =>
+      tools([{ guard: () => undefined } as never]).resolve(t!.ctx),
+    ).toThrow(/name.*tagged|tagged.*name/i);
+  });
+
+  /**
+   * @case Whitespace-surrounded fn tag is trimmed at storage so exact selectors match
+   * @preconditions Fn registered with tags: [" read-only "]
+   * @expectedResult { tagged: "read-only" } matches the fn
+   */
+  test("fn tags are trimmed at storage", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              padded: {
+                description: "x",
+                schema: defaultFns.currentTime.schema,
+                handler: () => "ok",
+                tags: ["  read-only  "],
+              },
+            },
+          }),
+        ],
+      })
+      .build();
+
+    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
+    expect(resolved.map((r) => r.name)).toContain("padded");
+  });
+});
+
 describe("tools() resolver - dedup and prefix-convention coverage", () => {
   let t: TestContext | undefined;
   afterEach(async () => {

--- a/packages/ai/test/tools-selection.test.ts
+++ b/packages/ai/test/tools-selection.test.ts
@@ -390,6 +390,72 @@ describe("tools() resolver - regression", () => {
   });
 
   /**
+   * @case directTool override tags drive tag selection
+   * @preconditions Route tagged "read-only"; functions: { safeFetch: directTool("fetch-source", { tags: ["safe"] }) }; selector { tagged: "safe" }
+   * @expectedResult Wrapper "safeFetch" is included via the override tag, even though the underlying route doesn't carry "safe"
+   */
+  test("tag walk respects directTool override tags", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              safeFetch: directTool("fetch-source", { tags: ["safe"] }),
+            },
+          }),
+        ],
+      })
+      .routes([
+        craft()
+          .id("fetch-source")
+          .description("Fetch a source.")
+          .input(z.object({}))
+          .tag("read-only")
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const resolved = tools([{ tagged: "safe" }]).resolve(t.ctx);
+    expect(resolved.map((r) => r.name)).toContain("safeFetch");
+  });
+
+  /**
+   * @case directTool with override tags hides itself from selectors that match the underlying route's tags
+   * @preconditions Route tagged "read-only"; wrapper directTool with tags: ["safe"] (read-only NOT included); selector { tagged: "read-only" }
+   * @expectedResult Wrapper not included (its overrides don't carry read-only); underlying route surfaces under direct_<id>
+   */
+  test("directTool override tags replace the route's tags for matching", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              safeFetch: directTool("fetch-source", { tags: ["safe"] }),
+            },
+          }),
+        ],
+      })
+      .routes([
+        craft()
+          .id("fetch-source")
+          .description("Fetch a source.")
+          .input(z.object({}))
+          .tag("read-only")
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name);
+    expect(names).not.toContain("safeFetch");
+    expect(names).toContain("direct_fetch-source");
+  });
+
+  /**
    * @case Whitespace-surrounded fn tag is trimmed at storage so exact selectors match
    * @preconditions Fn registered with tags: [" read-only "]
    * @expectedResult { tagged: "read-only" } matches the fn

--- a/packages/routecraft/src/adapters/direct/index.ts
+++ b/packages/routecraft/src/adapters/direct/index.ts
@@ -82,5 +82,6 @@ export {
   ADAPTER_DIRECT_STORE,
   ADAPTER_DIRECT_OPTIONS,
   ADAPTER_DIRECT_REGISTRY,
+  getDirectChannel,
   sanitizeEndpoint,
 } from "./shared";

--- a/packages/routecraft/src/adapters/direct/shared.ts
+++ b/packages/routecraft/src/adapters/direct/shared.ts
@@ -126,6 +126,9 @@ export function registerRoute(
   }
   if (discovery?.input !== undefined) metadata.input = discovery.input;
   if (discovery?.output !== undefined) metadata.output = discovery.output;
+  if (discovery?.tags !== undefined && discovery.tags.length > 0) {
+    metadata.tags = [...discovery.tags];
+  }
   registry.set(endpoint, metadata);
 
   context.logger.debug(

--- a/packages/routecraft/src/adapters/direct/types.ts
+++ b/packages/routecraft/src/adapters/direct/types.ts
@@ -1,7 +1,7 @@
 import type { CraftContext } from "../../context";
 import type { Exchange } from "../../exchange";
 import type { RegisteredDirectEndpoint } from "../../registry";
-import type { RouteSchemas } from "../../route";
+import type { RouteSchemas, Tag } from "../../route";
 
 /**
  * @deprecated Use `CraftConfig.direct` (a `Pick<DirectBaseOptions, "channelType">`) instead.
@@ -55,6 +55,8 @@ export interface DirectRouteMetadata {
   input?: RouteSchemas;
   /** Output schemas (response body, response headers). */
   output?: RouteSchemas;
+  /** Tags used by selectors (e.g. `tools({ tagged: "read-only" })`). */
+  tags?: Tag[];
 }
 
 /** Base options shared between source and destination. */

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -429,9 +429,9 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   }
 
   /**
-   * Tag the next route. Accepts a single tag or an array. Subsequent
-   * `.tag()` / `.tags()` calls before `.from()` accumulate (deduplicated,
-   * insertion order preserved). Empty strings are rejected.
+   * Tag the next route. Accepts a single tag or an array; multiple
+   * `.tag()` calls before `.from()` accumulate (deduplicated, insertion
+   * order preserved). Empty strings are rejected.
    *
    * Tags drive selectors like `tools({ tagged: "read-only" })` in
    * `@routecraft/ai`; use the `KnownTag` literals (`"read-only"`,
@@ -442,7 +442,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     const incoming = (Array.isArray(value) ? value : [value]).map((t) => {
       if (typeof t !== "string" || t.trim() === "") {
         throw rcError("RC2001", undefined, {
-          message: `Route .tag()/.tags() value must be a non-empty string.`,
+          message: `Route .tag() value must be a non-empty string.`,
         });
       }
       return t;
@@ -452,14 +452,6 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     for (const t of incoming) if (!merged.includes(t)) merged.push(t);
     this.mergeDiscovery({ tags: merged });
     return this;
-  }
-
-  /**
-   * Alias for `.tag([...])`. Reads more naturally when assigning multiple
-   * tags at once.
-   */
-  tags(values: Tag[]): this {
-    return this.tag(values);
   }
 
   private mergeDiscovery(partial: Partial<RouteDiscovery>): void {

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -7,6 +7,7 @@ import {
   type ErrorHandler,
   type RouteDiscovery,
   type RouteSchemas,
+  type Tag,
 } from "./route.ts";
 import {
   CraftContext,
@@ -425,6 +426,40 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   output(schemas: RouteSchemas | StandardSchemaV1): this {
     this.mergeDiscovery({ output: this.normalizeSchemas(schemas) });
     return this;
+  }
+
+  /**
+   * Tag the next route. Accepts a single tag or an array. Subsequent
+   * `.tag()` / `.tags()` calls before `.from()` accumulate (deduplicated,
+   * insertion order preserved). Empty strings are rejected.
+   *
+   * Tags drive selectors like `tools({ tagged: "read-only" })` in
+   * `@routecraft/ai`; use the `KnownTag` literals (`"read-only"`,
+   * `"destructive"`, `"idempotent"`) where they fit, and any string
+   * otherwise.
+   */
+  tag(value: Tag | Tag[]): this {
+    const incoming = (Array.isArray(value) ? value : [value]).map((t) => {
+      if (typeof t !== "string" || t.trim() === "") {
+        throw rcError("RC2001", undefined, {
+          message: `Route .tag()/.tags() value must be a non-empty string.`,
+        });
+      }
+      return t;
+    });
+    const existing = this.pendingOptions?.discovery?.tags ?? [];
+    const merged = [...existing];
+    for (const t of incoming) if (!merged.includes(t)) merged.push(t);
+    this.mergeDiscovery({ tags: merged });
+    return this;
+  }
+
+  /**
+   * Alias for `.tag([...])`. Reads more naturally when assigning multiple
+   * tags at once.
+   */
+  tags(values: Tag[]): this {
+    return this.tag(values);
   }
 
   private mergeDiscovery(partial: Partial<RouteDiscovery>): void {

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -445,7 +445,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
           message: `Route .tag() value must be a non-empty string.`,
         });
       }
-      return t;
+      return t.trim();
     });
     const existing = this.pendingOptions?.discovery?.tags ?? [];
     const merged = [...existing];

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -49,6 +49,8 @@ export {
   type ForwardFn,
   type RouteDiscovery,
   type RouteSchemas,
+  type KnownTag,
+  type Tag,
 } from "./route.ts";
 
 export { type Source, type SourceMeta } from "./operations/from.ts";

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -203,6 +203,7 @@ export {
   ADAPTER_DIRECT_STORE,
   ADAPTER_DIRECT_OPTIONS,
   ADAPTER_DIRECT_REGISTRY,
+  getDirectChannel,
   sanitizeEndpoint,
 } from "./adapters/direct/index.ts";
 export { type TimerOptions } from "./adapters/timer/index.ts";

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -94,7 +94,7 @@ export type Tag = KnownTag | (string & {});
  * `input` / `output` for framework-enforced validation regardless of adapter.
  *
  * Set via the `.title()`, `.description()`, `.input()`, `.output()`,
- * `.tag()` and `.tags()` builder methods. All fields are optional.
+ * and `.tag()` builder methods. All fields are optional.
  */
 export interface RouteDiscovery {
   /** Human-readable display title for discovery consumers (agents, docs). */

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -74,12 +74,27 @@ export interface RouteSchemas {
 }
 
 /**
+ * Well-known tag values surfaced as autocomplete suggestions while still
+ * accepting any user-defined string. Use these consistently to enable
+ * downstream filtering (e.g. an agent that only whitelists `"read-only"`
+ * tools).
+ */
+export type KnownTag = "read-only" | "destructive" | "idempotent";
+
+/**
+ * Tag value: one of the framework's well-known tags or any user string.
+ * The `& {}` keeps autocomplete on `KnownTag` while accepting arbitrary
+ * strings.
+ */
+export type Tag = KnownTag | (string & {});
+
+/**
  * Route-level discovery bundle. Adapters that maintain registries (direct,
  * mcp) mirror these fields into their registry entries; the engine uses
  * `input` / `output` for framework-enforced validation regardless of adapter.
  *
- * Set via the `.title()`, `.description()`, `.input()`, and `.output()`
- * builder methods. All fields are optional.
+ * Set via the `.title()`, `.description()`, `.input()`, `.output()`,
+ * `.tag()` and `.tags()` builder methods. All fields are optional.
  */
 export interface RouteDiscovery {
   /** Human-readable display title for discovery consumers (agents, docs). */
@@ -90,6 +105,11 @@ export interface RouteDiscovery {
   input?: RouteSchemas;
   /** Output schemas runtime-enforced before the primary destination. */
   output?: RouteSchemas;
+  /**
+   * Tags used by tag-based selectors (e.g. agents whitelisting
+   * `{ tagged: "read-only" }`). Empty/missing means no tags.
+   */
+  tags?: Tag[];
 }
 
 /**


### PR DESCRIPTION
## Summary

First half of issue #224. Lands the entire **agent tool DSL and resolution layer** — tags, builders, the `tools([...])` selector, and storage on agents and the context — without yet wiring tools into the LLM call. Lets us merge a complete, fully-tested vertical slice and review the runtime piece in a focused follow-up PR.

After this PR, the user-facing surface is final. The agent runtime accepts and validates `tools:` everywhere, but does not yet pass tools to `generateText`. The follow-up PR (Commit E) flips that on.

## What ships

```ts
agentPlugin({
  functions: {
    ...defaultFns,                                 // currentTime, randomUuid
    sendSlack: { description, schema, handler, tags: ["destructive", "messaging"] },
    fetchOrder: directTool("fetch-order"),         // wraps a direct route as a fn
  },
  agents: {
    researcher: {
      description, model, system,
      tools: tools([
        "currentTime",
        "fetchOrder",
        "direct_cancel-order",                     // prefix convention
        { name: "sendSlack", guard: requireApproval },
        { tagged: "read-only" },                   // single
        { tagged: ["read-only", "idempotent"] },   // OR-of-tags
      ]),
    },
  },
  tools: tools(["currentTime", { tagged: "read-only" }]),  // context default
})
```

### Five commits, one per layer

| Commit | What |
|---|---|
| `ec5685b` | `KnownTag` / `Tag` types, `.tag()` route builder, tags on `RouteDiscovery` and `DirectRouteMetadata` |
| `86434d2` | `tags?: Tag[]` on `FnOptions` + validation |
| `40e6c54` | `directTool` builder with deferred resolution; `agentTool` / `mcpTool` stubs (story E/F); `defaultFns` |
| `b3faaa9` | `tools(items)` resolver with prefix auto-resolution and tag selectors |
| `df3af49` | Context-default `agentPlugin({ tools })` and per-agent `tools:` field with validation |

### Key design decisions baked in

- **Tags**: `KnownTag = "read-only" \| "destructive" \| "idempotent"`, plus `(string & {})` so any user string is accepted with autocomplete on the literals.
- **Builder helpers** (`directTool` / `agentTool` / `mcpTool`) return deferred descriptors; resolution happens at agent dispatch time when the direct registry / agent registry are populated. `agentTool` / `mcpTool` are exported as throwing stubs so the `tools()` prefix auto-resolution can recognise `agent_*` / `mcp_*` and surface a clear "story E/F" message rather than treating them as unknown fn names.
- **`tools([...])`** accepts three item forms only: bare string, `{ name, guard? }`, `{ tagged, guard? }`. **No description / schema overrides at the use site** — definition belongs at registration. Want a custom view of a tool? Register it as a separate fn (e.g. `safeFetchOrder: directTool("fetch-order", { description, tags })`).
- **Resolution rules**: bare names hit the fn registry first; `direct_*` falls back to wrapping a direct route via `directTool` if no fn-registry match. `agent_*` / `mcp_*` throw not-yet-supported. Explicit refs always win over tag-selector matches; tag-zero-match returns nothing (no throw).
- **Tag selectors walk both registries** strictly (no best-effort skip). A fn-registry `directTool` wrapper supersedes the same direct route surfaced via the prefix convention — `DeferredFn.targetId` makes that dedup work.
- **Override vs extend**: explicit `tools:` on an agent replaces context default entirely. Matches the existing precedent (`mergedOptions` in `LlmDestinationAdapter`, cron / mail adapter resolution rules).
- **Guards stay inline** (`{ name, guard }` and `{ tagged, guard }`). A separate `guards:` map was considered for declarative tool lists (markdown loading) and deferred to a follow-up — purely additive when needed, no design change required.

## What is NOT in this PR

- No `AgentDestinationAdapter.send()` change. Agents still call `generateText({ prompt, system })` with no `tools` argument.
- No `tools:` resolution at runtime, no Vercel `tool({ inputSchema, execute })` bridge, no `stopWhen` / `maxSteps`.
- `agentTool` and `mcpTool` are throwing stubs, intentional. Real implementations land in stories F and E.

These ship in the next PR (Commit E).

## Tests

- `885 passed | 1 skipped` across the full workspace.
- Per-area:
  - `tools-builders.test.ts` — `directTool` deferred resolution, `agentTool` / `mcpTool` stubs, `defaultFns` shape and `currentTime` runtime.
  - `tools-selection.test.ts` — `tools()` resolver: bare refs, prefix convention, fn-registry-wins-over-prefix, unknown-name throws, agent_*/mcp_* stubs, `{ name, guard }`, single + OR-of-tags selectors, tag-zero-match, explicit-wins-over-tag-selector, dedup with `directTool` wrappers.
  - `tools-default.test.ts` — context-default storage, missing default is undefined, two-installs-conflict throws, non-`ToolSelection` throws (top-level + per-agent + inline), per-agent `tools:` round-trips through the registry.
  - `fn.test.ts` — `tags?: Tag[]` validation on `FnOptions`.

## Test plan

- [ ] CI green
- [ ] CodeRabbit / cubic-dev-ai review
- [ ] Verify the runtime is genuinely a no-op for `tools:` (i.e. defining tools doesn't break existing agent behaviour)

Refs #224. Follow-up PR: agent runtime tool-calling loop via Vercel SDK (`generateText({ tools, stopWhen })`).

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the agent tool DSL and resolution layer: tags on routes/fns, builder helpers, the `tools([...])` selector, and context/agent storage. Agents now accept and validate `tools`, but tools are not yet passed to the LLM (part 1 of #224).

- New Features
  - Tags: `KnownTag`/`Tag`, `.tag()` on routes (trimmed, deduped), mirrored into direct-route metadata.
  - Functions: `tags?: Tag[]` on `FnOptions` with validation and trimming.
  - Builders: `directTool(routeId, overrides?)` (deferred; overrides description/schema/tags), `agentTool`/`mcpTool` stubs, and `defaultFns` (`currentTime`, `randomUuid`).
  - Selection: `tools([...])` accepts names, `{ name, guard }`, and `{ tagged, guard }`; `direct_*` auto-wrap, dedup, explicit-over-tag precedence; `agent_*`/`mcp_*` error until follow-ups.
  - Storage: context default via `agentPlugin({ tools })` (single default enforced) and per-agent `tools`; validated inline and at init; stored under `ADAPTER_TOOLS_DEFAULT`. Public exports added from `@routecraft/ai`; `getDirectChannel` and tag types re-exported from `@routecraft/routecraft`.
  - Docs: added “Agent tools (experimental DSL)” to the plugins reference.

- Bug Fixes
  - Builder overrides now only allow description/schema/tags; attach guards at use site via `tools([{ name, guard }])`.
  - `tools([...])` rejects object items missing both `name` and `tagged`.
  - Tag selectors skip non-direct deferred stubs and only resolve `directTool` wrappers that match; wrappers supersede the same route surfaced via `direct_*`.
  - `directTool` dispatch sanitizes route ids and propagates a correlation id; `FnHandlerContext` supports `correlationId`.
  - Route and fn tags are trimmed at storage so exact selectors match.
  - Tag selection respects `directTool(..., { tags })` overrides; override tags replace the route’s tags for matching, and are now trimmed, deduped, and validated (non-array/blank entries throw).

<sup>Written for commit 3301fba797109c5a784de759db3d12f126210ae9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

