### PR TITLE
refactor(ai)!: agentPlugin({ defaultOptions }) for context-level agent defaults (#224 refinement)

### DIFF
--- a/.standards/README.md
+++ b/.standards/README.md
@@ -9,9 +9,9 @@ Internal development standards for Routecraft contributors (human and AI). These
 | Document | Scope |
 |----------|-------|
 | [Adapter Architecture](./adapter-architecture.md) | Patterns, file structure, facade, authoring guide, skeletons, and anti-patterns for adapters |
-| [Naming Policy](./naming-policy.md) | Source/Destination vs Server/Client naming conventions for interfaces and option types |
+| [Naming Policy](./naming-policy.md) | Source/Destination vs Server/Client naming, schema field names (`input`/`output`), prompt-source field names |
 | [Error and Logging Policy](./error-and-logging-policy.md) | Throw/boundary rules, structured logging, level semantics, error code philosophy |
-| [Type Safety and Schemas](./type-safety-and-schemas.md) | Type flow policy, Standard Schema usage, plugin vs config vs store guidance |
+| [Type Safety and Schemas](./type-safety-and-schemas.md) | Type flow policy, factory option types (no `Partial<>` on factory args), Standard Schema usage, plugin vs config vs store guidance |
 | [Type Safety Registries](./type-safety-registries.md) | Declaration-merging registries for typed adapters and endpoints; codegen direction |
 
 ## Related

--- a/.standards/naming-policy.md
+++ b/.standards/naming-policy.md
@@ -24,6 +24,47 @@ Examples: `DirectServerOptions` / `DirectClientOptions`, `McpServerOptions` / `M
 
 Adapters that only act as source or only as destination (timer, simple, log, noop) use a single options type: **XxxOptions** (e.g., `TimerOptions`, `LogOptions`). Do not use Server/Client in their option names.
 
+## Schema field names
+
+When an adapter or builder method declares a Standard Schema for a body / payload, use **`input`** and **`output`**. Do not invent variants like `schema`, `inputSchema`, `outputSchema`, `requestSchema`, or `responseSchema`, unless there is a standard.
+
+### On the route builder
+
+```ts
+craft()
+  .from(direct())
+  .input(BodySchema)    // validates the source body
+  .output(ResultSchema) // validates the final result
+```
+
+### On adapter option types
+
+```ts
+agent({
+  system: "...",
+  output: ResultSchema, // declared output shape, validated after the call
+})
+
+llm("anthropic:claude-sonnet-4-6", {
+  output: ResultSchema,
+})
+
+const greet: FnOptions = {
+  description: "Greets someone",
+  input: NameSchema,    // validates the LLM-supplied input
+  handler: async (input) => `hello ${input.name}`,
+}
+```
+
+### Exceptions
+
+- **External wire formats** keep their on-the-wire names. The MCP protocol defines tool descriptors with `inputSchema` / `outputSchema`; types that mirror the wire format (e.g., `McpTool` in `packages/ai/src/mcp/types.ts`) keep those names. Field-level renames here would lie about the protocol.
+- **Domain-specific prompt sources** use a domain-accurate name, not `input`. Chat-shaped adapters use `user` (paired with `system`); embedding adapters use `using`. These compute the value the model consumes, which is conceptually different from a validating schema. The `input` name is reserved for schema fields, so collision-free naming forces a different word here.
+
+### Why
+
+A consistent vocabulary across the framework (`input` / `output`) means a reader can move between adapters without learning per-adapter renames. The previous mix (`schema`, `outputSchema`, etc.) made it harder to reason about which adapter validated what.
+
 ## Summary
 
 | What | Convention |
@@ -31,5 +72,7 @@ Adapters that only act as source or only as destination (timer, simple, log, noo
 | Interfaces | `Source` / `Destination` (pipeline role; all adapters) |
 | Option types (two-sided) | `XxxServerOptions` / `XxxClientOptions` |
 | Option types (single-role) | `XxxOptions` |
+| Schema fields | `input` / `output` (route builder and adapter options) |
+| Domain prompt source | `user` (chat) or `using` (embedding); not `input` |
 
-For the structural pattern (base, union, intersection), see [adapter-architecture.md](./adapter-architecture.md).
+For the structural pattern (base, union, intersection), see [adapter-architecture.md](./adapter-architecture.md). For factory option-type rules, see [type-safety-and-schemas.md](./type-safety-and-schemas.md#factory-option-types).

--- a/.standards/type-safety-and-schemas.md
+++ b/.standards/type-safety-and-schemas.md
@@ -11,7 +11,7 @@ Routecraft must be **100% type safe**. The exchange body (or destination result)
 ### What this means
 
 - **Sources** (e.g., `direct`, `mcp`, `simple`): Declare the body type `T` they produce. When a schema is provided, infer `T` from the schema (e.g., `StandardSchemaV1.InferOutput<S>`) so the route is typed from the start.
-- **Destinations** (e.g., `to`, `tap`, `enrich`): Declare the result type `R` they return. When a schema or typed option is provided (e.g., `llm(..., { outputSchema })`), the result type must reflect it.
+- **Destinations** (e.g., `to`, `tap`, `enrich`): Declare the result type `R` they return. When a schema or typed option is provided (e.g., `llm(..., { output })`), the result type must reflect it.
 - **Steps** (transform, process, filter, validate, header, split, aggregate, enrich): Input is `Current`; output type must be explicit. After a step, the route's `Current` type must be updated so the next step receives the correct type.
 - **Helpers** (e.g., `only`, `json`): Preserve or infer types. `only(getValue, into)` should type `getValue` as `(r: R) => V` and, when `into` is a string literal, allow the builder to infer the enriched body type.
 - **Runtime:** The builder chain is fully typed. The runnable `Route` and event/consumer handlers receive `Exchange` (body: `unknown`) at runtime; use `Route<T>` when you know the body type, or narrow/assert in handlers.
@@ -22,6 +22,53 @@ Routecraft must be **100% type safe**. The exchange body (or destination result)
 2. **Generics must flow.** Every public API that accepts or produces a body/result type must use generics (`Source<T>`, `Destination<T, R>`, `Transformer<T, R>`, `DestinationAggregator<T, R>`) and the builder must propagate `Current` through the chain.
 3. **New operations and adapters:** Declare input and output types; ensure the route builder's `Current` is updated after the step so downstream steps stay typed.
 4. **Tests:** Add type-level tests (e.g., `expectTypeOf`) where new type inference or propagation is added, so regressions are caught.
+
+---
+
+## Factory option types
+
+Adapter factories must use the option interface directly. Do not wrap factory args in `Partial<>`.
+
+### Rule
+
+```ts
+// Good: required fields are required, optional fields are marked ? on the interface.
+export interface EmbeddingOptions<T = unknown> {
+  using: (exchange: Exchange<T>) => string | string[];
+}
+
+export function embedding<T>(
+  modelId: EmbeddingModelId,
+  options: EmbeddingOptions<T>, // not Partial<EmbeddingOptions<T>>
+): Destination<T, EmbeddingResult> { ... }
+```
+
+```ts
+// Bad: Partial<> hides the requirement, so embedding(modelId, {}) typechecks
+// but throws at runtime.
+export function embedding<T>(
+  modelId: EmbeddingModelId,
+  options?: Partial<EmbeddingOptions<T>>,
+): Destination<T, EmbeddingResult> { ... }
+```
+
+If every field on the option interface is optional, the factory parameter itself can be optional (`options?: HttpOptions`). The interface stays the source of truth for what is required.
+
+### Where `Partial<>` is allowed
+
+`Partial<>` is a legitimate type for **partial overrides**, not for factory args:
+
+| Site | Why `Partial<>` is correct |
+|------|---------------------------|
+| Plugin `defaultOptions?: Partial<T>` | Defaults can supply any subset of fields. |
+| `MergedOptions<T>.options: Partial<T>` | Adapter instance options merge with context defaults. |
+| Internal merge helpers (e.g., `MailClientManager.resolveImapOptions(account, overrides: Partial<MailServerOptions>)`) | Per-call overrides are partial by definition. |
+
+### Why
+
+The factory is the user-facing system boundary, so it carries the strongest contract. Wrapping its args in `Partial<>` defeats the type system: the interface declares `using` as required, but `Partial<>` quietly makes it optional, so the failure surfaces at runtime instead of at the call site. The embedding adapter shipped with this exact bug for the duration the wrapper was in place.
+
+The framework boundary (plugin defaults, `MergedOptions<T>`) is a different surface where partial values are the actual contract. Keep `Partial<>` there; remove it from factories.
 
 ---
 

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -1643,8 +1643,8 @@ craft()
   .id('summarise')
   .from(source)
   .enrich(llm('anthropic:claude-haiku-4-5-20251001', {
-    systemPrompt: 'Summarise the following in one sentence.',
-    userPrompt: (ex) => ex.body.content,
+    system: 'Summarise the following in one sentence.',
+    user: (ex) => ex.body.content,
   }))
   .to(log())
 // Result merged into body: { ..., text: '...', usage: { inputTokens, outputTokens } }
@@ -1661,9 +1661,9 @@ craft()
   .id('classify')
   .from(source)
   .enrich(llm('openai:gpt-4o', {
-    systemPrompt: 'Classify the sentiment of the text.',
-    userPrompt: (ex) => ex.body.text,
-    outputSchema: sentimentSchema,
+    system: 'Classify the sentiment of the text.',
+    user: (ex) => ex.body.text,
+    output: sentimentSchema,
   }))
   .to(log())
 // result.output is typed as { sentiment: string, confidence: number }
@@ -1677,9 +1677,9 @@ Model ID format: `"provider:model-name"` (e.g., `"ollama:llama3.2"`, `"anthropic
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `systemPrompt` | `string \| (exchange) => string` | — | System prompt (static or derived from exchange) |
-| `userPrompt` | `string \| (exchange) => string` | — | User prompt (static or derived from exchange) |
-| `outputSchema` | `StandardSchemaV1` | — | Zod/Valibot/ArkType schema for structured output |
+| `system` | `string \| (exchange) => string` | — | System prompt (static or derived from exchange) |
+| `user` | `string \| (exchange) => string` | — | User prompt (static or derived from exchange) |
+| `output` | `StandardSchemaV1` | — | Zod/Valibot/ArkType schema for structured output |
 | `temperature` | `number` | — | Sampling temperature |
 | `maxTokens` | `number` | — | Maximum tokens to generate |
 | `topP` | `number` | — | Top-p sampling |
@@ -1691,7 +1691,7 @@ Model ID format: `"provider:model-name"` (e.g., `"ollama:llama3.2"`, `"anthropic
 | Field | Type | Description |
 |-------|------|-------------|
 | `text` | `string` | Raw model output |
-| `output` | `T` | Parsed structured output (only when `outputSchema` provided) |
+| `output` | `T` | Parsed structured output (only when an `output` schema was supplied) |
 | `usage.inputTokens` | `number` | Input token count |
 | `usage.outputTokens` | `number` | Output token count |
 | `usage.totalTokens` | `number` | Total token count |

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -1723,13 +1723,17 @@ craft()
   }))
   .to(direct('reply'))
 
-// By name: register once, use from any route in the context.
+// By name: register once, use from any route in the context. Per-agent
+// fields can be omitted when defaultOptions supplies them.
 agentPlugin({
+  defaultOptions: {
+    model: 'anthropic:claude-opus-4-7',
+  },
   agents: {
     summariser: {
       description: 'Summarises documents into bullet points',
-      model: 'anthropic:claude-opus-4-7',
       system: 'Be concise.',
+      // model inherited from defaultOptions
     },
   },
 })
@@ -1741,7 +1745,7 @@ craft()
   .to(log())
 ```
 
-Model ID format: `"provider:model-name"` (same as `llm()`). You can also pass an inline `LlmModelConfig` object to skip `llmPlugin()` registration when you have ad-hoc credentials.
+Model ID format: `"provider:model-name"` (same as `llm()`). The provider must be registered via `llmPlugin({ providers: {...} })`. There is no inline-credentials escape hatch on `agent({...})`; centralised wiring via `llmPlugin` is the only path.
 
 **Supported providers:** `openai`, `anthropic`, `ollama`, `openrouter`, `gemini`
 
@@ -1749,9 +1753,11 @@ Model ID format: `"provider:model-name"` (same as `llm()`). You can also pass an
 
 | Option | Type | Default | Required | Description |
 |--------|------|---------|----------|-------------|
-| `model` | `LlmModelId \| LlmModelConfig` | -- | Yes | `"provider:model"` string (resolved via `llmPlugin`) or an inline `LlmModelConfig` object |
+| `model` | `LlmModelId` | -- | No\* | `"provider:model"` string resolved via `llmPlugin`. Required unless `defaultOptions.model` supplies a fallback; otherwise dispatch throws `RC5003` |
 | `system` | `string` | -- | Yes | System prompt. Load from disk yourself when sourcing from a file |
 | `user` | `(exchange) => string` | body as-is / JSON | No | Override for deriving the user prompt. Defaults to body (string as-is, JSON for objects) |
+| `tools` | `ToolSelection` | -- | No | Tool whitelist built via `tools([...])`. Inherits `defaultOptions.tools` when omitted; an explicit value replaces the default entirely |
+| `output` | `StandardSchemaV1` | -- | No | Schema for structured output. Validated and parsed onto `AgentResult.output` after dispatch (runtime ships in a follow-up release) |
 
 **`AgentRegisteredOptions` (entries in `agentPlugin({ agents: {...} })`, for by-name reuse):** same as `AgentOptions` plus:
 
@@ -1766,14 +1772,16 @@ The id is the record key in `agentPlugin({ agents: { [id]: {...} } })`.
 | Field | Type | Description |
 |-------|------|-------------|
 | `text` | `string` | Generated text from the model |
+| `output` | `T` | Parsed structured output (only when an `output` schema was supplied; runtime ships in a follow-up) |
 | `usage.inputTokens` | `number` | Input token count (when reported) |
 | `usage.outputTokens` | `number` | Output token count (when reported) |
 | `usage.totalTokens` | `number` | Total token count (when reported) |
 
 **Resolution semantics:**
 
-- `agent("name")` only resolves registered agents. To call a route-backed agent from another route, use `.to(direct("route-id"))` -- `direct` runs the full pipeline of the target route, `agent("name")` runs the registered agent's LLM call inline.
-- Duplicate registered agent ids, missing description, or a malformed model string fail at context init with `RC5003` (Adapter misconfigured).
+- `agent("name")` only resolves registered agents. To call a route-backed agent from another route, use `.to(direct("route-id"))`. `direct` runs the full pipeline of the target route; `agent("name")` runs the registered agent's LLM call inline.
+- Model resolution at dispatch is `instance value > defaultOptions.model > throw RC5003`.
+- Duplicate registered agent ids, missing description, malformed model string when present, or a non-`ToolSelection` `tools` value fail at context init with `RC5003` (Adapter misconfigured).
 - Referencing an unknown registered agent name fails at dispatch with `RC5004` (No handler available).
 
 Provider credentials are configured once in `llmPlugin()` and shared across all `agent()` calls. See [Plugins reference](/docs/reference/plugins).

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -460,12 +460,12 @@ agentPlugin({
   functions: {
     currentTime: {
       description: 'Current UTC timestamp in ISO 8601',
-      schema: z.object({}),
+      input: z.object({}),
       handler: async () => new Date().toISOString(),
     },
     sendSlackMessage: {
       description: 'Post a message to a Slack channel',
-      schema: z.object({ channel: z.string(), text: z.string() }),
+      input: z.object({ channel: z.string(), text: z.string() }),
       handler: async (input, ctx) => {
         ctx.logger.info({ channel: input.channel }, 'Posting to Slack')
         return { ok: true }
@@ -486,14 +486,14 @@ agentPlugin({
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `description` | `string` | Yes | Human-readable description. Used in observability and as the tool description when exposed to an agent |
-| `schema` | `StandardSchemaV1` | Yes | Standard Schema for the input (Zod, Valibot, ArkType, etc.). Validated at invocation time |
+| `input` | `StandardSchemaV1` | Yes | Standard Schema for the input (Zod, Valibot, ArkType, etc.). Validated at invocation time |
 | `handler` | `(input, ctx) => Promise<TOut> \| TOut` | Yes | Called with validated input and a `FnHandlerContext` (`{ logger, abortSignal, context }`) |
 
-**Errors at context init (`RC5003`):** missing description, schema is not a Standard Schema, schema's `validate` is not a function, missing handler, empty id key, duplicate id across installs.
+**Errors at context init (`RC5003`):** missing description, `input` is not a Standard Schema, `input`'s `validate` is not a function, missing handler, empty id key, duplicate id across installs.
 
 ### Testing fns
 
-There is no public `invokeFn` helper -- agents are the only legitimate dispatcher for registered fns. To exercise a fn's schema and handler in isolation in tests, use `testFn` from `@routecraft/testing`:
+There is no public `invokeFn` helper -- agents are the only legitimate dispatcher for registered fns. To exercise a fn's input schema and handler in isolation in tests, use `testFn` from `@routecraft/testing`:
 
 ```ts
 import { testFn } from '@routecraft/testing'
@@ -501,7 +501,7 @@ import { z } from 'zod'
 
 const greet = {
   description: 'Greets someone',
-  schema: z.object({ name: z.string() }),
+  input: z.object({ name: z.string() }),
   handler: async (input, ctx) => `hello ${input.name}`,
 }
 
@@ -509,7 +509,7 @@ const out = await testFn(greet, { name: 'alice' })
 // out === 'hello alice'
 ```
 
-`testFn` validates the input against the schema, calls the handler with a synthetic `{ logger, abortSignal }` context, and returns the handler's output. Validation failures throw `RC5002`. It works structurally on any `{ schema, handler }` shape, so real `FnOptions` values pass without modification.
+`testFn` validates the input against the `input` schema, calls the handler with a synthetic `{ logger, abortSignal }` context, and returns the handler's output. Validation failures throw `RC5002`. It works structurally on any `{ input, handler }` shape, so real `FnOptions` values pass without modification.
 
 ### Agent tools (experimental DSL)
 
@@ -529,7 +529,7 @@ import {
 agentPlugin({
   functions: {
     ...defaultFns,                                  // currentTime, randomUuid (read-only, idempotent)
-    sendSlack: { description, schema, handler, tags: ['destructive', 'messaging'] },
+    sendSlack: { description, input, handler, tags: ['destructive', 'messaging'] },
     fetchOrder: directTool('fetch-order'),          // wraps a direct route as a fn
   },
   agents: {
@@ -565,7 +565,7 @@ Resolution rules:
 - Final list deduplicated by tool name.
 - Explicit refs always win over tag-selector matches, regardless of position in the list.
 - A `directTool(routeId)` fn-registry wrapper supersedes the same direct route surfaced via the prefix convention.
-- Schema, description, and tag overrides at the use site are intentionally not supported. Definition is a registration concern: register a separate fn with `directTool(routeId, { description, schema, tags })` if you need a custom view.
+- Input, description, and tag overrides at the use site are intentionally not supported. Definition is a registration concern: register a separate fn with `directTool(routeId, { description, input, tags })` if you need a custom view.
 
 #### Builders
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -515,7 +515,7 @@ const out = await testFn(greet, { name: 'alice' })
 
 > **Status: DSL-only.** The configuration surface below is fully implemented and validated; the agent runtime that actually presents these tools to the LLM and dispatches them lands in a follow-up release. Setting `tools:` on an agent today is a no-op at dispatch time.
 
-Tags, the `tools([...])` selector, the builder helpers, and the context-default tool list register and validate cleanly so user code can be written against the final shape now.
+Tags, the `tools([...])` selector, the builder helpers, and the context-level `defaultOptions` bag register and validate cleanly so user code can be written against the final shape now.
 
 ```ts
 import {
@@ -534,7 +534,7 @@ agentPlugin({
   },
   agents: {
     researcher: {
-      description, model, system,
+      description, system,                          // model + tools inherit from defaultOptions
       tools: tools([
         'currentTime',                              // bare ref
         'fetchOrder',
@@ -545,7 +545,10 @@ agentPlugin({
       ]),
     },
   },
-  tools: tools(['currentTime', { tagged: 'read-only' }]),  // context default
+  defaultOptions: {
+    model: 'anthropic:claude-opus-4-7',             // applies to agents that omit `model`
+    tools: tools(['currentTime', { tagged: 'read-only' }]),
+  },
 })
 ```
 
@@ -585,9 +588,35 @@ type KnownTag = 'read-only' | 'destructive' | 'idempotent';
 
 Any user string is also accepted; the `KnownTag` literals just power autocomplete.
 
-#### Context-default tool list
+#### Context-level `defaultOptions`
 
-`agentPlugin({ tools: tools([...]) })` registers a default tool list for the context. Agents that omit their own `tools:` field inherit it. An agent that sets `tools:` replaces the default entirely (override, not extend). Two installs each supplying a default throw at context init -- combine selectors into a single `tools([...])` call.
+Mirrors the `llmPlugin({ defaultOptions })` pattern: a single bag of values applied to any agent that omits the corresponding field. Two fields today, easy to extend.
+
+| Field | Type | Inherited by |
+|---|---|---|
+| `defaultOptions.model` | `LlmModelId` (string) | Agents that omit `model` |
+| `defaultOptions.tools` | `ToolSelection` (from `tools([...])`) | Agents that omit `tools` |
+
+Resolution at dispatch is per-key: instance value > plugin default > (for `model`) throw, (for `tools`) `undefined`. Agents that set the field replace the default entirely (override, not extend).
+
+Two `agentPlugin` installs that each set the same field throw at context init. Two installs that set DIFFERENT fields merge cleanly.
+
+```ts
+agentPlugin({
+  defaultOptions: {
+    model: 'anthropic:claude-opus-4-7',
+    tools: tools(['currentTime', { tagged: 'read-only' }]),
+  },
+  agents: {
+    researcher: { description, system },                            // inherits both
+    fast:       { description, model: 'anthropic:claude-haiku-4-5', system },
+  },
+})
+```
+
+#### Soft dependency on `llmPlugin`
+
+Agent model references use the `"providerId:modelName"` format and resolve against the LLM provider registry populated by `llmPlugin`. **You must install `llmPlugin` with the relevant providers.** This is intentional: provider credentials live in one place, agents reference them by id. There is no inline-credentials escape hatch on `agent({...})` -- if you want centralised wiring, use `llmPlugin`.
 
 ### Typed fn ids (`FnRegistry`)
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -434,14 +434,17 @@ craft()
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `description` | `string` | Yes | Human-readable description. Surfaces in observability and is used as the tool description when the agent is exposed to other agents |
-| `model` | `LlmModelId \| LlmModelConfig` | Yes | `"provider:model"` string (resolved via `llmPlugin`) or an inline `LlmModelConfig` |
+| `model` | `LlmModelId` | No\* | `"provider:model"` string resolved via `llmPlugin`. Required unless `defaultOptions.model` supplies a fallback; otherwise dispatch throws `RC5003` |
 | `system` | `string` | Yes | System prompt |
 | `user` | `(exchange) => string` | No | Override for deriving the user prompt from the incoming exchange |
+| `tools` | `ToolSelection` | No | Tool whitelist built via `tools([...])`. Inherits `defaultOptions.tools` when omitted; an explicit value replaces the default entirely |
+| `output` | `StandardSchemaV1` | No | Schema for structured output. Validated and parsed onto `AgentResult.output` after dispatch (runtime ships in a follow-up release) |
 
 **Resolution semantics:**
 
 - `agent("name")` resolves only registered agents. Route-backed agents are called via `.to(direct("route-id"))` and run the full pipeline of the target route; `agent("name")` runs the registered agent's LLM call inline.
-- The plugin throws at context init (`RC5003`) on: duplicate ids across installs, empty id key, missing description, invalid model string, or empty system.
+- The plugin throws at context init (`RC5003`) on: duplicate ids across installs, empty id key, missing description, malformed model string when present, empty system, or a non-`ToolSelection` `tools` value.
+- The agent throws at dispatch (`RC5003`) when neither the agent nor `defaultOptions.model` supplies a model.
 - `agent("unknown")` fails at dispatch (`RC5004`) with the list of registered agent ids.
 
 See the [`agent`](/docs/reference/adapters#agent) adapter for usage patterns.
@@ -493,7 +496,7 @@ agentPlugin({
 
 ### Testing fns
 
-There is no public `invokeFn` helper -- agents are the only legitimate dispatcher for registered fns. To exercise a fn's input schema and handler in isolation in tests, use `testFn` from `@routecraft/testing`:
+There is no public `invokeFn` helper. Agents are the only legitimate dispatcher for registered fns. To exercise a fn's input schema and handler in isolation in tests, use `testFn` from `@routecraft/testing`:
 
 ```ts
 import { testFn } from '@routecraft/testing'
@@ -616,7 +619,7 @@ agentPlugin({
 
 #### Soft dependency on `llmPlugin`
 
-Agent model references use the `"providerId:modelName"` format and resolve against the LLM provider registry populated by `llmPlugin`. **You must install `llmPlugin` with the relevant providers.** This is intentional: provider credentials live in one place, agents reference them by id. There is no inline-credentials escape hatch on `agent({...})` -- if you want centralised wiring, use `llmPlugin`.
+Agent model references use the `"providerId:modelName"` format and resolve against the LLM provider registry populated by `llmPlugin`. **You must install `llmPlugin` with the relevant providers.** This is intentional: provider credentials live in one place, and agents reference them by id. There is no inline-credentials escape hatch on `agent({...})`; centralised wiring via `llmPlugin` is the only path.
 
 ### Typed fn ids (`FnRegistry`)
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -75,8 +75,8 @@ const ctx = new ContextBuilder()
       )
       .enrich(http({ url: (ex) => ex.body.url }))
       .to(llm('anthropic:claude-sonnet-4-6', {
-        systemPrompt: 'Summarize the following webpage content concisely.',
-        userPrompt: (ex) => String(ex.body),
+        system: 'Summarize the following webpage content concisely.',
+        user: (ex) => String(ex.body),
       })),
   ])
   .build();

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -42,6 +42,16 @@ export function validateAgentOptions(options: AgentOptions): void {
       message: `Agent: "tools" must be the result of tools([...]).`,
     });
   }
+  if (options.output !== undefined) {
+    const standard = (
+      options.output as { ["~standard"]?: { validate?: unknown } }
+    )["~standard"];
+    if (typeof standard?.validate !== "function") {
+      throw rcError("RC5003", undefined, {
+        message: `Agent: "output" must be a Standard Schema (Zod/Valibot/ArkType/etc.).`,
+      });
+    }
+  }
 }
 
 /**

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -43,6 +43,11 @@ export function validateAgentOptions(options: AgentOptions): void {
     });
   }
   if (options.output !== undefined) {
+    if (options.output === null || typeof options.output !== "object") {
+      throw rcError("RC5003", undefined, {
+        message: `Agent: "output" must be a Standard Schema (Zod/Valibot/ArkType/etc.).`,
+      });
+    }
     const standard = (
       options.output as { ["~standard"]?: { validate?: unknown } }
     )["~standard"];

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -21,7 +21,14 @@ export function validateAgentOptions(options: AgentOptions): void {
       message: `Agent: "system" is required and must be a non-empty string.`,
     });
   }
-  if (typeof options.model === "string") {
+  // `model` is optional: inheritable from agentPlugin({ defaultOptions:
+  // { model } }) at dispatch time. Validate the shape only when present.
+  if (options.model !== undefined) {
+    if (typeof options.model !== "string" || options.model.trim() === "") {
+      throw rcError("RC5003", undefined, {
+        message: `Agent: "model" must be a non-empty "providerId:modelName" string when present.`,
+      });
+    }
     try {
       parseProviderModel(options.model);
     } catch {
@@ -29,14 +36,6 @@ export function validateAgentOptions(options: AgentOptions): void {
         message: `Agent: "model" string must be in "providerId:modelName" form (e.g. ollama:llama3). Got: "${options.model}"`,
       });
     }
-  } else if (
-    options.model === null ||
-    typeof options.model !== "object" ||
-    typeof (options.model as { provider?: unknown }).provider !== "string"
-  ) {
-    throw rcError("RC5003", undefined, {
-      message: `Agent: "model" must be either a "providerId:modelName" string or an LlmModelConfig object with a "provider" field.`,
-    });
   }
   if (options.tools !== undefined && !isToolSelection(options.tools)) {
     throw rcError("RC5003", undefined, {

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -69,8 +69,8 @@ export class AgentDestinationAdapter implements Destination<
 
     const { config, modelName } = resolveModel(merged.model, context);
 
-    const systemPrompt = merged.system;
-    const userPrompt =
+    const system = merged.system;
+    const user =
       merged.user !== undefined
         ? resolvePrompt(merged.user, exchange)
         : resolveUserPromptDefault(exchange);
@@ -82,8 +82,8 @@ export class AgentDestinationAdapter implements Destination<
         temperature: DEFAULT_TEMPERATURE,
         maxTokens: DEFAULT_MAX_TOKENS,
       },
-      systemPrompt,
-      userPrompt,
+      system,
+      user,
     });
 
     const out: AgentResult = { text: result.text };

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -11,8 +11,12 @@ import {
   resolvePrompt,
   resolveUserPromptDefault,
 } from "../llm/shared.ts";
-import { ADAPTER_AGENT_REGISTRY } from "./store.ts";
+import {
+  ADAPTER_AGENT_DEFAULT_OPTIONS,
+  ADAPTER_AGENT_REGISTRY,
+} from "./store.ts";
 import type {
+  AgentDefaultOptions,
   AgentOptions,
   AgentRegisteredOptions,
   AgentResult,
@@ -52,14 +56,23 @@ export class AgentDestinationAdapter implements Destination<
 
   async send(exchange: Exchange<unknown>): Promise<AgentResult> {
     const context = getExchangeContext(exchange);
-    const options = this.resolveOptions(context);
+    const baseOptions = this.resolveOptions(context);
+    const merged = mergeWithDefaults(baseOptions, context);
 
-    const { config, modelName } = resolveModel(options.model, context);
+    if (merged.model === undefined) {
+      throw rcError("RC5003", undefined, {
+        message:
+          `Agent: no "model" supplied and no agentPlugin({ defaultOptions: { model } }) is set on this context. ` +
+          `Specify "model" on the agent or set a context-level default.`,
+      });
+    }
 
-    const systemPrompt = options.system;
+    const { config, modelName } = resolveModel(merged.model, context);
+
+    const systemPrompt = merged.system;
     const userPrompt =
-      options.user !== undefined
-        ? resolvePrompt(options.user, exchange)
+      merged.user !== undefined
+        ? resolvePrompt(merged.user, exchange)
         : resolveUserPromptDefault(exchange);
 
     const result = await callLlm({
@@ -122,14 +135,7 @@ export class AgentDestinationAdapter implements Destination<
     if (this.binding.kind === "by-name") metadata["agent"] = this.binding.name;
     if (this.binding.kind === "inline") {
       const model = this.binding.options.model;
-      if (typeof model === "string") {
-        metadata["model"] = model;
-      } else {
-        const modelId = (model as { modelId?: string }).modelId;
-        metadata["model"] = modelId
-          ? `${model.provider}:${modelId}`
-          : model.provider;
-      }
+      if (typeof model === "string") metadata["model"] = model;
     }
     if (r.usage?.inputTokens !== undefined) {
       metadata["inputTokens"] = r.usage.inputTokens;
@@ -139,4 +145,30 @@ export class AgentDestinationAdapter implements Destination<
     }
     return metadata;
   }
+}
+
+/**
+ * Merge per-agent options with the context-level defaults registered
+ * via `agentPlugin({ defaultOptions: {...} })`. Per-agent values win
+ * per key; missing fields fall back to defaults (mirrors the LLM
+ * destination's `mergedOptions` pattern).
+ *
+ * @internal
+ */
+function mergeWithDefaults(
+  base: AgentOptions | AgentRegisteredOptions,
+  context: CraftContext | undefined,
+): AgentOptions | AgentRegisteredOptions {
+  const defaults = context?.getStore(
+    ADAPTER_AGENT_DEFAULT_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
+  ) as AgentDefaultOptions | undefined;
+  if (!defaults) return base;
+  const out = { ...base } as AgentOptions | AgentRegisteredOptions;
+  if (out.model === undefined && defaults.model !== undefined) {
+    out.model = defaults.model;
+  }
+  if (out.tools === undefined && defaults.tools !== undefined) {
+    out.tools = defaults.tools;
+  }
+  return out;
 }

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -1,8 +1,12 @@
 export { agent } from "./agent.ts";
 export { AgentDestinationAdapter, type AgentBinding } from "./destination.ts";
 export { agentPlugin, type AgentPluginOptions } from "./plugin.ts";
-export { ADAPTER_AGENT_REGISTRY, ADAPTER_TOOLS_DEFAULT } from "./store.ts";
+export {
+  ADAPTER_AGENT_DEFAULT_OPTIONS,
+  ADAPTER_AGENT_REGISTRY,
+} from "./store.ts";
 export type {
+  AgentDefaultOptions,
   AgentOptions,
   AgentRegisteredOptions,
   AgentResult,

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -27,7 +27,7 @@ export interface AgentPluginOptions {
   /**
    * Ad-hoc in-process functions available to agents (via `tools: [...]`
    * in follow-up stories). Keyed by the fn id; each entry is either an
-   * eagerly-authored `FnOptions` (description, schema, handler) or a
+   * eagerly-authored `FnOptions` (description, input, handler) or a
    * deferred descriptor emitted by a builder helper such as
    * `directTool(routeId)` / `agentTool(agentId)` / `mcpTool(server, tool)`.
    * Deferred descriptors resolve at agent dispatch time when all
@@ -101,7 +101,7 @@ function validateRegisteredAgent(
  *   functions: {
  *     currentTime: {
  *       description: "Current UTC timestamp in ISO 8601",
- *       schema: z.object({}),
+ *       input: z.object({}),
  *       handler: async () => new Date().toISOString(),
  *     },
  *   },

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -45,10 +45,10 @@ export interface AgentPluginOptions {
    * Context-level defaults applied to any agent that doesn't override
    * them. Mirrors the `llmPlugin({ defaultOptions })` pattern:
    *
-   * - `model` (`LlmModelId` string) — used by agents that omit `model`.
+   * - `model` (`LlmModelId` string) is used by agents that omit `model`.
    *   Requires `llmPlugin` to be installed with the relevant provider.
-   * - `tools` (`ToolSelection` from `tools([...])`) — used by agents
-   *   that omit `tools`. Override-not-extend; an explicit `tools:` on
+   * - `tools` (`ToolSelection` from `tools([...])`) is used by agents
+   *   that omit `tools`. Override-not-extend: an explicit `tools:` on
    *   an agent replaces this default entirely.
    *
    * Multiple `agentPlugin` installs that each set the same default
@@ -164,7 +164,7 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
         }
         if (entry === null || typeof entry !== "object") {
           throw rcError("RC5003", undefined, {
-            message: `agentPlugin: fn "${id}" entry must be an object with description, schema, and handler.`,
+            message: `agentPlugin: fn "${id}" entry must be an object with description, input, and handler.`,
           });
         }
         if (!isDeferredFn(entry)) {

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -4,19 +4,23 @@ import {
   type CraftPlugin,
 } from "@routecraft/routecraft";
 import { validateAgentOptions } from "./agent.ts";
-import { ADAPTER_AGENT_REGISTRY, ADAPTER_TOOLS_DEFAULT } from "./store.ts";
+import {
+  ADAPTER_AGENT_DEFAULT_OPTIONS,
+  ADAPTER_AGENT_REGISTRY,
+} from "./store.ts";
 import { validateFnOptions } from "../fn/fn.ts";
 import { ADAPTER_FN_REGISTRY } from "../fn/store.ts";
-import type { AgentRegisteredOptions } from "./types.ts";
+import { parseProviderModel } from "../llm/shared.ts";
+import type { AgentDefaultOptions, AgentRegisteredOptions } from "./types.ts";
 import { isDeferredFn, type FnEntry } from "./tools/types.ts";
-import { isToolSelection, type ToolSelection } from "./tools/selection.ts";
+import { isToolSelection } from "./tools/selection.ts";
 
 export interface AgentPluginOptions {
   /**
    * Agents available for by-name lookup via `agent("id")`. Keyed by the
-   * agent id; each entry provides the agent's description, model, system,
-   * and optional user-prompt override. Duplicate ids across multiple
-   * `agentPlugin` installs throw at context init.
+   * agent id; each entry provides the agent's description, optional
+   * model, system, and optional user-prompt override. Duplicate ids
+   * across multiple `agentPlugin` installs throw at context init.
    */
   agents?: Record<string, AgentRegisteredOptions>;
 
@@ -38,14 +42,19 @@ export interface AgentPluginOptions {
   functions?: Record<string, FnEntry>;
 
   /**
-   * Context-default tool list for agents that don't specify their own
-   * `tools:` field. Build via `tools([...])`. An agent that does set
-   * `tools:` replaces this default entirely (override, not extend).
+   * Context-level defaults applied to any agent that doesn't override
+   * them. Mirrors the `llmPlugin({ defaultOptions })` pattern:
    *
-   * Multiple `agentPlugin` installs that each provide a default throw
-   * at context init: a context can only have one default tool list.
+   * - `model` (`LlmModelId` string) — used by agents that omit `model`.
+   *   Requires `llmPlugin` to be installed with the relevant provider.
+   * - `tools` (`ToolSelection` from `tools([...])`) — used by agents
+   *   that omit `tools`. Override-not-extend; an explicit `tools:` on
+   *   an agent replaces this default entirely.
+   *
+   * Multiple `agentPlugin` installs that each set the same default
+   * field throw at context init.
    */
-  tools?: ToolSelection;
+  defaultOptions?: AgentDefaultOptions;
 }
 
 function validateRegisteredAgent(
@@ -102,12 +111,7 @@ function validateRegisteredAgent(
 export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
   const agents = options.agents ?? {};
   const functions = options.functions ?? {};
-  const defaultTools = options.tools;
-  if (defaultTools !== undefined && !isToolSelection(defaultTools)) {
-    throw rcError("RC5003", undefined, {
-      message: `agentPlugin: "tools" must be the result of tools([...]).`,
-    });
-  }
+  const defaultOptions = validatePluginDefaults(options.defaultOptions);
   return {
     apply(ctx: CraftContext) {
       // Merge into an existing registry when present so multiple
@@ -180,20 +184,84 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
         );
       }
 
-      if (defaultTools !== undefined) {
-        const existingDefault = ctx.getStore(
-          ADAPTER_TOOLS_DEFAULT as keyof import("@routecraft/routecraft").StoreRegistry,
-        );
-        if (existingDefault !== undefined) {
-          throw rcError("RC5003", undefined, {
-            message: `agentPlugin: a default tool list is already set on this context. Combine selectors into a single tools([...]) call.`,
-          });
-        }
+      if (defaultOptions !== undefined) {
+        const existing = ctx.getStore(
+          ADAPTER_AGENT_DEFAULT_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
+        ) as AgentDefaultOptions | undefined;
+        const merged = mergePluginDefaults(existing, defaultOptions);
         ctx.setStore(
-          ADAPTER_TOOLS_DEFAULT as keyof import("@routecraft/routecraft").StoreRegistry,
-          defaultTools,
+          ADAPTER_AGENT_DEFAULT_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
+          merged,
         );
       }
     },
+  };
+}
+
+/**
+ * Validate the shape of `agentPlugin({ defaultOptions: ... })` at
+ * plugin-construction time. Returns the validated value (with no
+ * mutations) or undefined when no defaults were supplied.
+ *
+ * @internal
+ */
+function validatePluginDefaults(
+  raw: AgentDefaultOptions | undefined,
+): AgentDefaultOptions | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw rcError("RC5003", undefined, {
+      message: `agentPlugin: "defaultOptions" must be an object with optional "model" / "tools".`,
+    });
+  }
+  if (raw.model !== undefined) {
+    if (typeof raw.model !== "string" || raw.model.trim() === "") {
+      throw rcError("RC5003", undefined, {
+        message: `agentPlugin: "defaultOptions.model" must be a non-empty "providerId:modelName" string.`,
+      });
+    }
+    try {
+      parseProviderModel(raw.model);
+    } catch {
+      throw rcError("RC5003", undefined, {
+        message: `agentPlugin: "defaultOptions.model" must be in "providerId:modelName" form (e.g. anthropic:claude-opus-4-7). Got: "${raw.model}"`,
+      });
+    }
+  }
+  if (raw.tools !== undefined && !isToolSelection(raw.tools)) {
+    throw rcError("RC5003", undefined, {
+      message: `agentPlugin: "defaultOptions.tools" must be the result of tools([...]).`,
+    });
+  }
+  return raw;
+}
+
+/**
+ * Merge a freshly-supplied `defaultOptions` into the value already
+ * stored by a previous `agentPlugin` install. Per-field conflicts
+ * throw so a context cannot accidentally end up with two competing
+ * defaults for the same field.
+ *
+ * @internal
+ */
+function mergePluginDefaults(
+  existing: AgentDefaultOptions | undefined,
+  next: AgentDefaultOptions,
+): AgentDefaultOptions {
+  if (!existing) return { ...next };
+  if (next.model !== undefined && existing.model !== undefined) {
+    throw rcError("RC5003", undefined, {
+      message: `agentPlugin: "defaultOptions.model" is already set on this context. A context can have only one default model.`,
+    });
+  }
+  if (next.tools !== undefined && existing.tools !== undefined) {
+    throw rcError("RC5003", undefined, {
+      message: `agentPlugin: "defaultOptions.tools" is already set on this context. Combine selectors into a single tools([...]) call.`,
+    });
+  }
+  return {
+    ...existing,
+    ...(next.model !== undefined ? { model: next.model } : {}),
+    ...(next.tools !== undefined ? { tools: next.tools } : {}),
   };
 }

--- a/packages/ai/src/agent/store.ts
+++ b/packages/ai/src/agent/store.ts
@@ -1,5 +1,4 @@
-import type { AgentRegisteredOptions } from "./types.ts";
-import type { ToolSelection } from "./tools/selection.ts";
+import type { AgentDefaultOptions, AgentRegisteredOptions } from "./types.ts";
 
 /**
  * Store key for the registry of agents installed by `agentPlugin`. Resolved
@@ -13,19 +12,22 @@ export const ADAPTER_AGENT_REGISTRY = Symbol.for(
 );
 
 /**
- * Store key for the context-default tool selection installed via
- * `agentPlugin({ tools })`. Agents that omit their own `tools:` field
- * fall back to this list at dispatch time.
+ * Store key for the context-level agent defaults installed via
+ * `agentPlugin({ defaultOptions: {...} })`. Agents that omit a field
+ * inherit it from here at dispatch time.
+ *
+ * Mirrors the `llmPlugin({ defaultOptions })` pattern so the same merge
+ * model carries across.
  *
  * @experimental
  */
-export const ADAPTER_TOOLS_DEFAULT = Symbol.for(
-  "routecraft.adapter.tools.default",
+export const ADAPTER_AGENT_DEFAULT_OPTIONS = Symbol.for(
+  "routecraft.adapter.agent.default-options",
 );
 
 declare module "@routecraft/routecraft" {
   interface StoreRegistry {
     [ADAPTER_AGENT_REGISTRY]: Map<string, AgentRegisteredOptions>;
-    [ADAPTER_TOOLS_DEFAULT]: ToolSelection;
+    [ADAPTER_AGENT_DEFAULT_OPTIONS]: AgentDefaultOptions;
   }
 }

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -51,7 +51,7 @@ const emptyObjectSchema: StandardSchemaV1<unknown, Record<string, never>> = {
  * narrow the underlying tool's surface to a specific agent without
  * touching the underlying registration.
  *
- * Only the LLM-facing contract (description, schema, tags) can be
+ * Only the LLM-facing contract (description, input, tags) can be
  * overridden here. Guards are policy and live at the consumer:
  * attach them in `tools([{ name, guard }])` at the agent's call site.
  *
@@ -64,7 +64,7 @@ export interface ToolBuilderOverrides<TIn = unknown> {
    * Replace the underlying input schema. Replaces, does not merge with,
    * the underlying schema.
    */
-  schema?: StandardSchemaV1<unknown, TIn>;
+  input?: StandardSchemaV1<unknown, TIn>;
   /**
    * Replace the underlying tags. Replaces, does not merge with, the
    * underlying tags.
@@ -75,7 +75,7 @@ export interface ToolBuilderOverrides<TIn = unknown> {
 /**
  * Wrap a registered direct route as a fn-shaped tool. The route's
  * `.description()`, `.input()` schema, and tags become the fn's
- * description, schema, and tags by default; pass `overrides` to narrow
+ * description, input, and tags by default; pass `overrides` to narrow
  * any of them for the calling agent.
  *
  * Resolution is deferred to agent dispatch time, when the direct
@@ -120,10 +120,10 @@ export function directTool<TIn = unknown>(
           message: `directTool: route "${routeId}" has no .description() and no override was provided (referenced as fn "${fnId}").`,
         });
       }
-      const schema =
-        overrides?.schema ??
+      const input =
+        overrides?.input ??
         (route.input?.body as StandardSchemaV1<unknown, TIn> | undefined);
-      if (!schema) {
+      if (!input) {
         throw rcError("RC5003", undefined, {
           message: `directTool: route "${routeId}" has no .input(...) schema and no override was provided (referenced as fn "${fnId}").`,
         });
@@ -133,7 +133,7 @@ export function directTool<TIn = unknown>(
         dispatchDirect(hctx, routeId, input)) as FnOptions["handler"];
       return {
         description,
-        schema,
+        input,
         ...(tags && tags.length > 0 ? { tags: [...tags] } : {}),
         handler,
       } as FnOptions;
@@ -305,13 +305,13 @@ export function mcpTool(
 export const defaultFns = {
   currentTime: {
     description: "Returns the current UTC timestamp in ISO 8601 format.",
-    schema: emptyObjectSchema,
+    input: emptyObjectSchema,
     handler: () => new Date().toISOString(),
     tags: ["read-only", "idempotent"] satisfies KnownTag[],
   } satisfies FnOptions<Record<string, never>, string>,
   randomUuid: {
     description: "Generates a fresh random UUID v4.",
-    schema: emptyObjectSchema,
+    input: emptyObjectSchema,
     handler: () => randomUUID(),
     tags: ["read-only"] satisfies KnownTag[],
   } satisfies FnOptions<Record<string, never>, string>,

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -78,7 +78,7 @@ export interface ResolvedTool {
   /** Description shown to the LLM. */
   description: string;
   /** Standard Schema validating the LLM-supplied input. */
-  schema: StandardSchemaV1<unknown, unknown>;
+  input: StandardSchemaV1<unknown, unknown>;
   /** Optional tags inherited from the underlying registration. */
   tags?: Tag[];
   /** Optional guard run after validation, before the handler. */
@@ -263,7 +263,7 @@ function toResolvedTool(
   return {
     name,
     description: fn.description,
-    schema: fn.schema as StandardSchemaV1<unknown, unknown>,
+    input: fn.input as StandardSchemaV1<unknown, unknown>,
     ...(fn.tags && fn.tags.length > 0 ? { tags: fn.tags } : {}),
     ...(guard ? { guard } : {}),
     handler: fn.handler as FnOptions["handler"],

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -29,7 +29,7 @@ export interface AgentDefaultOptions {
    *
    * Agents that omit `model` inherit this default at dispatch time.
    * Both this default and the per-agent `model` are `LlmModelId`
-   * strings; agents do not author provider credentials inline -- that
+   * strings. Agents do not author provider credentials inline; that
    * responsibility lives with `llmPlugin`.
    */
   model?: LlmModelId;
@@ -94,7 +94,7 @@ export interface AgentOptions {
    * Mirrors the `llm({ output })` option and the route-level
    * `.output(schema)` builder method, so the same word is used for
    * "declared output shape" everywhere in the framework. Per-agent
-   * only -- not part of `defaultOptions`, since output shape is
+   * only (not part of `defaultOptions`), since output shape is
    * intrinsic to a specific agent's job.
    *
    * The runtime that wires this through `generateText({ output })`

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -1,5 +1,5 @@
 import type { Exchange } from "@routecraft/routecraft";
-import type { LlmModelConfig, LlmModelId, LlmUsage } from "../llm/types.ts";
+import type { LlmModelId, LlmUsage } from "../llm/types.ts";
 import type { ToolSelection } from "./tools/selection.ts";
 
 /**
@@ -10,6 +10,37 @@ import type { ToolSelection } from "./tools/selection.ts";
  * @experimental
  */
 export type AgentUserPromptSource = (exchange: Exchange<unknown>) => string;
+
+/**
+ * Context-level defaults applied to any agent that doesn't override them.
+ * Set via `agentPlugin({ defaultOptions: {...} })`. Per-agent values
+ * win over these.
+ *
+ * Mirrors the `llmPlugin({ defaultOptions })` shape so the same mental
+ * model carries across.
+ *
+ * @experimental
+ */
+export interface AgentDefaultOptions {
+  /**
+   * Default model reference. Format: "providerId:modelName". The
+   * provider must be registered via `llmPlugin({ providers })`.
+   *
+   * Agents that omit `model` inherit this default at dispatch time.
+   * Both this default and the per-agent `model` are `LlmModelId`
+   * strings; agents do not author provider credentials inline -- that
+   * responsibility lives with `llmPlugin`.
+   */
+  model?: LlmModelId;
+
+  /**
+   * Default tool selection. Build via `tools([...])` from
+   * `@routecraft/ai`. Agents that omit `tools` inherit this default;
+   * an explicit `tools:` on the agent replaces this default entirely
+   * (override, not extend).
+   */
+  tools?: ToolSelection;
+}
 
 /**
  * Options for the agent destination when defined inline in a route.
@@ -23,11 +54,13 @@ export type AgentUserPromptSource = (exchange: Exchange<unknown>) => string;
  */
 export interface AgentOptions {
   /**
-   * Model reference. Either a "providerId:modelName" string resolved against
-   * the providers registered via `llmPlugin`, or an inline `LlmModelConfig`
-   * for ad-hoc credentials without registration.
+   * Model reference of the form "providerId:modelName". The provider
+   * must be registered via `llmPlugin({ providers })`. Optional when
+   * `agentPlugin({ defaultOptions: { model } })` supplies a default;
+   * resolution at dispatch is "instance value > plugin default >
+   * throw RC5003".
    */
-  model: LlmModelId | LlmModelConfig;
+  model?: LlmModelId;
 
   /**
    * System prompt as a plain string. Load from disk yourself when you want
@@ -46,9 +79,9 @@ export interface AgentOptions {
    * `tools([...])` from `@routecraft/ai`. Resolved against the live
    * fn / direct registries at agent dispatch time.
    *
-   * When omitted, the agent inherits the context-default tool list set
-   * via `agentPlugin({ tools })`. An explicit value here replaces the
-   * default entirely (no extension).
+   * When omitted, the agent inherits the default set on
+   * `agentPlugin({ defaultOptions: { tools } })`. An explicit value
+   * here replaces the default entirely (no extension).
    */
   tools?: ToolSelection;
 }

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -1,4 +1,5 @@
 import type { Exchange } from "@routecraft/routecraft";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { LlmModelId, LlmUsage } from "../llm/types.ts";
 import type { ToolSelection } from "./tools/selection.ts";
 
@@ -84,6 +85,23 @@ export interface AgentOptions {
    * here replaces the default entirely (no extension).
    */
   tools?: ToolSelection;
+
+  /**
+   * Optional output schema (Standard Schema). When set, the agent
+   * requests provider-level structured output and validates the
+   * result; the parsed value lands on `AgentResult.output`.
+   *
+   * Mirrors the `llm({ output })` option and the route-level
+   * `.output(schema)` builder method, so the same word is used for
+   * "declared output shape" everywhere in the framework. Per-agent
+   * only -- not part of `defaultOptions`, since output shape is
+   * intrinsic to a specific agent's job.
+   *
+   * The runtime that wires this through `generateText({ output })`
+   * lands in the next PR; defining this field today is accepted by
+   * validation but does not yet shape the dispatch.
+   */
+  output?: StandardSchemaV1;
 }
 
 /**

--- a/packages/ai/src/embedding/destination.ts
+++ b/packages/ai/src/embedding/destination.ts
@@ -82,7 +82,7 @@ export class EmbeddingDestinationAdapter<T = unknown>
 
   constructor(
     private readonly modelId: string,
-    options: Partial<EmbeddingOptions<T>> = {},
+    options: EmbeddingOptions<T>,
   ) {
     this.options = options as Partial<EmbeddingOptions>;
   }
@@ -103,12 +103,6 @@ export class EmbeddingDestinationAdapter<T = unknown>
       context,
     );
     const merged = this.mergedOptions(context!);
-
-    if (!merged.using) {
-      throw new Error(
-        "Embedding adapter: options.using(exchange) is required to build the string to embed.",
-      );
-    }
 
     const getText = buildText(
       merged.using as (e: Exchange<unknown>) => string | string[],

--- a/packages/ai/src/embedding/embedding.ts
+++ b/packages/ai/src/embedding/embedding.ts
@@ -17,7 +17,7 @@ import type {
  */
 export function embedding<T = unknown>(
   modelId: EmbeddingModelId,
-  options?: Partial<EmbeddingOptions<T>>,
+  options: EmbeddingOptions<T>,
 ): Destination<T, EmbeddingResult> {
   return new EmbeddingDestinationAdapter<T>(modelId, options);
 }

--- a/packages/ai/src/fn/fn.ts
+++ b/packages/ai/src/fn/fn.ts
@@ -11,7 +11,7 @@ import type { FnOptions } from "./types.ts";
 export function validateFnOptions(id: string, options: FnOptions): void {
   if (options === null || typeof options !== "object") {
     throw rcError("RC5003", undefined, {
-      message: `agentPlugin: fn "${id}" entry must be an object with description, schema, and handler.`,
+      message: `agentPlugin: fn "${id}" entry must be an object with description, input, and handler.`,
     });
   }
   if (
@@ -23,21 +23,21 @@ export function validateFnOptions(id: string, options: FnOptions): void {
     });
   }
   if (
-    options.schema === null ||
-    typeof options.schema !== "object" ||
-    typeof (options.schema as { ["~standard"]?: unknown })["~standard"] !==
+    options.input === null ||
+    typeof options.input !== "object" ||
+    typeof (options.input as { ["~standard"]?: unknown })["~standard"] !==
       "object"
   ) {
     throw rcError("RC5003", undefined, {
-      message: `agentPlugin: fn "${id}" "schema" is required and must be a Standard Schema value (Zod/Valibot/ArkType/etc.).`,
+      message: `agentPlugin: fn "${id}" "input" is required and must be a Standard Schema value (Zod/Valibot/ArkType/etc.).`,
     });
   }
   const standard = (
-    options.schema as { ["~standard"]?: { validate?: unknown } }
+    options.input as { ["~standard"]?: { validate?: unknown } }
   )["~standard"];
   if (typeof standard?.validate !== "function") {
     throw rcError("RC5003", undefined, {
-      message: `agentPlugin: fn "${id}" "schema" must be a Standard Schema with a callable validate.`,
+      message: `agentPlugin: fn "${id}" "input" must be a Standard Schema with a callable validate.`,
     });
   }
   if (typeof options.handler !== "function") {

--- a/packages/ai/src/fn/types.ts
+++ b/packages/ai/src/fn/types.ts
@@ -65,7 +65,7 @@ export interface FnOptions<TIn = unknown, TOut = unknown> {
    * time; validation failures throw RC5002. The schema's output type
    * (after any `.transform()`) is what the handler sees.
    */
-  schema: StandardSchemaV1<unknown, TIn>;
+  input: StandardSchemaV1<unknown, TIn>;
 
   /**
    * Handler called after schema validation with the (possibly coerced)

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -116,11 +116,12 @@ export {
   agent,
   AgentDestinationAdapter,
   agentPlugin,
+  ADAPTER_AGENT_DEFAULT_OPTIONS,
   ADAPTER_AGENT_REGISTRY,
-  ADAPTER_TOOLS_DEFAULT,
 } from "./agent/index.ts";
 export type {
   AgentBinding,
+  AgentDefaultOptions,
   AgentOptions,
   AgentPluginOptions,
   AgentRegisteredOptions,

--- a/packages/ai/src/llm/destination.ts
+++ b/packages/ai/src/llm/destination.ts
@@ -84,7 +84,7 @@ export class LlmDestinationAdapter<
 
   constructor(
     private readonly modelId: string,
-    options: Partial<LlmOptions> = {},
+    options: LlmOptions = {},
   ) {
     this.options = options as Partial<LlmOptionsMerged>;
   }

--- a/packages/ai/src/llm/destination.ts
+++ b/packages/ai/src/llm/destination.ts
@@ -71,7 +71,7 @@ const DEFAULT_MAX_TOKENS = 1024;
  * Use with .enrich(llm("providerId:modelName", options)) or .to(llm(...)).
  *
  * @experimental
- * @template S - Output schema type when outputSchema is provided; narrows result.output for downstream typing.
+ * @template S - Output schema type when an `output` schema is provided; narrows result.output for downstream typing.
  */
 export class LlmDestinationAdapter<
   S extends StandardSchemaV1 | undefined = undefined,
@@ -108,9 +108,9 @@ export class LlmDestinationAdapter<
     const { config, modelName } = resolveModel(this.modelId, context);
     const merged = this.mergedOptions(context!);
 
-    const systemPrompt = resolvePrompt(merged.systemPrompt, exchange);
-    const userPrompt =
-      resolvePrompt(merged.userPrompt, exchange) ||
+    const system = resolvePrompt(merged.system, exchange);
+    const user =
+      resolvePrompt(merged.user, exchange) ||
       resolveUserPromptDefault(exchange);
 
     const opts: Parameters<typeof callLlm>[0]["options"] = {
@@ -124,27 +124,25 @@ export class LlmDestinationAdapter<
       opts.presencePenalty = merged.presencePenalty;
 
     const output =
-      merged.outputSchema !== undefined
-        ? toAiOutputSpec(merged.outputSchema)
-        : undefined;
+      merged.output !== undefined ? toAiOutputSpec(merged.output) : undefined;
 
     const result = await callLlm({
       config,
       modelId: modelName,
       options: opts,
-      systemPrompt,
-      userPrompt,
+      system,
+      user,
       output,
     });
 
     if (
       result.output === undefined &&
       result.text &&
-      merged.outputSchema !== undefined
+      merged.output !== undefined
     ) {
       const fallback = await parseStructuredTextFallback(
         result.text,
-        merged.outputSchema,
+        merged.output,
       );
       if (fallback !== undefined) result.output = fallback;
     }

--- a/packages/ai/src/llm/llm.ts
+++ b/packages/ai/src/llm/llm.ts
@@ -16,7 +16,7 @@ import type { RegisteredLlmModelId } from "../registry.ts";
  */
 export function llm<S extends StandardSchemaV1 | undefined = undefined>(
   modelId: RegisteredLlmModelId,
-  options?: Partial<LlmOptions> & { output?: S },
+  options?: LlmOptions & { output?: S },
 ): Destination<unknown, LlmResultWithOutput<S>> {
   return new LlmDestinationAdapter<S>(modelId, options);
 }

--- a/packages/ai/src/llm/llm.ts
+++ b/packages/ai/src/llm/llm.ts
@@ -8,15 +8,15 @@ import type { RegisteredLlmModelId } from "../registry.ts";
  * Creates an LLM destination that calls a provider with a model. Use with .enrich() or .to().
  * Pass model id as "providerId:modelName" (e.g. ollama:lfm2.5-thinking). The provider must be
  * registered via llmPlugin({ providers: { ollama: { provider: "ollama" }, ... } }).
- * When options.outputSchema is provided, the result type narrows so body.output is typed downstream.
+ * When options.output is provided, the result type narrows so body.output is typed downstream.
  *
  * @experimental
  * @param modelId - "providerId:modelName"; the provider is resolved from the plugin, the model name is sent to the provider.
- * @param options - Optional overrides (systemPrompt, userPrompt, temperature, maxTokens, outputSchema, etc.). User prompt defaults to exchange.body.
+ * @param options - Optional overrides (system, user, temperature, maxTokens, output, etc.). User prompt defaults to exchange.body.
  */
 export function llm<S extends StandardSchemaV1 | undefined = undefined>(
   modelId: RegisteredLlmModelId,
-  options?: Partial<LlmOptions> & { outputSchema?: S },
+  options?: Partial<LlmOptions> & { output?: S },
 ): Destination<unknown, LlmResultWithOutput<S>> {
   return new LlmDestinationAdapter<S>(modelId, options);
 }

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -99,8 +99,8 @@ export interface CallLlmParams {
     | "frequencyPenalty"
     | "presencePenalty"
   >;
-  systemPrompt: string;
-  userPrompt: string;
+  system: string;
+  user: string;
   /** Optional structured output spec (from toAiOutputSpec). Enables provider-level JSON schema. */
   output?: unknown;
 }
@@ -109,53 +109,18 @@ export interface CallLlmParams {
  * Dispatches to the appropriate provider and returns a normalized LlmResult.
  */
 export async function callLlm(params: CallLlmParams): Promise<LlmResult> {
-  const { config, modelId, options, systemPrompt, userPrompt, output } = params;
+  const { config, modelId, options, system, user, output } = params;
   switch (config.provider) {
     case "openai":
-      return callOpenAI(
-        config,
-        modelId,
-        options,
-        systemPrompt,
-        userPrompt,
-        output,
-      );
+      return callOpenAI(config, modelId, options, system, user, output);
     case "anthropic":
-      return callAnthropic(
-        config,
-        modelId,
-        options,
-        systemPrompt,
-        userPrompt,
-        output,
-      );
+      return callAnthropic(config, modelId, options, system, user, output);
     case "gemini":
-      return callGemini(
-        config,
-        modelId,
-        options,
-        systemPrompt,
-        userPrompt,
-        output,
-      );
+      return callGemini(config, modelId, options, system, user, output);
     case "openrouter":
-      return callOpenRouter(
-        config,
-        modelId,
-        options,
-        systemPrompt,
-        userPrompt,
-        output,
-      );
+      return callOpenRouter(config, modelId, options, system, user, output);
     case "ollama":
-      return callOllama(
-        config,
-        modelId,
-        options,
-        systemPrompt,
-        userPrompt,
-        output,
-      );
+      return callOllama(config, modelId, options, system, user, output);
     default: {
       const _: never = config;
       throw new Error(
@@ -169,8 +134,8 @@ async function callOpenAI(
   config: import("../types.ts").LlmModelConfigOpenAI,
   modelId: string,
   options: CallLlmParams["options"],
-  systemPrompt: string,
-  userPrompt: string,
+  system: string,
+  user: string,
   output: CallLlmParams["output"],
 ): Promise<LlmResult> {
   let createOpenAI: (s: {
@@ -195,13 +160,13 @@ async function callOpenAI(
   const model = openai(modelId);
   const genParams: Parameters<typeof generateText>[0] = {
     model: model as Parameters<typeof generateText>[0]["model"],
-    prompt: userPrompt,
+    prompt: user,
     ...(options.maxTokens !== undefined && {
       maxOutputTokens: options.maxTokens,
     }),
     temperature: options.temperature,
   };
-  if (systemPrompt) genParams.system = systemPrompt;
+  if (system) genParams.system = system;
   if (options.topP !== undefined) genParams.topP = options.topP;
   if (options.frequencyPenalty !== undefined)
     genParams.frequencyPenalty = options.frequencyPenalty;
@@ -222,8 +187,8 @@ async function callAnthropic(
   config: import("../types.ts").LlmModelConfigAnthropic,
   modelId: string,
   options: CallLlmParams["options"],
-  systemPrompt: string,
-  userPrompt: string,
+  system: string,
+  user: string,
   output: CallLlmParams["output"],
 ): Promise<LlmResult> {
   let createAnthropic: (s: { apiKey: string }) => (m: string) => unknown;
@@ -241,13 +206,13 @@ async function callAnthropic(
   const model = anthropic(modelId);
   const genParams: Parameters<typeof generateText>[0] = {
     model: model as Parameters<typeof generateText>[0]["model"],
-    prompt: userPrompt,
+    prompt: user,
     ...(options.maxTokens !== undefined && {
       maxOutputTokens: options.maxTokens,
     }),
     temperature: options.temperature,
   };
-  if (systemPrompt) genParams.system = systemPrompt;
+  if (system) genParams.system = system;
   // Same option keys as callOpenAI; SDK passes through. Anthropic supports topP;
   // frequencyPenalty/presencePenalty may be unsupported (SDK may warn).
   if (options.topP !== undefined) genParams.topP = options.topP;
@@ -270,8 +235,8 @@ async function callGemini(
   config: import("../types.ts").LlmModelConfigGemini,
   modelId: string,
   options: CallLlmParams["options"],
-  systemPrompt: string,
-  userPrompt: string,
+  system: string,
+  user: string,
   output: CallLlmParams["output"],
 ): Promise<LlmResult> {
   let createGoogleGenerativeAI: (s: {
@@ -292,13 +257,13 @@ async function callGemini(
   const model = google(modelId);
   const genParams: Parameters<typeof generateText>[0] = {
     model: model as Parameters<typeof generateText>[0]["model"],
-    prompt: userPrompt,
+    prompt: user,
     ...(options.maxTokens !== undefined && {
       maxOutputTokens: options.maxTokens,
     }),
     temperature: options.temperature,
   };
-  if (systemPrompt) genParams.system = systemPrompt;
+  if (system) genParams.system = system;
   // Same option keys as callOpenAI; SDK passes through. Gemini may not support
   // all (e.g. frequencyPenalty/presencePenalty); check result.warnings if needed.
   if (options.topP !== undefined) genParams.topP = options.topP;
@@ -321,8 +286,8 @@ async function callOpenRouter(
   config: import("../types.ts").LlmModelConfigOpenRouter,
   modelId: string,
   options: CallLlmParams["options"],
-  systemPrompt: string,
-  userPrompt: string,
+  system: string,
+  user: string,
   output: CallLlmParams["output"],
 ): Promise<LlmResult> {
   let createOpenRouter: (s: { apiKey: string }) => {
@@ -345,13 +310,13 @@ async function callOpenRouter(
   const model = rawModel as Parameters<typeof generateText>[0]["model"];
   const genParams: Parameters<typeof generateText>[0] = {
     model,
-    prompt: userPrompt,
+    prompt: user,
     ...(options.maxTokens !== undefined && {
       maxOutputTokens: options.maxTokens,
     }),
     temperature: options.temperature,
   };
-  if (systemPrompt) genParams.system = systemPrompt;
+  if (system) genParams.system = system;
   // Same option keys as callOpenAI. OpenRouter is OpenAI-compatible; typically supports all.
   if (options.topP !== undefined) genParams.topP = options.topP;
   if (options.frequencyPenalty !== undefined)
@@ -373,8 +338,8 @@ async function callOllama(
   config: import("../types.ts").LlmModelConfigOllama,
   modelId: string,
   options: CallLlmParams["options"],
-  systemPrompt: string,
-  userPrompt: string,
+  system: string,
+  user: string,
   output: CallLlmParams["output"],
 ): Promise<LlmResult> {
   let createOllama: (s: { baseURL?: string }) => (name: string) => unknown;
@@ -397,13 +362,13 @@ async function callOllama(
   const model = rawModel as Parameters<typeof generateText>[0]["model"];
   const genParams: Parameters<typeof generateText>[0] = {
     model,
-    prompt: userPrompt,
+    prompt: user,
     ...(options.maxTokens !== undefined && {
       maxOutputTokens: options.maxTokens,
     }),
     temperature: options.temperature,
   };
-  if (systemPrompt) genParams.system = systemPrompt;
+  if (system) genParams.system = system;
   // Same option keys as callOpenAI. Ollama supports top_p; frequencyPenalty/presencePenalty
   // may be unsupported (SDK may warn).
   if (options.topP !== undefined) genParams.topP = options.topP;

--- a/packages/ai/src/llm/structured-output.ts
+++ b/packages/ai/src/llm/structured-output.ts
@@ -33,7 +33,7 @@ export function toAiOutputSpec(schema: StandardSchemaV1): unknown {
 
   if (!standard?.validate) {
     throw new Error(
-      "LLM outputSchema must be a StandardSchemaV1 with ~standard.validate",
+      "LLM output schema must be a StandardSchemaV1 with ~standard.validate",
     );
   }
 
@@ -43,7 +43,7 @@ export function toAiOutputSpec(schema: StandardSchemaV1): unknown {
 
   if (!jsonSchemaObj || typeof jsonSchemaObj !== "object") {
     throw new Error(
-      "LLM outputSchema must expose ~standard.jsonSchema.output or .input for provider structured output",
+      "LLM output schema must expose ~standard.jsonSchema.output or .input for provider structured output",
     );
   }
 

--- a/packages/ai/src/llm/types.ts
+++ b/packages/ai/src/llm/types.ts
@@ -110,8 +110,8 @@ export type LlmPromptSource =
   | ((exchange: Exchange<unknown>) => string);
 
 export interface LlmOptions {
-  systemPrompt?: LlmPromptSource;
-  userPrompt?: LlmPromptSource;
+  system?: LlmPromptSource;
+  user?: LlmPromptSource;
   temperature?: number;
   maxTokens?: number;
   topP?: number;
@@ -122,8 +122,11 @@ export interface LlmOptions {
    * provider-level structured output and validates the result. Supported by
    * OpenAI (gpt-4o/mini) and Ollama; others may return JSON that is validated
    * after the call. On success, the parsed value is set on LlmResult.output.
+   *
+   * Mirrors the route-level `.output(schema)` naming so the same word is
+   * used for "declared output shape" everywhere in the framework.
    */
-  outputSchema?: StandardSchemaV1;
+  output?: StandardSchemaV1;
 }
 
 /** Internal merged type for adapter and store. */
@@ -149,7 +152,7 @@ export interface LlmUsage {
 export interface LlmResult {
   /** Generated text (raw string from the model). */
   text: string;
-  /** Parsed structured output when outputSchema was set and validation succeeded. */
+  /** Parsed structured output when `output` schema was set and validation succeeded. */
   output?: unknown;
   /** Token usage for the last step. Same shape as AI SDK usage. */
   usage?: LlmUsage;
@@ -158,8 +161,9 @@ export interface LlmResult {
 }
 
 /**
- * When outputSchema S is provided to llm(), the result type narrows output to InferOutput<S>.
- * Used for type inference from llm(modelId, { outputSchema }) so body.output is typed downstream.
+ * When an `output` schema S is provided to llm(), the result type narrows
+ * `output` to `InferOutput<S>`. Used for type inference from
+ * `llm(modelId, { output })` so body.output is typed downstream.
  */
 export type LlmResultWithOutput<S extends StandardSchemaV1 | undefined> =
   S extends StandardSchemaV1
@@ -222,6 +226,6 @@ export interface LlmPluginOptions {
    * Routes use llm("providerId:modelName"), e.g. llm("ollama:lfm2.5-thinking").
    */
   providers: LlmPluginProviders;
-  /** Optional context-level default options (systemPrompt, temperature, etc.). */
+  /** Optional context-level default options (system, temperature, etc.). */
   defaultOptions?: Partial<LlmOptionsMerged>;
 }

--- a/packages/ai/src/mcp/mcp.ts
+++ b/packages/ai/src/mcp/mcp.ts
@@ -1,7 +1,7 @@
 /**
  * Create an MCP endpoint for AI/MCP integration.
- * - .from(mcp(endpoint, options)): source with description (MCP server).
- *   When options.schema is provided, body type is inferred from it; otherwise unknown.
+ * - .from(mcp(options?)): source. Tool name comes from the route id; description
+ *   and input/output schemas come from the route builder.
  * - .to(mcp({ url | serverId, tool, args? })): remote tool (MCP client).
  * - .to(mcp("server:tool", { args? })): remote tool by name.
  * For in-process use direct("endpoint"), not mcp().

--- a/packages/ai/test/agent.test.ts
+++ b/packages/ai/test/agent.test.ts
@@ -89,15 +89,12 @@ describe("agent() destination", () => {
   });
 
   /**
-   * @case agent() accepts an inline LlmModelConfig object as model
-   * @preconditions model passed as { provider, apiKey } object
-   * @expectedResult Construction succeeds without llmPlugin in the context
+   * @case agent() accepts model as an optional field at construction
+   * @preconditions agent({ system }) -- no model, no defaults known yet
+   * @expectedResult Construction succeeds; resolution deferred to dispatch
    */
-  test("accepts an inline LlmModelConfig", () => {
-    const dest = agent({
-      model: { provider: "anthropic", apiKey: "sk-test" },
-      system: "ok",
-    });
+  test("accepts agent without model at construction", () => {
+    const dest = agent({ system: "ok" });
     expect(dest).toBeInstanceOf(AgentDestinationAdapter);
   });
 
@@ -145,6 +142,94 @@ describe("agent() destination", () => {
       outputTokens: 5,
       totalTokens: 15,
     });
+  });
+
+  /**
+   * @case Agent inherits defaultOptions.model when its own model is omitted
+   * @preconditions agentPlugin({ defaultOptions: { model: "..." } }) and inline agent({ system }) without model
+   * @expectedResult callLlm is invoked with the default model
+   */
+  test("agent inherits defaultOptions.model when omitted", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({
+            defaultOptions: { model: "anthropic:claude-opus-4-7" },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("default-model")
+          .from(simple("hello"))
+          .to(agent({ system: "Be helpful." }))
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock).toHaveBeenCalledTimes(1);
+    expect(callLlmMock.mock.calls[0][0].modelId).toBe("claude-opus-4-7");
+  });
+
+  /**
+   * @case Agent dispatch throws when no model is available at all
+   * @preconditions Inline agent without model; no defaultOptions.model on the plugin
+   * @expectedResult Dispatch throws RC5003 with a clear actionable message
+   */
+  test("agent dispatch throws when neither instance nor default supplies a model", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("no-model")
+          .from(simple("hello"))
+          .to(agent({ system: "Be helpful." })),
+      )
+      .build();
+
+    await t.test();
+    expect(t.errors[0]?.message).toMatch(/no "model"/i);
+  });
+
+  /**
+   * @case Per-agent model wins over defaultOptions.model
+   * @preconditions defaultOptions.model = anthropic; agent.model = openai
+   * @expectedResult callLlm is invoked with the agent's openai model id
+   */
+  test("per-agent model overrides defaultOptions.model", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({
+            providers: {
+              anthropic: { apiKey: "sk-test" },
+              openai: { apiKey: "sk-openai" },
+            },
+          }),
+          agentPlugin({
+            defaultOptions: { model: "anthropic:claude-opus-4-7" },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("override-model")
+          .from(simple("hi"))
+          .to(agent({ model: "openai:gpt-4o", system: "Be helpful." }))
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock.mock.calls[0][0].modelId).toBe("gpt-4o");
   });
 
   /**

--- a/packages/ai/test/agent.test.ts
+++ b/packages/ai/test/agent.test.ts
@@ -99,6 +99,30 @@ describe("agent() destination", () => {
   });
 
   /**
+   * @case agent({ output }) accepts a Standard Schema and validates its shape at construction
+   * @preconditions agent with a Zod object output and a non-Standard-Schema output
+   * @expectedResult Valid schema constructs; non-Standard value throws synchronously
+   */
+  test("agent({ output }) validates the schema shape at construction", async () => {
+    const { z } = await import("zod");
+    const schema = z.object({ ok: z.boolean() });
+    const dest = agent({
+      model: "anthropic:claude-opus-4-7",
+      system: "Be helpful.",
+      output: schema,
+    });
+    expect(dest).toBeInstanceOf(AgentDestinationAdapter);
+
+    expect(() =>
+      agent({
+        model: "anthropic:claude-opus-4-7",
+        system: "Be helpful.",
+        output: { not: "a schema" } as never,
+      }),
+    ).toThrow(/Standard Schema/);
+  });
+
+  /**
    * @case end-to-end: route with agent calls callLlm with system + body-derived user prompt
    * @preconditions Route from simple body, .to(agent({...})), .to(spy)
    * @expectedResult callLlm is called once with the configured system and the body as user prompt; downstream body is AgentResult
@@ -130,8 +154,8 @@ describe("agent() destination", () => {
 
     expect(callLlmMock).toHaveBeenCalledTimes(1);
     const args = callLlmMock.mock.calls[0][0];
-    expect(args.systemPrompt).toBe("Be helpful.");
-    expect(args.userPrompt).toBe("hello world");
+    expect(args.system).toBe("Be helpful.");
+    expect(args.user).toBe("hello world");
     expect(args.modelId).toBe("claude-opus-4-7");
 
     expect(sink.received).toHaveLength(1);
@@ -260,7 +284,7 @@ describe("agent() destination", () => {
     await t.test();
 
     expect(callLlmMock).toHaveBeenCalledTimes(1);
-    expect(callLlmMock.mock.calls[0][0].userPrompt).toBe('{"q":"what?"}');
+    expect(callLlmMock.mock.calls[0][0].user).toBe('{"q":"what?"}');
   });
 
   /**
@@ -292,7 +316,7 @@ describe("agent() destination", () => {
 
     await t.test();
 
-    expect(callLlmMock.mock.calls[0][0].userPrompt).toBe("Greet alice");
+    expect(callLlmMock.mock.calls[0][0].user).toBe("Greet alice");
   });
 });
 
@@ -463,10 +487,8 @@ describe("agent(name) by-name destination + agentPlugin", () => {
     await t.test();
 
     expect(callLlmMock).toHaveBeenCalledTimes(1);
-    expect(callLlmMock.mock.calls[0][0].systemPrompt).toBe(
-      "Summarise the input.",
-    );
-    expect(callLlmMock.mock.calls[0][0].userPrompt).toBe("a long document");
+    expect(callLlmMock.mock.calls[0][0].system).toBe("Summarise the input.");
+    expect(callLlmMock.mock.calls[0][0].user).toBe("a long document");
     expect(sink.received).toHaveLength(1);
     expect((sink.received[0].body as AgentResult).text).toBe(
       "stubbed-response",

--- a/packages/ai/test/agent.test.ts
+++ b/packages/ai/test/agent.test.ts
@@ -120,6 +120,23 @@ describe("agent() destination", () => {
         output: { not: "a schema" } as never,
       }),
     ).toThrow(/Standard Schema/);
+
+    // Null and non-object values must surface RC5003, not a raw TypeError
+    // from `(null)["~standard"]`.
+    expect(() =>
+      agent({
+        model: "anthropic:claude-opus-4-7",
+        system: "Be helpful.",
+        output: null as never,
+      }),
+    ).toThrow(/Standard Schema/);
+    expect(() =>
+      agent({
+        model: "anthropic:claude-opus-4-7",
+        system: "Be helpful.",
+        output: "not-an-object" as never,
+      }),
+    ).toThrow(/Standard Schema/);
   });
 
   /**

--- a/packages/ai/test/fn.test.ts
+++ b/packages/ai/test/fn.test.ts
@@ -29,7 +29,7 @@ describe("fn registration via agentPlugin", () => {
             functions: {
               currentTime: {
                 description: "Current UTC timestamp in ISO 8601",
-                schema: z.object({}),
+                input: z.object({}),
                 handler: async () => new Date().toISOString(),
               },
             },
@@ -59,7 +59,7 @@ describe("fn registration via agentPlugin", () => {
             agentPlugin({
               functions: {
                 broken: {
-                  schema: z.object({}),
+                  input: z.object({}),
                   handler: async () => 1,
                 } as unknown as FnOptions,
               },
@@ -84,9 +84,9 @@ describe("fn registration via agentPlugin", () => {
               functions: {
                 bad: {
                   description: "x",
-                  schema: {
+                  input: {
                     "~standard": { validate: "not-a-function" },
-                  } as unknown as FnOptions["schema"],
+                  } as unknown as FnOptions["input"],
                   handler: async () => 1,
                 } satisfies FnOptions,
               },
@@ -111,7 +111,7 @@ describe("fn registration via agentPlugin", () => {
               functions: {
                 dup: {
                   description: "first",
-                  schema: z.object({}),
+                  input: z.object({}),
                   handler: async () => 1,
                 },
               },
@@ -120,7 +120,7 @@ describe("fn registration via agentPlugin", () => {
               functions: {
                 dup: {
                   description: "second",
-                  schema: z.object({}),
+                  input: z.object({}),
                   handler: async () => 2,
                 },
               },
@@ -145,7 +145,7 @@ describe("fn registration via agentPlugin", () => {
               functions: {
                 "  ": {
                   description: "x",
-                  schema: z.object({}),
+                  input: z.object({}),
                   handler: async () => 1,
                 },
               },
@@ -169,7 +169,7 @@ describe("fn registration via agentPlugin", () => {
             functions: {
               currentTime: {
                 description: "Current UTC ISO 8601 timestamp.",
-                schema: z.object({}),
+                input: z.object({}),
                 handler: async () => new Date().toISOString(),
                 tags: ["read-only", "idempotent"],
               },
@@ -199,7 +199,7 @@ describe("fn registration via agentPlugin", () => {
               functions: {
                 bad: {
                   description: "x",
-                  schema: z.object({}),
+                  input: z.object({}),
                   handler: async () => 1,
                   tags: ["read-only", ""],
                 },
@@ -225,7 +225,7 @@ describe("fn registration via agentPlugin", () => {
               functions: {
                 bad: {
                   description: "x",
-                  schema: z.object({}),
+                  input: z.object({}),
                   handler: async () => 1,
                   tags: "read-only" as unknown as string[],
                 },
@@ -249,7 +249,7 @@ describe("testFn - exercise fn handlers in isolation", () => {
     await expect(
       testFn(
         {
-          schema: z.object({ channel: z.string(), text: z.string() }),
+          input: z.object({ channel: z.string(), text: z.string() }),
           handler,
         },
         { channel: 123, text: "x" },
@@ -272,7 +272,7 @@ describe("testFn - exercise fn handlers in isolation", () => {
       return `hello ${typed.name}`;
     });
     const result = await testFn(
-      { schema: z.object({ name: z.string() }), handler },
+      { input: z.object({ name: z.string() }), handler },
       { name: "alice" },
     );
     expect(result).toBe("hello alice");
@@ -291,7 +291,7 @@ describe("testFn - exercise fn handlers in isolation", () => {
       return "ok";
     });
     const result = await testFn(
-      { schema: z.object({}), handler },
+      { input: z.object({}), handler },
       {},
       { signal: controller.signal },
     );
@@ -308,7 +308,7 @@ describe("testFn - exercise fn handlers in isolation", () => {
       expect(ctx.abortSignal.aborted).toBe(false);
       return "ok";
     });
-    await testFn({ schema: z.object({}), handler }, {});
+    await testFn({ input: z.object({}), handler }, {});
     expect(handler).toHaveBeenCalled();
   });
 
@@ -320,7 +320,7 @@ describe("testFn - exercise fn handlers in isolation", () => {
   test("testFn accepts a real FnOptions value structurally", async () => {
     const fnSpec: FnOptions<{ q: string }, string> = {
       description: "Echoes",
-      schema: z.object({ q: z.string() }),
+      input: z.object({ q: z.string() }),
       handler: async (input) => input.q,
     };
     const result = await testFn(fnSpec, { q: "hi" });
@@ -341,7 +341,7 @@ describe("testFn - exercise fn handlers in isolation", () => {
     });
     const result = await testFn(
       {
-        schema: z.object({ n: z.string().transform(Number) }),
+        input: z.object({ n: z.string().transform(Number) }),
         handler,
       },
       { n: "42" },
@@ -359,7 +359,7 @@ describe("testFn - exercise fn handlers in isolation", () => {
     await expect(
       testFn(
         {
-          schema: z.object({}),
+          input: z.object({}),
           handler: async () => {
             throw boom;
           },
@@ -377,7 +377,7 @@ describe("testFn - exercise fn handlers in isolation", () => {
   test("testFn validation errors are RoutecraftError instances", async () => {
     try {
       await testFn(
-        { schema: z.object({ n: z.number() }), handler: async () => 1 },
+        { input: z.object({ n: z.number() }), handler: async () => 1 },
         { n: "not-a-number" },
       );
       throw new Error("testFn did not throw");

--- a/packages/ai/test/llm-type-safety.test.ts
+++ b/packages/ai/test/llm-type-safety.test.ts
@@ -5,7 +5,7 @@ import type { LlmResult, LlmResultWithOutput } from "../src/llm/types.ts";
 import type { Destination } from "@routecraft/routecraft";
 
 /**
- * Type-level tests: llm() return type narrows when outputSchema is provided.
+ * Type-level tests: llm() return type narrows when an `output` schema is provided.
  */
 describe("LLM adapter type safety", () => {
   /**
@@ -20,14 +20,14 @@ describe("LLM adapter type safety", () => {
   });
 
   /**
-   * @case llm(modelId, { outputSchema }) narrows result.output to schema output type
-   * @preconditions llm("ollama:x", { outputSchema: z.object({ answer: z.string() }) })
+   * @case llm(modelId, { output }) narrows result.output to schema output type
+   * @preconditions llm("ollama:x", { output: z.object({ answer: z.string() }) })
    * @expectedResult Return type is Destination with result.output typed as { answer: string }
    */
-  test("llm(modelId, { outputSchema }) narrows body.output type", () => {
+  test("llm(modelId, { output }) narrows body.output type", () => {
     const schema = z.object({ answer: z.string() });
     type Expected = LlmResultWithOutput<typeof schema>;
-    expectTypeOf(llm("ollama:x", { outputSchema: schema })).toMatchTypeOf<
+    expectTypeOf(llm("ollama:x", { output: schema })).toMatchTypeOf<
       Destination<unknown, Expected>
     >();
     // Ensure Expected has output?: { answer: string }

--- a/packages/ai/test/llm.test.ts
+++ b/packages/ai/test/llm.test.ts
@@ -22,17 +22,17 @@ describe("llm() DSL and adapter", () => {
   });
 
   /**
-   * @case llm(modelId, options) accepts optional systemPrompt and temperature
+   * @case llm(modelId, options) accepts optional system and temperature
    * @preconditions None
-   * @expectedResult Adapter options contain passed systemPrompt and temperature
+   * @expectedResult Adapter options contain passed system and temperature
    */
   test("llm(modelId, options) accepts optional options", () => {
     const dest = llm("ollama:my-model", {
-      systemPrompt: "You are helpful.",
+      system: "You are helpful.",
       temperature: 0.5,
     });
     expect(dest).toBeInstanceOf(LlmDestinationAdapter);
-    expect(dest.options.systemPrompt).toBe("You are helpful.");
+    expect(dest.options.system).toBe("You are helpful.");
     expect(dest.options.temperature).toBe(0.5);
   });
 

--- a/packages/ai/test/tools-builders.test.ts
+++ b/packages/ai/test/tools-builders.test.ts
@@ -109,7 +109,7 @@ describe("tool builders - directTool", () => {
     expect(resolved.description).toBe(
       "Fetch an order by id from the orders DB.",
     );
-    expect(resolved.schema).toBe(inputSchema);
+    expect(resolved.input).toBe(inputSchema);
     expect(resolved.tags).toEqual(["read-only"]);
     expect(typeof resolved.handler).toBe("function");
   });
@@ -129,7 +129,7 @@ describe("tool builders - directTool", () => {
               custom: directTool("fetch-order", {
                 description: "OVERRIDE description.",
                 tags: ["destructive"],
-                schema: overrideSchema,
+                input: overrideSchema,
               }),
             },
           }),
@@ -151,7 +151,7 @@ describe("tool builders - directTool", () => {
     if (!entry || !isDeferredFn(entry)) throw new Error("expected deferred");
     const resolved = entry.resolve(t.ctx, "custom");
     expect(resolved.description).toBe("OVERRIDE description.");
-    expect(resolved.schema).toBe(overrideSchema);
+    expect(resolved.input).toBe(overrideSchema);
     expect(resolved.tags).toEqual(["destructive"]);
   });
 

--- a/packages/ai/test/tools-default.test.ts
+++ b/packages/ai/test/tools-default.test.ts
@@ -2,8 +2,8 @@ import { describe, test, expect, afterEach } from "vitest";
 import { ContextBuilder } from "@routecraft/routecraft";
 import { testContext, type TestContext } from "@routecraft/testing";
 import {
+  ADAPTER_AGENT_DEFAULT_OPTIONS,
   ADAPTER_AGENT_REGISTRY,
-  ADAPTER_TOOLS_DEFAULT,
   agent,
   agentPlugin,
   defaultFns,
@@ -12,7 +12,7 @@ import {
   type AgentRegisteredOptions,
 } from "../src/index.ts";
 
-describe("agentPlugin context-default tools", () => {
+describe("agentPlugin defaultOptions storage", () => {
   let t: TestContext | undefined;
   afterEach(async () => {
     if (t) await t.stop();
@@ -20,74 +20,167 @@ describe("agentPlugin context-default tools", () => {
   });
 
   /**
-   * @case Context-default tools are stored under ADAPTER_TOOLS_DEFAULT
-   * @preconditions agentPlugin({ tools: tools(["currentTime"]) })
-   * @expectedResult Store contains a ToolSelection at the new symbol
+   * @case defaultOptions.tools is stored under ADAPTER_AGENT_DEFAULT_OPTIONS
+   * @preconditions agentPlugin({ defaultOptions: { tools: tools(["currentTime"]) } })
+   * @expectedResult Store entry has a `tools` ToolSelection
    */
-  test("agentPlugin stores its tools default in the context store", async () => {
+  test("agentPlugin stores defaultOptions.tools under the new symbol", async () => {
     t = await testContext()
       .with({
         plugins: [
           agentPlugin({
             functions: { ...defaultFns },
-            tools: tools(["currentTime"]),
+            defaultOptions: { tools: tools(["currentTime"]) },
           }),
         ],
       })
       .build();
 
-    const stored = t.ctx.getStore(ADAPTER_TOOLS_DEFAULT);
+    const stored = t.ctx.getStore(ADAPTER_AGENT_DEFAULT_OPTIONS);
     expect(stored).toBeDefined();
-    expect(isToolSelection(stored!)).toBe(true);
+    expect(isToolSelection(stored!.tools!)).toBe(true);
   });
 
   /**
-   * @case Without a context default, ADAPTER_TOOLS_DEFAULT is unset
-   * @preconditions agentPlugin without tools field
+   * @case defaultOptions.model is stored under ADAPTER_AGENT_DEFAULT_OPTIONS
+   * @preconditions agentPlugin({ defaultOptions: { model: "anthropic:claude-opus-4-7" } })
+   * @expectedResult Store entry has a `model` string
+   */
+  test("agentPlugin stores defaultOptions.model under the new symbol", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            defaultOptions: { model: "anthropic:claude-opus-4-7" },
+          }),
+        ],
+      })
+      .build();
+
+    const stored = t.ctx.getStore(ADAPTER_AGENT_DEFAULT_OPTIONS);
+    expect(stored?.model).toBe("anthropic:claude-opus-4-7");
+  });
+
+  /**
+   * @case Without defaultOptions, ADAPTER_AGENT_DEFAULT_OPTIONS is unset
+   * @preconditions agentPlugin without defaultOptions field
    * @expectedResult Store entry is undefined
    */
-  test("agentPlugin without tools field does not set the default", async () => {
+  test("agentPlugin without defaultOptions does not set the store", async () => {
     t = await testContext()
       .with({ plugins: [agentPlugin({ functions: { ...defaultFns } })] })
       .build();
 
-    expect(t.ctx.getStore(ADAPTER_TOOLS_DEFAULT)).toBeUndefined();
+    expect(t.ctx.getStore(ADAPTER_AGENT_DEFAULT_OPTIONS)).toBeUndefined();
   });
 
   /**
-   * @case Two installs both supplying a default throw at context init
-   * @preconditions Two agentPlugin entries each with a tools: tools([...])
+   * @case Two installs both supplying the same default field throw at context init
+   * @preconditions Two agentPlugin entries each set defaultOptions.tools
    * @expectedResult build() rejects with RC5003 mentioning the conflict
    */
-  test("two installs each supplying a tools default throws", async () => {
+  test("two installs each setting defaultOptions.tools throws", async () => {
     await expect(
       new ContextBuilder()
         .with({
           plugins: [
             agentPlugin({
               functions: { ...defaultFns },
-              tools: tools(["currentTime"]),
+              defaultOptions: { tools: tools(["currentTime"]) },
             }),
             agentPlugin({
-              tools: tools(["randomUuid"]),
+              defaultOptions: { tools: tools(["randomUuid"]) },
             }),
           ],
         })
         .build(),
-    ).rejects.toThrow(/default tool list is already set/i);
+    ).rejects.toThrow(/defaultOptions\.tools.*already set/i);
   });
 
   /**
-   * @case agentPlugin rejects a non-ToolSelection passed as tools
-   * @preconditions agentPlugin({ tools: ["currentTime"] as never })
+   * @case Two installs each setting defaultOptions.model throw at context init
+   * @preconditions Two agentPlugin entries each set a different default model
+   * @expectedResult build() rejects with RC5003 mentioning the conflict
+   */
+  test("two installs each setting defaultOptions.model throws", async () => {
+    await expect(
+      new ContextBuilder()
+        .with({
+          plugins: [
+            agentPlugin({
+              defaultOptions: { model: "anthropic:claude-opus-4-7" },
+            }),
+            agentPlugin({
+              defaultOptions: { model: "openai:gpt-4o" },
+            }),
+          ],
+        })
+        .build(),
+    ).rejects.toThrow(/defaultOptions\.model.*already set/i);
+  });
+
+  /**
+   * @case Two installs each setting a DIFFERENT default field merge cleanly
+   * @preconditions install A sets defaultOptions.model, install B sets defaultOptions.tools
+   * @expectedResult Both fields end up on the stored value
+   */
+  test("two installs setting different default fields merge", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            defaultOptions: { model: "anthropic:claude-opus-4-7" },
+          }),
+          agentPlugin({
+            functions: { ...defaultFns },
+            defaultOptions: { tools: tools(["currentTime"]) },
+          }),
+        ],
+      })
+      .build();
+
+    const stored = t.ctx.getStore(ADAPTER_AGENT_DEFAULT_OPTIONS);
+    expect(stored?.model).toBe("anthropic:claude-opus-4-7");
+    expect(isToolSelection(stored!.tools!)).toBe(true);
+  });
+
+  /**
+   * @case agentPlugin rejects defaultOptions that is not an object
+   * @preconditions agentPlugin({ defaultOptions: ["x"] as never })
    * @expectedResult Synchronous RC5003 thrown at plugin construction
    */
-  test("agentPlugin rejects a non-ToolSelection tools value", () => {
+  test("agentPlugin rejects a non-object defaultOptions", () => {
     expect(() =>
       agentPlugin({
-        tools: ["currentTime"] as never,
+        defaultOptions: ["x"] as never,
       }),
-    ).toThrow(/tools\(/);
+    ).toThrow(/defaultOptions/i);
+  });
+
+  /**
+   * @case agentPlugin rejects defaultOptions.tools that is not a ToolSelection
+   * @preconditions agentPlugin({ defaultOptions: { tools: ["x"] as never } })
+   * @expectedResult Synchronous RC5003 thrown
+   */
+  test("agentPlugin rejects a non-ToolSelection defaultOptions.tools", () => {
+    expect(() =>
+      agentPlugin({
+        defaultOptions: { tools: ["x"] as never },
+      }),
+    ).toThrow(/defaultOptions\.tools/i);
+  });
+
+  /**
+   * @case agentPlugin rejects defaultOptions.model that is not "providerId:modelName"
+   * @preconditions agentPlugin({ defaultOptions: { model: "anthropic-only" } })
+   * @expectedResult Synchronous RC5003 thrown
+   */
+  test("agentPlugin rejects a malformed defaultOptions.model", () => {
+    expect(() =>
+      agentPlugin({
+        defaultOptions: { model: "anthropic-only" },
+      }),
+    ).toThrow(/defaultOptions\.model/i);
   });
 });
 
@@ -127,6 +220,34 @@ describe("agentPlugin per-agent tools field", () => {
       | AgentRegisteredOptions
       | undefined;
     expect(entry?.tools).toBe(sel);
+  });
+
+  /**
+   * @case Registered agent without model is accepted at init when defaultOptions.model is set
+   * @preconditions defaultOptions.model set; agent omits model
+   * @expectedResult build() succeeds and the registered agent's model is undefined (resolved at dispatch)
+   */
+  test("registered agent without model is accepted when a default exists", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            defaultOptions: { model: "anthropic:claude-opus-4-7" },
+            agents: {
+              inheritor: {
+                description: "Inherits the default model.",
+                system: "Be precise.",
+              },
+            },
+          }),
+        ],
+      })
+      .build();
+
+    const entry = t.ctx.getStore(ADAPTER_AGENT_REGISTRY)?.get("inheritor") as
+      | AgentRegisteredOptions
+      | undefined;
+    expect(entry?.model).toBeUndefined();
   });
 
   /**
@@ -184,5 +305,29 @@ describe("agent() inline tools validation", () => {
       tools: tools(["currentTime"]),
     });
     expect(dest).toBeDefined();
+  });
+
+  /**
+   * @case Inline agent({}) without model is accepted at construction (resolution deferred to dispatch)
+   * @preconditions agent({ system: "..." }) -- no model, no defaults at construction
+   * @expectedResult agent() returns a destination without throwing
+   */
+  test("inline agent without model is accepted at construction", () => {
+    const dest = agent({ system: "Be helpful." });
+    expect(dest).toBeDefined();
+  });
+
+  /**
+   * @case Inline agent({ model: "..." }) with malformed model throws
+   * @preconditions agent with model: "anthropic-only" (no colon)
+   * @expectedResult Synchronous RC5003 thrown
+   */
+  test("inline agent rejects malformed model string", () => {
+    expect(() =>
+      agent({
+        model: "anthropic-only",
+        system: "Be helpful.",
+      }),
+    ).toThrow(/model/i);
   });
 });

--- a/packages/ai/test/tools-selection.test.ts
+++ b/packages/ai/test/tools-selection.test.ts
@@ -87,7 +87,7 @@ describe("tools() resolver - bare references", () => {
     expect(resolved).toHaveLength(1);
     expect(resolved[0].name).toBe("direct_fetch-order");
     expect(resolved[0].description).toBe("Fetch an order by id.");
-    expect(resolved[0].schema).toBe(inputSchema);
+    expect(resolved[0].input).toBe(inputSchema);
   });
 
   /**
@@ -103,7 +103,7 @@ describe("tools() resolver - bare references", () => {
             functions: {
               direct_x: {
                 description: "Explicit fn registry entry.",
-                schema: z.object({}),
+                input: z.object({}),
                 handler: () => "explicit",
                 tags: ["read-only"],
               },
@@ -260,7 +260,7 @@ describe("tools() resolver - tag selectors", () => {
         ...defaultFns,
         wipe: {
           description: "Wipe data.",
-          schema: z.object({}),
+          input: z.object({}),
           handler: () => "ok",
           tags: ["destructive"],
         },
@@ -468,7 +468,7 @@ describe("tools() resolver - regression", () => {
             functions: {
               padded: {
                 description: "x",
-                schema: defaultFns.currentTime.schema,
+                input: defaultFns.currentTime.input,
                 handler: () => "ok",
                 tags: ["  read-only  "],
               },

--- a/packages/routecraft/src/adapters/direct/destination.ts
+++ b/packages/routecraft/src/adapters/direct/destination.ts
@@ -19,12 +19,12 @@ export class DirectDestinationAdapter<T = unknown> implements Destination<
   readonly adapterId: string = "routecraft.adapter.direct";
 
   private rawEndpoint: DirectEndpoint<T>;
-  public options: Partial<DirectClientOptions>;
+  public options: DirectClientOptions;
   private lastResolvedEndpoint?: string;
 
   constructor(
     rawEndpoint: DirectEndpoint<T>,
-    options: Partial<DirectClientOptions> = {},
+    options: DirectClientOptions = {},
   ) {
     this.rawEndpoint = rawEndpoint;
     this.options = options;

--- a/packages/routecraft/src/adapters/direct/index.ts
+++ b/packages/routecraft/src/adapters/direct/index.ts
@@ -44,7 +44,7 @@ import type { DirectEndpoint, DirectServerOptions } from "./types";
  * .to(direct((ex) => ex.headers["x-endpoint"] as string))
  * ```
  */
-export function direct(options: Partial<DirectServerOptions>): Source<unknown>;
+export function direct(options: DirectServerOptions): Source<unknown>;
 export function direct(): Source<unknown>;
 export function direct<K extends RegisteredDirectEndpoint>(
   endpoint: K,
@@ -53,16 +53,14 @@ export function direct<T = unknown>(
   endpoint: DirectEndpoint<T>,
 ): Destination<T, T>;
 export function direct<T = unknown>(
-  arg?: DirectEndpoint<T> | Partial<DirectServerOptions>,
+  arg?: DirectEndpoint<T> | DirectServerOptions,
 ): Source<unknown> | Destination<T, T> {
   // String or function first-arg -> Destination (names a target route).
   if (typeof arg === "string" || typeof arg === "function") {
     return new DirectDestinationAdapter<T>(arg) as Destination<T, T>;
   }
   // Undefined or options object -> Source (endpoint resolved from route id).
-  return new DirectSourceAdapter(
-    (arg ?? {}) as Partial<DirectServerOptions>,
-  ) as Source<unknown>;
+  return new DirectSourceAdapter(arg ?? {}) as Source<unknown>;
 }
 
 // Re-export types for public API

--- a/packages/routecraft/src/adapters/direct/source.ts
+++ b/packages/routecraft/src/adapters/direct/source.ts
@@ -20,9 +20,9 @@ import { getDirectChannel, registerRoute, sanitizeEndpoint } from "./shared";
 export class DirectSourceAdapter<T = unknown> implements Source<T> {
   readonly adapterId: string = "routecraft.adapter.direct";
 
-  public options: Partial<DirectServerOptions>;
+  public options: DirectServerOptions;
 
-  constructor(options: Partial<DirectServerOptions> = {}) {
+  constructor(options: DirectServerOptions = {}) {
     this.options = options;
   }
 

--- a/packages/routecraft/src/adapters/mail/fetch-destination.ts
+++ b/packages/routecraft/src/adapters/mail/fetch-destination.ts
@@ -33,9 +33,9 @@ export class MailFetchDestinationAdapter implements Destination<
   MailFetchResult
 > {
   readonly adapterId = "routecraft.adapter.mail";
-  private readonly adapterOptions: Partial<MailServerOptions>;
+  private readonly adapterOptions: MailServerOptions;
 
-  constructor(options: Partial<MailServerOptions>) {
+  constructor(options: MailServerOptions) {
     this.adapterOptions = options;
   }
 

--- a/packages/routecraft/src/adapters/mail/index.ts
+++ b/packages/routecraft/src/adapters/mail/index.ts
@@ -69,23 +69,19 @@ import type {
  */
 export function mail(
   folder: string,
-  options: Partial<MailServerOptions>,
+  options: MailServerOptions,
 ): Source<MailMessage>;
 export function mail(folder: string): Destination<unknown, MailFetchResult>;
 export function mail(
-  options: Partial<MailServerOptions>,
+  options: MailServerOptions,
 ): Destination<unknown, MailFetchResult>;
 export function mail(action: MailAction): Destination<unknown, void>;
 export function mail(
-  options?: Partial<MailClientOptions>,
+  options?: MailClientOptions,
 ): Destination<MailSendPayload, MailSendResult>;
 export function mail(
-  folderOrOptions?:
-    | string
-    | Partial<MailServerOptions>
-    | Partial<MailClientOptions>
-    | MailAction,
-  options?: Partial<MailServerOptions>,
+  folderOrOptions?: string | MailServerOptions | MailClientOptions | MailAction,
+  options?: MailServerOptions,
 ):
   | Source<MailMessage>
   | Destination<unknown, MailFetchResult>
@@ -121,7 +117,7 @@ export function mail(
   // Object with server-specific keys -> Fetch Destination
   if (folderOrOptions && hasServerKeys(folderOrOptions)) {
     const adapter = new MailFetchDestinationAdapter(
-      folderOrOptions as Partial<MailServerOptions>,
+      folderOrOptions as MailServerOptions,
     );
     return tagAdapter(adapter, mail, args) as Destination<
       unknown,
@@ -131,7 +127,7 @@ export function mail(
 
   // No args or client-only keys -> Send Destination
   const adapter = new MailSendDestinationAdapter(
-    folderOrOptions as Partial<MailClientOptions> | undefined,
+    folderOrOptions as MailClientOptions | undefined,
   );
   return tagAdapter(adapter, mail, args) as Destination<
     MailSendPayload,

--- a/packages/routecraft/src/adapters/mail/send-destination.ts
+++ b/packages/routecraft/src/adapters/mail/send-destination.ts
@@ -38,11 +38,11 @@ export class MailSendDestinationAdapter implements Destination<
   MailSendResult
 > {
   readonly adapterId = "routecraft.adapter.mail";
-  private readonly adapterOptions: Partial<MailClientOptions>;
+  private readonly adapterOptions: MailClientOptions;
   private cachedTransporter?: Awaited<ReturnType<typeof createSmtpTransport>>;
   private cachedTransporterKey?: string;
 
-  constructor(options?: Partial<MailClientOptions>) {
+  constructor(options?: MailClientOptions) {
     this.adapterOptions = options ?? {};
   }
 

--- a/packages/routecraft/src/adapters/mail/source.ts
+++ b/packages/routecraft/src/adapters/mail/source.ts
@@ -72,10 +72,10 @@ const IDLE_RECONNECT_MAX_MS = 60_000;
  */
 export class MailSourceAdapter implements Source<MailMessage> {
   readonly adapterId = "routecraft.adapter.mail";
-  private readonly adapterOptions: Partial<MailServerOptions>;
+  private readonly adapterOptions: MailServerOptions;
   private readonly folder: string;
 
-  constructor(folder: string, options: Partial<MailServerOptions>) {
+  constructor(folder: string, options: MailServerOptions) {
     this.folder = folder;
     this.adapterOptions = options;
   }

--- a/packages/testing/src/test-fn.ts
+++ b/packages/testing/src/test-fn.ts
@@ -15,7 +15,7 @@ import {
  */
 export interface TestFnSpec<TIn, TOut> {
   /** Schema whose validated/coerced output is passed to `handler`. */
-  schema: StandardSchemaV1<unknown, TIn>;
+  input: StandardSchemaV1<unknown, TIn>;
   handler: (input: TIn, ctx: TestFnHandlerContext) => Promise<TOut> | TOut;
 }
 
@@ -64,7 +64,7 @@ export interface TestFnOptions {
  *
  * const greet = {
  *   description: "...",
- *   schema: z.object({ name: z.string() }),
+ *   input: z.object({ name: z.string() }),
  *   handler: async (input, ctx) => `hello ${input.name}`,
  * };
  *
@@ -77,12 +77,12 @@ export async function testFn<TIn, TOut>(
   input: unknown,
   options: TestFnOptions = {},
 ): Promise<TOut> {
-  const standard = (spec.schema as { ["~standard"]?: { validate?: unknown } })[
+  const standard = (spec.input as { ["~standard"]?: { validate?: unknown } })[
     "~standard"
   ];
   if (typeof standard?.validate !== "function") {
     throw rcError("RC5003", undefined, {
-      message: `testFn: spec.schema must be a Standard Schema with a callable validate.`,
+      message: `testFn: spec.input must be a Standard Schema with a callable validate.`,
     });
   }
 


### PR DESCRIPTION
## Summary

Aligns the agent plugin's context-level defaults with the `llmPlugin({ defaultOptions })` pattern: a single bag of values applied to any agent that doesn't override the corresponding field. Replaces the top-level `tools:` field landed in #254 and adds the long-needed `model` default.

```ts
agentPlugin({
  agents:    { ... },
  functions: { ... },
  defaultOptions: {
    model: "anthropic:claude-opus-4-7",
    tools: tools(["currentTime", { tagged: "read-only" }]),
  },
})
```

Mirrors the `llmPlugin({ defaultOptions })` shape so the same mental model carries across.

## Breaking changes (`@experimental` surface, no external consumers)

| Before | After |
|---|---|
| `agentPlugin({ tools: tools([...]) })` | `agentPlugin({ defaultOptions: { tools: tools([...]) } })` |
| `AgentOptions.model: LlmModelId \| LlmModelConfig` (required) | `AgentOptions.model?: LlmModelId` (optional, string only) |
| Inline `agent({ model: { provider, apiKey, ... } })` | Removed — `llmPlugin` is the single home for provider credentials |

Resolution at dispatch is now `instance > defaults.model > throw` for `model`, and `instance > defaults.tools > undefined` for `tools`.

## Why

- The framework convention is **identity at the call site, tuning from the plugin** (cron, mail, llm). Agents are higher-level than `llm()`; most contexts have many agents sharing one provider and a common tool list, so "share once, override per agent" reads better than repetition.
- A `defaultOptions` bag is symmetric with `llmPlugin` and leaves room for future shared defaults (e.g. `maxSteps`, `temperature`) without growing the top-level shape.
- Removing inline `LlmModelConfig` from agents centralises credentials in `llmPlugin`, mirroring how `llm()` already works. Agent code now references models by id, period.

## Implementation

- New `AgentDefaultOptions { model?, tools? }` interface; `ADAPTER_AGENT_DEFAULT_OPTIONS` store key replaces `ADAPTER_TOOLS_DEFAULT`.
- `agentPlugin` validates `defaultOptions` at construction (object shape, model is `providerId:modelName`, tools is a `ToolSelection`).
- Multiple `agentPlugin` installs that each set the SAME default field throw at context init; installs that set DIFFERENT fields merge cleanly.
- `AgentDestinationAdapter.send()` reads the stored defaults and falls back per-key before dispatching to `callLlm`. Throws RC5003 when neither side supplies a model.
- `validateAgentOptions` (inline `agent({...})`) permits an absent `model`; rejects only malformed strings when present.
- `getMetadata` no longer dereferences `LlmModelConfig` (path removed).

## Tests

- 905 pass / 1 skipped.
- `tools-default.test.ts` migrated to the new shape; new tests for:
  - `defaultOptions.model` storage.
  - "registered agent without model is accepted when default exists".
  - Conflicting installs (same field) throw; different-field installs merge.
  - Non-object / non-string / malformed-shape rejections at construction.
- `agent.test.ts`:
  - Dropped the inline `LlmModelConfig` test.
  - Added "constructs without model" and "inherits defaults.model at dispatch".
  - Added "per-agent model overrides defaults".
  - Added "dispatch throws when neither side supplies a model".

## Docs

- Plugins reference page rewrites the "Context-default tool list" section as **"Context-level `defaultOptions`"** with a small table and merge rules.
- Adds an explicit **"Soft dependency on `llmPlugin`"** note explaining provider wiring.

## Test plan

- [ ] CI green
- [ ] CodeRabbit / cubic-dev-ai reviews pass

Refs #224. Lands ahead of the runtime-wiring PR (Vercel `tool({...})` bridge + `generateText({ tools, stopWhen })`).

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors agent defaults to `agentPlugin({ defaultOptions })` with `model` and `tools`, aligns option names across agents and `llm()` (`system`, `user`, `output`), and removes `Partial<>` from factory args. Also renames fn schemas to `input`, adds `agent({ output })` validation, and updates standards/docs. Refs #224.

- **Refactors**
  - `agentPlugin({ defaultOptions: { model?, tools? } })`; replaces top‑level `tools`; stored under `ADAPTER_AGENT_DEFAULT_OPTIONS`; installs setting the same field throw, different fields merge.
  - `AgentOptions.model` is optional and string‑only (`"providerId:modelName"`); resolution is instance > default > throw. New `AgentOptions.output?: StandardSchemaV1` (validated at construction; DSL only for now).
  - `llm()` options renamed: `systemPrompt` -> `system`, `userPrompt` -> `user`, `outputSchema` -> `output`; internals (`callLlm` and providers) updated end‑to‑end.
  - Fn API rename: `FnOptions.schema` -> `FnOptions.input` (cascades to tool builders/selection, `ResolvedTool.input`, overrides, `defaultFns`, and `testFn`).
  - Adapter factories: remove `Partial<>` from option types (`embedding`, `llm`, `direct`, `mail`) so required fields are enforced at the call site.
  - Validation hardening: `agent({ output })` rejects null/non‑object values with `RC5003` instead of surfacing a raw TypeError.
  - Standards/docs: add schema field naming (`input`/`output`) and “no `Partial<>` on factory args”; update adapter/plugin docs to the new option names, `defaultOptions`, and the explicit `llmPlugin` soft dependency.

- **Migration**
  - `agentPlugin({ tools: tools([...]) })` -> `agentPlugin({ defaultOptions: { tools: tools([...]) } })`.
  - Remove inline model configs; use string ids and install providers via `llmPlugin({ providers })`. Ensure each agent sets `model` or inherits via `defaultOptions.model`.
  - Rename LLM option keys to `system`, `user`, `output`.
  - Rename fn specs to `input` (update custom fns, `directTool` overrides, and tests using `testFn`).
  - `embedding(modelId, options)`: pass a real `options` object with `using` (now type‑required). `direct(...)`, `mail(...)`, and `llm(...)` no longer accept `Partial<>` option bags.

<sup>Written for commit e1188b6ffac5e3e381d789a6d1f94246c289265e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

