### PR TITLE
feat(ai): agent runtime tool-calling loop (closes #224)

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -634,7 +634,7 @@ The current loop is synchronous and in-memory. A tool handler that `await`s for 
 | Under a minute | Fine. HTTP timeouts and restart risk are low. |
 | 1–10 minutes | Works on most platforms. Acceptable for "ask user, get reply during a meeting" flows. |
 | 10 min – 1 hour | Marginal. Platform request timeouts (Vercel, CloudRun, etc.) cap how long an HTTP request can hang. Use queue / cron entry points if the tool may take this long. |
-| Hours – days | Not viable in the synchronous loop. Wait for the [durable agents epic](https://github.com/routecraftjs/routecraft/issues/258) — `SuspendError` is exported today as a forward-compat stub so handler code can be written against the eventual surface. |
+| Hours – days | Not viable in the synchronous loop. Wait for the [durable agents epic](https://github.com/routecraftjs/routecraft/issues/258). `SuspendError` is exported today as a forward-compat stub so handler code can be written against the eventual surface. |
 
 A blocking tool handler today looks like:
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -514,11 +514,11 @@ const out = await testFn(greet, { name: 'alice' })
 
 `testFn` validates the input against the `input` schema, calls the handler with a synthetic `{ logger, abortSignal }` context, and returns the handler's output. Validation failures throw `RC5002`. It works structurally on any `{ input, handler }` shape, so real `FnOptions` values pass without modification.
 
-### Agent tools (experimental DSL)
+### Agent tools
 
-> **Status: DSL-only.** The configuration surface below is fully implemented and validated; the agent runtime that actually presents these tools to the LLM and dispatches them lands in a follow-up release. Setting `tools:` on an agent today is a no-op at dispatch time.
+> **Status: live.** Tools an agent declares via `tools([...])` are bridged into the Vercel AI SDK's tool-calling loop at dispatch time. The model sees each tool's name, description, and JSON schema; the SDK validates tool-call arguments against the schema, reports validation errors back to the model for self-correction, and otherwise invokes the agent's handler. Synchronous in-memory loop today; streaming and durable suspend/resume are tracked separately ([streaming agents](https://github.com/routecraftjs/routecraft/issues/257), [durable agents epic](https://github.com/routecraftjs/routecraft/issues/258)).
 
-Tags, the `tools([...])` selector, the builder helpers, and the context-level `defaultOptions` bag register and validate cleanly so user code can be written against the final shape now.
+Tags, the `tools([...])` selector, the builder helpers, and the context-level `defaultOptions` bag compose to give an agent a typed, whitelisted set of capabilities.
 
 ```ts
 import {
@@ -620,6 +620,35 @@ agentPlugin({
 #### Soft dependency on `llmPlugin`
 
 Agent model references use the `"providerId:modelName"` format and resolve against the LLM provider registry populated by `llmPlugin`. **You must install `llmPlugin` with the relevant providers.** This is intentional: provider credentials live in one place, and agents reference them by id. There is no inline-credentials escape hatch on `agent({...})`; centralised wiring via `llmPlugin` is the only path.
+
+#### Step cap (`maxSteps`)
+
+The Vercel AI SDK's tool-calling loop runs until the model returns a final text response or a stop condition fires. Each iteration is one step (one model call plus the resulting tool calls / results). The agent caps step count to **8 by default**; override per agent via `maxSteps:` or context-wide via `defaultOptions.maxSteps`. When the cap fires the SDK returns whatever text the model produced last; downstream logic should treat truncated output as a possible outcome.
+
+#### Human-in-the-loop (today: blocking; tomorrow: durable)
+
+The current loop is synchronous and in-memory. A tool handler that `await`s for a while pins the agent's await chain until it resolves. Practical sweet spot:
+
+| Tool wait time | Viability today |
+|---|---|
+| Under a minute | Fine. HTTP timeouts and restart risk are low. |
+| 1–10 minutes | Works on most platforms. Acceptable for "ask user, get reply during a meeting" flows. |
+| 10 min – 1 hour | Marginal. Platform request timeouts (Vercel, CloudRun, etc.) cap how long an HTTP request can hang. Use queue / cron entry points if the tool may take this long. |
+| Hours – days | Not viable in the synchronous loop. Wait for the [durable agents epic](https://github.com/routecraftjs/routecraft/issues/258) — `SuspendError` is exported today as a forward-compat stub so handler code can be written against the eventual surface. |
+
+A blocking tool handler today looks like:
+
+```ts
+{
+  description: "Ask a human for approval via email; wait up to 15 min.",
+  input: z.object({ question: z.string() }),
+  handler: async (input) => {
+    return await pollUntilReply(input.question, { timeoutMs: 15 * 60 * 1000 })
+  },
+}
+```
+
+When the durable epic lands, the same handler migrates by replacing the blocking await with `throw new SuspendError({ reason: "awaiting-human-approval" })` and consuming the resume callback in a separate route. The runtime contract (return value, schema, `FnHandlerContext`) stays identical.
 
 ### Typed fn ids (`FnRegistry`)
 

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -1,5 +1,6 @@
 import {
   getExchangeContext,
+  getExchangeRoute,
   rcError,
   type CraftContext,
   type Destination,
@@ -76,7 +77,14 @@ export class AgentDestinationAdapter implements Destination<
       context,
     });
 
-    return await session.runUntilDone(new AbortController().signal);
+    // Thread the route's abort signal through so the agent dispatch
+    // (LLM call + in-flight tool handlers) is cancelled when the
+    // route or context shuts down. Falls back to a never-firing
+    // signal when the exchange has no route binding (rare; mostly
+    // synthetic exchanges in tests).
+    const abortSignal =
+      getExchangeRoute(exchange)?.signal ?? new AbortController().signal;
+    return await session.runUntilDone(abortSignal);
   }
 
   /** Pull the agent options for this dispatch, either inline or from the registry. */

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -5,26 +5,19 @@ import {
   type Destination,
   type Exchange,
 } from "@routecraft/routecraft";
-import { callLlm } from "../llm/providers/index.ts";
-import {
-  resolveModel,
-  resolvePrompt,
-  resolveUserPromptDefault,
-} from "../llm/shared.ts";
+import { resolveModel } from "../llm/shared.ts";
+import { AgentSession, buildUserPrompt } from "./session.ts";
 import {
   ADAPTER_AGENT_DEFAULT_OPTIONS,
   ADAPTER_AGENT_REGISTRY,
 } from "./store.ts";
+import type { ResolvedTool } from "./tools/selection.ts";
 import type {
   AgentDefaultOptions,
   AgentOptions,
   AgentRegisteredOptions,
   AgentResult,
 } from "./types.ts";
-
-/** Default sampling settings; aligned with the LLM destination defaults. */
-const DEFAULT_TEMPERATURE = 0;
-const DEFAULT_MAX_TOKENS = 1024;
 
 const AGENT_REGISTRY_STORE_DESCRIPTION =
   ADAPTER_AGENT_REGISTRY.description ?? "routecraft.adapter.agent.registry";
@@ -35,14 +28,16 @@ export type AgentBinding =
   | { kind: "by-name"; name: string };
 
 /**
- * Agent destination adapter. Calls the configured LLM provider once with the
- * agent's system prompt and a user prompt derived from the exchange body.
- * Replaces the body with `AgentResult { text, usage? }`.
+ * Agent destination adapter. Resolves agent options (inline or
+ * registered), merges them with `agentPlugin({ defaultOptions })`,
+ * resolves the agent's tool selection against the live context, and
+ * dispatches the tool-calling loop via {@link AgentSession}. Replaces
+ * the exchange body with `AgentResult { text, output?, reasoning?, usage? }`.
  *
  * Resolution: when constructed inline, uses options directly. When
- * constructed by name, resolves the registered agent from the context store
- * (`ADAPTER_AGENT_REGISTRY`) at dispatch time, throwing a clear error if
- * the name is unknown.
+ * constructed by name, resolves the registered agent from the context
+ * store (`ADAPTER_AGENT_REGISTRY`) at dispatch time, throwing a clear
+ * error if the name is unknown.
  *
  * @experimental
  */
@@ -68,27 +63,20 @@ export class AgentDestinationAdapter implements Destination<
     }
 
     const { config, modelName } = resolveModel(merged.model, context);
+    const tools = resolveAgentTools(merged, context);
+    const user = buildUserPrompt(merged, exchange);
 
-    const system = merged.system;
-    const user =
-      merged.user !== undefined
-        ? resolvePrompt(merged.user, exchange)
-        : resolveUserPromptDefault(exchange);
-
-    const result = await callLlm({
-      config,
-      modelId: modelName,
-      options: {
-        temperature: DEFAULT_TEMPERATURE,
-        maxTokens: DEFAULT_MAX_TOKENS,
-      },
-      system,
+    const session = new AgentSession({
+      options: merged,
+      modelConfig: config,
+      modelName,
+      tools,
       user,
+      system: merged.system,
+      context,
     });
 
-    const out: AgentResult = { text: result.text };
-    if (result.usage) out.usage = result.usage;
-    return out;
+    return await session.runUntilDone(new AbortController().signal);
   }
 
   /** Pull the agent options for this dispatch, either inline or from the registry. */
@@ -112,7 +100,7 @@ export class AgentDestinationAdapter implements Destination<
       throw rcError("RC5004", undefined, {
         message:
           `Agent "${this.binding.name}" not found: no agents registered. ` +
-          `Add agentPlugin({ agents: [defineAgent({ id: "${this.binding.name}", ... })] }) to your config.`,
+          `Add agentPlugin({ agents: { "${this.binding.name}": {...} } }) to your config.`,
       });
     }
     const found = registry.get(this.binding.name);
@@ -170,5 +158,32 @@ function mergeWithDefaults(
   if (out.tools === undefined && defaults.tools !== undefined) {
     out.tools = defaults.tools;
   }
+  if (out.maxSteps === undefined && defaults.maxSteps !== undefined) {
+    out.maxSteps = defaults.maxSteps;
+  }
   return out;
+}
+
+/**
+ * Resolve the agent's `tools` selection against the live context. The
+ * selection is the `ToolSelection` object built via `tools([...])`;
+ * resolution walks the fn registry and direct registry to produce the
+ * final `ResolvedTool[]` the runtime hands to the LLM.
+ *
+ * Returns an empty array when the agent has no tools field set
+ * (and no context-default tools were inherited).
+ *
+ * @internal
+ */
+function resolveAgentTools(
+  options: AgentOptions | AgentRegisteredOptions,
+  context: CraftContext | undefined,
+): ResolvedTool[] {
+  if (options.tools === undefined) return [];
+  if (!context) {
+    throw rcError("RC5003", undefined, {
+      message: `Agent: cannot resolve tools without a CraftContext.`,
+    });
+  }
+  return options.tools.resolve(context);
 }

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -5,6 +5,7 @@ export {
   ADAPTER_AGENT_DEFAULT_OPTIONS,
   ADAPTER_AGENT_REGISTRY,
 } from "./store.ts";
+export { SuspendError, isSuspendError } from "./suspend.ts";
 export type {
   AgentDefaultOptions,
   AgentOptions,

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -1,0 +1,153 @@
+import type { CraftContext, Exchange } from "@routecraft/routecraft";
+import { callLlm } from "../llm/providers/index.ts";
+import {
+  resolveModel,
+  resolvePrompt,
+  resolveUserPromptDefault,
+} from "../llm/shared.ts";
+import type { LlmModelConfig, LlmResult } from "../llm/types.ts";
+import { toAiOutputSpec } from "../llm/structured-output.ts";
+import { buildVercelTools } from "./tool-bridge.ts";
+import type { ResolvedTool } from "./tools/selection.ts";
+import type {
+  AgentOptions,
+  AgentRegisteredOptions,
+  AgentResult,
+} from "./types.ts";
+
+/** Default sampling settings; aligned with the LLM destination defaults. */
+const DEFAULT_TEMPERATURE = 0;
+const DEFAULT_MAX_TOKENS = 1024;
+const DEFAULT_MAX_STEPS = 8;
+
+/**
+ * Resolved agent inputs ready for dispatch. Computed once by the
+ * destination's `send()` method (after merging `defaultOptions`,
+ * resolving the tool selection, and deriving the user prompt) and
+ * passed to the session constructor.
+ *
+ * @internal
+ */
+export interface AgentSessionInput {
+  /** Agent options after merging with `defaultOptions`. `model` resolved. */
+  readonly options: AgentOptions | AgentRegisteredOptions;
+  /** Provider config for the resolved model. */
+  readonly modelConfig: LlmModelConfig;
+  /** Provider-specific model name (after `parseProviderModel`). */
+  readonly modelName: string;
+  /** Resolved tool list (empty when the agent has no tools). */
+  readonly tools: ResolvedTool[];
+  /** Final user prompt for this dispatch. */
+  readonly user: string;
+  /** Final system prompt for this dispatch. */
+  readonly system: string;
+  /** Optional context reference passed to tool handlers. */
+  readonly context: CraftContext | undefined;
+}
+
+/**
+ * Internal session that drives one agent dispatch. Encapsulates the
+ * resolved tools + initial messages + provider config so the dispatch
+ * path is structured around discrete units of work.
+ *
+ * Today only the synchronous path (`runUntilDone()`) is implemented —
+ * it calls `generateText` once with the full tool list and lets the
+ * Vercel AI SDK handle the multi-step tool-calling loop internally.
+ *
+ * The session boundary exists so two follow-ups layer on without
+ * rearchitecting:
+ *
+ * - **Streaming** (#257) adds `runStream()` which calls `streamText`
+ *   with the same setup and returns an `AsyncIterable<AgentEvent>`.
+ * - **Durable agents** (#258) checkpoints the running messages array
+ *   between tool-call steps and lets a tool handler throw
+ *   `SuspendError` to pause the loop.
+ *
+ * @internal
+ */
+export class AgentSession {
+  constructor(public readonly input: AgentSessionInput) {}
+
+  /**
+   * Run the synchronous tool-calling loop until the model emits a
+   * final text response (or `stopWhen` fires). Returns the
+   * consolidated `AgentResult`.
+   */
+  async runUntilDone(abortSignal: AbortSignal): Promise<AgentResult> {
+    const { options, modelConfig, modelName, tools, user, system, context } =
+      this.input;
+
+    const vercelTools = await buildVercelTools(tools, context, abortSignal);
+    const stopWhen = await buildStopWhen(options.maxSteps ?? DEFAULT_MAX_STEPS);
+    const output =
+      options.output !== undefined ? toAiOutputSpec(options.output) : undefined;
+
+    const result = await callLlm({
+      config: modelConfig,
+      modelId: modelName,
+      options: {
+        temperature: DEFAULT_TEMPERATURE,
+        maxTokens: DEFAULT_MAX_TOKENS,
+      },
+      system,
+      user,
+      ...(output !== undefined ? { output } : {}),
+      ...(Object.keys(vercelTools).length > 0
+        ? { tools: vercelTools, stopWhen }
+        : {}),
+    });
+
+    return toAgentResult(result);
+  }
+}
+
+async function buildStopWhen(maxSteps: number): Promise<unknown> {
+  const { stepCountIs } = await import("ai");
+  return stepCountIs(maxSteps);
+}
+
+function toAgentResult(result: LlmResult): AgentResult {
+  const out: AgentResult = { text: result.text };
+  if (result.output !== undefined) out.output = result.output;
+  if (result.reasoning !== undefined) out.reasoning = result.reasoning;
+  if (result.usage) out.usage = result.usage;
+  return out;
+}
+
+/**
+ * Build the user prompt for an agent dispatch from the merged options
+ * and the incoming exchange. Uses the agent's `user:` resolver when
+ * present, otherwise derives a default from `exchange.body`
+ * (matches the existing LLM destination behaviour).
+ *
+ * @internal
+ */
+export function buildUserPrompt(
+  options: AgentOptions | AgentRegisteredOptions,
+  exchange: Exchange<unknown>,
+): string {
+  return options.user !== undefined
+    ? resolvePrompt(options.user, exchange)
+    : resolveUserPromptDefault(exchange);
+}
+
+/**
+ * Resolve the model id and provider config from the merged options
+ * and current context. Throws RC5003 with a clear message if no model
+ * is available (neither agent option nor `defaultOptions.model`).
+ *
+ * @internal
+ */
+export function buildModel(
+  options: AgentOptions | AgentRegisteredOptions,
+  context: CraftContext | undefined,
+): { config: LlmModelConfig; modelName: string } {
+  if (options.model === undefined) {
+    // Caller (destination) is expected to throw before this. Defensive
+    // path; re-raise here to avoid producing a malformed session.
+    throw new Error(
+      `AgentSession: no "model" supplied. Set "model" on the agent or via agentPlugin({ defaultOptions: { model } }).`,
+    );
+  }
+  return resolveModel(options.model, context);
+}

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -1,10 +1,6 @@
 import type { CraftContext, Exchange } from "@routecraft/routecraft";
 import { callLlm } from "../llm/providers/index.ts";
-import {
-  resolveModel,
-  resolvePrompt,
-  resolveUserPromptDefault,
-} from "../llm/shared.ts";
+import { resolvePrompt, resolveUserPromptDefault } from "../llm/shared.ts";
 import type { LlmModelConfig, LlmResult } from "../llm/types.ts";
 import { toAiOutputSpec } from "../llm/structured-output.ts";
 import { buildVercelTools } from "./tool-bridge.ts";
@@ -50,8 +46,8 @@ export interface AgentSessionInput {
  * resolved tools + initial messages + provider config so the dispatch
  * path is structured around discrete units of work.
  *
- * Today only the synchronous path (`runUntilDone()`) is implemented —
- * it calls `generateText` once with the full tool list and lets the
+ * Today only the synchronous path (`runUntilDone()`) is implemented.
+ * It calls `generateText` once with the full tool list and lets the
  * Vercel AI SDK handle the multi-step tool-calling loop internally.
  *
  * The session boundary exists so two follow-ups layer on without
@@ -78,9 +74,21 @@ export class AgentSession {
       this.input;
 
     const vercelTools = await buildVercelTools(tools, context, abortSignal);
-    const stopWhen = await buildStopWhen(options.maxSteps ?? DEFAULT_MAX_STEPS);
     const output =
       options.output !== undefined ? toAiOutputSpec(options.output) : undefined;
+
+    // Build stopWhen only when tools are present. Without tools the
+    // SDK returns after a single step, so the stop predicate (and its
+    // dynamic `import("ai")`) is unnecessary.
+    const toolExtras =
+      Object.keys(vercelTools).length > 0
+        ? {
+            tools: vercelTools,
+            stopWhen: await buildStopWhen(
+              options.maxSteps ?? DEFAULT_MAX_STEPS,
+            ),
+          }
+        : {};
 
     const result = await callLlm({
       config: modelConfig,
@@ -91,10 +99,9 @@ export class AgentSession {
       },
       system,
       user,
+      abortSignal,
       ...(output !== undefined ? { output } : {}),
-      ...(Object.keys(vercelTools).length > 0
-        ? { tools: vercelTools, stopWhen }
-        : {}),
+      ...toolExtras,
     });
 
     return toAgentResult(result);
@@ -129,25 +136,4 @@ export function buildUserPrompt(
   return options.user !== undefined
     ? resolvePrompt(options.user, exchange)
     : resolveUserPromptDefault(exchange);
-}
-
-/**
- * Resolve the model id and provider config from the merged options
- * and current context. Throws RC5003 with a clear message if no model
- * is available (neither agent option nor `defaultOptions.model`).
- *
- * @internal
- */
-export function buildModel(
-  options: AgentOptions | AgentRegisteredOptions,
-  context: CraftContext | undefined,
-): { config: LlmModelConfig; modelName: string } {
-  if (options.model === undefined) {
-    // Caller (destination) is expected to throw before this. Defensive
-    // path; re-raise here to avoid producing a malformed session.
-    throw new Error(
-      `AgentSession: no "model" supplied. Set "model" on the agent or via agentPlugin({ defaultOptions: { model } }).`,
-    );
-  }
-  return resolveModel(options.model, context);
 }

--- a/packages/ai/src/agent/suspend.ts
+++ b/packages/ai/src/agent/suspend.ts
@@ -1,0 +1,80 @@
+/**
+ * Signal raised by a fn handler when it cannot complete synchronously
+ * and the agent's tool-loop should pause until an external event (a
+ * human reply, a webhook, a long-running batch result) supplies the
+ * answer.
+ *
+ * **Stub today.** This type is exported so user code that wants to be
+ * forward-compatible with the durable-agents epic can throw it, but no
+ * runtime path catches it yet. When the durable epic lands, the agent
+ * runtime will catch this error, persist the message thread, and
+ * return `{ status: "suspended", checkpointId }` to the calling route
+ * instead of an `AgentResult`. See the durable-agents tracking issue
+ * for the full design.
+ *
+ * Until then, throwing this is a normal error and behaves like any
+ * other tool failure (feeds back to the model for self-correction).
+ *
+ * For human-in-the-loop flows where waits are short (seconds to
+ * minutes), the recommended pattern is to write a tool handler that
+ * blocks on the answer (`await pollUntilReply(...)`); the agent's
+ * await chain holds the loop in memory until the tool resolves.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * import { SuspendError } from "@routecraft/ai"
+ *
+ * const askApproval: FnOptions = {
+ *   description: "Ask a human for approval via email",
+ *   input: z.object({ question: z.string() }),
+ *   handler: async (input, ctx) => {
+ *     await sendApprovalRequest({
+ *       question: input.question,
+ *       callbackUrl: `${baseUrl}/resume/${ctx.checkpointId}`,
+ *     })
+ *     throw new SuspendError({ reason: "awaiting-human-approval" })
+ *   },
+ * }
+ * ```
+ */
+export class SuspendError extends Error {
+  /** Discriminator for runtime detection. */
+  override readonly name = "SuspendError";
+  /**
+   * Optional reason string surfaced in telemetry and the eventual
+   * suspended-agent record. Free-form; pick whatever your product
+   * vocabulary uses ("awaiting-human-approval", "waiting-for-webhook",
+   * etc.).
+   */
+  readonly reason?: string;
+  /**
+   * Optional channel hint indicating how the agent will be resumed.
+   * Surfaces in telemetry and lets the surrounding route decide how
+   * to react (e.g. return `202 Accepted` to the HTTP client).
+   */
+  readonly resumeChannel?: string;
+
+  constructor(opts?: { reason?: string; resumeChannel?: string }) {
+    super(
+      opts?.reason
+        ? `Agent suspended: ${opts.reason}`
+        : "Agent suspended pending external resumption.",
+    );
+    if (opts?.reason !== undefined) this.reason = opts.reason;
+    if (opts?.resumeChannel !== undefined) {
+      this.resumeChannel = opts.resumeChannel;
+    }
+  }
+}
+
+/**
+ * Type guard for `SuspendError`. Used by the runtime to detect
+ * suspension signals without importing the concrete class everywhere.
+ *
+ * @internal
+ */
+export function isSuspendError(value: unknown): value is SuspendError {
+  return value instanceof SuspendError;
+}

--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -29,14 +29,19 @@ export async function buildVercelTools(
   ctx: CraftContext | undefined,
   abortSignal: AbortSignal,
 ): Promise<Record<string, unknown>> {
-  if (resolved.length === 0) return {};
+  if (resolved.length === 0)
+    return Object.create(null) as Record<string, unknown>;
   const { tool } = await import("ai");
 
-  const out: Record<string, unknown> = {};
+  // Use a null-prototype object so dynamic tool names supplied at
+  // resolution time can never mutate Object.prototype (e.g. a tool
+  // accidentally named "__proto__" would otherwise be a vector for
+  // prototype pollution).
+  const out: Record<string, unknown> = Object.create(null);
   for (const r of resolved) {
     const guard = r.guard;
     const handler = r.handler;
-    const handlerCtx: FnHandlerContext = makeFnHandlerContext(
+    const baseCtx: FnHandlerContext = makeFnHandlerContext(
       r.name,
       ctx,
       abortSignal,
@@ -46,9 +51,24 @@ export async function buildVercelTools(
       inputSchema: toAiInputSchema(r.input) as Parameters<
         typeof tool
       >[0]["inputSchema"],
-      execute: async (input: unknown) => {
-        if (guard) await guard(input, handlerCtx);
-        return await handler(input, handlerCtx);
+      execute: async (
+        input: unknown,
+        callOpts?: {
+          abortSignal?: AbortSignal;
+          toolCallId?: string;
+          messages?: unknown[];
+        },
+      ) => {
+        // Merge per-call options (the SDK passes its own abortSignal
+        // and toolCallId per invocation) into the handler context so
+        // a tool can react to per-step cancellation, not just the
+        // session-wide signal captured at buildVercelTools time.
+        const callCtx: FnHandlerContext = {
+          ...baseCtx,
+          abortSignal: callOpts?.abortSignal ?? baseCtx.abortSignal,
+        };
+        if (guard) await guard(input, callCtx);
+        return await handler(input, callCtx);
       },
     });
   }

--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -1,0 +1,75 @@
+import {
+  logger as frameworkLogger,
+  type CraftContext,
+} from "@routecraft/routecraft";
+import { toAiInputSchema } from "../llm/structured-output.ts";
+import type { FnHandlerContext } from "../fn/types.ts";
+import type { ResolvedTool } from "./tools/selection.ts";
+
+/**
+ * Convert a list of `ResolvedTool` entries (the output of
+ * `tools([...]).resolve(ctx)`) into a Vercel AI SDK tool map suitable
+ * for `generateText({ tools })`.
+ *
+ * Each resulting tool runs:
+ * 1. The optional guard (registered via `tools([{ name, guard }])` or
+ *    `tools([{ tagged, guard }])`). Throwing inside the guard surfaces
+ *    back to the model as a tool error so the model can self-correct.
+ * 2. The underlying handler with `(input, fnHandlerContext)`.
+ *
+ * Schema validation is delegated to the SDK: when the model's tool-call
+ * args fail to match `inputSchema`, the SDK reports a tool error to
+ * the model without calling `execute`. Successful validation passes
+ * the parsed value through to `execute`.
+ *
+ * @internal
+ */
+export async function buildVercelTools(
+  resolved: ResolvedTool[],
+  ctx: CraftContext | undefined,
+  abortSignal: AbortSignal,
+): Promise<Record<string, unknown>> {
+  if (resolved.length === 0) return {};
+  const { tool } = await import("ai");
+
+  const out: Record<string, unknown> = {};
+  for (const r of resolved) {
+    const guard = r.guard;
+    const handler = r.handler;
+    const handlerCtx: FnHandlerContext = makeFnHandlerContext(
+      r.name,
+      ctx,
+      abortSignal,
+    );
+    out[r.name] = tool({
+      description: r.description,
+      inputSchema: toAiInputSchema(r.input) as Parameters<
+        typeof tool
+      >[0]["inputSchema"],
+      execute: async (input: unknown) => {
+        if (guard) await guard(input, handlerCtx);
+        return await handler(input, handlerCtx);
+      },
+    });
+  }
+  return out;
+}
+
+/**
+ * Construct the synthetic `FnHandlerContext` handed to a tool's guard
+ * and handler during agent dispatch. Mirrors the shape `testFn`
+ * provides: `logger`, `abortSignal`, optional `context`,
+ * optional `correlationId` (not yet populated by the runtime), and
+ * optional `checkpointId` (durable-agents epic).
+ */
+function makeFnHandlerContext(
+  toolName: string,
+  ctx: CraftContext | undefined,
+  abortSignal: AbortSignal,
+): FnHandlerContext {
+  return {
+    logger: frameworkLogger.child({ tool: toolName }),
+    abortSignal,
+    ...(ctx ? { context: ctx } : {}),
+  };
+}

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -17,10 +17,26 @@ import type { FnHandlerContext, FnOptions } from "../../fn/types.ts";
 import { DEFERRED_FN_BRAND, type DeferredFn } from "./types.ts";
 
 /**
+ * JSON Schema describing an empty object. Closed for additional
+ * properties so the LLM can't confuse models that have more fields.
+ */
+const EMPTY_OBJECT_JSON_SCHEMA = {
+  type: "object" as const,
+  properties: {},
+  additionalProperties: false,
+};
+
+/**
  * Standard Schema implementation of an empty input object. Used by the
  * `defaultFns` so this module stays free of a Zod runtime dependency
  * (per CLAUDE.md "Use Standard Schema, not Zod/Valibot directly in
  * shared code").
+ *
+ * Exposes both `~standard.validate` (mandatory per the spec) and the
+ * non-standard `~standard.jsonSchema.{input,output}` extension that
+ * the Vercel AI SDK bridge consumes — so this hand-rolled schema can
+ * back tools and structured-output specs alongside Zod / Valibot
+ * schemas without special-casing.
  */
 const emptyObjectSchema: StandardSchemaV1<unknown, Record<string, never>> = {
   "~standard": {
@@ -43,7 +59,15 @@ const emptyObjectSchema: StandardSchemaV1<unknown, Record<string, never>> = {
       }
       return { value: {} as Record<string, never> };
     },
-  },
+    // Non-standard `jsonSchema` extension consumed by the AI SDK bridge.
+    // Cast away from the strict StandardSchemaV1 shape since the spec
+    // doesn't include this field; library schemas (Zod, Valibot) ship it
+    // as an extension and the bridge looks it up defensively.
+    jsonSchema: {
+      input: () => EMPTY_OBJECT_JSON_SCHEMA,
+      output: () => EMPTY_OBJECT_JSON_SCHEMA,
+    },
+  } as StandardSchemaV1<unknown, Record<string, never>>["~standard"],
 };
 
 /**

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -41,6 +41,14 @@ export interface AgentDefaultOptions {
    * (override, not extend).
    */
   tools?: ToolSelection;
+
+  /**
+   * Default cap on tool-call steps for the Vercel AI SDK loop, applied
+   * to agents that omit `maxSteps`. Each step is one model call (which
+   * may emit any number of tool calls) plus the resulting tool results.
+   * Resolves to `stopWhen: stepCountIs(maxSteps)` at dispatch.
+   */
+  maxSteps?: number;
 }
 
 /**
@@ -96,12 +104,17 @@ export interface AgentOptions {
    * "declared output shape" everywhere in the framework. Per-agent
    * only (not part of `defaultOptions`), since output shape is
    * intrinsic to a specific agent's job.
-   *
-   * The runtime that wires this through `generateText({ output })`
-   * lands in the next PR; defining this field today is accepted by
-   * validation but does not yet shape the dispatch.
    */
   output?: StandardSchemaV1;
+
+  /**
+   * Cap on tool-call steps for the Vercel AI SDK loop. Each step is
+   * one model call (which may emit any number of tool calls) plus the
+   * resulting tool results. Resolves to `stopWhen: stepCountIs(n)` at
+   * dispatch. Defaults to 8 when neither the agent nor
+   * `defaultOptions.maxSteps` supplies a value.
+   */
+  maxSteps?: number;
 }
 
 /**
@@ -128,6 +141,18 @@ export interface AgentRegisteredOptions extends AgentOptions {
 export interface AgentResult {
   /** Generated text from the model. */
   text: string;
+  /**
+   * Parsed structured output when an `output` schema was supplied on
+   * `AgentOptions` and the model produced a value matching the schema.
+   * Undefined otherwise.
+   */
+  output?: unknown;
+  /**
+   * Raw reasoning text from the provider when supplied (Anthropic
+   * extended thinking, OpenAI o1, etc.). Useful for debugging and
+   * audit; most consumers ignore it.
+   */
+  reasoning?: string;
   /** Token usage when reported by the provider. */
   usage?: LlmUsage;
 }

--- a/packages/ai/src/fn/types.ts
+++ b/packages/ai/src/fn/types.ts
@@ -32,10 +32,22 @@ export interface FnHandlerContext {
    * Correlation id of the calling exchange, when the fn was invoked
    * from inside a running route or agent dispatch. Propagated to any
    * child exchanges (e.g. direct route calls) so traces stay linked.
-   * The agent runtime populates this in a follow-up commit; today only
-   * `directTool`-built handlers consume it.
    */
   readonly correlationId?: string;
+
+  /**
+   * Identifier for the durable-agents checkpoint when the fn is
+   * running inside a checkpointed agent session. Undefined today (no
+   * runtime populates it); the durable-agents epic supplies a real
+   * value so a tool handler that suspends can hand it to the
+   * resumption channel (e.g. embed it in a callback URL).
+   *
+   * Exposed now so handlers written today can be forward-compat with
+   * the durable epic without changing signature.
+   *
+   * @experimental
+   */
+  readonly checkpointId?: string;
 }
 
 /**

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -118,6 +118,8 @@ export {
   agentPlugin,
   ADAPTER_AGENT_DEFAULT_OPTIONS,
   ADAPTER_AGENT_REGISTRY,
+  SuspendError,
+  isSuspendError,
 } from "./agent/index.ts";
 export type {
   AgentBinding,

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -116,6 +116,17 @@ export interface CallLlmParams {
    * any other Vercel AI SDK stop predicate).
    */
   stopWhen?: unknown;
+  /**
+   * Optional abort signal forwarded into `generateText`. When the
+   * signal aborts mid-call, the SDK throws an AbortError and any
+   * in-flight tool handlers receive the same signal via their
+   * `FnHandlerContext.abortSignal`.
+   *
+   * Thread the route's signal here (`getExchangeRoute(exchange)?.signal`)
+   * so an in-flight agent dispatch is cancelled when the route or
+   * context shuts down.
+   */
+  abortSignal?: AbortSignal;
 }
 
 /**
@@ -129,6 +140,7 @@ interface ProviderExtras {
   output?: unknown;
   tools?: Record<string, unknown>;
   stopWhen?: unknown;
+  abortSignal?: AbortSignal;
 }
 
 function buildExtras(params: CallLlmParams): ProviderExtras {
@@ -138,6 +150,7 @@ function buildExtras(params: CallLlmParams): ProviderExtras {
     out.tools = params.tools;
     if (params.stopWhen !== undefined) out.stopWhen = params.stopWhen;
   }
+  if (params.abortSignal !== undefined) out.abortSignal = params.abortSignal;
   return out;
 }
 

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -103,24 +103,61 @@ export interface CallLlmParams {
   user: string;
   /** Optional structured output spec (from toAiOutputSpec). Enables provider-level JSON schema. */
   output?: unknown;
+  /**
+   * Optional Vercel AI SDK tool map. When supplied the SDK runs the
+   * tool-calling loop: presents tools to the model, dispatches calls,
+   * feeds results (and validation/guard errors) back, until the loop
+   * terminates (a final text response or `stopWhen` fires).
+   */
+  tools?: Record<string, unknown>;
+  /**
+   * Optional stop condition for the tool-calling loop. Required when
+   * `tools` is set; ignored otherwise. Built via `stepCountIs(n)` (or
+   * any other Vercel AI SDK stop predicate).
+   */
+  stopWhen?: unknown;
+}
+
+/**
+ * Per-provider extras forwarded into `generateText`. Centralised so
+ * each provider builds the same shape and the typecast at the call
+ * site stays narrow.
+ *
+ * @internal
+ */
+interface ProviderExtras {
+  output?: unknown;
+  tools?: Record<string, unknown>;
+  stopWhen?: unknown;
+}
+
+function buildExtras(params: CallLlmParams): ProviderExtras {
+  const out: ProviderExtras = {};
+  if (params.output !== undefined) out.output = params.output;
+  if (params.tools !== undefined && Object.keys(params.tools).length > 0) {
+    out.tools = params.tools;
+    if (params.stopWhen !== undefined) out.stopWhen = params.stopWhen;
+  }
+  return out;
 }
 
 /**
  * Dispatches to the appropriate provider and returns a normalized LlmResult.
  */
 export async function callLlm(params: CallLlmParams): Promise<LlmResult> {
-  const { config, modelId, options, system, user, output } = params;
+  const { config, modelId, options, system, user } = params;
+  const extras = buildExtras(params);
   switch (config.provider) {
     case "openai":
-      return callOpenAI(config, modelId, options, system, user, output);
+      return callOpenAI(config, modelId, options, system, user, extras);
     case "anthropic":
-      return callAnthropic(config, modelId, options, system, user, output);
+      return callAnthropic(config, modelId, options, system, user, extras);
     case "gemini":
-      return callGemini(config, modelId, options, system, user, output);
+      return callGemini(config, modelId, options, system, user, extras);
     case "openrouter":
-      return callOpenRouter(config, modelId, options, system, user, output);
+      return callOpenRouter(config, modelId, options, system, user, extras);
     case "ollama":
-      return callOllama(config, modelId, options, system, user, output);
+      return callOllama(config, modelId, options, system, user, extras);
     default: {
       const _: never = config;
       throw new Error(
@@ -136,7 +173,7 @@ async function callOpenAI(
   options: CallLlmParams["options"],
   system: string,
   user: string,
-  output: CallLlmParams["output"],
+  extras: ProviderExtras,
 ): Promise<LlmResult> {
   let createOpenAI: (s: {
     apiKey: string;
@@ -151,36 +188,19 @@ async function callOpenAI(
     }
     throw error;
   }
-  const { generateText } = await import("ai");
   const openaiSettings: { apiKey: string; baseURL?: string } = {
     apiKey: config.apiKey,
   };
   if (config.baseURL !== undefined) openaiSettings.baseURL = config.baseURL;
   const openai = createOpenAI(openaiSettings);
   const model = openai(modelId);
-  const genParams: Parameters<typeof generateText>[0] = {
-    model: model as Parameters<typeof generateText>[0]["model"],
-    prompt: user,
-    ...(options.maxTokens !== undefined && {
-      maxOutputTokens: options.maxTokens,
-    }),
-    temperature: options.temperature,
-  };
-  if (system) genParams.system = system;
-  if (options.topP !== undefined) genParams.topP = options.topP;
-  if (options.frequencyPenalty !== undefined)
-    genParams.frequencyPenalty = options.frequencyPenalty;
-  if (options.presencePenalty !== undefined)
-    genParams.presencePenalty = options.presencePenalty;
-  const params = output !== undefined ? { ...genParams, output } : genParams;
-  const result = await generateText(
-    params as Parameters<typeof generateText>[0],
+  return runGenerate(
+    model as Parameters<typeof runGenerate>[0],
+    options,
+    system,
+    user,
+    extras,
   );
-  const out: LlmResult = { text: result.text ?? "", raw: result };
-  if (result.usage) out.usage = toLlmUsage(result.usage);
-  const parsed = getStructuredOutput(result as { output?: unknown });
-  if (parsed !== undefined) out.output = parsed;
-  return out;
 }
 
 async function callAnthropic(
@@ -189,7 +209,7 @@ async function callAnthropic(
   options: CallLlmParams["options"],
   system: string,
   user: string,
-  output: CallLlmParams["output"],
+  extras: ProviderExtras,
 ): Promise<LlmResult> {
   let createAnthropic: (s: { apiKey: string }) => (m: string) => unknown;
   try {
@@ -201,34 +221,15 @@ async function callAnthropic(
     }
     throw error;
   }
-  const { generateText } = await import("ai");
   const anthropic = createAnthropic({ apiKey: config.apiKey });
   const model = anthropic(modelId);
-  const genParams: Parameters<typeof generateText>[0] = {
-    model: model as Parameters<typeof generateText>[0]["model"],
-    prompt: user,
-    ...(options.maxTokens !== undefined && {
-      maxOutputTokens: options.maxTokens,
-    }),
-    temperature: options.temperature,
-  };
-  if (system) genParams.system = system;
-  // Same option keys as callOpenAI; SDK passes through. Anthropic supports topP;
-  // frequencyPenalty/presencePenalty may be unsupported (SDK may warn).
-  if (options.topP !== undefined) genParams.topP = options.topP;
-  if (options.frequencyPenalty !== undefined)
-    genParams.frequencyPenalty = options.frequencyPenalty;
-  if (options.presencePenalty !== undefined)
-    genParams.presencePenalty = options.presencePenalty;
-  const params = output !== undefined ? { ...genParams, output } : genParams;
-  const result = await generateText(
-    params as Parameters<typeof generateText>[0],
+  return runGenerate(
+    model as Parameters<typeof runGenerate>[0],
+    options,
+    system,
+    user,
+    extras,
   );
-  const out: LlmResult = { text: result.text ?? "", raw: result };
-  if (result.usage) out.usage = toLlmUsage(result.usage);
-  const parsed = getStructuredOutput(result as { output?: unknown });
-  if (parsed !== undefined) out.output = parsed;
-  return out;
 }
 
 async function callGemini(
@@ -237,7 +238,7 @@ async function callGemini(
   options: CallLlmParams["options"],
   system: string,
   user: string,
-  output: CallLlmParams["output"],
+  extras: ProviderExtras,
 ): Promise<LlmResult> {
   let createGoogleGenerativeAI: (s: {
     apiKey: string;
@@ -252,34 +253,15 @@ async function callGemini(
     }
     throw error;
   }
-  const { generateText } = await import("ai");
   const google = createGoogleGenerativeAI({ apiKey: config.apiKey });
   const model = google(modelId);
-  const genParams: Parameters<typeof generateText>[0] = {
-    model: model as Parameters<typeof generateText>[0]["model"],
-    prompt: user,
-    ...(options.maxTokens !== undefined && {
-      maxOutputTokens: options.maxTokens,
-    }),
-    temperature: options.temperature,
-  };
-  if (system) genParams.system = system;
-  // Same option keys as callOpenAI; SDK passes through. Gemini may not support
-  // all (e.g. frequencyPenalty/presencePenalty); check result.warnings if needed.
-  if (options.topP !== undefined) genParams.topP = options.topP;
-  if (options.frequencyPenalty !== undefined)
-    genParams.frequencyPenalty = options.frequencyPenalty;
-  if (options.presencePenalty !== undefined)
-    genParams.presencePenalty = options.presencePenalty;
-  const params = output !== undefined ? { ...genParams, output } : genParams;
-  const result = await generateText(
-    params as Parameters<typeof generateText>[0],
+  return runGenerate(
+    model as Parameters<typeof runGenerate>[0],
+    options,
+    system,
+    user,
+    extras,
   );
-  const out: LlmResult = { text: result.text ?? "", raw: result };
-  if (result.usage) out.usage = toLlmUsage(result.usage);
-  const parsed = getStructuredOutput(result as { output?: unknown });
-  if (parsed !== undefined) out.output = parsed;
-  return out;
 }
 
 async function callOpenRouter(
@@ -288,7 +270,7 @@ async function callOpenRouter(
   options: CallLlmParams["options"],
   system: string,
   user: string,
-  output: CallLlmParams["output"],
+  extras: ProviderExtras,
 ): Promise<LlmResult> {
   let createOpenRouter: (s: { apiKey: string }) => {
     chat: (id: string) => unknown;
@@ -302,36 +284,17 @@ async function callOpenRouter(
     }
     throw error;
   }
-  const { generateText } = await import("ai");
   const openrouter = createOpenRouter({ apiKey: config.apiKey });
   const resolvedId = config.modelId ?? modelId;
   const rawModel = openrouter.chat(resolvedId);
   assertLanguageModelShape(rawModel, "OpenRouter", resolvedId);
-  const model = rawModel as Parameters<typeof generateText>[0]["model"];
-  const genParams: Parameters<typeof generateText>[0] = {
-    model,
-    prompt: user,
-    ...(options.maxTokens !== undefined && {
-      maxOutputTokens: options.maxTokens,
-    }),
-    temperature: options.temperature,
-  };
-  if (system) genParams.system = system;
-  // Same option keys as callOpenAI. OpenRouter is OpenAI-compatible; typically supports all.
-  if (options.topP !== undefined) genParams.topP = options.topP;
-  if (options.frequencyPenalty !== undefined)
-    genParams.frequencyPenalty = options.frequencyPenalty;
-  if (options.presencePenalty !== undefined)
-    genParams.presencePenalty = options.presencePenalty;
-  const params = output !== undefined ? { ...genParams, output } : genParams;
-  const result = await generateText(
-    params as Parameters<typeof generateText>[0],
+  return runGenerate(
+    rawModel as Parameters<typeof runGenerate>[0],
+    options,
+    system,
+    user,
+    extras,
   );
-  const out: LlmResult = { text: result.text ?? "", raw: result };
-  if (result.usage) out.usage = toLlmUsage(result.usage);
-  const parsed = getStructuredOutput(result as { output?: unknown });
-  if (parsed !== undefined) out.output = parsed;
-  return out;
 }
 
 async function callOllama(
@@ -340,7 +303,7 @@ async function callOllama(
   options: CallLlmParams["options"],
   system: string,
   user: string,
-  output: CallLlmParams["output"],
+  extras: ProviderExtras,
 ): Promise<LlmResult> {
   let createOllama: (s: { baseURL?: string }) => (name: string) => unknown;
   try {
@@ -352,16 +315,39 @@ async function callOllama(
     }
     throw error;
   }
-  const { generateText } = await import("ai");
   const ollama = createOllama({
     baseURL: config.baseURL ?? PROVIDER_DEFAULTS.ollama.baseURL,
   });
   const name = config.modelId ?? modelId;
   const rawModel = ollama(name);
   assertLanguageModelShape(rawModel, "Ollama", name);
-  const model = rawModel as Parameters<typeof generateText>[0]["model"];
+  return runGenerate(
+    rawModel as Parameters<typeof runGenerate>[0],
+    options,
+    system,
+    user,
+    extras,
+  );
+}
+
+/**
+ * Shared `generateText` invocation. Each provider helper builds the
+ * model and delegates here so the genParams shape, extras handling
+ * (output / tools / stopWhen), and result normalisation (text /
+ * output / reasoning / usage) live in one place.
+ *
+ * @internal
+ */
+async function runGenerate(
+  model: unknown,
+  options: CallLlmParams["options"],
+  system: string,
+  user: string,
+  extras: ProviderExtras,
+): Promise<LlmResult> {
+  const { generateText } = await import("ai");
   const genParams: Parameters<typeof generateText>[0] = {
-    model,
+    model: model as Parameters<typeof generateText>[0]["model"],
     prompt: user,
     ...(options.maxTokens !== undefined && {
       maxOutputTokens: options.maxTokens,
@@ -369,14 +355,12 @@ async function callOllama(
     temperature: options.temperature,
   };
   if (system) genParams.system = system;
-  // Same option keys as callOpenAI. Ollama supports top_p; frequencyPenalty/presencePenalty
-  // may be unsupported (SDK may warn).
   if (options.topP !== undefined) genParams.topP = options.topP;
   if (options.frequencyPenalty !== undefined)
     genParams.frequencyPenalty = options.frequencyPenalty;
   if (options.presencePenalty !== undefined)
     genParams.presencePenalty = options.presencePenalty;
-  const params = output !== undefined ? { ...genParams, output } : genParams;
+  const params = { ...genParams, ...extras };
   const result = await generateText(
     params as Parameters<typeof generateText>[0],
   );
@@ -384,5 +368,22 @@ async function callOllama(
   if (result.usage) out.usage = toLlmUsage(result.usage);
   const parsed = getStructuredOutput(result as { output?: unknown });
   if (parsed !== undefined) out.output = parsed;
+  const reasoning = readReasoning(result);
+  if (reasoning) out.reasoning = reasoning;
   return out;
+}
+
+/**
+ * Defensive accessor for reasoning text. Vercel AI SDK exposes
+ * `reasoningText` (concatenated string) when the provider returned
+ * reasoning blocks (Anthropic extended thinking, OpenAI o1, etc.).
+ * Some SDK versions or providers may omit it; treat absence as
+ * "no reasoning available."
+ */
+function readReasoning(result: unknown): string | undefined {
+  const r = result as { reasoningText?: unknown };
+  if (typeof r.reasoningText === "string" && r.reasoningText.length > 0) {
+    return r.reasoningText;
+  }
+  return undefined;
 }

--- a/packages/ai/src/llm/structured-output.ts
+++ b/packages/ai/src/llm/structured-output.ts
@@ -3,6 +3,123 @@ import { formatSchemaIssues } from "@routecraft/routecraft";
 import { Output, jsonSchema } from "ai";
 
 /**
+ * Build an AI SDK schema (`jsonSchema(...)`) from a Standard Schema. The
+ * `direction` argument selects which JSON-schema variant the underlying
+ * Standard Schema exposes:
+ *
+ * - `"output"` (provider structured output): prefer `~standard.jsonSchema.output`,
+ *   fall back to `.input`. The SDK validates the model's structured response
+ *   and we return the parsed value on `LlmResult.output` / `AgentResult.output`.
+ * - `"input"` (tool input schema): prefer `~standard.jsonSchema.input`, fall
+ *   back to `.output`. The SDK shows the JSON schema to the model in the tool
+ *   list and validates the model's tool-call args before calling `execute`.
+ *
+ * @internal
+ */
+function toAiSchema(
+  schema: StandardSchemaV1,
+  direction: "input" | "output",
+  errorContext: string,
+): unknown {
+  const standard = (schema as unknown as Record<string, unknown>)[
+    "~standard"
+  ] as
+    | {
+        validate: (
+          value: unknown,
+        ) =>
+          | { value?: unknown; issues?: unknown }
+          | Promise<{ value?: unknown; issues?: unknown }>;
+        jsonSchema?: {
+          output?: (opts: { target: string }) => Record<string, unknown>;
+          input?: (opts: { target: string }) => Record<string, unknown>;
+        };
+      }
+    | undefined;
+
+  if (!standard?.validate) {
+    throw new Error(
+      `${errorContext} must be a StandardSchemaV1 with ~standard.validate`,
+    );
+  }
+
+  const primary =
+    direction === "input"
+      ? standard.jsonSchema?.input
+      : standard.jsonSchema?.output;
+  const fallback =
+    direction === "input"
+      ? standard.jsonSchema?.output
+      : standard.jsonSchema?.input;
+  const jsonSchemaObj =
+    primary?.({ target: "draft-2020-12" }) ??
+    fallback?.({ target: "draft-2020-12" });
+
+  if (!jsonSchemaObj || typeof jsonSchemaObj !== "object") {
+    throw new Error(
+      `${errorContext} must expose ~standard.jsonSchema.input or .output for AI SDK use`,
+    );
+  }
+
+  function validate(
+    value: unknown,
+  ): { success: true; value: unknown } | { success: false; error: Error } {
+    let result:
+      | { value?: unknown; issues?: unknown }
+      | Promise<{
+          value?: unknown;
+          issues?: unknown;
+        }>;
+    try {
+      result = standard!.validate(value);
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err : new Error(String(err)),
+      };
+    }
+    if (result instanceof Promise) {
+      return {
+        success: false,
+        error: new Error(
+          `${errorContext}: async schema validation is not supported`,
+        ),
+      };
+    }
+    const hasIssues =
+      result.issues != null &&
+      (Array.isArray(result.issues)
+        ? result.issues.length > 0
+        : typeof result.issues === "object" && result.issues !== null
+          ? Object.keys(result.issues).length > 0
+          : Boolean(result.issues));
+    if (hasIssues) {
+      return {
+        success: false,
+        error: new Error(formatSchemaIssues(result.issues)),
+      };
+    }
+    return { success: true, value: result.value };
+  }
+
+  return jsonSchema(jsonSchemaObj as Parameters<typeof jsonSchema>[0], {
+    validate,
+  });
+}
+
+/**
+ * Build an AI SDK input schema for tool definitions
+ * (`tool({ inputSchema, execute })`). The SDK presents this schema to
+ * the model in the tool list and validates the model's tool-call
+ * arguments before invoking `execute`.
+ *
+ * @internal
+ */
+export function toAiInputSchema(schema: StandardSchemaV1): unknown {
+  return toAiSchema(schema, "input", "Tool input schema");
+}
+
+/**
  * Build an AI SDK output spec from a Standard Schema for provider-level
  * structured output (OpenAI response_format, Ollama format, etc.) and validation.
  *

--- a/packages/ai/src/llm/structured-output.ts
+++ b/packages/ai/src/llm/structured-output.ts
@@ -121,93 +121,23 @@ export function toAiInputSchema(schema: StandardSchemaV1): unknown {
 
 /**
  * Build an AI SDK output spec from a Standard Schema for provider-level
- * structured output (OpenAI response_format, Ollama format, etc.) and validation.
+ * structured output (OpenAI response_format, Ollama format, etc.) and
+ * validation. Delegates to {@link toAiSchema} so the JSON-schema
+ * extraction, validation wrapper, and error messages stay aligned with
+ * the input-schema path used by tool definitions (no risk of drift
+ * between the two paths).
  *
  * The AI SDK accepts Zod directly in Output.object({ schema: z.object(...) }).
- * This package uses Standard Schema (per .standards/type-safety-and-schemas.md), so
- * it cannot depend on Zod. This helper bridges any Standard Schema (Zod, Valibot,
- * ArkType, etc.) by using the SDK’s lower-level jsonSchema(jsonSchemaObj, {
- * validate }): we get the JSON schema from ~standard.jsonSchema.output/.input
- * and use ~standard.validate as the validate callback. Callers can pass a Zod
- * schema (as Standard Schema), Valibot, or ArkType and get the same behavior.
+ * This package uses Standard Schema (per .standards/type-safety-and-schemas.md),
+ * so it cannot depend on Zod. The `toAiSchema` helper bridges any
+ * Standard Schema (Zod, Valibot, ArkType, etc.) by using the SDK's
+ * lower-level `jsonSchema(jsonSchemaObj, { validate })`.
  */
 export function toAiOutputSpec(schema: StandardSchemaV1): unknown {
-  const standard = (schema as unknown as Record<string, unknown>)[
-    "~standard"
-  ] as
-    | {
-        validate: (
-          value: unknown,
-        ) =>
-          | { value?: unknown; issues?: unknown }
-          | Promise<{ value?: unknown; issues?: unknown }>;
-        jsonSchema?: {
-          output?: (opts: { target: string }) => Record<string, unknown>;
-          input?: (opts: { target: string }) => Record<string, unknown>;
-        };
-      }
-    | undefined;
-
-  if (!standard?.validate) {
-    throw new Error(
-      "LLM output schema must be a StandardSchemaV1 with ~standard.validate",
-    );
-  }
-
-  const jsonSchemaObj =
-    standard.jsonSchema?.output?.({ target: "draft-2020-12" }) ??
-    standard.jsonSchema?.input?.({ target: "draft-2020-12" });
-
-  if (!jsonSchemaObj || typeof jsonSchemaObj !== "object") {
-    throw new Error(
-      "LLM output schema must expose ~standard.jsonSchema.output or .input for provider structured output",
-    );
-  }
-
-  function validate(
-    value: unknown,
-  ): { success: true; value: unknown } | { success: false; error: Error } {
-    let result:
-      | { value?: unknown; issues?: unknown }
-      | Promise<{
-          value?: unknown;
-          issues?: unknown;
-        }>;
-    try {
-      result = standard!.validate(value);
-    } catch (err) {
-      return {
-        success: false,
-        error: err instanceof Error ? err : new Error(String(err)),
-      };
-    }
-    if (result instanceof Promise) {
-      return {
-        success: false,
-        error: new Error(
-          "Async output schema is not supported for LLM structured output",
-        ),
-      };
-    }
-    const hasIssues =
-      result.issues != null &&
-      (Array.isArray(result.issues)
-        ? result.issues.length > 0
-        : typeof result.issues === "object" && result.issues !== null
-          ? Object.keys(result.issues).length > 0
-          : Boolean(result.issues));
-    if (hasIssues) {
-      return {
-        success: false,
-        error: new Error(formatSchemaIssues(result.issues)),
-      };
-    }
-    return { success: true, value: result.value };
-  }
-
-  const aiSchema = jsonSchema(
-    jsonSchemaObj as Parameters<typeof jsonSchema>[0],
-    { validate },
-  );
+  const aiSchema = toAiSchema(
+    schema,
+    "output",
+    "LLM output schema",
+  ) as Parameters<typeof Output.object>[0]["schema"];
   return Output.object({ schema: aiSchema });
 }

--- a/packages/ai/src/llm/types.ts
+++ b/packages/ai/src/llm/types.ts
@@ -154,6 +154,12 @@ export interface LlmResult {
   text: string;
   /** Parsed structured output when `output` schema was set and validation succeeded. */
   output?: unknown;
+  /**
+   * Raw reasoning text from the provider (Anthropic extended thinking,
+   * OpenAI o1, etc.) when supplied. Most callers can ignore this; it is
+   * useful for debugging, audit trails, and chain-of-thought displays.
+   */
+  reasoning?: string;
   /** Token usage for the last step. Same shape as AI SDK usage. */
   usage?: LlmUsage;
   /** Full generateText() result for advanced use (debugging, response metadata). */

--- a/packages/ai/test/agent-runtime.test.ts
+++ b/packages/ai/test/agent-runtime.test.ts
@@ -1,0 +1,317 @@
+import { describe, test, expect, afterEach, vi, beforeEach } from "vitest";
+import { craft, simple } from "@routecraft/routecraft";
+import { spy, testContext, type TestContext } from "@routecraft/testing";
+import { z } from "zod";
+import {
+  agent,
+  agentPlugin,
+  defaultFns,
+  llmPlugin,
+  tools,
+  type AgentResult,
+} from "../src/index.ts";
+import type { LlmResult } from "../src/llm/types.ts";
+
+// Mock the LLM dispatcher so the runtime tests stay hermetic. Each
+// happy-path test asserts on the dispatcher args (tools, output,
+// stopWhen, modelId, etc.) and controls the response shape.
+vi.mock("../src/llm/providers/index.ts", () => ({
+  callLlm: vi.fn(
+    async (): Promise<LlmResult> => ({
+      text: "stubbed-response",
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    }),
+  ),
+}));
+
+import { callLlm } from "../src/llm/providers/index.ts";
+const callLlmMock = callLlm as unknown as ReturnType<typeof vi.fn>;
+
+describe("agent runtime: tool wiring through callLlm", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    callLlmMock.mockClear();
+    callLlmMock.mockResolvedValue({
+      text: "stubbed-response",
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    });
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Agent without tools dispatches callLlm without `tools` or `stopWhen`
+   * @preconditions Inline agent({ system, model }) — no tools field
+   * @expectedResult callLlm receives the prompt only; no tools, stopWhen, or output
+   */
+  test("agent without tools omits tool wiring", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("no-tools")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "Be helpful.",
+              model: "anthropic:claude-opus-4-7",
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock).toHaveBeenCalledTimes(1);
+    const args = callLlmMock.mock.calls[0][0];
+    expect(args.tools).toBeUndefined();
+    expect(args.stopWhen).toBeUndefined();
+    expect(args.output).toBeUndefined();
+    expect(args.modelId).toBe("claude-opus-4-7");
+  });
+
+  /**
+   * @case Agent with one fn tool passes a single Vercel tool to callLlm with stopWhen
+   * @preconditions agentPlugin functions: { currentTime }; agent.tools = tools(["currentTime"])
+   * @expectedResult callLlm receives tools.currentTime (Vercel tool object) and a stopWhen
+   */
+  test("agent with one fn tool passes the tool map to callLlm", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({ functions: { ...defaultFns } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("with-tool")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "Be helpful.",
+              model: "anthropic:claude-opus-4-7",
+              tools: tools(["currentTime"]),
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock).toHaveBeenCalledTimes(1);
+    const args = callLlmMock.mock.calls[0][0];
+    expect(args.tools).toBeDefined();
+    expect(Object.keys(args.tools as Record<string, unknown>)).toEqual([
+      "currentTime",
+    ]);
+    expect(args.stopWhen).toBeDefined();
+  });
+
+  /**
+   * @case maxSteps shorthand resolves to a stopWhen value
+   * @preconditions agent.maxSteps = 3
+   * @expectedResult callLlm receives a stopWhen (we don't unpack the SDK helper's shape; presence is enough)
+   */
+  test("maxSteps shorthand produces a stopWhen", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({ functions: { ...defaultFns } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("maxsteps")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              tools: tools(["currentTime"]),
+              maxSteps: 3,
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock.mock.calls[0][0].stopWhen).toBeDefined();
+  });
+
+  /**
+   * @case Agent with output schema passes an `output` spec to callLlm
+   * @preconditions agent.output = z.object({ summary: z.string() })
+   * @expectedResult callLlm receives a non-undefined `output`
+   */
+  test("agent({ output }) passes the output spec through callLlm", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("with-output")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              output: z.object({ summary: z.string() }),
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock.mock.calls[0][0].output).toBeDefined();
+  });
+
+  /**
+   * @case AgentResult propagates `reasoning` from LlmResult.reasoning
+   * @preconditions Stubbed callLlm returns reasoning = "thinking out loud"
+   * @expectedResult Downstream body has body.reasoning === "thinking out loud"
+   */
+  test("AgentResult propagates reasoning when the provider supplies it", async () => {
+    callLlmMock.mockResolvedValueOnce({
+      text: "final answer",
+      reasoning: "thinking out loud",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    });
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("reasoning")
+          .from(simple("hi"))
+          .to(agent({ system: "x", model: "anthropic:claude-opus-4-7" }))
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    const body = sink.received[0].body as AgentResult;
+    expect(body.text).toBe("final answer");
+    expect(body.reasoning).toBe("thinking out loud");
+  });
+
+  /**
+   * @case AgentResult propagates `output` from LlmResult.output
+   * @preconditions Stubbed callLlm returns output = { summary: "..." }
+   * @expectedResult Downstream body has body.output === { summary: "..." }
+   */
+  test("AgentResult propagates structured output", async () => {
+    callLlmMock.mockResolvedValueOnce({
+      text: "raw",
+      output: { summary: "the summary" },
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    });
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("structured")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              output: z.object({ summary: z.string() }),
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    const body = sink.received[0].body as AgentResult;
+    expect(body.output).toEqual({ summary: "the summary" });
+  });
+
+  /**
+   * @case Agent inherits defaultOptions.tools when tools field is omitted
+   * @preconditions agentPlugin.defaultOptions.tools = tools(["currentTime"]); agent omits tools
+   * @expectedResult callLlm receives the inherited tool map
+   */
+  test("agent inherits defaultOptions.tools when its own tools is omitted", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({
+            functions: { ...defaultFns },
+            defaultOptions: { tools: tools(["currentTime"]) },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("inherits-tools")
+          .from(simple("hi"))
+          .to(agent({ system: "x", model: "anthropic:claude-opus-4-7" })),
+      )
+      .build();
+
+    await t.test();
+    const args = callLlmMock.mock.calls[0][0];
+    expect(Object.keys(args.tools as Record<string, unknown>)).toEqual([
+      "currentTime",
+    ]);
+  });
+
+  /**
+   * @case Explicit tools on the agent override defaultOptions.tools entirely
+   * @preconditions defaultOptions.tools includes only "currentTime"; agent.tools includes only "randomUuid"
+   * @expectedResult callLlm receives only "randomUuid"
+   */
+  test("per-agent tools overrides defaultOptions.tools", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({
+            functions: { ...defaultFns },
+            defaultOptions: { tools: tools(["currentTime"]) },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("override-tools")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              tools: tools(["randomUuid"]),
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    const args = callLlmMock.mock.calls[0][0];
+    expect(Object.keys(args.tools as Record<string, unknown>)).toEqual([
+      "randomUuid",
+    ]);
+  });
+});

--- a/packages/ai/test/tool-bridge.test.ts
+++ b/packages/ai/test/tool-bridge.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect, vi } from "vitest";
+import { z } from "zod";
+import { buildVercelTools } from "../src/agent/tool-bridge.ts";
+import type { ResolvedTool } from "../src/agent/tools/selection.ts";
+
+describe("buildVercelTools — execute path", () => {
+  /**
+   * @case Empty input returns empty record
+   * @preconditions buildVercelTools([], undefined, signal)
+   * @expectedResult Returned object has no keys
+   */
+  test("empty resolved tools returns an empty map", async () => {
+    const out = await buildVercelTools(
+      [],
+      undefined,
+      new AbortController().signal,
+    );
+    expect(Object.keys(out)).toEqual([]);
+  });
+
+  /**
+   * @case Single resolved tool produces one Vercel tool keyed by name
+   * @preconditions Resolved tool with name "echo", description, input schema, handler
+   * @expectedResult Returned map has key "echo"; calling its execute invokes handler with the input
+   */
+  test("single resolved tool builds a Vercel tool that runs the handler", async () => {
+    const handler = vi.fn(
+      async (input: unknown) => `echoed ${(input as { msg: string }).msg}`,
+    );
+    const resolved: ResolvedTool = {
+      name: "echo",
+      description: "Echoes the input.",
+      input: z.object({ msg: z.string() }),
+      handler: handler as ResolvedTool["handler"],
+    };
+
+    const map = await buildVercelTools(
+      [resolved],
+      undefined,
+      new AbortController().signal,
+    );
+    expect(Object.keys(map)).toEqual(["echo"]);
+
+    const tool = map["echo"] as {
+      execute: (input: unknown) => Promise<unknown>;
+    };
+    const result = await tool.execute({ msg: "hi" });
+    expect(result).toBe("echoed hi");
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toEqual({ msg: "hi" });
+  });
+
+  /**
+   * @case Guard runs before handler and can short-circuit by throwing
+   * @preconditions Resolved tool with a guard that throws
+   * @expectedResult execute() rejects with the guard's error; handler is never called
+   */
+  test("guard throwing prevents the handler from running", async () => {
+    const handler = vi.fn();
+    const guard = vi.fn(async () => {
+      throw new Error("denied");
+    });
+    const resolved: ResolvedTool = {
+      name: "guarded",
+      description: "Has a guard.",
+      input: z.object({}),
+      guard: guard as NonNullable<ResolvedTool["guard"]>,
+      handler: handler as ResolvedTool["handler"],
+    };
+
+    const map = await buildVercelTools(
+      [resolved],
+      undefined,
+      new AbortController().signal,
+    );
+    const tool = map["guarded"] as {
+      execute: (input: unknown) => Promise<unknown>;
+    };
+    await expect(tool.execute({})).rejects.toThrow(/denied/);
+    expect(handler).not.toHaveBeenCalled();
+    expect(guard).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * @case Guard that resolves passes through to the handler
+   * @preconditions Guard returns void (no throw)
+   * @expectedResult Handler runs and returns its value
+   */
+  test("guard resolving lets the handler run", async () => {
+    const handler = vi.fn(async () => "ok");
+    const guard = vi.fn(async () => undefined);
+    const resolved: ResolvedTool = {
+      name: "ok-guard",
+      description: "Guard then run.",
+      input: z.object({}),
+      guard: guard as NonNullable<ResolvedTool["guard"]>,
+      handler: handler as ResolvedTool["handler"],
+    };
+    const map = await buildVercelTools(
+      [resolved],
+      undefined,
+      new AbortController().signal,
+    );
+    const tool = map["ok-guard"] as {
+      execute: (input: unknown) => Promise<unknown>;
+    };
+    const result = await tool.execute({});
+    expect(result).toBe("ok");
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ai/test/tool-bridge.test.ts
+++ b/packages/ai/test/tool-bridge.test.ts
@@ -19,9 +19,9 @@ describe("buildVercelTools — execute path", () => {
   });
 
   /**
-   * @case Single resolved tool produces one Vercel tool keyed by name
-   * @preconditions Resolved tool with name "echo", description, input schema, handler
-   * @expectedResult Returned map has key "echo"; calling its execute invokes handler with the input
+   * @case Single resolved tool produces one Vercel tool keyed by name; per-call options merge into the handler context
+   * @preconditions Resolved tool; execute called with the SDK's `(input, options)` signature carrying a per-call abortSignal
+   * @expectedResult Returned map has key "echo"; handler receives the input as the first arg and a context whose abortSignal is the per-call one (not the construction-time signal)
    */
   test("single resolved tool builds a Vercel tool that runs the handler", async () => {
     const handler = vi.fn(
@@ -34,20 +34,37 @@ describe("buildVercelTools — execute path", () => {
       handler: handler as ResolvedTool["handler"],
     };
 
-    const map = await buildVercelTools(
-      [resolved],
-      undefined,
-      new AbortController().signal,
-    );
+    const sessionSignal = new AbortController().signal;
+    const map = await buildVercelTools([resolved], undefined, sessionSignal);
     expect(Object.keys(map)).toEqual(["echo"]);
 
+    // Exercise the SDK's (input, options) contract — the second arg
+    // carries a per-call abortSignal which must override the
+    // session-wide one captured at buildVercelTools time.
+    const perCallSignal = new AbortController().signal;
     const tool = map["echo"] as {
-      execute: (input: unknown) => Promise<unknown>;
+      execute: (
+        input: unknown,
+        opts?: {
+          abortSignal?: AbortSignal;
+          toolCallId?: string;
+          messages?: unknown[];
+        },
+      ) => Promise<unknown>;
     };
-    const result = await tool.execute({ msg: "hi" });
+    const result = await tool.execute(
+      { msg: "hi" },
+      { toolCallId: "call-1", messages: [], abortSignal: perCallSignal },
+    );
     expect(result).toBe("echoed hi");
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler.mock.calls[0][0]).toEqual({ msg: "hi" });
+    const callArgs = handler.mock.calls[0] as unknown as [
+      input: unknown,
+      ctx: { abortSignal: AbortSignal },
+    ];
+    expect(callArgs[0]).toEqual({ msg: "hi" });
+    expect(callArgs[1].abortSignal).toBe(perCallSignal);
+    expect(callArgs[1].abortSignal).not.toBe(sessionSignal);
   });
 
   /**

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -22,6 +22,7 @@ export {
   type Exchange,
   type ExchangeHeaders,
   getExchangeContext,
+  getExchangeRoute,
   type HeaderKeysRegistry,
   HeadersKeys,
   type HeaderValue,


### PR DESCRIPTION
## Summary

The runtime half of #224. Wires the Vercel AI SDK's native tool-calling loop into the agent destination so `agent({ tools: tools([...]) })` actually presents tools to the model, dispatches calls, and feeds errors back for self-correction. The DSL pieces landed in #254 / #256; this PR turns them on.

After this merges, **#224 closes**. The synchronous in-memory loop is the final piece for that issue. Streaming (#257) and durable agents (#258) are tracked separately.

## What ships

```ts
agentPlugin({
  functions: { ...defaultFns, fetchOrder: directTool("fetch-order"), sendSlack: {...} },
  agents: {
    coordinator: {
      description: "Plan and delegate research workflows.",
      system: "...",
      tools: tools([
        "currentTime",
        "fetchOrder",
        { name: "sendSlack", guard: requireApproval },
        { tagged: "read-only" },
      ]),
      output: ResultSchema,                // optional structured output
      maxSteps: 12,                        // optional step cap (default 8)
    },
  },
  defaultOptions: { model: "anthropic:claude-opus-4-7" },
})
```

The model now sees the registered tools, calls them, gets results back through the SDK loop, and either produces a final text response or stops at `stepCountIs(maxSteps ?? 8)`.

## Implementation

### Internal `AgentSession` class

Wraps resolved tools + initial prompts + provider config. Exposes `runUntilDone(abortSignal): Promise<AgentResult>` for the synchronous path. The session boundary exists so streaming (#257) adds `runStream()` and durability (#258) checkpoints between steps without rearchitecting — same setup, additional consumption methods.

### Tool bridge (`buildVercelTools`)

Converts `ResolvedTool[]` (from `tools([...]).resolve(ctx)`) into a Vercel SDK tool map. Each tool's `execute` runs the optional guard then dispatches to the underlying handler. Schema validation is delegated to the SDK so input failures feed back to the model for self-correction without invoking `execute`.

### Standard Schema → AI SDK input bridge

Extracted `toAiInputSchema` sibling of the existing `toAiOutputSpec` in `structured-output.ts`. Builds a `jsonSchema(...)` from a Standard Schema, preferring the schema's `~standard.jsonSchema.input` over `.output` (the schema's input shape is what the LLM produces).

### Provider extension

`callLlm` extended with optional `tools` and `stopWhen` parameters. Each provider helper (`callOpenAI` / `callAnthropic` / `callGemini` / `callOpenRouter` / `callOllama`) now delegates to a shared `runGenerate` that:
- Builds the genParams once.
- Spreads optional extras (`output`, `tools`, `stopWhen`).
- Captures `reasoning` from the result defensively (Anthropic extended thinking, OpenAI o1).

This collapses ~250 lines of repeated boilerplate across providers and makes future tool-related changes single-site.

### `AgentResult` extensions

Adds two optional fields:
- `output?: unknown` — parsed structured output when the agent has an `output:` schema.
- `reasoning?: string` — raw reasoning text when the provider supplied it.

### `maxSteps` shorthand

New optional `maxSteps?: number` on `AgentOptions` and `AgentDefaultOptions`. Resolves to `stopWhen: stepCountIs(maxSteps ?? 8)` at dispatch.

### Forward-compat hooks for #257 (streaming) and #258 (durable agents)

Shipped in this PR even though no path uses them today, so the follow-ups are additive:

- `SuspendError` exported `@experimental`. A tool handler that wants to be forward-compat with the durable epic can throw it — today it propagates as a normal tool error; the durable runtime will catch it explicitly.
- `FnHandlerContext.checkpointId?: string`. Undefined today; the durable runtime populates it.
- `AgentSession` per-step boundary is the unit of work that streaming iterates and durability checkpoints.

## Tests

918 pass / 1 skipped. New:

- `agent-runtime.test.ts` (8 cases): `callLlm` receives `tools` only when the agent has them; `stopWhen` present alongside tools; `maxSteps` shorthand produces a `stopWhen`; `output` spec passes through; `reasoning` and `output` flow back into `AgentResult`; `defaultOptions.tools` inheritance; per-agent tools override entirely.
- `tool-bridge.test.ts` (4 cases): empty resolved set; single tool's execute runs handler; guard throwing short-circuits the handler; guard resolving allows the handler to run.

## Behaviour preserved

Agents without `tools:` continue to call `generateText` with no tools / stopWhen — identical to the existing synchronous LLM dispatch. No regression for routes that already use `agent()`.

## Defaultfns hand-rolled schema fix

The hand-rolled `emptyObjectSchema` in `defaultFns` now exposes the non-standard `~standard.jsonSchema.{input,output}` extension that Zod / Valibot ship — so it can back tools and structured-output specs alongside library schemas without special-casing.

## Docs

Plugins reference page agent-tools section updated:
- Drop the "experimental DSL only" status banner. The runtime is live now.
- Add a step-cap section (default 8, override per-agent or via defaults).
- Add a **human-in-the-loop** section with a viability table by wait duration and a concrete migration path from today's blocking-tool pattern to `SuspendError` when the durable epic (#258) lands. Same handler signature on both sides.

## Test plan

- [ ] CI green
- [ ] CodeRabbit / cubic-dev-ai reviews pass
- [ ] Manual smoke: a route ending `.to(agent({...with tools...}))` returns an `AgentResult` with the model's text and (when applicable) `reasoning` / `output`.

Closes #224. Forward-compat for #257 and #258.

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a synchronous `ai` tool-calling loop to the agent runtime so `agent({ tools: tools([...]) })` presents tools to the model, dispatches calls, and returns results (including structured output and reasoning). Also propagates route abort signals end-to-end for safe cancellation. Closes #224 and keeps existing behavior for agents without tools.

- New Features
  - Tool loop via `AgentSession`; stops at `maxSteps` (default 8). Override per agent or via `defaultOptions.maxSteps`.
  - Tool bridge `buildVercelTools`: maps `ResolvedTool[]` to `ai` tools, validates with `toAiInputSchema`, runs guards before handlers.
  - `AgentResult` now includes `output?` (structured) and `reasoning?` (when the provider supplies it).
  - Forward-compat: export `SuspendError` and add `FnHandlerContext.checkpointId?`.
  - Docs: tools are live, step cap documented, human-in-the-loop guidance added.

- Refactors
  - `callLlm` now accepts `tools`, `stopWhen`, and `abortSignal`; providers delegate to shared `runGenerate` and capture `reasoning`.
  - Abort propagation: route `AbortSignal` threads into LLM calls and per-tool executes, cancelling in-flight work.
  - Safety: tool map uses `Object.create(null)` to prevent prototype pollution.
  - DRY: `toAiOutputSpec` now delegates to the shared `toAiSchema` helper.
  - Perf: build `stopWhen` only when tools are present.
  - Destination resolves tools, builds prompts with `buildUserPrompt`, and runs the loop through `AgentSession`.

<sup>Written for commit 20c6861a4d6e4ddceabe1d339c7a5fd3ef64c1c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

