### PR TITLE
feat(ai): streaming agents via onEvent (closes #257)

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -650,6 +650,44 @@ A blocking tool handler today looks like:
 
 When the durable epic lands, the same handler migrates by replacing the blocking await with `throw new SuspendError({ reason: "awaiting-human-approval" })` and consuming the resume callback in a separate route. The runtime contract (return value, schema, `FnHandlerContext`) stays identical.
 
+#### Streaming (`onEvent`)
+
+Set `onEvent` on an agent to stream tokens, tool calls, and finish reasons live as the model generates them. Internally the dispatch switches from `generateText` to `streamText`; externally the destination still returns a consolidated `AgentResult` once the stream drains, so downstream pipeline ops are unaffected.
+
+```ts
+agent({
+  model: "openai:gpt-4o",
+  system: "Be helpful.",
+  tools: tools(["search"]),
+  onEvent: (event) => {
+    if (event.type === "text-delta") sse.send({ data: event.text });
+    if (event.type === "tool-call") sse.send({ data: `calling ${event.toolName}` });
+  },
+})
+```
+
+Event shapes (discriminated union, exported as `AgentEvent`):
+
+| Type | Fields | When |
+|---|---|---|
+| `text-delta` | `text` | Each token (or token chunk) emitted by the model. |
+| `reasoning-delta` | `text` | Provider reasoning text (Anthropic extended thinking, OpenAI o1). Useful for "thinking..." UI. |
+| `tool-call` | `toolCallId`, `toolName`, `input` | Model decided to call a tool. `input` is the validated args. |
+| `tool-result` | `toolCallId`, `toolName`, `output` | Tool handler returned a value. |
+| `tool-error` | `toolCallId`, `toolName`, `error` | Handler, guard, or input validation threw. |
+| `step-finish` | `finishReason`, `usage?` | One step (model call + tools) ended. |
+| `finish` | `finishReason`, `usage?` | The whole dispatch ended. |
+| `error` | `error` | Provider or transport error surfaced through the stream. |
+
+Behaviour notes:
+
+- **Listener errors are contained.** A throw inside `onEvent` is caught and logged; the dispatch keeps running and the consolidated `AgentResult` still reaches downstream ops.
+- **Async listeners are awaited.** Returning a `Promise` from `onEvent` applies back-pressure to the stream, which is what you want when forwarding to a slow consumer (database, remote SSE channel).
+- **Stream errors still throw.** Provider errors surface as an `error` event AND propagate out of the dispatch promise, so failure handling matches the non-streaming path.
+- **Per-agent only.** `onEvent` is not part of `defaultOptions` because event sinks are typically request-scoped (a per-connection SSE channel). For observability across all agents, use a telemetry plugin.
+
+The 90% use case is forwarding tokens into an HTTP SSE response so a UI updates as the model writes.
+
 ### Typed fn ids (`FnRegistry`)
 
 For compile-time autocomplete of fn ids in the agent `tools: [...]` field (follow-up story), populate the `FnRegistry` marker interface via declaration merging in your project:

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -84,6 +84,13 @@ export class AgentDestinationAdapter implements Destination<
     // synthetic exchanges in tests).
     const abortSignal =
       getExchangeRoute(exchange)?.signal ?? new AbortController().signal;
+
+    // Streaming is selected by the presence of `onEvent`. The
+    // consolidated AgentResult is returned in both paths, so
+    // downstream pipeline ops are unaffected by the choice.
+    if (merged.onEvent !== undefined) {
+      return await session.runStream(abortSignal, merged.onEvent);
+    }
     return await session.runUntilDone(abortSignal);
   }
 

--- a/packages/ai/src/agent/events.ts
+++ b/packages/ai/src/agent/events.ts
@@ -1,0 +1,160 @@
+import type { LlmUsage } from "../llm/types.ts";
+
+/**
+ * Discriminated union of events emitted by a streaming agent dispatch.
+ * Forwarded to the user-supplied `AgentOptions.onEvent` listener while
+ * the model + tool-calling loop runs. The set is a normalised subset of
+ * the Vercel AI SDK's `streamText` full-stream parts; low-level parts
+ * (text-start, text-end, tool-input-* deltas, abort) are filtered out
+ * so the routecraft surface stays stable across SDK versions.
+ *
+ * @experimental
+ */
+export type AgentEvent =
+  /** Incremental text from the model. Concatenate to render tokens live. */
+  | { type: "text-delta"; text: string }
+  /**
+   * Incremental reasoning text from the provider (Anthropic extended
+   * thinking, OpenAI o1). Useful for "thinking..." UI; safe to ignore.
+   */
+  | { type: "reasoning-delta"; text: string }
+  /** Model decided to call a tool. `input` is the validated args. */
+  | {
+      type: "tool-call";
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+    }
+  /** Tool handler returned successfully. `output` is the handler's return value. */
+  | {
+      type: "tool-result";
+      toolCallId: string;
+      toolName: string;
+      output: unknown;
+    }
+  /** Tool handler (or guard, or input validation) threw. */
+  | {
+      type: "tool-error";
+      toolCallId: string;
+      toolName: string;
+      error: unknown;
+    }
+  /**
+   * One step of the loop ended (a model call + any tool calls + their
+   * results). Emitted before the next step begins, and once before
+   * `finish` for the final step.
+   */
+  | {
+      type: "step-finish";
+      finishReason: string;
+      usage?: LlmUsage;
+    }
+  /** The whole dispatch ended. Final consolidated result is returned by the destination. */
+  | {
+      type: "finish";
+      finishReason: string;
+      usage?: LlmUsage;
+    }
+  /** Provider or transport error surfaced through the stream. */
+  | { type: "error"; error: unknown };
+
+/**
+ * Listener for streaming agent dispatches. Set on `AgentOptions.onEvent`
+ * to receive events. Async listeners are awaited so back-pressure on a
+ * slow consumer (e.g. an SSE channel) propagates into the stream.
+ *
+ * Throws inside the listener are caught and logged; they do not abort
+ * the agent dispatch.
+ *
+ * @experimental
+ */
+export type AgentEventListener = (event: AgentEvent) => void | Promise<void>;
+
+/**
+ * Convert a Vercel AI SDK `streamText` full-stream part into an
+ * `AgentEvent`. Returns `null` for parts that have no public-surface
+ * equivalent (text-start/end markers, tool-input-* deltas, abort, raw
+ * provider parts, etc.).
+ *
+ * @internal
+ */
+export function normalizeStreamPart(part: unknown): AgentEvent | null {
+  if (part === null || typeof part !== "object") return null;
+  const p = part as Record<string, unknown>;
+  const type = p["type"];
+  switch (type) {
+    case "text-delta": {
+      const text = readString(p, "text") ?? readString(p, "textDelta");
+      if (text === undefined || text.length === 0) return null;
+      return { type: "text-delta", text };
+    }
+    case "reasoning-delta": {
+      const text = readString(p, "text") ?? readString(p, "delta");
+      if (text === undefined || text.length === 0) return null;
+      return { type: "reasoning-delta", text };
+    }
+    case "tool-call": {
+      const toolCallId = readString(p, "toolCallId");
+      const toolName = readString(p, "toolName");
+      if (toolCallId === undefined || toolName === undefined) return null;
+      const input = p["input"] ?? p["args"];
+      return { type: "tool-call", toolCallId, toolName, input };
+    }
+    case "tool-result": {
+      const toolCallId = readString(p, "toolCallId");
+      const toolName = readString(p, "toolName");
+      if (toolCallId === undefined || toolName === undefined) return null;
+      const output = p["output"] ?? p["result"];
+      return { type: "tool-result", toolCallId, toolName, output };
+    }
+    case "tool-error": {
+      const toolCallId = readString(p, "toolCallId");
+      const toolName = readString(p, "toolName");
+      if (toolCallId === undefined || toolName === undefined) return null;
+      return {
+        type: "tool-error",
+        toolCallId,
+        toolName,
+        error: p["error"],
+      };
+    }
+    case "finish-step": {
+      const finishReason = readString(p, "finishReason") ?? "unknown";
+      const usage = readUsage(p["usage"]);
+      return usage
+        ? { type: "step-finish", finishReason, usage }
+        : { type: "step-finish", finishReason };
+    }
+    case "finish": {
+      const finishReason = readString(p, "finishReason") ?? "unknown";
+      const usage = readUsage(p["totalUsage"]) ?? readUsage(p["usage"]);
+      return usage
+        ? { type: "finish", finishReason, usage }
+        : { type: "finish", finishReason };
+    }
+    case "error": {
+      return { type: "error", error: p["error"] };
+    }
+    default:
+      return null;
+  }
+}
+
+function readString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = obj[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+function readUsage(value: unknown): LlmUsage | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  const u = value as Record<string, unknown>;
+  const out: LlmUsage = {};
+  if (typeof u["inputTokens"] === "number") out.inputTokens = u["inputTokens"];
+  if (typeof u["outputTokens"] === "number")
+    out.outputTokens = u["outputTokens"];
+  if (typeof u["totalTokens"] === "number") out.totalTokens = u["totalTokens"];
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -1,5 +1,6 @@
 export { agent } from "./agent.ts";
 export { AgentDestinationAdapter, type AgentBinding } from "./destination.ts";
+export type { AgentEvent, AgentEventListener } from "./events.ts";
 export { agentPlugin, type AgentPluginOptions } from "./plugin.ts";
 export {
   ADAPTER_AGENT_DEFAULT_OPTIONS,

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -140,7 +140,7 @@ export class AgentSession {
     modelName: string;
     system: string;
     user: string;
-    output: unknown;
+    output?: unknown;
     toolExtras:
       | { tools: Record<string, unknown>; stopWhen: unknown }
       | Record<string, never>;
@@ -148,8 +148,6 @@ export class AgentSession {
     const { options, modelConfig, modelName, tools, user, system, context } =
       this.input;
     const vercelTools = await buildVercelTools(tools, context, abortSignal);
-    const output =
-      options.output !== undefined ? toAiOutputSpec(options.output) : undefined;
     const toolExtras =
       Object.keys(vercelTools).length > 0
         ? {
@@ -159,7 +157,10 @@ export class AgentSession {
             ),
           }
         : {};
-    return { modelConfig, modelName, system, user, output, toolExtras };
+    const base = { modelConfig, modelName, system, user, toolExtras };
+    return options.output !== undefined
+      ? { ...base, output: toAiOutputSpec(options.output) }
+      : base;
   }
 }
 

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -1,8 +1,9 @@
 import type { CraftContext, Exchange } from "@routecraft/routecraft";
-import { callLlm } from "../llm/providers/index.ts";
+import { callLlm, streamLlm } from "../llm/providers/index.ts";
 import { resolvePrompt, resolveUserPromptDefault } from "../llm/shared.ts";
 import type { LlmModelConfig, LlmResult } from "../llm/types.ts";
 import { toAiOutputSpec } from "../llm/structured-output.ts";
+import type { AgentEventListener } from "./events.ts";
 import { buildVercelTools } from "./tool-bridge.ts";
 import type { ResolvedTool } from "./tools/selection.ts";
 import type {
@@ -46,18 +47,20 @@ export interface AgentSessionInput {
  * resolved tools + initial messages + provider config so the dispatch
  * path is structured around discrete units of work.
  *
- * Today only the synchronous path (`runUntilDone()`) is implemented.
- * It calls `generateText` once with the full tool list and lets the
- * Vercel AI SDK handle the multi-step tool-calling loop internally.
+ * Two execution paths are exposed:
  *
- * The session boundary exists so two follow-ups layer on without
- * rearchitecting:
+ * - {@link AgentSession.runUntilDone} calls `generateText` once with
+ *   the full tool list and lets the Vercel AI SDK handle the
+ *   multi-step tool-calling loop internally. Returns the consolidated
+ *   {@link AgentResult} when the loop terminates.
+ * - {@link AgentSession.runStream} calls `streamText` with the same
+ *   setup, forwards every normalised event through the user-supplied
+ *   listener, and returns the same consolidated {@link AgentResult}
+ *   once the stream drains.
  *
- * - **Streaming** (#257) adds `runStream()` which calls `streamText`
- *   with the same setup and returns an `AsyncIterable<AgentEvent>`.
- * - **Durable agents** (#258) checkpoints the running messages array
- *   between tool-call steps and lets a tool handler throw
- *   `SuspendError` to pause the loop.
+ * Future hook (durable agents, #258): checkpoints the running messages
+ * array between tool-call steps and lets a tool handler throw
+ * `SuspendError` to pause the loop.
  *
  * @internal
  */
@@ -70,26 +73,8 @@ export class AgentSession {
    * consolidated `AgentResult`.
    */
   async runUntilDone(abortSignal: AbortSignal): Promise<AgentResult> {
-    const { options, modelConfig, modelName, tools, user, system, context } =
-      this.input;
-
-    const vercelTools = await buildVercelTools(tools, context, abortSignal);
-    const output =
-      options.output !== undefined ? toAiOutputSpec(options.output) : undefined;
-
-    // Build stopWhen only when tools are present. Without tools the
-    // SDK returns after a single step, so the stop predicate (and its
-    // dynamic `import("ai")`) is unnecessary.
-    const toolExtras =
-      Object.keys(vercelTools).length > 0
-        ? {
-            tools: vercelTools,
-            stopWhen: await buildStopWhen(
-              options.maxSteps ?? DEFAULT_MAX_STEPS,
-            ),
-          }
-        : {};
-
+    const { modelConfig, modelName, system, user, output, toolExtras } =
+      await this.prepare(abortSignal);
     const result = await callLlm({
       config: modelConfig,
       modelId: modelName,
@@ -103,8 +88,78 @@ export class AgentSession {
       ...(output !== undefined ? { output } : {}),
       ...toolExtras,
     });
-
     return toAgentResult(result);
+  }
+
+  /**
+   * Run the streaming tool-calling loop. Same setup as
+   * {@link AgentSession.runUntilDone}, but the dispatch goes through
+   * `streamText`: each normalised event is forwarded to `onEvent`
+   * while the loop runs, and the consolidated {@link AgentResult} is
+   * returned once the stream drains.
+   *
+   * Listener errors are caught and logged inside the LLM-provider
+   * layer; they never abort the dispatch. Stream-level errors
+   * (provider failure, network error) are surfaced as an "error"
+   * event AND propagate by rejecting this promise, so callers handle
+   * failure exactly like the sync path.
+   */
+  async runStream(
+    abortSignal: AbortSignal,
+    onEvent: AgentEventListener,
+  ): Promise<AgentResult> {
+    const { modelConfig, modelName, system, user, output, toolExtras } =
+      await this.prepare(abortSignal);
+    const result = await streamLlm({
+      config: modelConfig,
+      modelId: modelName,
+      options: {
+        temperature: DEFAULT_TEMPERATURE,
+        maxTokens: DEFAULT_MAX_TOKENS,
+      },
+      system,
+      user,
+      abortSignal,
+      onEvent,
+      ...(output !== undefined ? { output } : {}),
+      ...toolExtras,
+    });
+    return toAgentResult(result);
+  }
+
+  /**
+   * Shared setup for both dispatch paths: build the Vercel tool map,
+   * resolve the structured-output spec, and compute the
+   * tools/stopWhen extras. Pulled out so `runUntilDone` and
+   * `runStream` differ only in which underlying SDK call they make.
+   *
+   * @internal
+   */
+  private async prepare(abortSignal: AbortSignal): Promise<{
+    modelConfig: LlmModelConfig;
+    modelName: string;
+    system: string;
+    user: string;
+    output: unknown;
+    toolExtras:
+      | { tools: Record<string, unknown>; stopWhen: unknown }
+      | Record<string, never>;
+  }> {
+    const { options, modelConfig, modelName, tools, user, system, context } =
+      this.input;
+    const vercelTools = await buildVercelTools(tools, context, abortSignal);
+    const output =
+      options.output !== undefined ? toAiOutputSpec(options.output) : undefined;
+    const toolExtras =
+      Object.keys(vercelTools).length > 0
+        ? {
+            tools: vercelTools,
+            stopWhen: await buildStopWhen(
+              options.maxSteps ?? DEFAULT_MAX_STEPS,
+            ),
+          }
+        : {};
+    return { modelConfig, modelName, system, user, output, toolExtras };
   }
 }
 

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -1,6 +1,7 @@
 import type { Exchange } from "@routecraft/routecraft";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { LlmModelId, LlmUsage } from "../llm/types.ts";
+import type { AgentEventListener } from "./events.ts";
 import type { ToolSelection } from "./tools/selection.ts";
 
 /**
@@ -115,6 +116,26 @@ export interface AgentOptions {
    * `defaultOptions.maxSteps` supplies a value.
    */
   maxSteps?: number;
+
+  /**
+   * Listener invoked for each event emitted while the model + tool
+   * loop runs. Setting this switches the dispatch from `generateText`
+   * to `streamText` under the hood; the destination still returns a
+   * consolidated {@link AgentResult} once the stream drains, so
+   * downstream pipeline ops are unaffected.
+   *
+   * Use for live UI updates (SSE, WebSocket, console). For server-side
+   * persistence or telemetry without a streamed UI, use the regular
+   * (non-streaming) dispatch and read `AgentResult` directly.
+   *
+   * Listener errors are caught and logged, never propagate into the
+   * dispatch. Async listeners are awaited so back-pressure on a slow
+   * consumer flows back into the stream.
+   *
+   * Per-agent only; not part of `defaultOptions` because event sinks
+   * are typically request-scoped (e.g. a per-connection SSE channel).
+   */
+  onEvent?: AgentEventListener;
 }
 
 /**

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -124,6 +124,8 @@ export {
 export type {
   AgentBinding,
   AgentDefaultOptions,
+  AgentEvent,
+  AgentEventListener,
   AgentOptions,
   AgentPluginOptions,
   AgentRegisteredOptions,

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -1,3 +1,6 @@
+import { logger as frameworkLogger } from "@routecraft/routecraft";
+import type { AgentEventListener } from "../../agent/events.ts";
+import { normalizeStreamPart } from "../../agent/events.ts";
 import type {
   LlmModelConfig,
   LlmOptionsMerged,
@@ -130,9 +133,9 @@ export interface CallLlmParams {
 }
 
 /**
- * Per-provider extras forwarded into `generateText`. Centralised so
- * each provider builds the same shape and the typecast at the call
- * site stays narrow.
+ * Per-provider extras forwarded into `generateText` / `streamText`.
+ * Centralised so each path builds the same shape and the typecast at
+ * the call site stays narrow.
  *
  * @internal
  */
@@ -155,22 +158,65 @@ function buildExtras(params: CallLlmParams): ProviderExtras {
 }
 
 /**
- * Dispatches to the appropriate provider and returns a normalized LlmResult.
+ * Dispatch via Vercel AI SDK `generateText` and return a normalised
+ * {@link LlmResult}. Resolves the language model for the configured
+ * provider, then delegates to the shared {@link runGenerate} helper.
  */
 export async function callLlm(params: CallLlmParams): Promise<LlmResult> {
   const { config, modelId, options, system, user } = params;
-  const extras = buildExtras(params);
+  const model = await resolveLanguageModel(config, modelId);
+  return runGenerate(model, options, system, user, buildExtras(params));
+}
+
+/**
+ * Streaming counterpart to {@link callLlm}. Resolves the language model
+ * for the configured provider, calls Vercel's `streamText`, forwards
+ * each normalised stream event to `onEvent`, and finally returns the
+ * consolidated {@link LlmResult} once the stream drains.
+ *
+ * Used by the agent destination when the user supplies
+ * `AgentOptions.onEvent`. Exposed at the LLM-provider layer so the
+ * provider plumbing (model resolution, option mapping, reasoning
+ * extraction) stays in one place.
+ */
+export async function streamLlm(
+  params: CallLlmParams & { onEvent: AgentEventListener },
+): Promise<LlmResult> {
+  const { config, modelId, options, system, user, onEvent } = params;
+  const model = await resolveLanguageModel(config, modelId);
+  return runStreamGenerate(
+    model,
+    options,
+    system,
+    user,
+    buildExtras(params),
+    onEvent,
+  );
+}
+
+/**
+ * Resolve the AI SDK `LanguageModel` for a given provider config.
+ * Single source of truth used by both the synchronous (`callLlm` →
+ * `runGenerate`) and streaming (`streamLlm` → `runStreamGenerate`)
+ * paths so provider setup is not duplicated per dispatch mode.
+ *
+ * @internal
+ */
+async function resolveLanguageModel(
+  config: LlmModelConfig,
+  modelId: string,
+): Promise<unknown> {
   switch (config.provider) {
     case "openai":
-      return callOpenAI(config, modelId, options, system, user, extras);
+      return resolveOpenAI(config, modelId);
     case "anthropic":
-      return callAnthropic(config, modelId, options, system, user, extras);
+      return resolveAnthropic(config, modelId);
     case "gemini":
-      return callGemini(config, modelId, options, system, user, extras);
+      return resolveGemini(config, modelId);
     case "openrouter":
-      return callOpenRouter(config, modelId, options, system, user, extras);
+      return resolveOpenRouter(config, modelId);
     case "ollama":
-      return callOllama(config, modelId, options, system, user, extras);
+      return resolveOllama(config, modelId);
     default: {
       const _: never = config;
       throw new Error(
@@ -180,14 +226,10 @@ export async function callLlm(params: CallLlmParams): Promise<LlmResult> {
   }
 }
 
-async function callOpenAI(
+async function resolveOpenAI(
   config: import("../types.ts").LlmModelConfigOpenAI,
   modelId: string,
-  options: CallLlmParams["options"],
-  system: string,
-  user: string,
-  extras: ProviderExtras,
-): Promise<LlmResult> {
+): Promise<unknown> {
   let createOpenAI: (s: {
     apiKey: string;
     baseURL?: string;
@@ -201,29 +243,18 @@ async function callOpenAI(
     }
     throw error;
   }
-  const openaiSettings: { apiKey: string; baseURL?: string } = {
+  const settings: { apiKey: string; baseURL?: string } = {
     apiKey: config.apiKey,
   };
-  if (config.baseURL !== undefined) openaiSettings.baseURL = config.baseURL;
-  const openai = createOpenAI(openaiSettings);
-  const model = openai(modelId);
-  return runGenerate(
-    model as Parameters<typeof runGenerate>[0],
-    options,
-    system,
-    user,
-    extras,
-  );
+  if (config.baseURL !== undefined) settings.baseURL = config.baseURL;
+  const openai = createOpenAI(settings);
+  return openai(modelId);
 }
 
-async function callAnthropic(
+async function resolveAnthropic(
   config: import("../types.ts").LlmModelConfigAnthropic,
   modelId: string,
-  options: CallLlmParams["options"],
-  system: string,
-  user: string,
-  extras: ProviderExtras,
-): Promise<LlmResult> {
+): Promise<unknown> {
   let createAnthropic: (s: { apiKey: string }) => (m: string) => unknown;
   try {
     const mod = await import("@ai-sdk/anthropic");
@@ -235,24 +266,13 @@ async function callAnthropic(
     throw error;
   }
   const anthropic = createAnthropic({ apiKey: config.apiKey });
-  const model = anthropic(modelId);
-  return runGenerate(
-    model as Parameters<typeof runGenerate>[0],
-    options,
-    system,
-    user,
-    extras,
-  );
+  return anthropic(modelId);
 }
 
-async function callGemini(
+async function resolveGemini(
   config: import("../types.ts").LlmModelConfigGemini,
   modelId: string,
-  options: CallLlmParams["options"],
-  system: string,
-  user: string,
-  extras: ProviderExtras,
-): Promise<LlmResult> {
+): Promise<unknown> {
   let createGoogleGenerativeAI: (s: {
     apiKey: string;
   }) => (m: string) => unknown;
@@ -267,24 +287,13 @@ async function callGemini(
     throw error;
   }
   const google = createGoogleGenerativeAI({ apiKey: config.apiKey });
-  const model = google(modelId);
-  return runGenerate(
-    model as Parameters<typeof runGenerate>[0],
-    options,
-    system,
-    user,
-    extras,
-  );
+  return google(modelId);
 }
 
-async function callOpenRouter(
+async function resolveOpenRouter(
   config: import("../types.ts").LlmModelConfigOpenRouter,
   modelId: string,
-  options: CallLlmParams["options"],
-  system: string,
-  user: string,
-  extras: ProviderExtras,
-): Promise<LlmResult> {
+): Promise<unknown> {
   let createOpenRouter: (s: { apiKey: string }) => {
     chat: (id: string) => unknown;
   };
@@ -301,23 +310,13 @@ async function callOpenRouter(
   const resolvedId = config.modelId ?? modelId;
   const rawModel = openrouter.chat(resolvedId);
   assertLanguageModelShape(rawModel, "OpenRouter", resolvedId);
-  return runGenerate(
-    rawModel as Parameters<typeof runGenerate>[0],
-    options,
-    system,
-    user,
-    extras,
-  );
+  return rawModel;
 }
 
-async function callOllama(
+async function resolveOllama(
   config: import("../types.ts").LlmModelConfigOllama,
   modelId: string,
-  options: CallLlmParams["options"],
-  system: string,
-  user: string,
-  extras: ProviderExtras,
-): Promise<LlmResult> {
+): Promise<unknown> {
   let createOllama: (s: { baseURL?: string }) => (name: string) => unknown;
   try {
     const mod = await import("ollama-ai-provider-v2");
@@ -334,13 +333,41 @@ async function callOllama(
   const name = config.modelId ?? modelId;
   const rawModel = ollama(name);
   assertLanguageModelShape(rawModel, "Ollama", name);
-  return runGenerate(
-    rawModel as Parameters<typeof runGenerate>[0],
-    options,
-    system,
-    user,
-    extras,
-  );
+  return rawModel;
+}
+
+/**
+ * Build the common `generateText` / `streamText` argument shape from
+ * the merged options + system/user prompts + extras. Both the
+ * synchronous and streaming paths feed this into their respective SDK
+ * call so option mapping (temperature, max tokens, etc.) lives in one
+ * place.
+ *
+ * @internal
+ */
+function buildSdkParams(
+  model: unknown,
+  options: CallLlmParams["options"],
+  system: string,
+  user: string,
+  extras: ProviderExtras,
+): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    model,
+    prompt: user,
+    temperature: options.temperature,
+  };
+  if (options.maxTokens !== undefined)
+    params["maxOutputTokens"] = options.maxTokens;
+  if (system) params["system"] = system;
+  if (options.topP !== undefined) params["topP"] = options.topP;
+  if (options.frequencyPenalty !== undefined) {
+    params["frequencyPenalty"] = options.frequencyPenalty;
+  }
+  if (options.presencePenalty !== undefined) {
+    params["presencePenalty"] = options.presencePenalty;
+  }
+  return { ...params, ...extras };
 }
 
 /**
@@ -359,21 +386,7 @@ async function runGenerate(
   extras: ProviderExtras,
 ): Promise<LlmResult> {
   const { generateText } = await import("ai");
-  const genParams: Parameters<typeof generateText>[0] = {
-    model: model as Parameters<typeof generateText>[0]["model"],
-    prompt: user,
-    ...(options.maxTokens !== undefined && {
-      maxOutputTokens: options.maxTokens,
-    }),
-    temperature: options.temperature,
-  };
-  if (system) genParams.system = system;
-  if (options.topP !== undefined) genParams.topP = options.topP;
-  if (options.frequencyPenalty !== undefined)
-    genParams.frequencyPenalty = options.frequencyPenalty;
-  if (options.presencePenalty !== undefined)
-    genParams.presencePenalty = options.presencePenalty;
-  const params = { ...genParams, ...extras };
+  const params = buildSdkParams(model, options, system, user, extras);
   const result = await generateText(
     params as Parameters<typeof generateText>[0],
   );
@@ -384,6 +397,88 @@ async function runGenerate(
   const reasoning = readReasoning(result);
   if (reasoning) out.reasoning = reasoning;
   return out;
+}
+
+/**
+ * Shared `streamText` invocation. Iterates the SDK's `fullStream`,
+ * forwards each normalised event to `onEvent`, then awaits the
+ * consolidated values (text, usage, reasoning, optional structured
+ * output) once the stream drains.
+ *
+ * Listener errors are caught and logged; they do not abort the
+ * dispatch. Stream errors surface via an "error" event AND propagate
+ * out of `await result.text`, so the dispatch fails normally after
+ * the listener has been informed.
+ *
+ * @internal
+ */
+async function runStreamGenerate(
+  model: unknown,
+  options: CallLlmParams["options"],
+  system: string,
+  user: string,
+  extras: ProviderExtras,
+  onEvent: AgentEventListener,
+): Promise<LlmResult> {
+  const { streamText } = await import("ai");
+  const params = buildSdkParams(model, options, system, user, extras);
+  const result = streamText(params as Parameters<typeof streamText>[0]);
+
+  for await (const part of result.fullStream) {
+    const event = normalizeStreamPart(part);
+    if (event === null) continue;
+    try {
+      await onEvent(event);
+    } catch (err) {
+      frameworkLogger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "agent.onEvent listener threw; ignoring and continuing stream",
+      );
+    }
+  }
+
+  // Drain consolidated values. `result.text` rejects with the same
+  // error that surfaced through fullStream, so failures propagate
+  // through this await.
+  const text = await result.text;
+  const out: LlmResult = { text: text ?? "", raw: result };
+  const usage = await safeAwait<{
+    inputTokens?: number | undefined;
+    outputTokens?: number | undefined;
+    totalTokens?: number | undefined;
+  }>(result.usage);
+  if (usage) out.usage = toLlmUsage(usage);
+  const reasoning = await safeAwait<string | undefined>(
+    (result as { reasoningText?: PromiseLike<string | undefined> })
+      .reasoningText,
+  );
+  if (typeof reasoning === "string" && reasoning.length > 0) {
+    out.reasoning = reasoning;
+  }
+  const structured = await safeAwait<unknown>(
+    (result as { experimental_output?: PromiseLike<unknown> })
+      .experimental_output,
+  );
+  if (structured !== undefined) out.output = structured;
+  return out;
+}
+
+/**
+ * Await a value that may be a `PromiseLike<T>` (the AI SDK uses
+ * `PromiseLike` for stream consolidation accessors) and swallow
+ * rejections, returning `undefined` instead. Used to read optional
+ * accessors (usage, reasoning, structured output) where absence is
+ * not an error.
+ */
+async function safeAwait<T>(
+  value: T | PromiseLike<T> | undefined,
+): Promise<T | undefined> {
+  if (value === undefined) return undefined;
+  try {
+    return await value;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -468,6 +468,10 @@ async function runStreamGenerate(
  * rejections, returning `undefined` instead. Used to read optional
  * accessors (usage, reasoning, structured output) where absence is
  * not an error.
+ *
+ * Rejections are logged at debug level so a real provider regression
+ * (SDK shape change, transport error on the optional accessor itself)
+ * leaves a breadcrumb without surfacing as a user-visible warning.
  */
 async function safeAwait<T>(
   value: T | PromiseLike<T> | undefined,
@@ -475,7 +479,11 @@ async function safeAwait<T>(
   if (value === undefined) return undefined;
   try {
     return await value;
-  } catch {
+  } catch (err) {
+    frameworkLogger.debug(
+      { err },
+      "llm.streamLlm: optional accessor rejected; treating as absent",
+    );
     return undefined;
   }
 }

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -431,7 +431,7 @@ async function runStreamGenerate(
       await onEvent(event);
     } catch (err) {
       frameworkLogger.warn(
-        { err: err instanceof Error ? err.message : String(err) },
+        { err },
         "agent.onEvent listener threw; ignoring and continuing stream",
       );
     }
@@ -456,8 +456,7 @@ async function runStreamGenerate(
     out.reasoning = reasoning;
   }
   const structured = await safeAwait<unknown>(
-    (result as { experimental_output?: PromiseLike<unknown> })
-      .experimental_output,
+    (result as { output?: PromiseLike<unknown> }).output,
   );
   if (structured !== undefined) out.output = structured;
   return out;

--- a/packages/ai/test/agent-events.test.ts
+++ b/packages/ai/test/agent-events.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect } from "vitest";
+import { normalizeStreamPart } from "../src/agent/events.ts";
+
+describe("normalizeStreamPart — Vercel SDK part → AgentEvent", () => {
+  /**
+   * @case Plain text deltas map 1:1 onto text-delta events
+   * @preconditions Part of shape { type: "text-delta", text }
+   * @expectedResult Returns { type: "text-delta", text }
+   */
+  test("text-delta passes through", () => {
+    expect(normalizeStreamPart({ type: "text-delta", text: "hi" })).toEqual({
+      type: "text-delta",
+      text: "hi",
+    });
+  });
+
+  /**
+   * @case Empty text deltas are dropped (would emit a no-op event)
+   * @preconditions Part with empty text
+   * @expectedResult null (filtered)
+   */
+  test("empty text-delta is filtered", () => {
+    expect(normalizeStreamPart({ type: "text-delta", text: "" })).toBeNull();
+  });
+
+  /**
+   * @case Reasoning deltas surface for "thinking..." UI
+   * @preconditions Part of shape { type: "reasoning-delta", text }
+   * @expectedResult Returns { type: "reasoning-delta", text }
+   */
+  test("reasoning-delta passes through", () => {
+    expect(
+      normalizeStreamPart({ type: "reasoning-delta", text: "musing" }),
+    ).toEqual({ type: "reasoning-delta", text: "musing" });
+  });
+
+  /**
+   * @case Tool calls carry id, name, and validated input
+   * @preconditions Part of shape { type: "tool-call", toolCallId, toolName, input }
+   * @expectedResult Returns the same shape with `input` (not `args`)
+   */
+  test("tool-call maps cleanly", () => {
+    expect(
+      normalizeStreamPart({
+        type: "tool-call",
+        toolCallId: "c1",
+        toolName: "echo",
+        input: { msg: "hi" },
+      }),
+    ).toEqual({
+      type: "tool-call",
+      toolCallId: "c1",
+      toolName: "echo",
+      input: { msg: "hi" },
+    });
+  });
+
+  /**
+   * @case Tool result carries handler return value
+   * @preconditions Part of shape { type: "tool-result", toolCallId, toolName, output }
+   * @expectedResult Returns the same shape with `output` (not `result`)
+   */
+  test("tool-result maps cleanly", () => {
+    expect(
+      normalizeStreamPart({
+        type: "tool-result",
+        toolCallId: "c1",
+        toolName: "echo",
+        output: "echoed hi",
+      }),
+    ).toEqual({
+      type: "tool-result",
+      toolCallId: "c1",
+      toolName: "echo",
+      output: "echoed hi",
+    });
+  });
+
+  /**
+   * @case Tool error carries the thrown value
+   * @preconditions Part of shape { type: "tool-error", toolCallId, toolName, error }
+   * @expectedResult Returns the same shape
+   */
+  test("tool-error maps cleanly", () => {
+    const err = new Error("boom");
+    expect(
+      normalizeStreamPart({
+        type: "tool-error",
+        toolCallId: "c1",
+        toolName: "echo",
+        error: err,
+      }),
+    ).toEqual({
+      type: "tool-error",
+      toolCallId: "c1",
+      toolName: "echo",
+      error: err,
+    });
+  });
+
+  /**
+   * @case Step finish carries reason and optional usage
+   * @preconditions Part with finishReason and usage
+   * @expectedResult Returns step-finish with same fields
+   */
+  test("finish-step maps to step-finish with usage", () => {
+    expect(
+      normalizeStreamPart({
+        type: "finish-step",
+        finishReason: "tool-calls",
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      }),
+    ).toEqual({
+      type: "step-finish",
+      finishReason: "tool-calls",
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    });
+  });
+
+  /**
+   * @case Final finish prefers totalUsage when present
+   * @preconditions Part with totalUsage
+   * @expectedResult Returns finish with usage from totalUsage
+   */
+  test("finish prefers totalUsage over usage", () => {
+    expect(
+      normalizeStreamPart({
+        type: "finish",
+        finishReason: "stop",
+        totalUsage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      }),
+    ).toEqual({
+      type: "finish",
+      finishReason: "stop",
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+    });
+  });
+
+  /**
+   * @case Error events surface to the listener
+   * @preconditions Part of shape { type: "error", error }
+   * @expectedResult Returns { type: "error", error }
+   */
+  test("error passes through", () => {
+    const err = { code: "ECONNRESET" };
+    expect(normalizeStreamPart({ type: "error", error: err })).toEqual({
+      type: "error",
+      error: err,
+    });
+  });
+
+  /**
+   * @case Low-level parts are filtered (text-start/end, tool-input-*, abort, raw)
+   * @preconditions Parts with types not in the public surface
+   * @expectedResult null
+   */
+  test("low-level SDK parts are filtered out", () => {
+    expect(normalizeStreamPart({ type: "text-start", id: "0" })).toBeNull();
+    expect(normalizeStreamPart({ type: "text-end", id: "0" })).toBeNull();
+    expect(
+      normalizeStreamPart({ type: "tool-input-start", id: "x" }),
+    ).toBeNull();
+    expect(
+      normalizeStreamPart({ type: "tool-input-delta", id: "x", delta: "{" }),
+    ).toBeNull();
+    expect(normalizeStreamPart({ type: "abort" })).toBeNull();
+    expect(normalizeStreamPart({ type: "raw", payload: {} })).toBeNull();
+  });
+
+  /**
+   * @case Garbage input is dropped, not thrown
+   * @preconditions Non-object inputs
+   * @expectedResult null for each
+   */
+  test("non-object input returns null", () => {
+    expect(normalizeStreamPart(null)).toBeNull();
+    expect(normalizeStreamPart(undefined)).toBeNull();
+    expect(normalizeStreamPart("text")).toBeNull();
+    expect(normalizeStreamPart(42)).toBeNull();
+  });
+});

--- a/packages/ai/test/agent-events.test.ts
+++ b/packages/ai/test/agent-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { normalizeStreamPart } from "../src/agent/events.ts";
 
-describe("normalizeStreamPart — Vercel SDK part → AgentEvent", () => {
+describe("normalizeStreamPart: Vercel SDK part to AgentEvent", () => {
   /**
    * @case Plain text deltas map 1:1 onto text-delta events
    * @preconditions Part of shape { type: "text-delta", text }
@@ -24,6 +24,17 @@ describe("normalizeStreamPart — Vercel SDK part → AgentEvent", () => {
   });
 
   /**
+   * @case Legacy SDK field name `textDelta` is honoured for cross-version safety
+   * @preconditions Part with `textDelta` instead of `text`
+   * @expectedResult Returns text-delta with the legacy field's value
+   */
+  test("text-delta accepts legacy `textDelta` field", () => {
+    expect(
+      normalizeStreamPart({ type: "text-delta", textDelta: "legacy" }),
+    ).toEqual({ type: "text-delta", text: "legacy" });
+  });
+
+  /**
    * @case Reasoning deltas surface for "thinking..." UI
    * @preconditions Part of shape { type: "reasoning-delta", text }
    * @expectedResult Returns { type: "reasoning-delta", text }
@@ -32,6 +43,17 @@ describe("normalizeStreamPart — Vercel SDK part → AgentEvent", () => {
     expect(
       normalizeStreamPart({ type: "reasoning-delta", text: "musing" }),
     ).toEqual({ type: "reasoning-delta", text: "musing" });
+  });
+
+  /**
+   * @case Legacy SDK field name `delta` is honoured for cross-version safety
+   * @preconditions Part with `delta` instead of `text`
+   * @expectedResult Returns reasoning-delta with the legacy field's value
+   */
+  test("reasoning-delta accepts legacy `delta` field", () => {
+    expect(
+      normalizeStreamPart({ type: "reasoning-delta", delta: "musing-legacy" }),
+    ).toEqual({ type: "reasoning-delta", text: "musing-legacy" });
   });
 
   /**

--- a/packages/ai/test/agent-streaming.test.ts
+++ b/packages/ai/test/agent-streaming.test.ts
@@ -243,7 +243,7 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
     // The mocked streamLlm awaits onEvent in a try/catch (mirrors the
     // real implementation), so all 3 events are still attempted and
     // the consolidated AgentResult still flows downstream.
-    expect(received).toBeGreaterThan(0);
+    expect(received).toBe(3);
     const body = sink.received[0].body as AgentResult;
     expect(body.text).toBe("Hello");
   });
@@ -280,5 +280,10 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
 
     await t.test();
     expect(events).toHaveLength(3);
+    // Awaiting an async listener must preserve dispatch order; without
+    // back-pressure the events would interleave.
+    expect(events[0]).toEqual({ type: "text-delta", text: "Hel" });
+    expect(events[1]).toEqual({ type: "text-delta", text: "lo" });
+    expect(events[2]).toMatchObject({ type: "finish", finishReason: "stop" });
   });
 });

--- a/packages/ai/test/agent-streaming.test.ts
+++ b/packages/ai/test/agent-streaming.test.ts
@@ -1,0 +1,284 @@
+import { describe, test, expect, afterEach, vi, beforeEach } from "vitest";
+import { craft, simple } from "@routecraft/routecraft";
+import { spy, testContext, type TestContext } from "@routecraft/testing";
+import {
+  agent,
+  llmPlugin,
+  type AgentEvent,
+  type AgentResult,
+} from "../src/index.ts";
+import type { LlmResult } from "../src/llm/types.ts";
+
+// Mock both LLM dispatch paths so the streaming tests stay hermetic.
+// `streamLlm` synthesises a small event stream (text-delta x2 +
+// finish), forwards it to `onEvent`, and returns a consolidated
+// LlmResult mirroring what the real provider would build after the
+// stream drains. `callLlm` stays available for the non-streaming
+// regression check.
+vi.mock("../src/llm/providers/index.ts", () => ({
+  callLlm: vi.fn(
+    async (): Promise<LlmResult> => ({
+      text: "non-stream",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    }),
+  ),
+  streamLlm: vi.fn(
+    async ({
+      onEvent,
+    }: {
+      onEvent: (e: AgentEvent) => void | Promise<void>;
+    }): Promise<LlmResult> => {
+      // Mirror the real runStreamGenerate: listener throws are caught
+      // and logged so a noisy consumer doesn't break the dispatch.
+      const safe = async (e: AgentEvent) => {
+        try {
+          await onEvent(e);
+        } catch {
+          // swallow, mirrors frameworkLogger.warn in the real path
+        }
+      };
+      await safe({ type: "text-delta", text: "Hel" });
+      await safe({ type: "text-delta", text: "lo" });
+      await safe({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+      });
+      return {
+        text: "Hello",
+        usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+      };
+    },
+  ),
+}));
+
+import { callLlm, streamLlm } from "../src/llm/providers/index.ts";
+const callLlmMock = callLlm as unknown as ReturnType<typeof vi.fn>;
+const streamLlmMock = streamLlm as unknown as ReturnType<typeof vi.fn>;
+
+describe("agent streaming: onEvent → streamLlm wiring", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    callLlmMock.mockClear();
+    streamLlmMock.mockClear();
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Agent without onEvent uses the synchronous path
+   * @preconditions Inline agent with no `onEvent`
+   * @expectedResult callLlm called once; streamLlm not called
+   */
+  test("no onEvent → callLlm, not streamLlm", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("sync-only")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "Be helpful.",
+              model: "anthropic:claude-opus-4-7",
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock).toHaveBeenCalledTimes(1);
+    expect(streamLlmMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * @case Agent with onEvent triggers the streaming path
+   * @preconditions Inline agent with `onEvent` callback
+   * @expectedResult streamLlm called once; callLlm not called
+   */
+  test("onEvent present → streamLlm, not callLlm", async () => {
+    const events: AgentEvent[] = [];
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("stream-on")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "Be helpful.",
+              model: "anthropic:claude-opus-4-7",
+              onEvent: (e) => {
+                events.push(e);
+              },
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(streamLlmMock).toHaveBeenCalledTimes(1);
+    expect(callLlmMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * @case Listener receives every emitted event in order
+   * @preconditions onEvent collects all events into an array
+   * @expectedResult Events seen are [text-delta "Hel", text-delta "lo", finish]
+   */
+  test("listener receives events in dispatch order", async () => {
+    const events: AgentEvent[] = [];
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("event-order")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              onEvent: (e) => {
+                events.push(e);
+              },
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(events).toHaveLength(3);
+    expect(events[0]).toEqual({ type: "text-delta", text: "Hel" });
+    expect(events[1]).toEqual({ type: "text-delta", text: "lo" });
+    expect(events[2]).toMatchObject({ type: "finish", finishReason: "stop" });
+  });
+
+  /**
+   * @case Body is the consolidated AgentResult after the stream drains
+   * @preconditions Streaming agent followed by a sink
+   * @expectedResult Sink sees AgentResult { text: "Hello", usage: {...} }
+   */
+  test("downstream body is the consolidated AgentResult", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("stream-then-sink")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              onEvent: () => {},
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    const body = sink.received[0].body as AgentResult;
+    expect(body.text).toBe("Hello");
+    expect(body.usage).toEqual({
+      inputTokens: 3,
+      outputTokens: 2,
+      totalTokens: 5,
+    });
+  });
+
+  /**
+   * @case Throwing listener does not abort the dispatch
+   * @preconditions onEvent throws on the first text-delta
+   * @expectedResult Dispatch completes, AgentResult body still consolidated, subsequent events still attempted
+   */
+  test("listener throw is contained; dispatch completes", async () => {
+    let received = 0;
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("throwing-listener")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              onEvent: () => {
+                received++;
+                throw new Error("listener boom");
+              },
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    // The mocked streamLlm awaits onEvent in a try/catch (mirrors the
+    // real implementation), so all 3 events are still attempted and
+    // the consolidated AgentResult still flows downstream.
+    expect(received).toBeGreaterThan(0);
+    const body = sink.received[0].body as AgentResult;
+    expect(body.text).toBe("Hello");
+  });
+
+  /**
+   * @case Async listener is awaited so back-pressure flows back into the stream
+   * @preconditions onEvent returns a Promise that resolves after a tick
+   * @expectedResult All events delivered before the dispatch resolves
+   */
+  test("async listener is awaited", async () => {
+    const events: AgentEvent[] = [];
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("async-listener")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              onEvent: async (e) => {
+                await new Promise((r) => setTimeout(r, 1));
+                events.push(e);
+              },
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(events).toHaveLength(3);
+  });
+});

--- a/packages/ai/test/stream-llm.test.ts
+++ b/packages/ai/test/stream-llm.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { logger as frameworkLogger } from "@routecraft/routecraft";
+
+// Mock the Vercel AI SDK so the real `streamLlm` (not its
+// re-implementation in agent-streaming.test.ts) is exercised end to
+// end. The mock provides a minimal `streamText` whose `fullStream`
+// yields a controlled sequence and whose consolidation accessors
+// resolve as Promises.
+vi.mock("ai", () => ({
+  streamText: vi.fn(() => ({
+    fullStream: (async function* () {
+      yield { type: "text-delta", text: "ok" };
+      yield { type: "finish", finishReason: "stop" };
+    })(),
+    text: Promise.resolve("ok"),
+    usage: Promise.resolve(undefined),
+    reasoningText: Promise.resolve(undefined),
+    output: Promise.resolve(undefined),
+  })),
+}));
+
+// Mock the Anthropic provider so resolveLanguageModel doesn't try to
+// load `@ai-sdk/anthropic` from disk during the test.
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(
+    () =>
+      function model() {
+        return { doGenerate: () => null, doStream: () => null };
+      },
+  ),
+}));
+
+import { streamLlm } from "../src/llm/providers/index.ts";
+
+describe("streamLlm: production listener-error containment", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(frameworkLogger, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  /**
+   * @case A throwing listener does not reject the dispatch
+   * @preconditions onEvent throws synchronously on every invocation
+   * @expectedResult Promise resolves with the consolidated LlmResult; warn called per throw
+   */
+  test("throwing onEvent does not abort dispatch", async () => {
+    const result = await streamLlm({
+      config: { provider: "anthropic", apiKey: "sk-test" },
+      modelId: "claude-test",
+      options: { temperature: 0, maxTokens: 64 },
+      system: "x",
+      user: "y",
+      onEvent: () => {
+        throw new Error("listener boom");
+      },
+    });
+    expect(result.text).toBe("ok");
+    // 2 events normalised → 2 listener invocations → 2 warn entries.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0]?.[1]).toMatch(/agent\.onEvent listener threw/);
+  });
+
+  /**
+   * @case Listener that throws on the first event still receives the second
+   * @preconditions onEvent throws on the first call, succeeds on the rest
+   * @expectedResult Both events are delivered (catch lives per-event, not per-stream)
+   */
+  test("subsequent events still delivered after a listener throw", async () => {
+    let calls = 0;
+    await streamLlm({
+      config: { provider: "anthropic", apiKey: "sk-test" },
+      modelId: "claude-test",
+      options: { temperature: 0, maxTokens: 64 },
+      system: "x",
+      user: "y",
+      onEvent: () => {
+        calls++;
+        if (calls === 1) throw new Error("first-only");
+      },
+    });
+    expect(calls).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an `onEvent` callback to `AgentOptions`. Its presence switches the dispatch from `generateText` to `streamText` under the hood; the destination still returns a consolidated `AgentResult` once the stream drains, so downstream pipeline ops are unaffected.

```ts
agent({
  model: "openai:gpt-4o",
  system: "Be helpful.",
  tools: tools(["search"]),
  onEvent: (event) => {
    if (event.type === "text-delta") sse.send({ data: event.text });
    if (event.type === "tool-call") sse.send({ data: `calling ${event.toolName}` });
  },
})
```

## Public surface

- `AgentEvent` discriminated union: `text-delta`, `reasoning-delta`, `tool-call`, `tool-result`, `tool-error`, `step-finish`, `finish`, `error`.
- `AgentEventListener` type.
- `AgentOptions.onEvent` (per-agent only; not on `defaultOptions` because event sinks are typically request-scoped).

## Internal

- `AgentSession.runStream()` mirrors `runUntilDone()` via a shared `prepare()` helper so the two dispatch modes differ only in which SDK call they make.
- `streamLlm` and `runStreamGenerate` in the provider layer.
- Provider setup DRY'd via `resolveLanguageModel` + `buildSdkParams`, shared by both the sync and streaming paths (the 5 per-provider `call*` helpers collapsed into 5 `resolve*` helpers).
- `normalizeStreamPart` adapts SDK `fullStream` parts onto `AgentEvent`; low-level parts (text-start/end, tool-input-* deltas, abort, raw provider parts) are filtered so the routecraft surface stays stable across SDK versions.

## Behaviour notes

- **Listener errors are contained.** A throw inside `onEvent` is caught and logged; the dispatch keeps running and the consolidated `AgentResult` still reaches downstream ops.
- **Async listeners are awaited.** Returning a `Promise` from `onEvent` applies back-pressure to the stream, which is what you want when forwarding to a slow consumer.
- **Stream errors still throw.** Provider errors surface as an `error` event AND propagate out of the dispatch promise, so failure handling matches the non-streaming path.
- **Abort still propagates.** Same route signal threading as `runUntilDone` — route shutdown aborts the in-flight stream and any in-flight tool handlers.

## Tests

17 new tests:

- `agent-events.test.ts` (11) — unit tests for `normalizeStreamPart` covering every event type plus filtering of low-level SDK parts and garbage input.
- `agent-streaming.test.ts` (6) — integration tests through the destination: no-onEvent uses `callLlm`; with-onEvent uses `streamLlm`; events arrive in dispatch order; consolidated `AgentResult` reaches downstream sink; throwing listener doesn't abort the dispatch; async listener is awaited.

Full suite: 935 pass / 1 skipped (was 918; +17 new, no regressions).

## Verification

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm test`
- [x] `pnpm build`

## Test plan

- [ ] Wire an `onEvent` callback to a real provider (OpenAI / Anthropic) and verify text deltas arrive incrementally
- [ ] Verify tool-call / tool-result events are emitted when the agent invokes a tool
- [ ] Confirm route shutdown cancels an in-flight streaming dispatch

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `onEvent` to `AgentOptions` to stream agent events (tokens, tool calls/results, finish/errors) while still returning a consolidated `AgentResult` when the stream ends. Enables real-time UIs and closes Linear #257.

- **New Features**
  - `AgentOptions.onEvent` switches dispatch to `streamText`; without it we use `generateText`.
  - Exports `AgentEvent` and `AgentEventListener`.
  - Listener errors are contained; async listeners are awaited; provider errors emit `error` and also reject the dispatch.
  - Docs updated with a streaming section.

- **Refactors**
  - Added `AgentSession.runStream()` and a shared `prepare()` to keep sync/stream paths aligned; `AgentDestinationAdapter` chooses streaming based on `onEvent`.
  - Provider layer unified: `streamLlm`/`runStreamGenerate`, shared `resolveLanguageModel` and `buildSdkParams`; `normalizeStreamPart` maps SDK parts to `AgentEvent` (now handles legacy `textDelta`/`delta` fields).
  - Streaming path now returns structured output via `result.output`; listener logging passes the full error object for better traces.
  - `safeAwait` now logs at debug level when optional accessors (usage/reasoning/output) reject, to aid provider regression debugging.

<sup>Written for commit 510b314b99e05bc664fbbe82423fa5c0da7a8798. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

