### PR TITLE
Add config applier system and first-class AI plugin keys

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
@@ -32,9 +32,9 @@ export const craftConfig = defineConfig({
 | `once` | `Partial<Record<EventName, EventHandler \| EventHandler[]>>` | No | — | One-time event handlers that fire once then auto-unsubscribe |
 | `cron` | `Partial<CronOptions>` | No | -- | Default options for all `cron()` sources ([details](#cron)) |
 | `direct` | `{ channelType?: DirectChannelType }` | No | -- | Custom channel implementation for all `direct()` endpoints ([details](#direct)) |
-| `mail` | `MailContextConfig` | No | — | Mail adapter accounts (IMAP/SMTP) keyed by name |
-| `telemetry` | `TelemetryOptions` | No | — | Telemetry plugin configuration (SQLite, OpenTelemetry) |
-| `plugins` | `CraftPlugin[]` | No | — | Custom plugins to initialize before routes are registered |
+| `mail` | `MailContextConfig` | No | -- | Mail adapter accounts (IMAP/SMTP) keyed by name |
+| `telemetry` | `TelemetryOptions` | No | -- | Telemetry plugin configuration (SQLite, OpenTelemetry) |
+| `plugins` | `CraftPlugin[]` | No | -- | Custom plugins to initialize before routes are registered |
 
 ### Ecosystem keys (added by `@routecraft/ai`)
 

--- a/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
@@ -6,20 +6,22 @@ Full reference for `CraftConfig` fields and logging options. {% .lead %}
 
 ## CraftConfig
 
-The main configuration object for context settings. Export it as `craftConfig` (named export) alongside your capabilities when using `craft run`:
+The main configuration object for context settings. Export it as `craftConfig` (named export) alongside your capabilities when using `craft run`. The recommended pattern is `defineConfig`, an identity helper that preserves literal-type inference (so autocomplete works for first-class keys):
 
 ```ts
-import type { CraftConfig } from '@routecraft/routecraft'
+import { defineConfig } from '@routecraft/routecraft'
 
-export const craftConfig = {
+export const craftConfig = defineConfig({
   store: new Map([
     ['my.adapter.config', { apiKey: 'xyz' }]
   ]),
   on: {
     'context:starting': ({ ts }) => console.log('Starting at', ts)
-  }
-} satisfies CraftConfig
+  },
+})
 ```
+
+`defineConfig` is a no-op at runtime; it returns the input unchanged. The legacy `satisfies CraftConfig` pattern continues to work.
 
 ## Configuration fields
 
@@ -30,7 +32,35 @@ export const craftConfig = {
 | `once` | `Partial<Record<EventName, EventHandler \| EventHandler[]>>` | No | — | One-time event handlers that fire once then auto-unsubscribe |
 | `cron` | `Partial<CronOptions>` | No | -- | Default options for all `cron()` sources ([details](#cron)) |
 | `direct` | `{ channelType?: DirectChannelType }` | No | -- | Custom channel implementation for all `direct()` endpoints ([details](#direct)) |
-| `plugins` | `CraftPlugin[]` | No | — | Plugins to initialize before routes are registered |
+| `mail` | `MailContextConfig` | No | — | Mail adapter accounts (IMAP/SMTP) keyed by name |
+| `telemetry` | `TelemetryOptions` | No | — | Telemetry plugin configuration (SQLite, OpenTelemetry) |
+| `plugins` | `CraftPlugin[]` | No | — | Custom plugins to initialize before routes are registered |
+
+### Ecosystem keys (added by `@routecraft/ai`)
+
+When `@routecraft/ai` is imported (anywhere in the project), `CraftConfig` is augmented with first-class keys for the AI plugins. Each key carries the same options as the corresponding factory and participates in the standard plugin lifecycle.
+
+| Field | Type | Equivalent factory |
+|-------|------|--------------------|
+| `llm` | `LlmPluginOptions` | `llmPlugin(options)` |
+| `mcp` | `McpPluginOptions` | `mcpPlugin(options)` |
+| `embedding` | `EmbeddingPluginOptions` | `embeddingPlugin(options)` |
+| `agent` | `AgentPluginOptions` | `agentPlugin(options)` |
+
+```ts
+import { defineConfig } from '@routecraft/routecraft'
+import '@routecraft/ai' // augments CraftConfig with llm/mcp/embedding/agent
+
+export const craftConfig = defineConfig({
+  llm: {
+    providers: { openai: { apiKey: process.env.OPENAI_API_KEY! } },
+    defaultProvider: 'openai',
+  },
+  mcp: { clients: { /* ... */ } },
+})
+```
+
+The legacy `plugins: [llmPlugin(...)]` form continues to work and is the right escape hatch for shared plugin instances or programmatic composition.
 
 ## Core adapter defaults
 

--- a/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
@@ -62,6 +62,10 @@ export const craftConfig = defineConfig({
 
 The legacy `plugins: [llmPlugin(...)]` form continues to work and is the right escape hatch for shared plugin instances or programmatic composition.
 
+{% callout type="note" %}
+**Troubleshooting:** if TypeScript reports `Object literal may only specify known properties, and 'llm' does not exist in type 'CraftConfig'` (or the same for `mcp`, `embedding`, `agent`), the augmentation has not been loaded. Add `import '@routecraft/ai'` to a file that's part of your project's compilation -- usually next to `defineConfig` in `craft.config.ts`. The side-effect import is what merges the AI keys into `CraftConfig`.
+{% /callout %}
+
 ## Core adapter defaults
 
 Core adapters have dedicated config fields so you can set context-wide defaults without importing a plugin. See [Merged Options](/docs/advanced/merged-options) for how the merge hierarchy works.

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -17,6 +17,34 @@ Full catalog of built-in plugins with options and behaviour. {% .lead %}
 Core adapter defaults (`cron`, `direct`) are set via dedicated fields on `CraftConfig`, not via plugins. See [Configuration](/docs/reference/configuration) and [Merged Options](/docs/advanced/merged-options).
 {% /callout %}
 
+## First-class config keys
+
+Importing `@routecraft/ai` augments `CraftConfig` with first-class keys for the AI plugins. Setting `llm`, `mcp`, `embedding`, or `agent` on the config is equivalent to pushing the corresponding plugin onto `plugins: []`. Lifecycle (`apply`, `teardown`, plugin events) is identical.
+
+```ts
+// Before (still supported -- use this for shared plugin instances or programmatic composition)
+import { defineConfig } from '@routecraft/routecraft'
+import { llmPlugin, mcpPlugin } from '@routecraft/ai'
+
+export const craftConfig = defineConfig({
+  plugins: [
+    llmPlugin({ providers: { openai: { apiKey: '...' } } }),
+    mcpPlugin({ clients: { /* ... */ } }),
+  ],
+})
+
+// After (recommended for declarative configs)
+import { defineConfig } from '@routecraft/routecraft'
+import '@routecraft/ai' // augments CraftConfig
+
+export const craftConfig = defineConfig({
+  llm: { providers: { openai: { apiKey: '...' } } },
+  mcp: { clients: { /* ... */ } },
+})
+```
+
+The factories listed below remain available unchanged. Use them via `plugins: []` when you need to instantiate a plugin once and reuse it (e.g. across multiple contexts) or compose plugins programmatically.
+
 ## llmPlugin
 
 ```ts

--- a/examples/src/craft.config.ts
+++ b/examples/src/craft.config.ts
@@ -2,6 +2,18 @@ import { defineConfig } from "@routecraft/routecraft";
 import { jwt } from "@routecraft/ai";
 import { version } from "../package.json";
 
+// Fail fast on a missing JWT secret. An empty HMAC key is a footgun: the
+// validator would silently accept any token signed with the empty string.
+// Other env vars in this file fall back to placeholders or empty strings
+// because their failure modes (mail auth rejection, mismatched issuer/
+// audience) are non-silent.
+const JWT_SECRET = process.env["JWT_SECRET"];
+if (!JWT_SECRET) {
+  throw new Error(
+    "JWT_SECRET is required to run this example. Set it in your .env or shell.",
+  );
+}
+
 export const craftConfig = defineConfig({
   telemetry: { sqlite: { captureSnapshots: true } },
   mail: {
@@ -30,7 +42,7 @@ export const craftConfig = defineConfig({
     version,
     transport: "http",
     auth: jwt({
-      secret: process.env["JWT_SECRET"] ?? "",
+      secret: JWT_SECRET,
       issuer: process.env["JWT_ISSUER"] ?? "https://idp.example.com",
       audience: process.env["JWT_AUDIENCE"] ?? "https://mcp.example.com",
     }),

--- a/examples/src/craft.config.ts
+++ b/examples/src/craft.config.ts
@@ -1,8 +1,8 @@
-import { mcpPlugin, jwt } from "@routecraft/ai";
-import type { CraftConfig } from "@routecraft/routecraft";
+import { defineConfig } from "@routecraft/routecraft";
+import { jwt } from "@routecraft/ai";
 import { version } from "../package.json";
 
-export const craftConfig: CraftConfig = {
+export const craftConfig = defineConfig({
   telemetry: { sqlite: { captureSnapshots: true } },
   mail: {
     accounts: {
@@ -25,16 +25,14 @@ export const craftConfig: CraftConfig = {
       },
     },
   },
-  plugins: [
-    mcpPlugin({
-      name: "routecraft",
-      version: version,
-      transport: "http",
-      auth: jwt({
-        secret: process.env["JWT_SECRET"] ?? "",
-        issuer: process.env["JWT_ISSUER"] ?? "https://idp.example.com",
-        audience: process.env["JWT_AUDIENCE"] ?? "https://mcp.example.com",
-      }),
+  mcp: {
+    name: "routecraft",
+    version,
+    transport: "http",
+    auth: jwt({
+      secret: process.env["JWT_SECRET"] ?? "",
+      issuer: process.env["JWT_ISSUER"] ?? "https://idp.example.com",
+      audience: process.env["JWT_AUDIENCE"] ?? "https://mcp.example.com",
     }),
-  ],
-};
+  },
+});

--- a/packages/ai/src/config.ts
+++ b/packages/ai/src/config.ts
@@ -1,0 +1,51 @@
+import { registerConfigApplier } from "@routecraft/routecraft";
+import { llmPlugin } from "./llm/plugin.ts";
+import { mcpPlugin } from "./mcp/plugin.ts";
+import { embeddingPlugin } from "./embedding/plugin.ts";
+import { agentPlugin } from "./agent/plugin.ts";
+import type { LlmPluginOptions } from "./llm/types.ts";
+import type { McpPluginOptions } from "./mcp/types.ts";
+import type { EmbeddingPluginOptions } from "./embedding/types.ts";
+import type { AgentPluginOptions } from "./agent/plugin.ts";
+
+/**
+ * Promote AI ecosystem plugins to first-class keys on `CraftConfig`. Once
+ * `@routecraft/ai` is imported, users can write:
+ *
+ * ```typescript
+ * import { defineConfig } from "@routecraft/routecraft";
+ * import "@routecraft/ai";
+ *
+ * export default defineConfig({
+ *   llm: { providers: { openai: { apiKey: "..." } } },
+ *   mcp: { clients: { ... } },
+ *   embedding: { providers: { ... } },
+ *   agent: { agents: { ... }, functions: { ... } },
+ * });
+ * ```
+ *
+ * Each key carries the same options as the corresponding plugin factory and
+ * participates in the standard plugin lifecycle (registered/starting/started
+ * /stopping/stopped events; teardown on shutdown).
+ *
+ * The existing `llmPlugin`, `mcpPlugin`, `embeddingPlugin`, and `agentPlugin`
+ * factories remain available for use via `plugins: [...]` (e.g. for shared
+ * plugin instances or programmatic composition).
+ */
+declare module "@routecraft/routecraft" {
+  interface CraftConfig {
+    /** LLM provider configuration. Equivalent to `plugins: [llmPlugin(...)]`. */
+    llm?: LlmPluginOptions;
+    /** MCP server / client configuration. Equivalent to `plugins: [mcpPlugin(...)]`. */
+    mcp?: McpPluginOptions;
+    /** Embedding provider configuration. Equivalent to `plugins: [embeddingPlugin(...)]`. */
+    embedding?: EmbeddingPluginOptions;
+    /** Agent and tool registry. Equivalent to `plugins: [agentPlugin(...)]`. */
+    agent?: AgentPluginOptions;
+  }
+}
+
+registerConfigApplier("llm", (options) => llmPlugin(options));
+registerConfigApplier("mcp", (options) => mcpPlugin(options));
+registerConfigApplier("embedding", (options) => embeddingPlugin(options));
+registerConfigApplier("agent", (options) => agentPlugin(options));

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,3 +1,8 @@
+// Side-effect import: augments `CraftConfig` with first-class `llm`, `mcp`,
+// `embedding`, and `agent` keys, and registers the corresponding config
+// appliers so those keys produce plugins on context startup.
+import "./config.ts";
+
 // Cross-instance identity (Symbol.for) for MCP adapters
 export { BRAND, isMcpAdapter } from "./brand.ts";
 

--- a/packages/ai/test/config-applier.test.ts
+++ b/packages/ai/test/config-applier.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
 import { CraftContext, defineConfig } from "@routecraft/routecraft";
 import { ADAPTER_LLM_PROVIDERS } from "../src/llm/types.ts";
 import { ADAPTER_AGENT_REGISTRY } from "../src/agent/index.ts";
+import type { LlmPluginOptions } from "../src/llm/types.ts";
+import type { McpPluginOptions } from "../src/mcp/types.ts";
+import type { EmbeddingPluginOptions } from "../src/embedding/types.ts";
+import type { AgentPluginOptions } from "../src/agent/plugin.ts";
 // Side-effect import: registers config appliers for llm/mcp/embedding/agent.
 import "../src/index.ts";
 
@@ -90,5 +94,29 @@ describe("@routecraft/ai config appliers", () => {
     expect((providers as Map<string, unknown>).has("openai")).toBe(true);
 
     await ctx.stop();
+  });
+
+  /**
+   * @case @routecraft/ai augments CraftConfig with llm/mcp/embedding/agent
+   *   keys typed as their respective plugin options
+   * @preconditions @routecraft/ai is imported (side-effect registers
+   *   appliers and merges the augmentation into CraftConfig)
+   * @expectedResult defineConfig accepts each AI key with the matching
+   *   options type. A regression that broke the augmentation, the
+   *   self-reference in define-config.ts, or the import path used by
+   *   registerConfigApplier would fail these assertions.
+   */
+  test("augments CraftConfig with AI keys typed as plugin options", () => {
+    const cfg = defineConfig({
+      llm: { providers: { openai: { apiKey: "sk" } } },
+      mcp: {},
+      embedding: { providers: {} },
+      agent: { agents: {} },
+    });
+
+    expectTypeOf(cfg.llm).toMatchTypeOf<LlmPluginOptions>();
+    expectTypeOf(cfg.mcp).toMatchTypeOf<McpPluginOptions>();
+    expectTypeOf(cfg.embedding).toMatchTypeOf<EmbeddingPluginOptions>();
+    expectTypeOf(cfg.agent).toMatchTypeOf<AgentPluginOptions>();
   });
 });

--- a/packages/ai/test/config-applier.test.ts
+++ b/packages/ai/test/config-applier.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "vitest";
+import { CraftContext, defineConfig } from "@routecraft/routecraft";
+import { ADAPTER_LLM_PROVIDERS } from "../src/llm/types.ts";
+import { ADAPTER_AGENT_REGISTRY } from "../src/agent/index.ts";
+// Side-effect import: registers config appliers for llm/mcp/embedding/agent.
+import "../src/index.ts";
+
+/**
+ * The AI package's barrel registers config appliers as a side effect, so
+ * importing `@routecraft/ai` (or its src/index.ts) anywhere is enough to
+ * make `llm`, `mcp`, `embedding`, and `agent` first-class CraftConfig keys.
+ */
+describe("@routecraft/ai config appliers", () => {
+  /**
+   * @case Setting `llm` on CraftConfig registers providers in the store
+   * @preconditions Config has `llm: { providers: { openai: { apiKey } } }`; no plugins[] entry
+   * @expectedResult After initPlugins(), ADAPTER_LLM_PROVIDERS map contains "openai"
+   */
+  test("llm key registers providers via the store", async () => {
+    const ctx = new CraftContext(
+      defineConfig({
+        llm: {
+          providers: { openai: { apiKey: "sk-test" } },
+        },
+      }),
+    );
+    await ctx.initPlugins();
+
+    const providers = ctx.getStore(ADAPTER_LLM_PROVIDERS);
+    expect(providers).toBeInstanceOf(Map);
+    expect((providers as Map<string, unknown>).has("openai")).toBe(true);
+
+    await ctx.stop();
+  });
+
+  /**
+   * @case Setting `agent` on CraftConfig registers named agents in the store
+   * @preconditions Config has `agent: { agents: { reply: { ... } } }`
+   * @expectedResult After initPlugins(), ADAPTER_AGENT_REGISTRY contains "reply"
+   */
+  test("agent key registers agents via the store", async () => {
+    const ctx = new CraftContext(
+      defineConfig({
+        agent: {
+          agents: {
+            reply: {
+              model: "openai:gpt-4o-mini",
+              system: "You are concise.",
+              description: "Reply to incoming messages concisely.",
+            },
+          },
+        },
+      }),
+    );
+    await ctx.initPlugins();
+
+    const registry = ctx.getStore(ADAPTER_AGENT_REGISTRY);
+    expect(registry).toBeInstanceOf(Map);
+    expect((registry as Map<string, unknown>).has("reply")).toBe(true);
+
+    await ctx.stop();
+  });
+
+  /**
+   * @case `llm` first-class key and a user `plugins: []` entry coexist
+   *   without conflict
+   * @preconditions Config has `llm` set AND a no-op user plugin in plugins[]
+   * @expectedResult Both run; provider store is populated; no errors emitted
+   */
+  test("llm key coexists with user plugins[]", async () => {
+    let userPluginRan = false;
+    const ctx = new CraftContext(
+      defineConfig({
+        llm: {
+          providers: { openai: { apiKey: "sk-test" } },
+        },
+        plugins: [
+          {
+            apply() {
+              userPluginRan = true;
+            },
+          },
+        ],
+      }),
+    );
+    await ctx.initPlugins();
+
+    expect(userPluginRan).toBe(true);
+    const providers = ctx.getStore(ADAPTER_LLM_PROVIDERS);
+    expect((providers as Map<string, unknown>).has("openai")).toBe(true);
+
+    await ctx.stop();
+  });
+});

--- a/packages/create-routecraft/templates/base/craft.config.ts
+++ b/packages/create-routecraft/templates/base/craft.config.ts
@@ -1,3 +1,3 @@
-import type { CraftConfig } from "@routecraft/routecraft";
+import { defineConfig } from "@routecraft/routecraft";
 
-export const craftConfig: CraftConfig = {};
+export const craftConfig = defineConfig({});

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -92,6 +92,20 @@ export class ContextBuilder {
   /**
    * Configure the context with the provided config object.
    *
+   * Merge semantics across multiple `with()` calls are not symmetric:
+   *
+   * - `plugins` accumulates: every `with()` call appends its `plugins[]`
+   *   to a builder-side list. Builder stores and event handlers also
+   *   accumulate.
+   * - Every other key (`store`'s value map aside, plus `cron`, `direct`,
+   *   `http`, `mail`, `telemetry`, and any ecosystem-augmented keys such
+   *   as `llm`, `mcp`) is last-writer-wins: a second `with()` replaces
+   *   the previously stored config object, and only the most recent
+   *   non-`plugins` keys reach the constructor.
+   *
+   * If you need to combine non-`plugins` keys across sources, merge them
+   * into a single object before calling `with()` (or call `with()` once).
+   *
    * @param config The configuration object for the context
    * @returns This builder instance for method chaining
    */

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -32,9 +32,6 @@ import {
   DefaultExchange,
   getExchangeContext,
 } from "./exchange.ts";
-import { MailClientManager } from "./adapters/mail/client-manager.ts";
-import { MAIL_CLIENT_MANAGER } from "./adapters/mail/shared.ts";
-import { telemetry } from "./telemetry/index.ts";
 import {
   type Splitter,
   type CallableSplitter,
@@ -89,7 +86,6 @@ export class ContextBuilder {
   protected eventHandlers = new Map<EventName, Set<EventHandler<EventName>>>();
   protected onceHandlers = new Map<EventName, Set<EventHandler<EventName>>>();
   protected plugins: Array<import("./context.ts").CraftPlugin> = [];
-  protected mailConfig?: import("./adapters/mail/types.ts").MailContextConfig;
 
   constructor() {}
 
@@ -127,23 +123,11 @@ export class ContextBuilder {
       }
     }
 
-    // Note: config.once handlers are registered by the CraftContext constructor directly,
-    // so we do not copy them into onceHandlers here to avoid double-registration.
-
-    // Note: config.cron and config.direct are handled by the CraftContext
-    // constructor directly -- no extraction needed here.
-
-    // Extract mail config if provided
-    if (config.mail) {
-      this.mailConfig = config.mail;
-    }
-
-    // Convert telemetry config into a plugin
-    if (config.telemetry) {
-      this.plugins.push(telemetry(config.telemetry));
-    }
-
-    // Extract plugins if provided
+    // Accumulate plugins across multiple with() calls. The CraftContext
+    // constructor handles config.cron, config.direct, config.http,
+    // config.mail, and config.telemetry from `this.config`; we don't
+    // duplicate those conversions here. Only `plugins` needs to be
+    // accumulated because successive with() calls overwrite this.config.
     if (config.plugins) {
       this.plugins.push(...config.plugins);
     }
@@ -265,11 +249,17 @@ export class ContextBuilder {
    * ```
    */
   async build(): Promise<{ context: CraftContext; client: CraftClient }> {
-    const configWithPlugins = {
+    // The builder accumulates plugins across multiple with() calls into
+    // `this.plugins`; replace `config.plugins` with the accumulated list so
+    // the constructor sees the union, not just the last with()'s plugins.
+    // Config keys like `telemetry`, `mail`, and registered config appliers
+    // (e.g. `llm`, `mcp`) are converted into plugins inside the constructor
+    // and run before user `plugins[]`; see CraftContext.constructor.
+    const mergedConfig: CraftConfig = {
       ...this.config,
       plugins: this.plugins,
     };
-    const ctx = new CraftContext(configWithPlugins);
+    const ctx = new CraftContext(mergedConfig);
 
     // Add stores from builder (config stores already added in constructor)
     for (const [key, value] of this.initialStores) {
@@ -278,7 +268,10 @@ export class ContextBuilder {
       }
     }
 
-    // Attach event handlers from builder (config handlers already added in constructor)
+    // Attach event handlers from builder. `config.on` handlers are already
+    // registered by the constructor, but the builder's `eventHandlers` map
+    // also contains them (with the same handler references), so the
+    // CraftContext's Set-based registry deduplicates.
     for (const [event, handlers] of this.eventHandlers.entries()) {
       for (const handler of handlers) {
         ctx.on(event as EventName, handler as EventHandler<EventName>);
@@ -290,16 +283,6 @@ export class ContextBuilder {
       for (const handler of handlers) {
         ctx.once(event as EventName, handler as EventHandler<EventName>);
       }
-    }
-
-    // Note: cron and direct defaults are set by the CraftContext constructor
-    // via config.cron / config.direct -- no need to set them again here.
-
-    // Set up mail client manager if mail config is present
-    if (this.mailConfig) {
-      const manager = new MailClientManager(this.mailConfig);
-      ctx.setStore(MAIL_CLIENT_MANAGER as keyof StoreRegistry, manager);
-      ctx.registerTeardown(() => manager.drain());
     }
 
     // Run plugins before routes are registered (context runs config.plugins)

--- a/packages/routecraft/src/config-applier.ts
+++ b/packages/routecraft/src/config-applier.ts
@@ -59,6 +59,11 @@ function getRegistry(): Map<string, AnyConfigApplier> {
  * participate in the standard lifecycle: `apply()` runs during
  * `initPlugins()`, `teardown()` runs during `context.stop()`.
  *
+ * The framework invokes the applier whenever `config[key] !== undefined`.
+ * Falsy values (`false`, `0`, `""`, `null`) are still passed through; only
+ * `undefined` means "not set". This lets primitive-valued keys behave
+ * sensibly without needing a wrapper object.
+ *
  * Re-registering a key replaces the previous registration: last writer wins.
  * The registry is shared across copies of the package via `Symbol.for`, but
  * an applier registered by one copy of an ecosystem package is a different

--- a/packages/routecraft/src/config-applier.ts
+++ b/packages/routecraft/src/config-applier.ts
@@ -1,0 +1,104 @@
+import type { CraftPlugin } from "./context.ts";
+// Self-reference via the published specifier so ecosystem augmentations
+// (`declare module "@routecraft/routecraft" { interface CraftConfig { ... } }`)
+// propagate into this module's view of `CraftConfig`. Importing through
+// `./context.ts` would resolve to a separate module identity and miss the
+// augmentations.
+import type { CraftConfig } from "@routecraft/routecraft";
+
+/**
+ * Build a {@link CraftPlugin} from the value found at a given key on
+ * {@link CraftConfig}. Receives the non-undefined value of `config[K]` and
+ * returns a plugin whose `apply` and (optional) `teardown` participate in the
+ * standard plugin lifecycle.
+ *
+ * @template K - Key on `CraftConfig` this applier handles
+ */
+export type ConfigApplier<K extends keyof CraftConfig> = (
+  options: NonNullable<CraftConfig[K]>,
+) => CraftPlugin;
+
+/**
+ * Internal applier signature used by the registry. Public callers go through
+ * {@link registerConfigApplier} which preserves the typed `K`.
+ */
+type AnyConfigApplier = (options: unknown) => CraftPlugin;
+
+/**
+ * Cross-instance registry. `Symbol.for` so multiple copies of the package in
+ * a workspace share a single registry; without this, an applier registered
+ * by one package copy would be invisible to a `CraftContext` constructed
+ * from another copy.
+ */
+const REGISTRY_KEY: unique symbol = Symbol.for(
+  "routecraft.config-applier-registry",
+);
+
+type GlobalWithRegistry = typeof globalThis & {
+  [REGISTRY_KEY]?: Map<string, AnyConfigApplier>;
+};
+
+function getRegistry(): Map<string, AnyConfigApplier> {
+  const g = globalThis as GlobalWithRegistry;
+  let registry = g[REGISTRY_KEY];
+  if (!registry) {
+    registry = new Map<string, AnyConfigApplier>();
+    g[REGISTRY_KEY] = registry;
+  }
+  return registry;
+}
+
+/**
+ * Register a function that converts a {@link CraftConfig} key into a plugin.
+ *
+ * Ecosystem packages call this once at module load time (typically from a
+ * side-effect import) so that setting `config[key]` becomes equivalent to
+ * pushing the corresponding plugin onto `config.plugins`. Resulting plugins
+ * participate in the standard lifecycle: `apply()` runs during
+ * `initPlugins()`, `teardown()` runs during `context.stop()`.
+ *
+ * Re-registering the same key with the same applier is a silent no-op
+ * (multiple package copies in a workspace are tolerated). Re-registering
+ * with a different applier replaces the previous registration; the last
+ * registration wins.
+ *
+ * @template K - Key on `CraftConfig` this applier handles
+ * @param key - The `CraftConfig` key
+ * @param applier - Factory that builds a plugin from the value at `config[key]`
+ *
+ * @experimental
+ *
+ * @example
+ * ```typescript
+ * declare module "@routecraft/routecraft" {
+ *   interface CraftConfig {
+ *     myKey?: MyOptions;
+ *   }
+ * }
+ *
+ * registerConfigApplier("myKey", (options) => myPlugin(options));
+ * ```
+ */
+export function registerConfigApplier<K extends keyof CraftConfig>(
+  key: K,
+  applier: ConfigApplier<K>,
+): void {
+  // Cast: at runtime we always invoke the applier with the value at config[key],
+  // which TS narrows to the registered type at the registration site. Storing
+  // as an unknown-keyed function lets the registry hold heterogeneous appliers.
+  getRegistry().set(key as string, applier as AnyConfigApplier);
+}
+
+/**
+ * Get the registered config appliers in registration order.
+ *
+ * Consumed by `CraftContext` and `ContextBuilder` to convert first-class
+ * config keys into plugins at construction time. Iteration order matches
+ * registration order, which the constructor relies on to position ecosystem
+ * appliers between core inline conversions and `config.plugins`.
+ *
+ * @internal
+ */
+export function getConfigAppliers(): ReadonlyMap<string, AnyConfigApplier> {
+  return getRegistry();
+}

--- a/packages/routecraft/src/config-applier.ts
+++ b/packages/routecraft/src/config-applier.ts
@@ -13,6 +13,8 @@ import type { CraftConfig } from "@routecraft/routecraft";
  * standard plugin lifecycle.
  *
  * @template K - Key on `CraftConfig` this applier handles
+ *
+ * @experimental
  */
 export type ConfigApplier<K extends keyof CraftConfig> = (
   options: NonNullable<CraftConfig[K]>,
@@ -57,10 +59,14 @@ function getRegistry(): Map<string, AnyConfigApplier> {
  * participate in the standard lifecycle: `apply()` runs during
  * `initPlugins()`, `teardown()` runs during `context.stop()`.
  *
- * Re-registering the same key with the same applier is a silent no-op
- * (multiple package copies in a workspace are tolerated). Re-registering
- * with a different applier replaces the previous registration; the last
- * registration wins.
+ * Re-registering a key replaces the previous registration: last writer wins.
+ * The registry is shared across copies of the package via `Symbol.for`, but
+ * an applier registered by one copy of an ecosystem package is a different
+ * function reference from the same applier registered by another copy. If
+ * two copies of `@routecraft/ai` end up in the same workspace, the last one
+ * to load is the one whose applier (and therefore whose `llmPlugin`
+ * instance) runs. Structure your workspace to avoid duplicate copies of the
+ * same ecosystem package; this registry does not transparently de-duplicate.
  *
  * @template K - Key on `CraftConfig` this applier handles
  * @param key - The `CraftConfig` key

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -258,14 +258,23 @@ export class CraftContext {
 
       // Walk registered config appliers (e.g. @routecraft/ai promotes `llm`,
       // `mcp`, `embedding`, `agent` to first-class keys via this registry).
-      // Order is significant: ecosystem appliers go after core inline
-      // conversions and before user `config.plugins`, so reverse-iteration
-      // teardown gives the correct order (user plugins first, then
-      // ecosystem, then core).
+      //
+      // The push order into `this.plugins` drives both apply() order
+      // (forward) and teardown() order (reverse) for entries that go
+      // through the plugin lifecycle:
+      //   1. telemetry plugin (if config.telemetry)
+      //   2. ecosystem appliers, in registration order
+      //   3. user config.plugins
+      //
+      // Reverse-iteration in performShutdown() therefore tears down user
+      // plugins first, then ecosystem appliers, then telemetry. Mail is
+      // not a plugin -- it registers a callback in this.teardownCallbacks,
+      // which runs after all plugin teardowns regardless of where the
+      // mail block sits in this constructor.
       const configRecord = config as unknown as Record<string, unknown>;
       for (const [key, factory] of getConfigAppliers()) {
         const value = configRecord[key];
-        if (value !== undefined) {
+        if (value) {
           this.plugins.push(factory(value));
         }
       }

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -15,6 +15,7 @@ import { MAIL_CLIENT_MANAGER } from "./adapters/mail/shared.ts";
 import { type TelemetryOptions } from "./telemetry/types.ts";
 import { telemetry } from "./telemetry/index.ts";
 import { type AdapterOverride, RC_ADAPTER_OVERRIDES } from "./testing-hooks.ts";
+import { getConfigAppliers } from "./config-applier.ts";
 
 import {
   type EventHandler,
@@ -85,8 +86,21 @@ export interface CraftPlugin {
 
 /**
  * Configuration options for creating a CraftContext.
+ *
+ * Declared as an `interface` so ecosystem packages can extend it via
+ * declaration merging. Pair an augmentation with `registerConfigApplier`
+ * to promote an ecosystem capability to a first-class config key.
+ *
+ * @example
+ * ```typescript
+ * declare module "@routecraft/routecraft" {
+ *   interface CraftConfig {
+ *     myCapability?: MyCapabilityOptions;
+ *   }
+ * }
+ * ```
  */
-export type CraftConfig = {
+export interface CraftConfig {
   /** Initial values for the context store */
   store?: Map<keyof StoreRegistry, StoreRegistry[keyof StoreRegistry]>;
   /** Event handlers to register on context creation */
@@ -109,7 +123,7 @@ export type CraftConfig = {
   mail?: MailContextConfig;
   /** Telemetry plugin configuration (SQLite, OpenTelemetry) */
   telemetry?: TelemetryOptions;
-};
+}
 
 /**
  * The main context for running and managing routes.
@@ -240,6 +254,20 @@ export class CraftContext {
       // Convert telemetry config into a plugin
       if (config.telemetry) {
         this.plugins.push(telemetry(config.telemetry));
+      }
+
+      // Walk registered config appliers (e.g. @routecraft/ai promotes `llm`,
+      // `mcp`, `embedding`, `agent` to first-class keys via this registry).
+      // Order is significant: ecosystem appliers go after core inline
+      // conversions and before user `config.plugins`, so reverse-iteration
+      // teardown gives the correct order (user plugins first, then
+      // ecosystem, then core).
+      const configRecord = config as unknown as Record<string, unknown>;
+      for (const [key, factory] of getConfigAppliers()) {
+        const value = configRecord[key];
+        if (value !== undefined) {
+          this.plugins.push(factory(value));
+        }
       }
 
       if (config.plugins?.length) {

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -271,10 +271,17 @@ export class CraftContext {
       // not a plugin -- it registers a callback in this.teardownCallbacks,
       // which runs after all plugin teardowns regardless of where the
       // mail block sits in this constructor.
+      //
+      // The applier guard is strictly `value !== undefined`, not a truthy
+      // check. The applier registry is an open extension point: ecosystem
+      // packages can register appliers for any value shape, including
+      // primitives where `false`, `0`, or `""` are valid. "Not set" must
+      // mean only `undefined` so applier authors can rely on a stable
+      // contract regardless of value type.
       const configRecord = config as unknown as Record<string, unknown>;
       for (const [key, factory] of getConfigAppliers()) {
         const value = configRecord[key];
-        if (value) {
+        if (value !== undefined) {
           this.plugins.push(factory(value));
         }
       }

--- a/packages/routecraft/src/define-config.ts
+++ b/packages/routecraft/src/define-config.ts
@@ -1,0 +1,33 @@
+// Self-reference via the published specifier so ecosystem augmentations
+// (`declare module "@routecraft/routecraft" { interface CraftConfig { ... } }`)
+// propagate into this module's view of `CraftConfig`. Importing through
+// `./context.ts` would resolve to a separate module identity and miss the
+// augmentations. See config-applier.ts for the same pattern.
+import type { CraftConfig } from "@routecraft/routecraft";
+
+/**
+ * Identity helper for typing a {@link CraftConfig}. Returns the input
+ * unchanged at runtime; the generic parameter preserves the literal type at
+ * the call site so users get autocomplete for first-class keys (including
+ * keys augmented by ecosystem packages such as `@routecraft/ai`).
+ *
+ * @template T - Inferred config shape
+ * @param config - Config object
+ * @returns The same config object
+ *
+ * @experimental
+ *
+ * @example
+ * ```typescript
+ * import { defineConfig } from "@routecraft/routecraft";
+ * import "@routecraft/ai"; // augments CraftConfig with `llm`, `mcp`, etc.
+ *
+ * export default defineConfig({
+ *   cron: { timezone: "UTC" },
+ *   llm: { providers: { openai: { apiKey: process.env.OPENAI_API_KEY! } } },
+ * });
+ * ```
+ */
+export function defineConfig<T extends CraftConfig>(config: T): T {
+  return config;
+}

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -38,6 +38,8 @@ export {
   type CraftConfig,
   type CraftPlugin,
 } from "./context.ts";
+export { defineConfig } from "./define-config.ts";
+export { registerConfigApplier, type ConfigApplier } from "./config-applier.ts";
 export { type HttpConfig } from "./adapters/http/types.ts";
 /** @deprecated Use `CraftConfig.direct` instead. Will be removed in next major version. */
 export { type DirectConfig } from "./adapters/direct/types.ts";

--- a/packages/routecraft/test/config-applier.test.ts
+++ b/packages/routecraft/test/config-applier.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  CraftContext,
+  type CraftPlugin,
+  defineConfig,
+  registerConfigApplier,
+} from "../src/index.ts";
+
+/**
+ * Access the cross-instance applier registry directly so tests can sandbox
+ * registrations and reset between cases. Mirrors the symbol used in
+ * config-applier.ts.
+ */
+const REGISTRY_KEY = Symbol.for("routecraft.config-applier-registry");
+
+type GlobalWithRegistry = typeof globalThis & {
+  [REGISTRY_KEY]?: Map<string, (opts: unknown) => CraftPlugin>;
+};
+
+function snapshotRegistry(): Map<string, (opts: unknown) => CraftPlugin> {
+  const g = globalThis as GlobalWithRegistry;
+  return new Map(g[REGISTRY_KEY] ?? new Map());
+}
+
+function restoreRegistry(
+  snapshot: Map<string, (opts: unknown) => CraftPlugin>,
+): void {
+  const g = globalThis as GlobalWithRegistry;
+  g[REGISTRY_KEY] = new Map(snapshot);
+}
+
+/**
+ * Augment CraftConfig with sandbox keys so the test file can register
+ * appliers without depending on @routecraft/ai. The augmentation must
+ * target the published module specifier so it propagates to the same
+ * interface identity that registerConfigApplier and defineConfig see.
+ */
+declare module "@routecraft/routecraft" {
+  interface CraftConfig {
+    __testApplier?: { value: string };
+    __testApplierB?: { value: string };
+  }
+}
+
+describe("registerConfigApplier", () => {
+  let snapshot: Map<string, (opts: unknown) => CraftPlugin>;
+
+  afterEach(() => {
+    if (snapshot) restoreRegistry(snapshot);
+  });
+
+  /**
+   * @case A registered config applier produces a plugin during context init
+   *   when the corresponding key is set on CraftConfig
+   * @preconditions Applier registered for "__testApplier"; config has the key set
+   * @expectedResult Plugin's apply() runs during initPlugins() with the config value
+   */
+  test("applier produces a plugin when key is present", async () => {
+    snapshot = snapshotRegistry();
+
+    const applied: Array<{ value: string }> = [];
+    registerConfigApplier("__testApplier", (options) => ({
+      apply() {
+        applied.push(options);
+      },
+    }));
+
+    const ctx = new CraftContext({ __testApplier: { value: "hello" } });
+    await ctx.initPlugins();
+
+    expect(applied).toEqual([{ value: "hello" }]);
+  });
+
+  /**
+   * @case A registered config applier is skipped when the corresponding key
+   *   is absent from the config
+   * @preconditions Applier registered for "__testApplier"; config omits the key
+   * @expectedResult The applier is never invoked
+   */
+  test("applier is not invoked when key is absent", async () => {
+    snapshot = snapshotRegistry();
+
+    let called = false;
+    registerConfigApplier("__testApplier", () => ({
+      apply() {
+        called = true;
+      },
+    }));
+
+    const ctx = new CraftContext({});
+    await ctx.initPlugins();
+
+    expect(called).toBe(false);
+  });
+
+  /**
+   * @case Plugins from config appliers run before user-supplied plugins
+   * @preconditions Applier registered for "__testApplier"; config has key + plugins[]
+   * @expectedResult initPlugins runs the applier-produced plugin first, then user plugins
+   */
+  test("applier-produced plugin runs before user plugins[]", async () => {
+    snapshot = snapshotRegistry();
+
+    const order: string[] = [];
+    registerConfigApplier("__testApplier", () => ({
+      apply() {
+        order.push("applier");
+      },
+    }));
+
+    const userPlugin: CraftPlugin = {
+      apply() {
+        order.push("user");
+      },
+    };
+
+    const ctx = new CraftContext({
+      __testApplier: { value: "x" },
+      plugins: [userPlugin],
+    });
+    await ctx.initPlugins();
+
+    expect(order).toEqual(["applier", "user"]);
+  });
+
+  /**
+   * @case Multiple config appliers run in registration order, before user plugins
+   * @preconditions Two appliers registered (__testApplier, __testApplierB); both keys set
+   * @expectedResult Apply order matches registration order; user plugins run last
+   */
+  test("multiple appliers run in registration order", async () => {
+    snapshot = snapshotRegistry();
+
+    const order: string[] = [];
+    registerConfigApplier("__testApplier", () => ({
+      apply() {
+        order.push("a");
+      },
+    }));
+    registerConfigApplier("__testApplierB", () => ({
+      apply() {
+        order.push("b");
+      },
+    }));
+
+    const userPlugin: CraftPlugin = {
+      apply() {
+        order.push("user");
+      },
+    };
+
+    const ctx = new CraftContext({
+      __testApplier: { value: "1" },
+      __testApplierB: { value: "2" },
+      plugins: [userPlugin],
+    });
+    await ctx.initPlugins();
+
+    expect(order).toEqual(["a", "b", "user"]);
+  });
+
+  /**
+   * @case Teardown for an applier-produced plugin runs during context.stop(),
+   *   in reverse-of-startup order so user plugins tear down first
+   * @preconditions Applier produces a plugin with teardown; user plugins[] also has teardown
+   * @expectedResult Stop calls user teardown first, then applier teardown
+   */
+  test("teardown runs in reverse order on stop", async () => {
+    snapshot = snapshotRegistry();
+
+    const order: string[] = [];
+    registerConfigApplier("__testApplier", () => ({
+      apply() {},
+      teardown() {
+        order.push("applier-teardown");
+      },
+    }));
+
+    const userPlugin: CraftPlugin = {
+      apply() {},
+      teardown() {
+        order.push("user-teardown");
+      },
+    };
+
+    const ctx = new CraftContext({
+      __testApplier: { value: "x" },
+      plugins: [userPlugin],
+    });
+    await ctx.initPlugins();
+    await ctx.stop();
+
+    expect(order).toEqual(["user-teardown", "applier-teardown"]);
+  });
+
+  /**
+   * @case Re-registering the same key with a new applier replaces the previous
+   *   registration (last writer wins)
+   * @preconditions Two registerConfigApplier calls for the same key
+   * @expectedResult Only the latest applier runs when the context is built
+   */
+  test("re-registration replaces the previous applier", async () => {
+    snapshot = snapshotRegistry();
+
+    const calls: string[] = [];
+    registerConfigApplier("__testApplier", () => ({
+      apply() {
+        calls.push("first");
+      },
+    }));
+    registerConfigApplier("__testApplier", () => ({
+      apply() {
+        calls.push("second");
+      },
+    }));
+
+    const ctx = new CraftContext({ __testApplier: { value: "x" } });
+    await ctx.initPlugins();
+
+    expect(calls).toEqual(["second"]);
+  });
+});
+
+describe("defineConfig", () => {
+  /**
+   * @case defineConfig is an identity function at runtime
+   * @preconditions Any CraftConfig-shaped object is passed in
+   * @expectedResult Returns the same reference, unchanged
+   */
+  test("returns the input unchanged", () => {
+    const input = { cron: { timezone: "UTC" } };
+    const output = defineConfig(input);
+
+    expect(output).toBe(input);
+  });
+});

--- a/packages/routecraft/test/config-applier.test.ts
+++ b/packages/routecraft/test/config-applier.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, test } from "vitest";
 import {
+  type CraftConfig,
   CraftContext,
   type CraftPlugin,
   defineConfig,
@@ -232,5 +233,48 @@ describe("defineConfig", () => {
     const output = defineConfig(input);
 
     expect(output).toBe(input);
+  });
+
+  /**
+   * @case defineConfig preserves the literal shape of its input rather than
+   *   widening to CraftConfig
+   * @preconditions A config literal with a known cron field
+   * @expectedResult The return type carries the literal `cron` field; a
+   *   regression that widened the signature to (config: CraftConfig) =>
+   *   CraftConfig would lose this and fail the type assertion
+   */
+  test("preserves literal types via the generic parameter", () => {
+    const cfg = defineConfig({ cron: { timezone: "UTC" } });
+
+    // The literal shape survives: cfg.cron is the literal object, not the
+    // wider Partial<CronOptions> from CraftConfig.
+    expectTypeOf(cfg).toMatchTypeOf<{ cron: { timezone: string } }>();
+    expectTypeOf(cfg).toMatchTypeOf<CraftConfig>();
+  });
+
+  /**
+   * @case Sandbox-augmented CraftConfig keys are accepted by defineConfig
+   * @preconditions The test file augments CraftConfig with `__testApplier`
+   * @expectedResult defineConfig typechecks with the augmented key, proving
+   *   the augmentation flows through the package specifier into the
+   *   define-config module's view of CraftConfig
+   */
+  test("accepts augmented CraftConfig keys", () => {
+    const cfg = defineConfig({ __testApplier: { value: "ok" } });
+
+    expectTypeOf(cfg.__testApplier).toMatchTypeOf<{ value: string }>();
+  });
+
+  /**
+   * @case defineConfig rejects unknown keys at compile time
+   * @preconditions A config literal with a key not present on CraftConfig
+   *   (after all augmentations seen in this compilation)
+   * @expectedResult `@ts-expect-error` is satisfied because the call would
+   *   otherwise produce TS2353 (excess property). If a regression widened
+   *   the type and accepted the key, the directive would fail the build.
+   */
+  test("rejects unknown keys at compile time", () => {
+    // @ts-expect-error: bogusKey is not a CraftConfig field
+    defineConfig({ bogusKey: 1 });
   });
 });

--- a/packages/routecraft/test/config-applier.test.ts
+++ b/packages/routecraft/test/config-applier.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, describe, expect, expectTypeOf, test } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  test,
+} from "vitest";
 import {
   type CraftConfig,
   CraftContext,
@@ -44,10 +51,17 @@ declare module "@routecraft/routecraft" {
 }
 
 describe("registerConfigApplier", () => {
-  let snapshot: Map<string, (opts: unknown) => CraftPlugin>;
+  // Capture in beforeEach (not in each test body) so a future setup change
+  // that throws before the test body runs still restores the registry.
+  let snapshot: Map<string, (opts: unknown) => CraftPlugin> | undefined;
+
+  beforeEach(() => {
+    snapshot = snapshotRegistry();
+  });
 
   afterEach(() => {
     if (snapshot) restoreRegistry(snapshot);
+    snapshot = undefined;
   });
 
   /**
@@ -57,8 +71,6 @@ describe("registerConfigApplier", () => {
    * @expectedResult Plugin's apply() runs during initPlugins() with the config value
    */
   test("applier produces a plugin when key is present", async () => {
-    snapshot = snapshotRegistry();
-
     const applied: Array<{ value: string }> = [];
     registerConfigApplier("__testApplier", (options) => ({
       apply() {
@@ -79,8 +91,6 @@ describe("registerConfigApplier", () => {
    * @expectedResult The applier is never invoked
    */
   test("applier is not invoked when key is absent", async () => {
-    snapshot = snapshotRegistry();
-
     let called = false;
     registerConfigApplier("__testApplier", () => ({
       apply() {
@@ -100,8 +110,6 @@ describe("registerConfigApplier", () => {
    * @expectedResult initPlugins runs the applier-produced plugin first, then user plugins
    */
   test("applier-produced plugin runs before user plugins[]", async () => {
-    snapshot = snapshotRegistry();
-
     const order: string[] = [];
     registerConfigApplier("__testApplier", () => ({
       apply() {
@@ -130,8 +138,6 @@ describe("registerConfigApplier", () => {
    * @expectedResult Apply order matches registration order; user plugins run last
    */
   test("multiple appliers run in registration order", async () => {
-    snapshot = snapshotRegistry();
-
     const order: string[] = [];
     registerConfigApplier("__testApplier", () => ({
       apply() {
@@ -167,8 +173,6 @@ describe("registerConfigApplier", () => {
    * @expectedResult Stop calls user teardown first, then applier teardown
    */
   test("teardown runs in reverse order on stop", async () => {
-    snapshot = snapshotRegistry();
-
     const order: string[] = [];
     registerConfigApplier("__testApplier", () => ({
       apply() {},
@@ -201,8 +205,6 @@ describe("registerConfigApplier", () => {
    * @expectedResult Only the latest applier runs when the context is built
    */
   test("re-registration replaces the previous applier", async () => {
-    snapshot = snapshotRegistry();
-
     const calls: string[] = [];
     registerConfigApplier("__testApplier", () => ({
       apply() {


### PR DESCRIPTION
## Summary

This PR introduces a config applier registry system that allows ecosystem packages to promote their plugins to first-class `CraftConfig` keys. It also adds a `defineConfig` helper for better type inference and updates the AI package to use this new system, making `llm`, `mcp`, `embedding`, and `agent` declarative config options.

## Key Changes

- **Config Applier System** (`config-applier.ts`):
  - New `registerConfigApplier<K>()` function allows ecosystem packages to register factories that convert config keys into plugins
  - Cross-instance registry using `Symbol.for()` ensures appliers are shared across package copies in a workspace
  - Appliers run during `CraftContext` initialization, positioned between core conversions and user `plugins[]`
  - Teardown runs in reverse order (user plugins first, then appliers)

- **defineConfig Helper** (`define-config.ts`):
  - Identity function that preserves literal type inference for better autocomplete
  - Enables ecosystem augmentations to flow through the type system
  - Recommended pattern for config exports (replaces `satisfies CraftConfig`)

- **CraftConfig Interface Change**:
  - Changed from `type` to `interface` to support declaration merging by ecosystem packages
  - Documented the pattern for augmenting with new keys

- **AI Package Integration** (`packages/ai/src/config.ts`):
  - New module that augments `CraftConfig` with `llm`, `mcp`, `embedding`, and `agent` keys
  - Registers config appliers for each key via side-effect import
  - Each key carries the same options as the corresponding plugin factory

- **CraftContext Constructor Updates**:
  - Integrated config applier lookup and plugin generation
  - Maintains plugin execution order: telemetry → appliers (in registration order) → user plugins
  - Reverse teardown order ensures proper cleanup

- **ContextBuilder Simplification**:
  - Removed duplicate handling of `telemetry` and `mail` config
  - Constructor now handles all config-to-plugin conversions
  - Builder only accumulates `plugins[]` across multiple `with()` calls

## Implementation Details

- **Module Self-Reference Pattern**: Both `config-applier.ts` and `define-config.ts` import `CraftConfig` via the published package specifier (`@routecraft/routecraft`) rather than relative imports. This ensures ecosystem augmentations (via `declare module`) propagate correctly into these modules' type views.

- **Plugin Ordering**: The constructor builds the plugin list in a specific order to ensure ecosystem appliers run before user plugins but after core conversions like telemetry. This is critical for proper initialization and teardown sequencing.

- **Comprehensive Tests**: Added 280+ lines of tests in `routecraft/test/config-applier.test.ts` covering registration, execution order, teardown, re-registration, and type preservation. Added 120+ lines in `ai/test/config-applier.test.ts` validating AI plugin integration and type augmentation.

- **Documentation Updates**: Updated configuration and plugins reference docs to explain first-class keys, the `defineConfig` pattern, and the equivalence between config keys and plugin factories.

https://claude.ai/code/session_01MmTGoUdCtWxUKLkAVtK9UB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a config applier registry and `defineConfig` to promote ecosystem plugins to first-class `CraftConfig` keys. `@routecraft/ai` now exposes `llm`, `mcp`, `embedding`, and `agent` as config fields with correct ordering/teardown; examples now fail fast if `JWT_SECRET` is unset.

- **New Features**
  - `registerConfigApplier<K>()` (shared via `Symbol.for`) to turn config keys into plugins; appliers run when `config[key] !== undefined` so falsy values are allowed.
  - `defineConfig()` identity helper for better literal-type inference; `CraftConfig` is now an `interface` to allow augmentation.
  - `@routecraft/ai` registers first-class keys: `llm`, `mcp`, `embedding`, `agent` (same options as their factories); enabled via side-effect import.
  - Plugin order: telemetry → appliers (registration order) → user `plugins[]`; teardown is reversed. Builder simplified; `with()` docs clarify merge semantics.
  - Docs/tests updated (troubleshooting `import '@routecraft/ai'`); examples/template use `defineConfig` and first-class `mcp`; example now errors early if `JWT_SECRET` is missing to avoid empty-key tokens.

- **Migration**
  - Use `defineConfig()` in `craft.config.ts`.
  - Add `import '@routecraft/ai'` to enable `llm/mcp/embedding/agent` keys.
  - Existing `plugins: [llmPlugin(...)]` etc. still work; no runtime changes required.

<sup>Written for commit 7f6a1ded2a4ddf9606b3090ca67c83a9fbbbba1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

