### PR TITLE
feat(ai)!: agent system/user accept string or function (llm parity)

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -435,8 +435,8 @@ craft()
 |--------|------|----------|-------------|
 | `description` | `string` | Yes | Human-readable description. Surfaces in observability and is used as the tool description when the agent is exposed to other agents |
 | `model` | `LlmModelId` | No\* | `"provider:model"` string resolved via `llmPlugin`. Required unless `defaultOptions.model` supplies a fallback; otherwise dispatch throws `RC5003` |
-| `system` | `string` | Yes | System prompt |
-| `user` | `(exchange) => string` | No | Override for deriving the user prompt from the incoming exchange |
+| `system` | `string \| (exchange) => string` | Yes | System prompt. Static string or a function that derives it from the exchange (mirrors `llm({ system })`) |
+| `user` | `string \| (exchange) => string` | No | User prompt override. Static string or a function that derives it from the exchange. Defaults to `exchange.body` (string as-is, JSON for objects) when omitted |
 | `tools` | `ToolSelection` | No | Tool whitelist built via `tools([...])`. Inherits `defaultOptions.tools` when omitted; an explicit value replaces the default entirely |
 | `output` | `StandardSchemaV1` | No | Schema for structured output. Validated and parsed onto `AgentResult.output` after dispatch (runtime ships in a follow-up release) |
 

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -16,9 +16,28 @@ import type { AgentOptions, AgentResult } from "./types.ts";
  * @internal
  */
 export function validateAgentOptions(options: AgentOptions): void {
-  if (typeof options.system !== "string" || options.system.trim() === "") {
+  // `system` accepts the same string-or-function shape as `llm({ system })`.
+  // For the static form, require non-empty so misconfiguration ("" or
+  // missing) surfaces at construction. The function form is validated at
+  // dispatch (its return value flows through `resolvePrompt`).
+  if (typeof options.system === "string") {
+    if (options.system.trim() === "") {
+      throw rcError("RC5003", undefined, {
+        message: `Agent: "system" is required and must be a non-empty string (or a function that returns one).`,
+      });
+    }
+  } else if (typeof options.system !== "function") {
     throw rcError("RC5003", undefined, {
-      message: `Agent: "system" is required and must be a non-empty string.`,
+      message: `Agent: "system" must be a string or a function (exchange) => string.`,
+    });
+  }
+  if (
+    options.user !== undefined &&
+    typeof options.user !== "string" &&
+    typeof options.user !== "function"
+  ) {
+    throw rcError("RC5003", undefined, {
+      message: `Agent: "user" must be a string or a function (exchange) => string when present.`,
     });
   }
   // `model` is optional: inheritable from agentPlugin({ defaultOptions:

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -6,7 +6,7 @@ import {
   type Destination,
   type Exchange,
 } from "@routecraft/routecraft";
-import { resolveModel } from "../llm/shared.ts";
+import { resolveModel, resolvePrompt } from "../llm/shared.ts";
 import { AgentSession, buildUserPrompt } from "./session.ts";
 import {
   ADAPTER_AGENT_DEFAULT_OPTIONS,
@@ -66,6 +66,10 @@ export class AgentDestinationAdapter implements Destination<
     const { config, modelName } = resolveModel(merged.model, context);
     const tools = resolveAgentTools(merged, context);
     const user = buildUserPrompt(merged, exchange);
+    // System accepts the same string-or-function shape as `llm({ system })`,
+    // so resolve it against the exchange here. The session then receives a
+    // plain string, matching what the provider layer expects.
+    const system = resolvePrompt(merged.system, exchange);
 
     const session = new AgentSession({
       options: merged,
@@ -73,7 +77,7 @@ export class AgentDestinationAdapter implements Destination<
       modelName,
       tools,
       user,
-      system: merged.system,
+      system,
       context,
     });
 

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -70,6 +70,16 @@ export class AgentDestinationAdapter implements Destination<
     // so resolve it against the exchange here. The session then receives a
     // plain string, matching what the provider layer expects.
     const system = resolvePrompt(merged.system, exchange);
+    // Mirror the construction-time check (validateAgentOptions) so a
+    // function-form `system` resolver can't silently drop the prompt at
+    // dispatch by returning an empty string.
+    if (system.trim() === "") {
+      throw rcError("RC5003", undefined, {
+        message:
+          `Agent: "system" resolved to an empty string. ` +
+          `When "system" is a function, it must return a non-empty string for the incoming exchange.`,
+      });
+    }
 
     const session = new AgentSession({
       options: merged,

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -1,6 +1,5 @@
-import type { Exchange } from "@routecraft/routecraft";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import type { LlmModelId, LlmUsage } from "../llm/types.ts";
+import type { LlmModelId, LlmPromptSource, LlmUsage } from "../llm/types.ts";
 import type { AgentEventListener } from "./events.ts";
 import type { ToolSelection } from "./tools/selection.ts";
 
@@ -9,9 +8,14 @@ import type { ToolSelection } from "./tools/selection.ts";
  * the user prompt from `exchange.body` (string body as-is, JSON-stringified
  * for objects, `String()` otherwise).
  *
+ * Alias of {@link LlmPromptSource} so the same prompt-source contract
+ * applies to both the `agent` and `llm` destinations: pass a static
+ * string for fixed prompts, or a function that derives the prompt from
+ * the incoming exchange.
+ *
  * @experimental
  */
-export type AgentUserPromptSource = (exchange: Exchange<unknown>) => string;
+export type AgentUserPromptSource = LlmPromptSource;
 
 /**
  * Context-level defaults applied to any agent that doesn't override them.
@@ -73,16 +77,20 @@ export interface AgentOptions {
   model?: LlmModelId;
 
   /**
-   * System prompt as a plain string. Load from disk yourself when you want
-   * to source it from a file (e.g. `readFileSync("./prompt.md", "utf-8")`).
+   * System prompt. Either a static string or a function that derives
+   * the prompt from the incoming exchange (mirrors `llm({ system })`).
+   * Load from disk yourself when you want to source the static form
+   * from a file (e.g. `readFileSync("./prompt.md", "utf-8")`).
    */
-  system: string;
+  system: LlmPromptSource;
 
   /**
-   * Optional override for deriving the user prompt from the incoming
-   * exchange. Defaults to the body (string as-is, JSON for objects).
+   * Optional override for the user prompt. Either a static string or
+   * a function that derives the prompt from the incoming exchange
+   * (mirrors `llm({ user })`). Defaults to the exchange body (string
+   * as-is, JSON for objects, `String()` otherwise) when omitted.
    */
-  user?: AgentUserPromptSource;
+  user?: LlmPromptSource;
 
   /**
    * Tools the agent is allowed to call. Build via

--- a/packages/ai/test/agent-prompt-source.test.ts
+++ b/packages/ai/test/agent-prompt-source.test.ts
@@ -176,4 +176,34 @@ describe("agent prompt source: string and function forms (llm parity)", () => {
     await t.test();
     expect(callLlmMock.mock.calls[0][0].user).toBe("body-as-prompt");
   });
+
+  /**
+   * @case Function-form `system` that returns "" throws at dispatch
+   * @preconditions system: () => "" — empty resolved value
+   * @expectedResult Dispatch rejects with RC5003 and never calls the provider
+   */
+  test("function-form system returning empty string throws at dispatch", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("system-empty-fn")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: () => "",
+              model: "anthropic:claude-opus-4-7",
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(t.errors[0]?.message).toMatch(/system.*resolved to an empty string/);
+    expect(callLlmMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ai/test/agent-prompt-source.test.ts
+++ b/packages/ai/test/agent-prompt-source.test.ts
@@ -1,0 +1,179 @@
+import { describe, test, expect, afterEach, vi, beforeEach } from "vitest";
+import { craft, simple } from "@routecraft/routecraft";
+import { testContext, type TestContext } from "@routecraft/testing";
+import { agent, llmPlugin } from "../src/index.ts";
+import type { LlmResult } from "../src/llm/types.ts";
+
+// Mock the LLM dispatcher so the runtime tests stay hermetic. Each
+// test asserts on the resolved system / user strings handed to the
+// provider layer.
+vi.mock("../src/llm/providers/index.ts", () => ({
+  callLlm: vi.fn(
+    async (): Promise<LlmResult> => ({
+      text: "stubbed-response",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    }),
+  ),
+}));
+
+import { callLlm } from "../src/llm/providers/index.ts";
+const callLlmMock = callLlm as unknown as ReturnType<typeof vi.fn>;
+
+describe("agent prompt source: string and function forms (llm parity)", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    callLlmMock.mockClear();
+    callLlmMock.mockResolvedValue({
+      text: "ok",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    });
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Static string `system` is forwarded unchanged
+   * @preconditions agent({ system: "static" })
+   * @expectedResult callLlm receives system === "static"
+   */
+  test("system as static string", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("system-string")
+          .from(simple("body"))
+          .to(
+            agent({
+              system: "static system prompt",
+              model: "anthropic:claude-opus-4-7",
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock.mock.calls[0][0].system).toBe("static system prompt");
+  });
+
+  /**
+   * @case Function `system` runs against the exchange and resolves to the returned string
+   * @preconditions agent({ system: (exchange) => `Hello ${exchange.body}` })
+   * @expectedResult callLlm receives the resolved system string
+   */
+  test("system as function gets the exchange", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("system-fn")
+          .from(simple("Alice"))
+          .to(
+            agent({
+              system: (exchange) => `Hello ${exchange.body as string}`,
+              model: "anthropic:claude-opus-4-7",
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock.mock.calls[0][0].system).toBe("Hello Alice");
+  });
+
+  /**
+   * @case Static string `user` overrides the body-default fallback
+   * @preconditions agent({ user: "fixed user prompt" })
+   * @expectedResult callLlm receives user === "fixed user prompt" (not the body)
+   */
+  test("user as static string overrides body fallback", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("user-string")
+          .from(simple("body-text"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              user: "fixed user prompt",
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock.mock.calls[0][0].user).toBe("fixed user prompt");
+  });
+
+  /**
+   * @case Function `user` derives the prompt from the exchange
+   * @preconditions agent({ user: (exchange) => `q: ${exchange.body}` })
+   * @expectedResult callLlm receives the resolved user string
+   */
+  test("user as function gets the exchange", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("user-fn")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              user: (exchange) => `q: ${exchange.body as string}`,
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock.mock.calls[0][0].user).toBe("q: hi");
+  });
+
+  /**
+   * @case Omitting `user` falls back to the body default (regression)
+   * @preconditions agent without `user`; body is a string
+   * @expectedResult callLlm receives user === body string
+   */
+  test("user omitted falls back to body (regression)", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("user-default")
+          .from(simple("body-as-prompt"))
+          .to(agent({ system: "x", model: "anthropic:claude-opus-4-7" })),
+      )
+      .build();
+
+    await t.test();
+    expect(callLlmMock.mock.calls[0][0].user).toBe("body-as-prompt");
+  });
+});


### PR DESCRIPTION
## Summary

`agent({ system, user })` now accepts the same `string | (exchange) => string` shape as `llm({ system, user })`. Removes the asymmetry where the agent's `system` was string-only and `user` was function-only.

```ts
agent({
  model: "openai:gpt-4o",
  // Either form works for both fields:
  system: (exchange) => `Help user ${exchange.headers.get("x-user-id")}`,
  user: "Summarise the input.",
})
```

## Changes

- `AgentOptions.system` widens from `string` to `LlmPromptSource` (string or function). Still required.
- `AgentOptions.user` widens from `(exchange) => string` to `LlmPromptSource`. Still optional, still falls back to the body default when omitted.
- `AgentUserPromptSource` is now an alias of `LlmPromptSource` so existing imports keep compiling and now also accept strings.
- Destination resolves `system` against the exchange via `resolvePrompt` before passing the resolved string into the session. The session and provider layers continue to receive a plain string, so no changes in the streaming or sync dispatch paths.
- `validateAgentOptions` now accepts both shapes and rejects empty static strings or wrong types with a clear `RC5003` message.
- Plugin reference docs updated to show both forms for both fields.

## Why "!"

Pure widening for type users — existing function-typed `user` and string-typed `system` continue to compile. The breaking marker is defensive: `AgentOptions.system` is a public type and the union widening is technically a structural change, even though no existing valid call site breaks.

## Tests

5 new tests in `agent-prompt-source.test.ts`:

- Static `system` is forwarded unchanged.
- Function `system` runs against the exchange and the resolved string flows through to the provider.
- Static `user` overrides the body fallback.
- Function `user` runs against the exchange.
- Omitting `user` still falls back to `exchange.body` (regression).

Suite: **944 pass / 1 skipped** (was 939, +5 new, no regressions).

## Verification

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm test`

## Test plan

- [ ] Verify CI green
- [ ] Confirm a real agent dispatch with a function-form `system` (e.g. injecting `exchange.headers.get("x-user-id")`) ends up in the model's system prompt

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`agent({ system, user })` now accepts `string | (exchange) => string`, matching `llm({ system, user })`. Also adds a dispatch-time guard so function-form `system` can’t resolve to an empty string.

- **New Features**
  - `AgentOptions.system` widened to `LlmPromptSource` (required).
  - `AgentOptions.user` widened to `LlmPromptSource` (optional; still falls back to `exchange.body`).
  - `AgentUserPromptSource` is now an alias of `LlmPromptSource`.
  - `destination` resolves prompts via `resolvePrompt`; throws `RC5003` if a function-form `system` resolves to an empty string; session/provider still get plain strings.
  - Validation accepts both shapes and errors with `RC5003` on empty/invalid input.
  - Reference docs updated; 6 tests added, including a regression that ensures empty-resolved `system` throws and the provider isn’t called.

- **Migration**
  - No changes expected for existing valid code; this is a type widening.
  - Marked breaking only because `AgentOptions.system` is a public type that changed shape.

<sup>Written for commit 6153b8256aaf5822d3a3b02c4a9b32e81638818f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

