### PR TITLE
feat(example): agent example

### DIFF
--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,5 +1,7 @@
 # MCP plugin -- used by the MCP adapter to expose routes as tools
-JWT_SECRET=change-me
+JWT_ISSUER=change-me
+JWT_AUDIENCE=https://idp.example.com
+JWT_SECRET=https://mcp.example.com
 
 # Mail adapter -- Gmail IMAP/SMTP (requires an App Password, not your login password)
 MAIL_USER=you@gmail.com

--- a/examples/src/agent.ts
+++ b/examples/src/agent.ts
@@ -1,0 +1,34 @@
+export { craftConfig } from "./craft.config.ts";
+import { craft, direct, simple } from "@routecraft/routecraft";
+import { agent, tools } from "@routecraft/ai";
+import { z } from "zod";
+
+const GreetInput = z.object({
+  user: z
+    .string()
+    .trim()
+    .min(1, { message: "User is required." })
+    .describe("The user to greet."),
+});
+type GreetInput = z.infer<typeof GreetInput>;
+
+export default craft()
+  .id("call")
+  .from(simple({ user: "Jaco" }))
+  .to(direct("greet-user"))
+
+  .id("greet-user")
+  .title("Greet user")
+  .description("Greet a user by name")
+  .input({ body: GreetInput })
+  .from<GreetInput>(direct())
+  .debug()
+  .to(
+    agent({
+      model: "gemini:gemini-3.1-pro-preview",
+      system: "Format time and date at 5 June 2026 08:30",
+      user: () => "What is the current time?",
+      tools: tools(["currentTime"]),
+    }),
+  )
+  .log();

--- a/examples/src/craft.config.ts
+++ b/examples/src/craft.config.ts
@@ -1,18 +1,8 @@
 import { defineConfig } from "@routecraft/routecraft";
 import { jwt } from "@routecraft/ai";
 import { version } from "../package.json";
-
-// Fail fast on a missing JWT secret. An empty HMAC key is a footgun: the
-// validator would silently accept any token signed with the empty string.
-// Other env vars in this file fall back to placeholders or empty strings
-// because their failure modes (mail auth rejection, mismatched issuer/
-// audience) are non-silent.
-const JWT_SECRET = process.env["JWT_SECRET"];
-if (!JWT_SECRET) {
-  throw new Error(
-    "JWT_SECRET is required to run this example. Set it in your .env or shell.",
-  );
-}
+import { env } from "./env";
+import { z } from "zod";
 
 export const craftConfig = defineConfig({
   telemetry: { sqlite: { captureSnapshots: true } },
@@ -22,17 +12,17 @@ export const craftConfig = defineConfig({
         imap: {
           host: "imap.gmail.com",
           auth: {
-            user: process.env["MAIL_USER"] ?? "",
-            pass: process.env["MAIL_APP_PASSWORD"] ?? "",
+            user: env.MAIL_USER,
+            pass: env.MAIL_APP_PASSWORD,
           },
         },
         smtp: {
           host: "smtp.gmail.com",
           auth: {
-            user: process.env["MAIL_USER"] ?? "",
-            pass: process.env["MAIL_APP_PASSWORD"] ?? "",
+            user: env.MAIL_USER,
+            pass: env.MAIL_APP_PASSWORD,
           },
-          from: process.env["MAIL_USER"] ?? "",
+          from: env.MAIL_USER,
         },
       },
     },
@@ -42,9 +32,25 @@ export const craftConfig = defineConfig({
     version,
     transport: "http",
     auth: jwt({
-      secret: JWT_SECRET,
-      issuer: process.env["JWT_ISSUER"] ?? "https://idp.example.com",
-      audience: process.env["JWT_AUDIENCE"] ?? "https://mcp.example.com",
+      secret: env.JWT_SECRET,
+      issuer: env.JWT_ISSUER,
+      audience: env.JWT_AUDIENCE,
     }),
+  },
+  llm: {
+    providers: {
+      gemini: {
+        apiKey: env.GEMINI_API_KEY,
+      },
+    },
+  },
+  agent: {
+    functions: {
+      currentTime: {
+        description: "Current UTC timestamp in ISO 8601",
+        input: z.object({}),
+        handler: async () => new Date().toISOString(),
+      },
+    },
   },
 });

--- a/examples/src/env.ts
+++ b/examples/src/env.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  JWT_SECRET: z.string().min(1),
+  JWT_ISSUER: z.string().min(1).default("https://idp.example.com"),
+  JWT_AUDIENCE: z.string().min(1).default("https://mcp.example.com"),
+  MAIL_USER: z.string().min(1),
+  MAIL_APP_PASSWORD: z.string().min(1),
+  GEMINI_API_KEY: z.string().min(1),
+  OPENROUTER_API_KEY: z.string().min(1),
+});
+
+export const env = envSchema.parse(process.env);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "version:set": "node .github/scripts/set-version.mjs",
     "publish:all": "pnpm run build && pnpm -r publish --no-git-checks",
     "pack:all": "pnpm run build && rm -rf dist && mkdir dist && pnpm -r exec pnpm pack --pack-destination ../../dist",
-    "craft": "node packages/cli/dist/index.js",
+    "craft": "node packages/cli/dist/index.js --log-level info",
     "docs": "pnpm --filter routecraft.dev dev",
     "all": " pnpm lint --fix && pnpm format:write && pnpm typecheck && pnpm build && pnpm test"
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a runnable `@routecraft/ai` agent example using the Gemini provider with a `currentTime` tool. Switches the examples to typed env validation and updates JWT/mail/Gemini config; the `craft` CLI now logs at info level.

- **New Features**
  - New example `examples/src/agent.ts` that runs an agent (`gemini:gemini-3.1-pro-preview`) with the `currentTime` tool, then debug/logs the run.
  - Typed env via `zod` in `examples/src/env.ts`; `examples/src/craft.config.ts` reads JWT, mail, and `llm.providers.gemini.apiKey` from env.
  - Registers `agent.functions.currentTime` that returns the current UTC timestamp (ISO 8601).

- **Migration**
  - Add to `.env`: `JWT_SECRET`, `JWT_ISSUER`, `JWT_AUDIENCE`, `MAIL_USER`, `MAIL_APP_PASSWORD`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`.
  - The example fails fast on missing env values; update `.env` before running `pnpm craft`.

<sup>Written for commit f744bcccb2afb239cb82f98d06aa9f95c56f79c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

