### PR TITLE
docs: add .standards/testing.md and .standards/ci-cd.md (closes #255)

### DIFF
--- a/.standards/README.md
+++ b/.standards/README.md
@@ -13,6 +13,8 @@ Internal development standards for Routecraft contributors (human and AI). These
 | [Error and Logging Policy](./error-and-logging-policy.md) | Throw/boundary rules, structured logging, level semantics, error code philosophy |
 | [Type Safety and Schemas](./type-safety-and-schemas.md) | Type flow policy, factory option types (no `Partial<>` on factory args), Standard Schema usage, plugin vs config vs store guidance |
 | [Type Safety Registries](./type-safety-registries.md) | Declaration-merging registries for typed adapters and endpoints; codegen direction |
+| [Testing](./testing.md) | Runner conventions, JSDoc-on-every-test, helpers from `@routecraft/testing`, lifecycle pattern, assertion patterns |
+| [CI/CD](./ci-cd.md) | PR gates, hook policy, peer-dependency rules, optional peer dependencies, release flow |
 
 ## Related
 

--- a/.standards/ci-cd.md
+++ b/.standards/ci-cd.md
@@ -1,0 +1,127 @@
+# CI/CD
+
+What `.github/workflows/ci.yml` enforces and the policies contributors must know to work with it.
+
+---
+
+## 1. Job graph
+
+```
+  changes  ─┬─►  validate ─┐
+            │              │
+   setup ───┼─►  test  ────┼─►  integration-test (npm + bun)  ──►  approve  ──►  merge
+            │              │                                         │
+            └─►  build ────┘                                         └─►  publish-canary  ──►  publish  ──►  deploy-pages
+```
+
+The `setup` job restores the pnpm cache. Every downstream job restores `**/node_modules` from the same cache key (`hashFiles('**/pnpm-lock.yaml')`), so `pnpm install` only runs on cache miss. `changes` skips downstream jobs when the diff doesn't touch package or workflow paths.
+
+## 2. The PR gates
+
+Every PR must pass these jobs before merge. The first column matches the GitHub status check name shown in the PR.
+
+| Job | Runs | Catches |
+|-----|------|---------|
+| `setup` | `pnpm install --frozen-lockfile` | Lockfile drift, install failures, dependabot lockfile updates. |
+| `validate` | `pnpm format && pnpm typecheck && pnpm lint && pnpm exec madge --circular .` | Prettier drift, TS errors, ESLint violations, circular imports. |
+| `test` | `pnpm test:coverage` (excludes `**/integration.test.ts`) | Unit-test regressions, coverage report uploaded as artifact. |
+| `build` | `pnpm run build` and `pnpm run limit:size` | Build failures, bundle size regressions (size-limit). |
+| `integration-test (npm)` | Smoke-test publishable + `pnpm test:integration` against a packed tarball | Tarball install path, `craft` CLI binary publishability. |
+| `integration-test (bun)` | `pnpm test:integration` under the Bun runtime | Bun runtime divergence in source / generated code. |
+| `cubic · AI code reviewer` | External AI reviewer | Dual-use review signal; informational on PR but does not gate merge. |
+
+The `validate` job is the cheapest signal — if it's red, fix that first. The `test` job uploads `coverage-report` as an artifact; reviewers can download to inspect uncovered lines.
+
+## 3. Rules contributors must follow
+
+### 3.1. Hooks must succeed; never `--no-verify`
+
+Husky + lint-staged run `eslint --fix`, `prettier --write`, and `pnpm typecheck` on every commit. If a hook fails, fix the underlying issue. Bypassing hooks (`--no-verify`, `--no-gpg-sign`) is forbidden unless the user explicitly asks for it. A hook failure is a green light to investigate, not a green light to skip.
+
+### 3.2. New commits, never `--amend` after a hook failure
+
+If a pre-commit hook fails, the commit didn't happen. `--amend` would modify the previous commit (which DID happen) and discard work. Re-stage and commit anew.
+
+### 3.3. The `changes` filter governs whether package jobs run
+
+`changes` checks paths against:
+
+- `packages` filter: `packages/**`, `examples/**`, `pnpm-lock.yaml`, `tsconfig*.json`, `.github/workflows/**`, `.github/scripts/**`.
+- `docs` filter: `apps/routecraft.dev/**`, `.github/workflows/**`.
+
+Pure docs-only PRs skip `integration-test`, `publish-canary`, and `publish`. If you add a new code path that should gate on CI, add it to the relevant filter.
+
+### 3.4. PR target trigger
+
+CI uses `pull_request_target`, not `pull_request`. This gives forks access to repo secrets (needed for the `dependabot[bot]` lockfile-update path), but it also means the workflow runs from `main`'s definition with the PR's head checked out. **Workflow file changes in a PR do NOT take effect for that PR's CI run.** They take effect after merge.
+
+## 4. Adding a new package to CI
+
+The CI doesn't enumerate packages — `pnpm -r run build`, `pnpm test`, etc. walk every workspace package. To make a new package CI-visible:
+
+1. Add it to `pnpm-workspace.yaml` (it'll get picked up automatically).
+2. Add `build`, `test` (if any tests exist), and ensure `tsc --noEmit` cleanliness from the workspace root.
+3. If the package publishes (`"private": false`), add it to:
+   - `.github/scripts/set-version.mjs` so the `version:set` script bumps it.
+   - The release-restore step in `integration-test` (the `git checkout --` line that resets package.jsons after `set-version` modifies them).
+   - `.github/scripts/smoke-test-publishable.mjs` if it should be exercised in the publish smoke test.
+4. If it depends on another workspace package, follow the dual-spec convention (see 5).
+
+## 5. Peer-dependency policy on `@routecraft/*`
+
+Every `@routecraft/*` workspace package that's a peer of another carries TWO entries:
+
+```jsonc
+"devDependencies": {
+  "@routecraft/routecraft": "workspace:^0.5.0"  // dev: pin to current version
+},
+"peerDependencies": {
+  "@routecraft/routecraft": "*"                  // runtime: accept any version
+}
+```
+
+Why both:
+
+- The `devDependencies` `workspace:^0.5.0` keeps local development synced. pnpm's `workspace:` protocol resolves to the in-tree package, so editing `@routecraft/routecraft` is immediately visible.
+- The `peerDependencies` `*` is what users see after publish. Bundling the peer would cause duplicate-instance bugs (two `RoutecraftError` classes, two adapter registries). `*` lets the user pick the version and forces a single instance.
+
+This is enforced informally by review. When adding a new internal package that other packages depend on, mirror this pattern.
+
+## 6. Optional peer dependencies (provider SDKs)
+
+External SDKs that a package only needs when a specific feature is used (Vercel AI SDK adapters, `@huggingface/transformers`, `@modelcontextprotocol/sdk`, etc.) live in `peerDependencies` AND `peerDependenciesMeta.<name>.optional = true`. The framework dynamically imports them inside the relevant code path and throws a friendly install message when the import fails. Don't add such deps to `dependencies` — that bloats every install.
+
+## 7. Local pre-PR checklist
+
+Run before opening a PR; matches what CI runs:
+
+```sh
+pnpm format     # prettier --check
+pnpm typecheck  # tsc --noEmit
+pnpm lint       # eslint
+pnpm test       # unit tests
+pnpm build      # all packages
+```
+
+Or the bundled `pnpm all`, which runs `lint --fix`, `format:write`, `typecheck`, `build`, `test` in one pass.
+
+Integration tests require a tarball + global CLI install and aren't expected to run locally for every PR. CI covers that path.
+
+## 8. Release flow
+
+| Trigger | Result |
+|---------|--------|
+| Push to `main` | Runs CI; on success runs `publish-canary` which publishes a `0.5.0-canary.<sha>` tag for every workspace package. |
+| GitHub release created | Runs CI; on success the `approve` + `merge` + `publish` chain publishes the tagged version to npm and `deploy-pages` deploys the docs site. |
+| `workflow_dispatch` (manual) | Runs CI without publish steps (useful for sanity-checking a PR-target run). |
+
+Versions are uniformly bumped via `pnpm run version:set <version>` (see `.github/scripts/set-version.mjs`), which patches every `package.json`, the CLI's `--version` constant, and the docs site's version selector. Don't hand-edit individual `package.json` versions.
+
+---
+
+## References
+
+- Workflow source: `.github/workflows/ci.yml`
+- Scripts: `.github/scripts/set-version.mjs`, `.github/scripts/smoke-test-publishable.mjs`
+- Definition of Done: `DEFINITION_OF_DONE.md`
+- Testing standards: `./testing.md`

--- a/.standards/testing.md
+++ b/.standards/testing.md
@@ -1,0 +1,137 @@
+# Testing
+
+Authoritative rules and conventions for tests in Routecraft.
+
+---
+
+## 1. Runner and layout
+
+- **Runner:** Vitest. Same config across packages; the workspace `vitest --run` is the source of truth (root `package.json` script `test`).
+- **File placement:** colocated with the package they exercise.
+  - Unit tests: `packages/<name>/test/*.test.ts`.
+  - Integration tests (real network, real subprocesses, slow setup): `packages/<name>/test/*.integration.test.ts` and run via `pnpm test:integration`. The default `pnpm test` excludes them.
+- **One feature per file.** Group tests around the unit they exercise, not by category. A test file maps to a code file (or a closely related cluster), not to "all the validation tests in the package".
+
+## 2. Every test gets a JSDoc header
+
+Each `test(...)` block must carry a JSDoc with three tags so a reader can scan a file and understand intent without reading bodies. Enforced by convention; PR review rejects tests missing it.
+
+```ts
+/**
+ * @case Single resolved tool produces one Vercel tool keyed by name
+ * @preconditions Resolved tool with name "echo"; SDK execute called with input only
+ * @expectedResult Returned map has key "echo"; handler receives the input as the first arg
+ */
+test("single resolved tool builds a Vercel tool that runs the handler", async () => {
+  // ...
+});
+```
+
+| Tag | Purpose |
+|-----|---------|
+| `@case` | What scenario the test covers, in user terms (one short sentence). |
+| `@preconditions` | The setup that distinguishes this case from neighbours. |
+| `@expectedResult` | The observable outcome the assertions check. |
+
+The `test(...)` string itself is the searchable label. Keep it short and declarative; the JSDoc carries the explanation.
+
+## 3. Test helpers from `@routecraft/testing`
+
+| Helper | Use for |
+|--------|---------|
+| `testContext()` | Build an isolated `CraftContext` with plugins, routes, and stores. Returns a `TestContext` with `start()` / `stop()` lifecycle and an in-memory event log. Default for any test that touches routes or plugins. |
+| `t.test()` | Run the routes once and wait for completion. Errors raised inside route handlers do not reject; inspect `t.errors` instead. |
+| `t.startAndWaitReady()` | Start the context without running routes (e.g. to assert on side effects of plugin init or to interact via direct endpoints). |
+| `spy()` | Spy destination that records every received exchange. Use as the terminal `.to()` when you want to assert on what reached it. |
+| `pseudo()` | Configurable adapter that you fully control (source, destination, both). Use when no real adapter fits the test scenario. |
+| `mockAdapter()` + `testContext().override()` | Replace a real adapter with a mock for one test run. Use when you need to assert on adapter-level interactions without standing up the real implementation. |
+| `testFn(spec, input)` | Exercise a fn-shaped spec (`{ schema, handler }`) directly. Validates input, builds a synthetic `FnHandlerContext`, and calls the handler. Use for unit-testing fns registered via `agentPlugin({ functions: { ... } })` without touching the agent loop. |
+| `fixture(path)` | Load a JSON fixture file. `fixtureEach(path, run)` runs one `test()` per array entry, using `entry.name` as the test name. |
+| `createSpyLogger()` / `createNoopSpyLogger()` | Capture or silence log output. Pass into `testContext({ spyLogger })` to assert on log calls (e.g. that a warn was emitted). |
+
+## 4. Lifecycle pattern
+
+```ts
+let t: TestContext | undefined;
+
+afterEach(async () => {
+  if (t) await t.stop();
+  t = undefined;
+});
+
+test("...", async () => {
+  t = await testContext().with({ ... }).routes(...).build();
+  await t.test();
+  expect(t.errors).toHaveLength(0);
+});
+```
+
+Rules:
+
+- Always assign to a single `let t` declared in the `describe` scope; the `afterEach` then handles teardown unconditionally.
+- Always `await t.stop()`; not awaiting leaks timers, http servers, and background tasks across tests.
+- Prefer `t.test()` over `t.startAndWaitReady()` when you want the routes to actually run. Use `startAndWaitReady` for tests that drive interaction through direct endpoints or that assert on plugin-init side effects.
+
+## 5. Asserting on `RoutecraftError`
+
+Prefer structural matchers over regex. Routecraft errors carry stable `rc` codes; assert on those.
+
+```ts
+expect(rcError).toMatchObject({ rc: "RC5003" });
+// or
+expect(isRoutecraftError(err)).toBe(true);
+expect((err as RoutecraftError).rc).toBe("RC5003");
+```
+
+When asserting on the error message, use a tight regex anchored to the actionable phrase, not the full sentence (which is more likely to be reworded).
+
+```ts
+expect(t.errors[0]?.message).toMatch(/no "model"/i);
+```
+
+Avoid full string equality on error messages; the wording is not part of the API and small changes will churn tests.
+
+## 6. Asserting on dispatch errors
+
+Errors thrown inside route handlers are caught by the runtime, logged at the boundary, and surfaced on `TestContext.errors` rather than rejecting `t.test()`. The pattern is:
+
+```ts
+await t.test();
+expect(t.errors[0]?.message).toMatch(/.../);
+```
+
+Errors thrown at construction (e.g. `validateAgentOptions` running inside `agent({...})`) DO reject the `await ... .build()` call. Use `await expect(builder).rejects.toThrow(...)` for those.
+
+## 7. Negative-path logging is expected
+
+Tests that exercise an error path through the framework boundary will produce error-level log output. This is deliberate: the framework's own logger ran. Do not treat such output as a test failure or filter it from CI logs. If a test produces noisy output but passes, leave it — the noise is the framework working as designed.
+
+## 8. Snapshots
+
+Avoid snapshot tests as a default. They make refactors painful and tend to be rubber-stamped on update. Use them only when:
+
+- The output is large but structurally stable (e.g. generated TypeScript types).
+- The assertion would otherwise require dozens of brittle `expect(...).toEqual(...)` lines that would all need to change together.
+
+If you reach for a snapshot, prefer inline (`toMatchInlineSnapshot()`) over a separate `__snapshots__` file so the expected value lives next to the test.
+
+## 9. Mocking guidance
+
+- **Mock at the boundary.** Mock `vi.mock("../src/llm/providers/index.ts")` to stub `callLlm` rather than mocking the Vercel AI SDK; the boundary is more stable than the dependency's API.
+- **Mock the SDK only when testing the boundary itself.** E.g. `stream-llm.test.ts` mocks `ai`'s `streamText` to exercise the real `streamLlm` containment behaviour.
+- **Mirror real behaviour in mocks.** If the real code catches listener errors, the mock should too — otherwise the test passes for the wrong reason.
+
+## 10. What runs in CI
+
+- `pnpm test` (excludes `*.integration.test.ts`) runs on the main `test` job.
+- `pnpm test:integration` runs on the dedicated `integration-test` matrix (bun + npm) against published-shaped tarballs.
+- Both must pass for a PR to be mergeable. See [CI/CD](./ci-cd.md).
+
+---
+
+## References
+
+- Test helpers source: `packages/testing/src/`
+- Vitest config: `vitest.config.ts` at the workspace root
+- CI workflow: `.github/workflows/ci.yml`
+- Definition of Done: `DEFINITION_OF_DONE.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ Detailed coding standards for contributors live in `.standards/`:
 - [Error and Logging Policy](.standards/error-and-logging-policy.md) -- throw/boundary rules, log levels, error codes
 - [Type Safety and Schemas](.standards/type-safety-and-schemas.md) -- type flow, Standard Schema, plugin vs config
 - [Type Safety Registries](.standards/type-safety-registries.md) -- declaration-merging registries for typed adapters and endpoints
+- [Testing](.standards/testing.md) -- runner conventions, JSDoc-on-every-test, helpers, lifecycle, assertion patterns
+- [CI/CD](.standards/ci-cd.md) -- PR gates, hook policy, peer-dependency rules, release flow
 
 ## Merge Checklist
 


### PR DESCRIPTION
## Summary

Codifies two conventions that have been informal up to now. Closes #255.

### `.standards/testing.md`

- Vitest runner + file placement (unit vs integration).
- The `@case` / `@preconditions` / `@expectedResult` JSDoc convention required on every test.
- The `@routecraft/testing` helpers (`testContext`, `testFn`, `spy`, `pseudo`, `mockAdapter`, `fixture`/`fixtureEach`, `createSpyLogger`) and when to reach for each.
- Lifecycle pattern (`afterEach` cleanup), `t.test()` vs `t.startAndWaitReady()`.
- Assertion patterns: `toMatchObject({ rc: "..." })` over loose regex; tight error-message regexes anchored to actionable phrases.
- Negative-path logging is expected (not a CI smell).
- Snapshot policy (avoid by default; inline if used).
- Mocking guidance (mock at the boundary, mirror real catch behaviour in mocks).

### `.standards/ci-cd.md`

- The job graph and what each gate catches (validate / test / build / integration-test bun+npm).
- The "hooks must succeed; never `--no-verify`" rule.
- The "new commit, never `--amend` after hook failure" rule.
- The `changes` paths filter and `pull_request_target` semantics.
- How to add a new package to CI (workspace + `version:set` + publish-script touchpoints).
- Peer-dependency policy: dual `workspace:^` (dev) + `*` (peer) on `@routecraft/*`, plus optional peers for provider SDKs.
- Local pre-PR checklist.
- Release flow (publish-canary on main; publish on tag).

Both linked from `CLAUDE.md` and `.standards/README.md`.

## Verification

- [x] `pnpm format`
- Docs-only PR; no code changes, no test changes.

## Test plan

- [ ] Reviewer reads through both files; flags anything inaccurate or missing.
- [ ] Confirms phrasing matches existing `.standards/*.md` style (numbered sections, tables, examples where they help).

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two standards docs that codify our testing and CI/CD conventions, and links them from `.standards/README.md` and `CLAUDE.md`. This clarifies expectations for contributors and keeps tests/CI consistent across the repo.

- **New Features**
  - `.standards/testing.md`: Vitest layout; required JSDoc tags (`@case`, `@preconditions`, `@expectedResult`); `@routecraft/testing` helpers; lifecycle pattern; assertion patterns; snapshot policy; mocking guidance.
  - `.standards/ci-cd.md`: Job graph and gates; hook rules; `changes` filters and `pull_request_target`; how to add a package; peer-dep policy (`workspace:^` dev + `*` peer) and optional peers; local pre-PR checklist; release flow.
  - Linked from `CLAUDE.md` and `.standards/README.md`.

<sup>Written for commit 48f15aecc3e3c154e1c87a166f5c4cd7a1a06197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

