### PR TITLE
feat(adapters): tag file/csv/json/jsonl/html factories for mockAdapter

### DIFF
--- a/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
@@ -171,7 +171,7 @@ const httpMock = mockAdapter(http, {
 
 `mockAdapter(target, behavior)` accepts two kinds of target:
 
-- **A factory function** -- e.g. `mockAdapter(mail, ...)`, `mockAdapter(http, ...)`. Matches every adapter instance that factory produced. Requires the factory to stamp its adapters via `tagAdapter()` internally. The first-party factories `mail()`, `http()`, and `mcp()` do this today.
+- **A factory function** -- e.g. `mockAdapter(mail, ...)`, `mockAdapter(http, ...)`. Matches every adapter instance that factory produced. Requires the factory to stamp its adapters via `tagAdapter()` internally. The first-party factories that do this today are `mail()`, `http()`, `mcp()`, `file()`, `csv()`, `json()` (file mode), `jsonl()` (every return path), and `html()` (file mode). The transformer-only return paths of `json()` and `html()` are intentionally not tagged because the override resolver only fires on `subscribe`/`send`.
 - **An adapter class** -- e.g. `mockAdapter(SomeAdapterClass, ...)`. Matches any adapter whose `constructor === target`. Works for every adapter, first-party or third-party, without opt-in tagging. Useful when a third-party adapter exports its class but not a tagged factory, or when you want to mock a specific role of a multi-role factory.
 
 The factory form is nicer when the factory covers a single role. The class form is required when the factory has no tag or when you want to target one specific role of a multi-role factory. Both forms can be mixed on the same `testContext()`.

--- a/packages/routecraft/src/adapters/csv/index.ts
+++ b/packages/routecraft/src/adapters/csv/index.ts
@@ -1,5 +1,6 @@
 import type { Source } from "../../operations/from.ts";
 import type { Destination } from "../../operations/to.ts";
+import { tagAdapter, factoryArgs } from "../shared/factory-tag.ts";
 import type { CsvOptions, CsvData, CsvRow } from "./types.ts";
 import { CsvSourceAdapter } from "./source.ts";
 import { CsvDestinationAdapter } from "./destination.ts";
@@ -58,19 +59,28 @@ export function csv(
  */
 export function csv(options: CsvOptions): CsvAdapter;
 export function csv(options: CsvOptions): Source<CsvRow> | CsvAdapter {
+  const args = factoryArgs(options);
   const source = new CsvSourceAdapter(options);
   if (options.chunked) {
-    return {
-      adapterId: "routecraft.adapter.csv",
-      subscribe: source.subscribe,
-    } as Source<CsvRow>;
+    return tagAdapter(
+      {
+        adapterId: "routecraft.adapter.csv",
+        subscribe: source.subscribe,
+      },
+      csv,
+      args,
+    ) as Source<CsvRow>;
   }
   const destination = new CsvDestinationAdapter(options);
-  return {
-    adapterId: "routecraft.adapter.csv",
-    subscribe: source.subscribe,
-    send: destination.send,
-  } as CsvAdapter;
+  return tagAdapter(
+    {
+      adapterId: "routecraft.adapter.csv",
+      subscribe: source.subscribe,
+      send: destination.send,
+    },
+    csv,
+    args,
+  ) as CsvAdapter;
 }
 
 // Re-export types

--- a/packages/routecraft/src/adapters/file/index.ts
+++ b/packages/routecraft/src/adapters/file/index.ts
@@ -1,5 +1,6 @@
 import type { Source } from "../../operations/from.ts";
 import type { Destination } from "../../operations/to.ts";
+import { tagAdapter, factoryArgs } from "../shared/factory-tag.ts";
 import type { FileOptions } from "./types.ts";
 import { FileSourceAdapter } from "./source.ts";
 import { FileDestinationAdapter } from "./destination.ts";
@@ -55,19 +56,28 @@ export function file(
  */
 export function file(options: FileOptions): FileAdapter;
 export function file(options: FileOptions): Source<string> | FileAdapter {
+  const args = factoryArgs(options);
   const source = new FileSourceAdapter(options);
   if (options.chunked) {
-    return {
-      adapterId: "routecraft.adapter.file",
-      subscribe: source.subscribe,
-    };
+    return tagAdapter(
+      {
+        adapterId: "routecraft.adapter.file",
+        subscribe: source.subscribe,
+      },
+      file,
+      args,
+    );
   }
   const destination = new FileDestinationAdapter(options);
-  return {
-    adapterId: "routecraft.adapter.file",
-    subscribe: source.subscribe,
-    send: destination.send,
-  };
+  return tagAdapter(
+    {
+      adapterId: "routecraft.adapter.file",
+      subscribe: source.subscribe,
+      send: destination.send,
+    },
+    file,
+    args,
+  );
 }
 
 // Re-export types for public API

--- a/packages/routecraft/src/adapters/html/index.ts
+++ b/packages/routecraft/src/adapters/html/index.ts
@@ -57,6 +57,7 @@ export function html<T = unknown, R = HtmlResult>(
 export function html<T = unknown, R = HtmlResult>(
   options: HtmlOptions<T, R>,
 ): (Transformer<T, R> & { readonly adapterId: string }) | HtmlAdapter<T, R> {
+  const args = factoryArgs(options);
   const transformer = new HtmlTransformerAdapter<T, R>(options);
   if (options.path) {
     const source = new HtmlSourceAdapter<T, R>(options);
@@ -75,7 +76,7 @@ export function html<T = unknown, R = HtmlResult>(
         send: destination.send,
       },
       html,
-      factoryArgs(options),
+      args,
     );
   }
   return {

--- a/packages/routecraft/src/adapters/html/index.ts
+++ b/packages/routecraft/src/adapters/html/index.ts
@@ -2,6 +2,7 @@ import type { Source } from "../../operations/from.ts";
 import type { Destination } from "../../operations/to.ts";
 import type { Transformer } from "../../operations/transform.ts";
 import type { Exchange } from "../../exchange.ts";
+import { tagAdapter, factoryArgs } from "../shared/factory-tag.ts";
 import type { HtmlOptions, HtmlResult } from "./types.ts";
 import { HtmlTransformerAdapter } from "./transformer.ts";
 import { HtmlSourceAdapter } from "./source.ts";
@@ -66,12 +67,16 @@ export function html<T = unknown, R = HtmlResult>(
       encoding: options.encoding,
       createDirs: options.createDirs,
     });
-    return {
-      adapterId: "routecraft.adapter.html",
-      transform: transformer.transform.bind(transformer),
-      subscribe: source.subscribe,
-      send: destination.send,
-    };
+    return tagAdapter(
+      {
+        adapterId: "routecraft.adapter.html",
+        transform: transformer.transform.bind(transformer),
+        subscribe: source.subscribe,
+        send: destination.send,
+      },
+      html,
+      factoryArgs(options),
+    );
   }
   return {
     adapterId: "routecraft.adapter.html",

--- a/packages/routecraft/src/adapters/json/index.ts
+++ b/packages/routecraft/src/adapters/json/index.ts
@@ -1,6 +1,7 @@
 import type { Source } from "../../operations/from.ts";
 import type { Destination } from "../../operations/to.ts";
 import type { Transformer } from "../../operations/transform.ts";
+import { tagAdapter, factoryArgs } from "../shared/factory-tag.ts";
 import type {
   JsonTransformerOptions,
   JsonFileOptions,
@@ -85,7 +86,8 @@ export function json<T = unknown, R = unknown, V = unknown>(
   options: JsonOptions<T, R, V> = {},
 ): Transformer<T, R> | Transformer<T, V> | JsonFileAdapterType {
   if (isFileMode(options)) {
-    return new JsonFileAdapter(options as JsonFileOptions);
+    const adapter = new JsonFileAdapter(options as JsonFileOptions);
+    return tagAdapter(adapter, json, factoryArgs(options));
   }
   return new JsonTransformerAdapter<T, R, V>(
     options as JsonTransformerOptions<T, R, V>,

--- a/packages/routecraft/src/adapters/json/index.ts
+++ b/packages/routecraft/src/adapters/json/index.ts
@@ -85,9 +85,10 @@ export function json(options: JsonFileOptions): JsonFileAdapterType;
 export function json<T = unknown, R = unknown, V = unknown>(
   options: JsonOptions<T, R, V> = {},
 ): Transformer<T, R> | Transformer<T, V> | JsonFileAdapterType {
+  const args = factoryArgs(options);
   if (isFileMode(options)) {
     const adapter = new JsonFileAdapter(options as JsonFileOptions);
-    return tagAdapter(adapter, json, factoryArgs(options));
+    return tagAdapter(adapter, json, args);
   }
   return new JsonTransformerAdapter<T, R, V>(
     options as JsonTransformerOptions<T, R, V>,

--- a/packages/routecraft/src/adapters/jsonl/index.ts
+++ b/packages/routecraft/src/adapters/jsonl/index.ts
@@ -1,5 +1,6 @@
 import type { Source } from "../../operations/from.ts";
 import type { Destination } from "../../operations/to.ts";
+import { tagAdapter, factoryArgs } from "../shared/factory-tag.ts";
 import type {
   JsonlSourceOptions,
   JsonlDestinationOptions,
@@ -67,25 +68,35 @@ export function jsonl<T = unknown>(
   | Source<T[]>
   | Destination<unknown, void>
   | (Source<T[]> & Destination<unknown, void>) {
+  const args = factoryArgs(options);
+
   // Destination-only: path is a function (not valid for source)
   if (typeof (options as JsonlDestinationOptions).path === "function") {
     const destination = new JsonlDestinationAdapter(
       options as JsonlDestinationOptions,
     );
-    return {
-      adapterId: "routecraft.adapter.jsonl",
-      send: destination.send,
-    } as Destination<unknown, void>;
+    return tagAdapter(
+      {
+        adapterId: "routecraft.adapter.jsonl",
+        send: destination.send,
+      },
+      jsonl,
+      args,
+    ) as Destination<unknown, void>;
   }
 
   const sourceOptions = options as JsonlSourceOptions;
   const source = new JsonlSourceAdapter<T>(sourceOptions);
 
   if (sourceOptions.chunked) {
-    return {
-      adapterId: "routecraft.adapter.jsonl",
-      subscribe: source.subscribe,
-    } as Source<T>;
+    return tagAdapter(
+      {
+        adapterId: "routecraft.adapter.jsonl",
+        subscribe: source.subscribe,
+      },
+      jsonl,
+      args,
+    ) as Source<T>;
   }
 
   const combined = options as JsonlCombinedOptions;
@@ -106,11 +117,15 @@ export function jsonl<T = unknown>(
   }
   const destination = new JsonlDestinationAdapter(destOptions);
 
-  return {
-    adapterId: "routecraft.adapter.jsonl",
-    subscribe: source.subscribe,
-    send: destination.send,
-  } as Source<T[]> & Destination<unknown, void>;
+  return tagAdapter(
+    {
+      adapterId: "routecraft.adapter.jsonl",
+      subscribe: source.subscribe,
+      send: destination.send,
+    },
+    jsonl,
+    args,
+  ) as Source<T[]> & Destination<unknown, void>;
 }
 
 // Re-export types

--- a/packages/testing/test/mock-adapter.test.ts
+++ b/packages/testing/test/mock-adapter.test.ts
@@ -475,6 +475,10 @@ describe("mockAdapter", () => {
   describe("first-party adapter factory tagging", () => {
     type TaggedDestinationCase = readonly [
       label: string,
+      // `unknown[]` would be stricter, but TypeScript rejects assigning a
+      // factory with specific options types into a parameter typed as
+      // `unknown[]` (function parameter contravariance). `any[]` is the
+      // only annotation that accepts the heterogenous factories below.
       factory: (...args: any[]) => unknown,
       build: () => Destination<unknown, unknown>,
     ];
@@ -602,6 +606,58 @@ describe("mockAdapter", () => {
       expect(htmlTransformer).toHaveProperty("transform");
       expect(htmlTransformer).not.toHaveProperty("subscribe");
       expect(htmlTransformer).not.toHaveProperty("send");
+    });
+
+    /**
+     * @case mockAdapter(json, { send }) does not intercept .transform(json()) call sites
+     * @preconditions Route uses simple(jsonString).transform(json()).to(spy); a send-only mock is registered for json
+     * @expectedResult The transformer parses the body normally; the send override is never invoked, confirming the resolver only fires on subscribe/send
+     */
+    test("send overrides do not intercept json() transformer-mode call sites", async () => {
+      const jsonMock = mockAdapter(json, {
+        send: async () => "should-never-fire",
+      });
+      const captured = spy<unknown>();
+
+      const route = craft()
+        .id("json-transformer-bypass")
+        .from(simple('{"x":1}'))
+        .transform(json())
+        .to(captured);
+
+      t = await testContext().override(jsonMock).routes(route).build();
+      await t.test();
+
+      expect(jsonMock.calls.send).toHaveLength(0);
+      expect(captured.received).toHaveLength(1);
+      expect(captured.received[0].body).toEqual({ x: 1 });
+      expect(t.errors).toHaveLength(0);
+    });
+
+    /**
+     * @case mockAdapter(html, { send }) does not intercept .transform(html({ selector })) call sites
+     * @preconditions Route uses simple(htmlString).transform(html({ selector, extract })).to(spy); a send-only mock is registered for html
+     * @expectedResult The transformer extracts the selector text normally; the send override is never invoked
+     */
+    test("send overrides do not intercept html() transformer-mode call sites", async () => {
+      const htmlMock = mockAdapter(html, {
+        send: async () => "should-never-fire",
+      });
+      const captured = spy<unknown>();
+
+      const route = craft()
+        .id("html-transformer-bypass")
+        .from(simple("<html><title>Hello</title></html>"))
+        .transform(html({ selector: "title", extract: "text" }))
+        .to(captured);
+
+      t = await testContext().override(htmlMock).routes(route).build();
+      await t.test();
+
+      expect(htmlMock.calls.send).toHaveLength(0);
+      expect(captured.received).toHaveLength(1);
+      expect(captured.received[0].body).toBe("Hello");
+      expect(t.errors).toHaveLength(0);
     });
 
     /**

--- a/packages/testing/test/mock-adapter.test.ts
+++ b/packages/testing/test/mock-adapter.test.ts
@@ -4,6 +4,11 @@ import {
   simple,
   http,
   mail,
+  file,
+  csv,
+  json,
+  jsonl,
+  html,
   type Destination,
   type Source,
   type Exchange,
@@ -14,10 +19,17 @@ import {
 import {
   mockAdapter,
   testContext,
+  spy,
   type AdapterMock,
   type MockAdapterBehavior,
   type TestContext,
 } from "@routecraft/testing";
+
+const RC_ADAPTER_FACTORY = Symbol.for("routecraft.adapter.factory");
+
+function readFactoryTag(adapter: unknown): unknown {
+  return (adapter as Record<symbol, unknown>)[RC_ADAPTER_FACTORY];
+}
 
 /**
  * A handwritten destination class with a stable constructor. Used to
@@ -463,6 +475,111 @@ describe("mockAdapter", () => {
       expect(mailMock.calls.source).toHaveLength(1);
       expect(mailMock.calls.source[0].yielded).toBe(1);
       expect(mailMock.calls.send).toHaveLength(1);
+    });
+  });
+
+  describe("first-party adapter factory tagging", () => {
+    /**
+     * @case file() instances carry the factory tag so mockAdapter(file, ...) can resolve them
+     * @preconditions file({ path }) constructs a Source+Destination adapter
+     * @expectedResult The instance carries RC_ADAPTER_FACTORY === file and mockAdapter(file, ...).override.target === file
+     */
+    test("file() is tagged with its factory", () => {
+      const adapter = file({ path: "/tmp/__never__.txt" });
+      expect(readFactoryTag(adapter)).toBe(file);
+      const mock = mockAdapter(file, { send: async () => undefined });
+      expect(mock.override.target).toBe(file);
+    });
+
+    /**
+     * @case csv() instances carry the factory tag so mockAdapter(csv, ...) can resolve them
+     * @preconditions csv({ path }) constructs a Source+Destination adapter; peer is loaded lazily on subscribe/send so construction is safe
+     * @expectedResult The instance carries RC_ADAPTER_FACTORY === csv and mockAdapter(csv, ...).override.target === csv
+     */
+    test("csv() is tagged with its factory", () => {
+      const adapter = csv({ path: "/tmp/__never__.csv" });
+      expect(readFactoryTag(adapter)).toBe(csv);
+      const mock = mockAdapter(csv, { send: async () => undefined });
+      expect(mock.override.target).toBe(csv);
+    });
+
+    /**
+     * @case json() file-mode instances carry the factory tag; transformer-mode instances do not (resolver does not fire on transform)
+     * @preconditions json({ path }) returns the file adapter; json({}) returns the transformer
+     * @expectedResult File-mode instance is tagged with json; transformer-mode instance has no factory tag
+     */
+    test("json() is tagged in file mode only", () => {
+      const fileAdapter = json({ path: "/tmp/__never__.json" });
+      expect(readFactoryTag(fileAdapter)).toBe(json);
+
+      const transformer = json({});
+      expect(readFactoryTag(transformer)).toBeUndefined();
+
+      const mock = mockAdapter(json, { send: async () => undefined });
+      expect(mock.override.target).toBe(json);
+    });
+
+    /**
+     * @case jsonl() instances carry the factory tag across all return paths
+     * @preconditions jsonl({ path: string }) returns Source+Destination; jsonl({ path: fn }) returns Destination-only; jsonl({ path, chunked: true }) returns Source-only
+     * @expectedResult Each return shape carries RC_ADAPTER_FACTORY === jsonl
+     */
+    test("jsonl() is tagged across return paths", () => {
+      const combined = jsonl({ path: "/tmp/__never__.jsonl" });
+      const destOnly = jsonl({ path: () => "/tmp/__never__.jsonl" });
+      const sourceOnly = jsonl({ path: "/tmp/__never__.jsonl", chunked: true });
+
+      expect(readFactoryTag(combined)).toBe(jsonl);
+      expect(readFactoryTag(destOnly)).toBe(jsonl);
+      expect(readFactoryTag(sourceOnly)).toBe(jsonl);
+
+      const mock = mockAdapter(jsonl, { send: async () => undefined });
+      expect(mock.override.target).toBe(jsonl);
+    });
+
+    /**
+     * @case html() file-mode instances carry the factory tag; transformer-only instances do not
+     * @preconditions html({ path, selector }) returns Transformer+Source+Destination; html({ selector }) returns transformer only
+     * @expectedResult File-mode instance is tagged with html; transformer-only instance has no factory tag
+     */
+    test("html() is tagged in file mode only", () => {
+      const fileAdapter = html({
+        path: "/tmp/__never__.html",
+        selector: "title",
+        extract: "text",
+      });
+      expect(readFactoryTag(fileAdapter)).toBe(html);
+
+      const transformer = html({ selector: "title", extract: "text" });
+      expect(readFactoryTag(transformer)).toBeUndefined();
+
+      const mock = mockAdapter(html, { send: async () => undefined });
+      expect(mock.override.target).toBe(html);
+    });
+
+    /**
+     * @case mockAdapter(file, { source }) actually intercepts a real .from(file(...)) at route execution time
+     * @preconditions Route subscribes to file() pointed at a non-existent path; mock is registered with a fixture
+     * @expectedResult Real filesystem read is bypassed; the spy destination receives the mock fixture
+     */
+    test("mockAdapter(file, { source }) intercepts a route built with the factory", async () => {
+      const fileMock = mockAdapter<typeof file, string>(file, {
+        source: ["mocked file body"],
+      });
+      const captured = spy<string>();
+
+      const route = craft()
+        .id("file-mock-smoke")
+        .from(file({ path: "/tmp/__never_exists__/x.txt" }))
+        .to(captured);
+
+      t = await testContext().override(fileMock).routes(route).build();
+      await t.test();
+
+      expect(fileMock.calls.source).toHaveLength(1);
+      expect(captured.received).toHaveLength(1);
+      expect(captured.received[0].body).toBe("mocked file body");
+      expect(t.errors).toHaveLength(0);
     });
   });
 });

--- a/packages/testing/test/mock-adapter.test.ts
+++ b/packages/testing/test/mock-adapter.test.ts
@@ -25,12 +25,6 @@ import {
   type TestContext,
 } from "@routecraft/testing";
 
-const RC_ADAPTER_FACTORY = Symbol.for("routecraft.adapter.factory");
-
-function readFactoryTag(adapter: unknown): unknown {
-  return (adapter as Record<symbol, unknown>)[RC_ADAPTER_FACTORY];
-}
-
 /**
  * A handwritten destination class with a stable constructor. Used to
  * exercise the class-based override path where no factory tagging exists.
@@ -479,90 +473,143 @@ describe("mockAdapter", () => {
   });
 
   describe("first-party adapter factory tagging", () => {
-    /**
-     * @case file() instances carry the factory tag so mockAdapter(file, ...) can resolve them
-     * @preconditions file({ path }) constructs a Source+Destination adapter
-     * @expectedResult The instance carries RC_ADAPTER_FACTORY === file and mockAdapter(file, ...).override.target === file
-     */
-    test("file() is tagged with its factory", () => {
-      const adapter = file({ path: "/tmp/__never__.txt" });
-      expect(readFactoryTag(adapter)).toBe(file);
-      const mock = mockAdapter(file, { send: async () => undefined });
-      expect(mock.override.target).toBe(file);
-    });
+    type TaggedDestinationCase = readonly [
+      label: string,
+      factory: (...args: any[]) => unknown,
+      build: () => Destination<unknown, unknown>,
+    ];
+
+    const taggedDestinationCases: readonly TaggedDestinationCase[] = [
+      [
+        "file",
+        file,
+        () =>
+          file({ path: "/tmp/__never__.txt" }) as unknown as Destination<
+            unknown,
+            unknown
+          >,
+      ],
+      [
+        "csv",
+        csv,
+        () =>
+          csv({ path: "/tmp/__never__.csv" }) as unknown as Destination<
+            unknown,
+            unknown
+          >,
+      ],
+      [
+        "json (file mode)",
+        json,
+        () =>
+          json({ path: "/tmp/__never__.json" }) as unknown as Destination<
+            unknown,
+            unknown
+          >,
+      ],
+      [
+        "jsonl (combined)",
+        jsonl,
+        () =>
+          jsonl({ path: "/tmp/__never__.jsonl" }) as unknown as Destination<
+            unknown,
+            unknown
+          >,
+      ],
+      [
+        "jsonl (destination-only)",
+        jsonl,
+        () =>
+          jsonl({
+            path: () => "/tmp/__never__.jsonl",
+          }) as unknown as Destination<unknown, unknown>,
+      ],
+      [
+        "html (file mode)",
+        html,
+        () =>
+          html({
+            path: "/tmp/__never__.html",
+            selector: "title",
+            extract: "text",
+          }) as unknown as Destination<unknown, unknown>,
+      ],
+    ];
 
     /**
-     * @case csv() instances carry the factory tag so mockAdapter(csv, ...) can resolve them
-     * @preconditions csv({ path }) constructs a Source+Destination adapter; peer is loaded lazily on subscribe/send so construction is safe
-     * @expectedResult The instance carries RC_ADAPTER_FACTORY === csv and mockAdapter(csv, ...).override.target === csv
+     * @case mockAdapter(factory, { send }) intercepts .to(factory(...)) for every newly tagged first-party factory
+     * @preconditions Each row builds a destination-capable instance via the factory and registers a send-only mock
+     * @expectedResult The mock records exactly one send call and no errors surface (real adapter I/O is bypassed)
      */
-    test("csv() is tagged with its factory", () => {
-      const adapter = csv({ path: "/tmp/__never__.csv" });
-      expect(readFactoryTag(adapter)).toBe(csv);
-      const mock = mockAdapter(csv, { send: async () => undefined });
-      expect(mock.override.target).toBe(csv);
-    });
+    test.each(taggedDestinationCases)(
+      "%s: factory tag enables .to() interception via mockAdapter",
+      async (_label, factory, build) => {
+        const mock = mockAdapter(factory, { send: async () => undefined });
+        const route = craft()
+          .id("tag-smoke")
+          .from(simple({ payload: 1 }))
+          .to(build());
+
+        t = await testContext().override(mock).routes(route).build();
+        await t.test();
+
+        expect(mock.calls.send).toHaveLength(1);
+        expect(t.errors).toHaveLength(0);
+      },
+    );
 
     /**
-     * @case json() file-mode instances carry the factory tag; transformer-mode instances do not (resolver does not fire on transform)
-     * @preconditions json({ path }) returns the file adapter; json({}) returns the transformer
-     * @expectedResult File-mode instance is tagged with json; transformer-mode instance has no factory tag
+     * @case jsonl() chunked source-only return path is tagged so mockAdapter(jsonl, { source }) intercepts .from(jsonl(...))
+     * @preconditions Route subscribes to jsonl({ path, chunked: true }) pointed at a non-existent path
+     * @expectedResult Mock source fixture is delivered; no real filesystem read is attempted
      */
-    test("json() is tagged in file mode only", () => {
-      const fileAdapter = json({ path: "/tmp/__never__.json" });
-      expect(readFactoryTag(fileAdapter)).toBe(json);
-
-      const transformer = json({});
-      expect(readFactoryTag(transformer)).toBeUndefined();
-
-      const mock = mockAdapter(json, { send: async () => undefined });
-      expect(mock.override.target).toBe(json);
-    });
-
-    /**
-     * @case jsonl() instances carry the factory tag across all return paths
-     * @preconditions jsonl({ path: string }) returns Source+Destination; jsonl({ path: fn }) returns Destination-only; jsonl({ path, chunked: true }) returns Source-only
-     * @expectedResult Each return shape carries RC_ADAPTER_FACTORY === jsonl
-     */
-    test("jsonl() is tagged across return paths", () => {
-      const combined = jsonl({ path: "/tmp/__never__.jsonl" });
-      const destOnly = jsonl({ path: () => "/tmp/__never__.jsonl" });
-      const sourceOnly = jsonl({ path: "/tmp/__never__.jsonl", chunked: true });
-
-      expect(readFactoryTag(combined)).toBe(jsonl);
-      expect(readFactoryTag(destOnly)).toBe(jsonl);
-      expect(readFactoryTag(sourceOnly)).toBe(jsonl);
-
-      const mock = mockAdapter(jsonl, { send: async () => undefined });
-      expect(mock.override.target).toBe(jsonl);
-    });
-
-    /**
-     * @case html() file-mode instances carry the factory tag; transformer-only instances do not
-     * @preconditions html({ path, selector }) returns Transformer+Source+Destination; html({ selector }) returns transformer only
-     * @expectedResult File-mode instance is tagged with html; transformer-only instance has no factory tag
-     */
-    test("html() is tagged in file mode only", () => {
-      const fileAdapter = html({
-        path: "/tmp/__never__.html",
-        selector: "title",
-        extract: "text",
+    test("jsonl (source-only): factory tag enables .from() interception", async () => {
+      const jsonlMock = mockAdapter<typeof jsonl, { line: number }>(jsonl, {
+        source: [{ line: 1 }],
       });
-      expect(readFactoryTag(fileAdapter)).toBe(html);
+      const captured = spy<{ line: number }>();
 
-      const transformer = html({ selector: "title", extract: "text" });
-      expect(readFactoryTag(transformer)).toBeUndefined();
+      const route = craft()
+        .id("jsonl-source-smoke")
+        .from(
+          jsonl<{ line: number }>({
+            path: "/tmp/__never_exists__/x.jsonl",
+            chunked: true,
+          }),
+        )
+        .to(captured);
 
-      const mock = mockAdapter(html, { send: async () => undefined });
-      expect(mock.override.target).toBe(html);
+      t = await testContext().override(jsonlMock).routes(route).build();
+      await t.test();
+
+      expect(jsonlMock.calls.source).toHaveLength(1);
+      expect(captured.received[0].body).toEqual({ line: 1 });
+      expect(t.errors).toHaveLength(0);
     });
 
     /**
-     * @case mockAdapter(file, { source }) actually intercepts a real .from(file(...)) at route execution time
+     * @case Transformer-only return paths of json() and html() are intentionally not tagged
+     * @preconditions json({}) and html({ selector, extract }) return transformer-only adapters
+     * @expectedResult Returned adapters expose `transform` but not `subscribe` or `send`, matching the design that the override resolver only fires on subscribe/send
+     */
+    test("json() and html() transformer-only returns expose transform but not subscribe/send", () => {
+      const jsonTransformer = json({});
+      expect(jsonTransformer).toHaveProperty("transform");
+      expect(jsonTransformer).not.toHaveProperty("subscribe");
+      expect(jsonTransformer).not.toHaveProperty("send");
+
+      const htmlTransformer = html({ selector: "title", extract: "text" });
+      expect(htmlTransformer).toHaveProperty("transform");
+      expect(htmlTransformer).not.toHaveProperty("subscribe");
+      expect(htmlTransformer).not.toHaveProperty("send");
+    });
+
+    /**
+     * @case mockAdapter(file, { source }) intercepts a real .from(file(...)) at route execution time
      * @preconditions Route subscribes to file() pointed at a non-existent path; mock is registered with a fixture
      * @expectedResult Real filesystem read is bypassed; the spy destination receives the mock fixture
      */
-    test("mockAdapter(file, { source }) intercepts a route built with the factory", async () => {
+    test("file: mockAdapter(file, { source }) intercepts a route built with the factory", async () => {
       const fileMock = mockAdapter<typeof file, string>(file, {
         source: ["mocked file body"],
       });


### PR DESCRIPTION
Wraps every Source/Destination return path of file(), csv(), json() (file
mode), jsonl(), and html() (file mode) with tagAdapter() so they participate
in mockAdapter(factory, ...) resolution alongside mail(), http(), and mcp().
Pure-transformer return paths of json() and html() stay untagged because the
override resolver only fires on .from / .to / .enrich call sites.

Adds smoke tests confirming the factory tag is attached for every newly
tagged return shape, plus an end-to-end test using file() to verify the
override path actually intercepts a real route at execution time.

Closes the "tag remaining adapters" follow-up from #235. The testId escape
hatch and @beta stabilisation remain open as separate decisions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable factory-level mocking for `file()`, `csv()`, `json()` (file mode), `jsonl()`, and `html()` (file mode) by tagging their Source/Destination returns. This lets `mockAdapter(factory, ...)` intercept subscribe/send on `.from()`/`.to()`; transformer-only `json()`/`html()` stay untagged.

- **New Features**
  - Tag Source/Destination returns with `tagAdapter()` for `file()`, `csv()`, `json()` (file), `jsonl()` (destination-only, source-only, and combined), and `html()` (file).
  - Tests: table-driven smoke tests for destination-capable factories; `jsonl` chunked source-only interception; negative tests confirm transformer-only `json()`/`html()` are not intercepted.
  - Docs: enumerate newly tagged factories and call out the subscribe/send-only boundary.

- **Refactors**
  - Cache `args = factoryArgs(options)` in `html()` and `json()` for a consistent tagging shape.
  - Tests assert via public `mockAdapter` behavior instead of internal symbol checks.

<sup>Written for commit 0c3d6c19738e68ffcb79f460d010e28ec8ccac43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

