### PR TITLE
feat(ai): per-binding description override on tools([{ name }])

### DIFF
--- a/.standards/ci-cd.md
+++ b/.standards/ci-cd.md
@@ -30,7 +30,7 @@ Every PR must pass these jobs before merge. The first column matches the GitHub 
 | `integration-test (bun)` | `pnpm test:integration` under the Bun runtime | Bun runtime divergence in source / generated code. |
 | `cubic · AI code reviewer` | External AI reviewer | Dual-use review signal; informational on PR but does not gate merge. |
 
-The `validate` job is the cheapest signal — if it's red, fix that first. The `test` job uploads `coverage-report` as an artifact; reviewers can download to inspect uncovered lines.
+The `validate` job is the cheapest signal: if it's red, fix that first. The `test` job uploads `coverage-report` as an artifact; reviewers can download to inspect uncovered lines.
 
 ## 3. Rules contributors must follow
 
@@ -57,7 +57,7 @@ CI uses `pull_request_target`, not `pull_request`. This gives forks access to re
 
 ## 4. Adding a new package to CI
 
-The CI doesn't enumerate packages — `pnpm -r run build`, `pnpm test`, etc. walk every workspace package. To make a new package CI-visible:
+The CI doesn't enumerate packages; `pnpm -r run build`, `pnpm test`, etc. walk every workspace package. To make a new package CI-visible:
 
 1. Add it to `pnpm-workspace.yaml` (it'll get picked up automatically).
 2. Add `build`, `test` (if any tests exist), and ensure `tsc --noEmit` cleanliness from the workspace root.
@@ -89,7 +89,7 @@ This is enforced informally by review. When adding a new internal package that o
 
 ## 6. Optional peer dependencies (provider SDKs)
 
-External SDKs that a package only needs when a specific feature is used (Vercel AI SDK adapters, `@huggingface/transformers`, `@modelcontextprotocol/sdk`, etc.) live in `peerDependencies` AND `peerDependenciesMeta.<name>.optional = true`. The framework dynamically imports them inside the relevant code path and throws a friendly install message when the import fails. Don't add such deps to `dependencies` — that bloats every install.
+External SDKs that a package only needs when a specific feature is used (Vercel AI SDK adapters, `@huggingface/transformers`, `@modelcontextprotocol/sdk`, etc.) live in `peerDependencies` AND `peerDependenciesMeta.<name>.optional = true`. The framework dynamically imports them inside the relevant code path and throws a friendly install message when the import fails. Don't add such deps to `dependencies`; that bloats every install.
 
 ## 7. Local pre-PR checklist
 

--- a/.standards/testing.md
+++ b/.standards/testing.md
@@ -104,7 +104,7 @@ Errors thrown at construction (e.g. `validateAgentOptions` running inside `agent
 
 ## 7. Negative-path logging is expected
 
-Tests that exercise an error path through the framework boundary will produce error-level log output. This is deliberate: the framework's own logger ran. Do not treat such output as a test failure or filter it from CI logs. If a test produces noisy output but passes, leave it — the noise is the framework working as designed.
+Tests that exercise an error path through the framework boundary will produce error-level log output. This is deliberate: the framework's own logger ran. Do not treat such output as a test failure or filter it from CI logs. If a test produces noisy output but passes, leave it: the noise is the framework working as designed.
 
 ## 8. Snapshots
 
@@ -119,7 +119,7 @@ If you reach for a snapshot, prefer inline (`toMatchInlineSnapshot()`) over a se
 
 - **Mock at the boundary.** Mock `vi.mock("../src/llm/providers/index.ts")` to stub `callLlm` rather than mocking the Vercel AI SDK; the boundary is more stable than the dependency's API.
 - **Mock the SDK only when testing the boundary itself.** E.g. `stream-llm.test.ts` mocks `ai`'s `streamText` to exercise the real `streamLlm` containment behaviour.
-- **Mirror real behaviour in mocks.** If the real code catches listener errors, the mock should too — otherwise the test passes for the wrong reason.
+- **Mirror real behaviour in mocks.** If the real code catches listener errors, the mock should too; otherwise the test passes for the wrong reason.
 
 ## 10. What runs in CI
 

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -168,8 +168,8 @@ Options:
 | `delayMs` | `number` | `0` | No | Delay before first execution in milliseconds |
 | `repeatCount` | `number` | `Infinity` | No | Number of executions before stopping |
 | `fixedRate` | `boolean` | `false` | No | Execute at exact intervals ignoring processing time |
-| `exactTime` | `string` | — | No | Execute daily at time of day `HH:mm:ss` (fires once/day) |
-| `timePattern` | `string` | — | No | Custom date format for execution times |
+| `exactTime` | `string` | -- | No | Execute daily at time of day `HH:mm:ss` (fires once/day) |
+| `timePattern` | `string` | -- | No | Custom date format for execution times |
 | `jitterMs` | `number` | `0` | No | Random jitter added to each scheduled run |
 
 **Headers added:** Timer metadata including fired time, counter, period, and next run time
@@ -417,7 +417,7 @@ craft()
 
 **Header Validation**
 
-Without `input.headers`, all headers pass through unchanged. When specified, the same Zod 4 rules apply — with one twist: validated header values are always merged over the original request headers, so caller-supplied pass-through keys survive schemas that would normally strip them.
+Without `input.headers`, all headers pass through unchanged. When specified, the same Zod 4 rules apply, with one twist: validated header values are always merged over the original request headers, so caller-supplied pass-through keys survive schemas that would normally strip them.
 
 ```ts
 // No header schema - all headers pass through unchanged
@@ -572,12 +572,12 @@ Options:
 | Field | Type | Default | Required | Description |
 | --- | --- | --- | --- | --- |
 | `method` | `HttpMethod` | `'GET'` | No | HTTP method to use |
-| `url` | `string \| (exchange) => string` | — | Yes | Target URL (string or derived from exchange) |
+| `url` | `string \| (exchange) => string` | -- | Yes | Target URL (string or derived from exchange) |
 | `headers` | `Record<string,string> \| (exchange) => Record<string,string>` | `{}` | No | Request headers |
 | `query` | `Record<string,string|number|boolean> \| (exchange) => Query` | `{}` | No | Query parameters appended to URL |
-| `body` | `unknown \| (exchange) => unknown` | — | No | Request body (JSON serialized when not string/binary) |
+| `body` | `unknown \| (exchange) => unknown` | -- | No | Request body (JSON serialized when not string/binary) |
 | `throwOnHttpError` | `boolean` | `true` | No | Throw when response is non-2xx |
-| `timeoutMs` | `number` | — | No | Request timeout in milliseconds |
+| `timeoutMs` | `number` | -- | No | Request timeout in milliseconds |
 
 **Returns:** `HttpResult` object with `status`, `headers`, `body`, and `url`
 
@@ -727,7 +727,7 @@ craft()
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `runtime` | `"throw"` or `"noop"` | `"throw"` | `"throw"` (default): throw with adapter name when executed. `"noop"`: resolve without error (for tests). |
-| `args` | `"keyed"` | — | Set to `"keyed"` to get a factory `(key: string, opts?) => PseudoAdapter<R>`. |
+| `args` | `"keyed"` | -- | Set to `"keyed"` to get a factory `(key: string, opts?) => PseudoAdapter<R>`. |
 
 **Replacing with a real adapter:** keep the same call shape; only the import changes:
 
@@ -867,9 +867,9 @@ Parse and format JSON data, or read/write JSON files.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `path` | `string` | — | Dot-notation path to extract (e.g., `"data.items[0]"`) |
+| `path` | `string` | -- | Dot-notation path to extract (e.g., `"data.items[0]"`) |
 | `from` | `(body) => string` | Uses `body` or `body.body` | Extract JSON string from exchange |
-| `getValue` | `(parsed) => V` | — | Transform parsed value |
+| `getValue` | `(parsed) => V` | -- | Transform parsed value |
 | `to` | `(body, result) => R` | Replaces body | Where to put result |
 
 **File Options** (when `path` is a file path):
@@ -881,8 +881,8 @@ Parse and format JSON data, or read/write JSON files.
 | `encoding` | `BufferEncoding` | `'utf-8'` | Text encoding |
 | `createDirs` | `boolean` | `false` | Create parent directories (destination only) |
 | `indent` / `space` | `number` | `0` | JSON formatting spaces (destination only) |
-| `reviver` | `(key, value) => unknown` | — | JSON.parse reviver (source only) |
-| `replacer` | `(key, value) => unknown` | — | JSON.stringify replacer (destination only) |
+| `reviver` | `(key, value) => unknown` | -- | JSON.parse reviver (source only) |
+| `replacer` | `(key, value) => unknown` | -- | JSON.stringify replacer (destination only) |
 
 **Exported types:** `JsonAdapter`, `JsonFileAdapter`, `JsonOptions`, `JsonTransformerOptions`, `JsonFileOptions`
 
@@ -1133,7 +1133,7 @@ Extract data from HTML using CSS selectors (powered by cheerio), or read/write H
 |--------|------|---------|-------------|
 | `selector` | `string` | Required | CSS selector to match elements |
 | `extract` | `'text' \| 'html' \| 'attr' \| 'outerHtml' \| 'innerText' \| 'textContent'` | `'text'` | What to extract from matched elements |
-| `attr` | `string` | — | Attribute name (required when `extract: 'attr'`) |
+| `attr` | `string` | -- | Attribute name (required when `extract: 'attr'`) |
 | `from` | `(body) => string` | Uses `body` or `body.body` | Extract HTML string from exchange |
 | `to` | `(body, result) => R` | Replaces body | Where to put extracted result |
 
@@ -1677,14 +1677,14 @@ Model ID format: `"provider:model-name"` (e.g., `"ollama:llama3.2"`, `"anthropic
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `system` | `string \| (exchange) => string` | — | System prompt (static or derived from exchange) |
-| `user` | `string \| (exchange) => string` | — | User prompt (static or derived from exchange) |
-| `output` | `StandardSchemaV1` | — | Zod/Valibot/ArkType schema for structured output |
-| `temperature` | `number` | — | Sampling temperature |
-| `maxTokens` | `number` | — | Maximum tokens to generate |
-| `topP` | `number` | — | Top-p sampling |
-| `frequencyPenalty` | `number` | — | Frequency penalty |
-| `presencePenalty` | `number` | — | Presence penalty |
+| `system` | `string \| (exchange) => string` | -- | System prompt (static or derived from exchange) |
+| `user` | `string \| (exchange) => string` | -- | User prompt (static or derived from exchange) |
+| `output` | `StandardSchemaV1` | -- | Zod/Valibot/ArkType schema for structured output |
+| `temperature` | `number` | -- | Sampling temperature |
+| `maxTokens` | `number` | -- | Maximum tokens to generate |
+| `topP` | `number` | -- | Top-p sampling |
+| `frequencyPenalty` | `number` | -- | Frequency penalty |
+| `presencePenalty` | `number` | -- | Presence penalty |
 
 **Result shape (merged into body by `.enrich()`):**
 

--- a/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
@@ -27,9 +27,9 @@ export const craftConfig = defineConfig({
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `store` | `Map<keyof StoreRegistry, StoreRegistry[keyof StoreRegistry]>` | No | — | Initial values for the context store |
-| `on` | `Partial<Record<EventName, EventHandler \| EventHandler[]>>` | No | — | Event handlers to register on context creation |
-| `once` | `Partial<Record<EventName, EventHandler \| EventHandler[]>>` | No | — | One-time event handlers that fire once then auto-unsubscribe |
+| `store` | `Map<keyof StoreRegistry, StoreRegistry[keyof StoreRegistry]>` | No | -- | Initial values for the context store |
+| `on` | `Partial<Record<EventName, EventHandler \| EventHandler[]>>` | No | -- | Event handlers to register on context creation |
+| `once` | `Partial<Record<EventName, EventHandler \| EventHandler[]>>` | No | -- | One-time event handlers that fire once then auto-unsubscribe |
 | `cron` | `Partial<CronOptions>` | No | -- | Default options for all `cron()` sources ([details](#cron)) |
 | `direct` | `{ channelType?: DirectChannelType }` | No | -- | Custom channel implementation for all `direct()` endpoints ([details](#direct)) |
 | `mail` | `MailContextConfig` | No | -- | Mail adapter accounts (IMAP/SMTP) keyed by name |

--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -529,7 +529,7 @@ Enrich the exchange with additional data from a destination adapter. Uses the sa
 .enrich(http({ url: 'https://api.example.com/user' }), only((r) => r.body?.name, "userName"))
 ```
 
-**`only(getValue, into?)`** — Returns an aggregator that merges one value from the enrichment result. Omit `into` to spread a plain object onto the body, or use fallbacks: string → `body.text`, array → `body.array`. Provide `into` to set `body[into]`. Values that are `null` or `undefined` are never merged (exchange unchanged).
+**`only(getValue, into?)`**: Returns an aggregator that merges one value from the enrichment result. Omit `into` to spread a plain object onto the body, or use fallbacks: string → `body.text`, array → `body.array`. Provide `into` to set `body[into]`. Values that are `null` or `undefined` are never merged (exchange unchanged).
 
 **Key difference from `.to()`:**
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -587,9 +587,9 @@ agentPlugin({
 
 Flat array of items. Each item is one of:
 
-- **Bare string** — name lookup. Plain ids resolve against the fn registry; `direct_*` falls back to the direct registry via `directTool`. `agent_*` and `mcp_*` are reserved for future stories and currently throw a clear "not yet supported" error.
-- **`{ name, guard?, description? }`** — same name lookup, with optional per-binding overrides. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct. The `description` override applies only to this binding (the registry entry stays the source of truth, so other agents binding the same fn still see the canonical description). Use it when an agent's calling context calls for a different framing of the tool than the registered description provides — descriptions affect LLM tool-selection accuracy noticeably.
-- **`{ tagged, guard? }`** — selects every fn / route whose tags overlap the requested set (single tag or array). Optional guard applies to every match. Tag-zero-match contributes nothing without throwing. No description override on the tagged form: applying a single description to N matched tools is almost always wrong.
+- **Bare string**: name lookup. Plain ids resolve against the fn registry; `direct_*` falls back to the direct registry via `directTool`. `agent_*` and `mcp_*` are reserved for future stories and currently throw a clear "not yet supported" error.
+- **`{ name, guard?, description? }`**: same name lookup, with optional per-binding overrides. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct. The `description` override applies only to this binding (the registry entry stays the source of truth, so other agents binding the same fn still see the canonical description). Use it when an agent's calling context calls for a different framing of the tool than the registered description provides; descriptions affect LLM tool-selection accuracy noticeably.
+- **`{ tagged, guard? }`**: selects every fn / route whose tags overlap the requested set (single tag or array). Optional guard applies to every match. Tag-zero-match contributes nothing without throwing. No description override on the tagged form: applying a single description to N matched tools is almost always wrong.
 
 Resolution rules:
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -588,15 +588,15 @@ agentPlugin({
 Flat array of items. Each item is one of:
 
 - **Bare string** — name lookup. Plain ids resolve against the fn registry; `direct_*` falls back to the direct registry via `directTool`. `agent_*` and `mcp_*` are reserved for future stories and currently throw a clear "not yet supported" error.
-- **`{ name, guard? }`** — same name lookup, with an optional guard attached. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct.
-- **`{ tagged, guard? }`** — selects every fn / route whose tags overlap the requested set (single tag or array). Optional guard applies to every match. Tag-zero-match contributes nothing without throwing.
+- **`{ name, guard?, description? }`** — same name lookup, with optional per-binding overrides. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct. The `description` override applies only to this binding (the registry entry stays the source of truth, so other agents binding the same fn still see the canonical description). Use it when an agent's calling context calls for a different framing of the tool than the registered description provides — descriptions affect LLM tool-selection accuracy noticeably.
+- **`{ tagged, guard? }`** — selects every fn / route whose tags overlap the requested set (single tag or array). Optional guard applies to every match. Tag-zero-match contributes nothing without throwing. No description override on the tagged form: applying a single description to N matched tools is almost always wrong.
 
 Resolution rules:
 
 - Final list deduplicated by tool name.
 - Explicit refs always win over tag-selector matches, regardless of position in the list.
 - A `directTool(routeId)` fn-registry wrapper supersedes the same direct route surfaced via the prefix convention.
-- Input, description, and tag overrides at the use site are intentionally not supported. Definition is a registration concern: register a separate fn with `directTool(routeId, { description, input, tags })` if you need a custom view.
+- `description` is the only override permitted at the use site, and only on the explicit `{ name }` form. Input schema, tags, and any other registration-time fields are not overridable here. Register a separate fn with `directTool(routeId, { input, tags })` if you need a fundamentally different view.
 
 #### Builders
 

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -34,7 +34,7 @@ const EMPTY_OBJECT_JSON_SCHEMA = {
  *
  * Exposes both `~standard.validate` (mandatory per the spec) and the
  * non-standard `~standard.jsonSchema.{input,output}` extension that
- * the Vercel AI SDK bridge consumes — so this hand-rolled schema can
+ * the Vercel AI SDK bridge consumes, so this hand-rolled schema can
  * back tools and structured-output specs alongside Zod / Valibot
  * schemas without special-casing.
  */

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -29,15 +29,22 @@ export type ToolGuard = (
  *
  * - bare string: name lookup. Plain ids resolve against the fn registry;
  *   `direct_*` falls back to the direct registry via `directTool`.
- * - `{ name, guard? }`: same lookup, with a guard attached to that tool.
+ * - `{ name, guard?, description? }`: same lookup, with optional
+ *   per-binding overrides. The `description` override applies only to
+ *   THIS binding (the registry entry stays the source of truth, so
+ *   other agents binding the same fn see the canonical description).
+ *   Use this when an agent's calling context calls for a different
+ *   framing of the tool than the registered description provides.
  * - `{ tagged, guard? }`: select every fn / route whose tags include any
  *   of the requested tag(s). Optional guard applies to every match.
+ *   No description override here: applying one description to N
+ *   matched tools is almost always wrong.
  *
  * @experimental
  */
 export type ToolsItem =
   | string
-  | { name: string; guard?: ToolGuard }
+  | { name: string; guard?: ToolGuard; description?: string }
   | { tagged: Tag | Tag[]; guard?: ToolGuard };
 
 /**
@@ -157,7 +164,7 @@ export function tools(items: ToolsItem[]): ToolSelection {
         }
         if (item === null || typeof item !== "object") {
           throw rcError("RC5003", undefined, {
-            message: `tools(): each item must be a string, { name, guard? }, or { tagged, guard? }.`,
+            message: `tools(): each item must be a string, { name, guard?, description? }, or { tagged, guard? }.`,
           });
         }
         if ("name" in item) {
@@ -166,7 +173,23 @@ export function tools(items: ToolsItem[]): ToolSelection {
               message: `tools(): { name } must be a non-empty string.`,
             });
           }
-          const tool = resolveByName(ctx, item.name, item.guard);
+          if (
+            item.description !== undefined &&
+            (typeof item.description !== "string" ||
+              item.description.trim() === "")
+          ) {
+            throw rcError("RC5003", undefined, {
+              message: `tools(): { name: "${item.name}", description } must be a non-empty string when present.`,
+            });
+          }
+          const base = resolveByName(ctx, item.name, item.guard);
+          // Per-binding description override. The registry entry is
+          // never mutated, so other agents binding the same fn still
+          // see the canonical description.
+          const tool: ResolvedTool =
+            item.description !== undefined
+              ? { ...base, description: item.description }
+              : base;
           explicit.set(tool.name, tool);
         } else if (!("tagged" in item)) {
           throw rcError("RC5003", undefined, {

--- a/packages/ai/src/agent/tools/types.ts
+++ b/packages/ai/src/agent/tools/types.ts
@@ -49,7 +49,7 @@ export interface DeferredFn {
    * `directTool(routeId, { tags: [...] })`). When present these take
    * precedence over the underlying registry's tags for tag-selector
    * matching, so the user's override actually drives selection.
-   * Undefined when no override was supplied — the resolver then peeks
+   * Undefined when no override was supplied; the resolver then peeks
    * the underlying registry's tags for the match decision.
    */
   readonly overrideTags?: readonly Tag[];

--- a/packages/ai/test/agent-prompt-source.test.ts
+++ b/packages/ai/test/agent-prompt-source.test.ts
@@ -179,7 +179,7 @@ describe("agent prompt source: string and function forms (llm parity)", () => {
 
   /**
    * @case Function-form `system` that returns "" throws at dispatch
-   * @preconditions system: () => "" — empty resolved value
+   * @preconditions system: () => "" (empty resolved value)
    * @expectedResult Dispatch rejects with RC5003 and never calls the provider
    */
   test("function-form system returning empty string throws at dispatch", async () => {

--- a/packages/ai/test/agent-runtime.test.ts
+++ b/packages/ai/test/agent-runtime.test.ts
@@ -45,7 +45,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
 
   /**
    * @case Agent without tools dispatches callLlm without `tools` or `stopWhen`
-   * @preconditions Inline agent({ system, model }) — no tools field
+   * @preconditions Inline agent({ system, model }) without a tools field
    * @expectedResult callLlm receives the prompt only; no tools, stopWhen, or output
    */
   test("agent without tools omits tool wiring", async () => {

--- a/packages/ai/test/mcp-server.test.ts
+++ b/packages/ai/test/mcp-server.test.ts
@@ -996,7 +996,7 @@ describe("McpServer", () => {
         expect(h["routecraft.auth.audience"]).toEqual(["aud-a", "aud-b"]);
         expect(h["routecraft.auth.roles"]).toEqual(["member"]);
         expect(h["routecraft.auth.scopes"]).toEqual(["read", "write"]);
-        // JWT principals have no clientId — header must be absent.
+        // JWT principals have no clientId; header must be absent.
         expect(h["routecraft.auth.client_id"]).toBeUndefined();
       });
 

--- a/packages/ai/test/tool-bridge.test.ts
+++ b/packages/ai/test/tool-bridge.test.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { buildVercelTools } from "../src/agent/tool-bridge.ts";
 import type { ResolvedTool } from "../src/agent/tools/selection.ts";
 
-describe("buildVercelTools — execute path", () => {
+describe("buildVercelTools: execute path", () => {
   /**
    * @case Empty input returns empty record
    * @preconditions buildVercelTools([], undefined, signal)
@@ -38,7 +38,7 @@ describe("buildVercelTools — execute path", () => {
     const map = await buildVercelTools([resolved], undefined, sessionSignal);
     expect(Object.keys(map)).toEqual(["echo"]);
 
-    // Exercise the SDK's (input, options) contract — the second arg
+    // Exercise the SDK's (input, options) contract; the second arg
     // carries a per-call abortSignal which must override the
     // session-wide one captured at buildVercelTools time.
     const perCallSignal = new AbortController().signal;

--- a/packages/ai/test/tools-selection.test.ts
+++ b/packages/ai/test/tools-selection.test.ts
@@ -199,6 +199,59 @@ describe("tools() resolver - { name, guard }", () => {
     t = await buildCtx({ functions: { ...defaultFns } });
     expect(() => tools([{ name: "" }]).resolve(t!.ctx)).toThrow(/non-empty/i);
   });
+
+  /**
+   * @case { name, description } overrides description for THIS binding
+   * @preconditions tools([{ name: "currentTime", description: "Per-agent framing" }]) with currentTime registered
+   * @expectedResult ResolvedTool.description is the override; the registry entry's description is unchanged
+   */
+  test("{ name, description } overrides description per binding", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    const [resolved] = tools([
+      {
+        name: "currentTime",
+        description: "Per-agent framing of the time tool.",
+      },
+    ]).resolve(t.ctx);
+    expect(resolved.description).toBe("Per-agent framing of the time tool.");
+
+    // Registry entry stays canonical: a second binding without the
+    // override sees the original description.
+    const [resolved2] = tools(["currentTime"]).resolve(t.ctx);
+    expect(resolved2.description).toBe(defaultFns.currentTime.description);
+    expect(resolved2.description).not.toBe(resolved.description);
+  });
+
+  /**
+   * @case { name, description } rejects empty/blank string
+   * @preconditions tools([{ name: "currentTime", description: "" }])
+   * @expectedResult RC5003 with a message naming the field
+   */
+  test("{ name, description } rejects empty string", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    expect(() =>
+      tools([{ name: "currentTime", description: "" }]).resolve(t!.ctx),
+    ).toThrow(/description.*non-empty/i);
+  });
+
+  /**
+   * @case { name, description } combines with guard override
+   * @preconditions Both description and guard set in the same item
+   * @expectedResult Resolved tool has both the override description and the guard
+   */
+  test("{ name, guard, description } applies both overrides", async () => {
+    t = await buildCtx({ functions: { ...defaultFns } });
+    const guard = vi.fn();
+    const [resolved] = tools([
+      {
+        name: "currentTime",
+        guard,
+        description: "Reframed for this agent.",
+      },
+    ]).resolve(t.ctx);
+    expect(resolved.guard).toBe(guard);
+    expect(resolved.description).toBe("Reframed for this agent.");
+  });
 });
 
 describe("tools() resolver - tag selectors", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Routecraft CLI — single entry point.
+ * Routecraft CLI: single entry point.
  *
  * 1. Check Node version (Pino 10 needs Node 18.19+)
  * 2. Define program and parse; log options are global and applied before lazy-loading run/util (which load the logger)
@@ -143,7 +143,7 @@ program
       setImmediate(() => process.exit(code));
       return;
     }
-    // Don't call process.exit() — let the event loop drain naturally.
+    // Don't call process.exit(); let the event loop drain naturally.
     // process.exit() triggers C++ static destructors that race with ONNX
     // Runtime cleanup (onnxruntime#25038: "mutex lock failed").
   });

--- a/packages/create-routecraft/test/integration.test.ts
+++ b/packages/create-routecraft/test/integration.test.ts
@@ -218,7 +218,7 @@ const integrationTest = packagesBuilt ? test : test.skip;
 // source. On local runs this catches stale dist after editing source without
 // running `pnpm build`. On CI it is a belt-and-suspenders against cache
 // issues on the `pull_request_target` workflow (see cache key scoping in
-// ci.yml). Cheap — one tsup run on a single package.
+// ci.yml). Cheap: one tsup run on a single package.
 if (packagesBuilt) {
   execSync("pnpm --filter @routecraft/routecraft build", {
     cwd: MONOREPO_ROOT,

--- a/packages/eslint-plugin-routecraft/README.md
+++ b/packages/eslint-plugin-routecraft/README.md
@@ -41,8 +41,8 @@ export default [
 
 ## Rules
 
-- `routecraft/require-named-route` — Enforce `.id(<non-empty string>)` before `.from()` in a `craft()` chain
-- `routecraft/batch-before-from` — Enforce `batch()` is used as a route-level operation before `.from()`
+- `routecraft/require-named-route`: Enforce `.id(<non-empty string>)` before `.from()` in a `craft()` chain
+- `routecraft/batch-before-from`: Enforce `batch()` is used as a route-level operation before `.from()`
 
 ### routecraft/require-named-route
 

--- a/packages/routecraft/src/adapters/direct/destination.ts
+++ b/packages/routecraft/src/adapters/direct/destination.ts
@@ -35,7 +35,7 @@ export class DirectDestinationAdapter<T = unknown> implements Destination<
     const { getExchangeContext } = await import("../../exchange");
     const context = getExchangeContext(exchange);
     if (!context) {
-      throw new Error("Exchange has no context — cannot send via direct");
+      throw new Error("Exchange has no context; cannot send via direct");
     }
 
     // Resolve endpoint dynamically if needed

--- a/packages/routecraft/src/adapters/direct/shared.ts
+++ b/packages/routecraft/src/adapters/direct/shared.ts
@@ -166,7 +166,7 @@ class InMemoryDirectChannel<T> implements DirectChannel<T> {
       return await this.handler(message);
     }
     throw rcError("RC5004", undefined, {
-      message: `No handler subscribed on direct endpoint "${endpoint}" — route may have stopped or was never started`,
+      message: `No handler subscribed on direct endpoint "${endpoint}"; route may have stopped or was never started`,
     });
   }
 

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -665,7 +665,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
         const context = getExchangeContext(exchange);
         if (!context) {
           throw rcError("RC5001", undefined, {
-            message: "Exchange has no context — cannot execute default split",
+            message: "Exchange has no context; cannot execute default split",
           });
         }
         const body = exchange.body;

--- a/packages/routecraft/src/operations/split.ts
+++ b/packages/routecraft/src/operations/split.ts
@@ -73,7 +73,7 @@ export class SplitStep<T = unknown, R = unknown> implements Step<
     const route = getExchangeRoute(exchange);
 
     if (!context) {
-      throw new Error("Exchange has no context — cannot execute split");
+      throw new Error("Exchange has no context; cannot execute split");
     }
 
     const routeId =

--- a/packages/routecraft/src/operations/tap.ts
+++ b/packages/routecraft/src/operations/tap.ts
@@ -58,7 +58,7 @@ export class TapStep<T = unknown> implements Step<Destination<T, unknown>> {
     const route = getExchangeRoute(exchange);
 
     if (!context || !route) {
-      throw new Error("Exchange has no context or route — cannot execute tap");
+      throw new Error("Exchange has no context or route; cannot execute tap");
     }
 
     const snapshot = snapshotExchange(exchange, context);

--- a/packages/testing/src/test-context.ts
+++ b/packages/testing/src/test-context.ts
@@ -179,7 +179,7 @@ export class TestContext {
    * Start context, wait for all routes ready, optionally delay, drain in-flight, then stop.
    * Assert after this returns (mocks, t.errors, t.ctx.getStore() all valid).
    *
-   * @param options.delayBeforeDrainMs — If set, wait this many ms after routes are ready before draining.
+   * @param options.delayBeforeDrainMs If set, wait this many ms after routes are ready before draining.
    *   Use for timer (or other deferred) sources so at least one message is processed before drain/stop.
    */
   async test(options?: TestOptions): Promise<void> {


### PR DESCRIPTION
## Summary

Adds an optional `description` field to the explicit `{ name }` form of `tools([...])` items. The override applies to **this binding only** — the fn registry entry stays the source of truth, so other agents binding the same fn still see the canonical description.

```ts
agent({
  tools: tools([
    "currentTime",                                                    // canonical
    { name: "fetchOrder", description: "Look up customer's recent purchases." }, // reframed
    { name: "sendSlack", guard: requireApproval, description: "Notify the on-call channel only." }, // both overrides
  ]),
})
```

## Motivation

Surfaced via feedback on #113: LLMs read tool descriptions hard, and the same underlying function may want different framings depending on which agent is calling it. Without a per-binding override, contributors either accept one-size-fits-all or register duplicate fns to differ on description — which drifts and inflates tool counts. Field report cited a 40% reduction in tool count once a similar setup consolidated to "registry + per-binding overrides".

## Design

- Override applies only to the explicit `{ name, ... }` form.
- Override is per-binding: `ResolvedTool.description` is set on the resolved entry returned to the agent; the registry entry never mutates.
- Empty / blank strings are rejected at `resolve()` with `RC5003`.
- The `{ tagged }` form intentionally does NOT support `description`. Applying a single description to N matched tools is almost always wrong.
- Composes with `guard?` — both can be set on the same item.

## Tests

3 new cases in `tools-selection.test.ts`:

- `{ name, description }` overrides the description for the binding; a second binding without the override sees the canonical description (registry stays clean).
- `{ name, description: "" }` throws `RC5003` at resolve.
- `{ name, guard, description }` applies both overrides.

Suite: **963 pass / 1 skipped** (was 960, +3 new, no regressions).

## Verification

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm test`

## Test plan

- [ ] Reviewer confirms the override semantics match expectation (per-binding only).
- [ ] CI green.

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional per-binding description override to `tools([{ name }])` so each agent can reframe a tool without changing the registry, improving LLM tool selection. Also includes a repo-wide punctuation cleanup per the style guide (no behavior changes).

- **New Features**
  - `tools([{ name, description }])` overrides the description for that binding only; the registry stays canonical.
  - Empty or blank `description` is rejected at resolve with `RC5003`.
  - `{ tagged }` items do not support `description`. Works with `guard?`. 3 tests added.

- **Refactors**
  - Replaced em-dashes across the repo with `:`/`;` and `--` in docs tables to match style guidelines; documentation and comments updated without changing behavior.

<sup>Written for commit 022fd2c261199e341b0247e6b1d504969697c1a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

