### PR TITLE
feat(routecraft)!: route source-level parse errors through .error() handler (closes #187)

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -747,11 +747,13 @@ import { mcp } from "@routecraft/mcp-adapter";
 
 Source adapters that convert raw bytes into a structured body (`json`, `html`, `csv`, `jsonl`, `mail`) accept a uniform `onParseError` option that controls what happens when parsing fails (malformed JSON, structurally-invalid CSV row, broken MIME, etc.). The default is `'fail'`.
 
-| Value | Behaviour | Use case |
-|-------|-----------|----------|
-| `'fail'` (default) | The exchange fails inside the pipeline. The route's `.error()` handler is invoked with an `RC5016` error, or `exchange:failed` fires when no handler is set. Streaming adapters (`csv` chunked, `jsonl` chunked, `mail`) continue to the next item. | Per-item observability with stream continuation. |
-| `'abort'` | The source aborts on the first parse failure. No exchange is created; the subscribe promise rejects and `context:error` fires. | Atomic-load semantics where partial data is unacceptable. |
-| `'skip'` | The malformed item is silently dropped. A `warn`-level log is emitted. No exchange is created. Streaming adapters continue. | Lossy upstreams (scraping, public feeds) where malformed items are expected. |
+All three modes are observable on the events bus -- parse failures are never silent.
+
+| Value | Lifecycle events | Use case |
+|-------|------------------|----------|
+| `'fail'` (default) | `exchange:started` -> `exchange:failed` (or `error:caught` if `.error()` recovers) with `error.rc === 'RC5016'`. Streaming adapters continue to the next item. | Per-item observability with stream continuation. |
+| `'abort'` | `exchange:started` -> `exchange:failed` for the bad item, then the source rejects and `context:error` fires. | Atomic-load semantics where partial data is unacceptable. |
+| `'drop'` | `exchange:started` -> `exchange:dropped` with `reason: 'parse-failed'`. No `.error()` invocation. Streaming adapters continue. | Lossy upstreams (scraping, public feeds) where malformed items are expected but should still be counted. |
 
 ```ts
 // Default: route per-line parse errors through .error(), keep streaming.
@@ -767,11 +769,16 @@ craft()
 // Stop the stream on the first malformed row (atomic-import semantics).
 craft().from(csv({ path: './daily.csv', chunked: true, onParseError: 'abort' })).to(load());
 
-// Silently drop unparseable mail messages.
-craft().from(mail('INBOX', { onParseError: 'skip' })).to(process());
+// Drop unparseable mail with structured event observability.
+craft().from(mail('INBOX', { onParseError: 'drop' })).to(process());
+
+// Subscribe to parse drops across all routes:
+ctx.on('route:*:exchange:dropped', ({ details }) => {
+  if (details.reason === 'parse-failed') metrics.increment('source.parse.dropped');
+});
 ```
 
-Internally, `'fail'` mode defers parsing to a synthetic first pipeline step injected by the runtime, so `exchange:started` fires before parsing runs. This is what lets the route's `.error()` handler catch parse failures without the source aborting.
+Internally, all three modes defer parsing to a synthetic first pipeline step injected by the runtime, so `exchange:started` fires before parsing runs. The synthetic step decides per-mode whether to throw (`'fail'`/`'abort'`) or emit `exchange:dropped` (`'drop'`).
 
 ## File adapters
 
@@ -913,7 +920,7 @@ Parse and format JSON data, or read/write JSON files.
 | `indent` / `space` | `number` | `0` | JSON formatting spaces (destination only) |
 | `reviver` | `(key, value) => unknown` | -- | JSON.parse reviver (source only) |
 | `replacer` | `(key, value) => unknown` | -- | JSON.stringify replacer (destination only) |
-| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle a parse failure (source only). See [parse error handling](#parse-error-handling). |
+| `onParseError` | `'fail' \| 'abort' \| 'drop'` | `'fail'` | How to handle a parse failure (source only). See [parse error handling](#parse-error-handling). |
 
 **Exported types:** `JsonAdapter`, `JsonFileAdapter`, `JsonOptions`, `JsonTransformerOptions`, `JsonFileOptions`
 
@@ -992,11 +999,11 @@ npm install papaparse
 | `mode` | `'write' \| 'append'` | `'write'` | File operation mode (destination only) |
 | `createDirs` | `boolean` | `false` | Create parent directories (destination only) |
 | `chunked` | `boolean` | `false` | Emit one exchange per row instead of entire array (source only) |
-| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle a row parse failure (source only). See [parse error handling](#parse-error-handling). |
+| `onParseError` | `'fail' \| 'abort' \| 'drop'` | `'fail'` | How to handle a row parse failure (source only). See [parse error handling](#parse-error-handling). |
 
 **Behavior:**
 - **Source** (default): Emits entire CSV as array of records (objects if `header: true`, arrays if `header: false`)
-- **Source** (`chunked: true`): Emits one exchange per row with `CSV_ROW` (1-based row number) and `CSV_PATH` headers. Returns `Source` only (no `Destination`). With `onParseError: 'fail'` (default) malformed rows are routed through the route's `.error()` handler and the stream continues; `'abort'` reverts to fail-fast on the first bad row; `'skip'` silently drops the row.
+- **Source** (`chunked: true`): Emits one exchange per row with `CSV_ROW` (1-based row number) and `CSV_PATH` headers. Returns `Source` only (no `Destination`). With `onParseError: 'fail'` (default) malformed rows are routed through the route's `.error()` handler and the stream continues; `'abort'` reverts to fail-fast on the first bad row; `'drop'` emits `exchange:dropped` with `reason: 'parse-failed'`.
 - **Destination**: Writes exchange body (array of objects/arrays) as CSV. For `mode: 'append'`, skips header row if file exists
 
 ```ts
@@ -1063,7 +1070,7 @@ Read and write [JSON Lines](https://jsonlines.org/) files (one JSON object per l
 | `encoding` | `BufferEncoding` | `'utf-8'` | Text encoding |
 | `chunked` | `boolean` | `false` | Emit one exchange per line instead of a single array |
 | `reviver` | `(key, value) => unknown` | - | Reviver function passed to `JSON.parse` |
-| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle a line parse failure. See [parse error handling](#parse-error-handling). |
+| `onParseError` | `'fail' \| 'abort' \| 'drop'` | `'fail'` | How to handle a line parse failure. See [parse error handling](#parse-error-handling). |
 
 **Destination options (`JsonlDestinationOptions`):**
 
@@ -1077,7 +1084,7 @@ Read and write [JSON Lines](https://jsonlines.org/) files (one JSON object per l
 
 **Behavior:**
 - **Source** (default): Reads file, splits lines, parses each as JSON, emits `T[]` array. Empty lines are skipped.
-- **Source** (`chunked: true`): Emits one `T` exchange per line with `JSONL_LINE` (1-based) and `JSONL_PATH` headers. Returns `Source` only (no `Destination`). With `onParseError: 'fail'` (default) malformed lines are routed through the route's `.error()` handler and the stream continues; `'abort'` aborts on the first bad line; `'skip'` silently drops the line.
+- **Source** (`chunked: true`): Emits one `T` exchange per line with `JSONL_LINE` (1-based) and `JSONL_PATH` headers. Returns `Source` only (no `Destination`). With `onParseError: 'fail'` (default) malformed lines are routed through the route's `.error()` handler and the stream continues; `'abort'` aborts on the first bad line; `'drop'` emits `exchange:dropped` with `reason: 'parse-failed'`.
 - **Destination**: Stringifies body to `JSON.stringify(body) + '\n'`. Array bodies write one line per element. Default mode is append.
 
 **Chunked headers:**
@@ -1180,7 +1187,7 @@ All transformer options above, plus:
 | `mode` | `'read' \| 'write' \| 'append'` | `'read'` for source, `'write'` for destination | File operation mode |
 | `encoding` | `BufferEncoding` | `'utf-8'` | Text encoding |
 | `createDirs` | `boolean` | `false` | Create parent directories (destination only) |
-| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle an extraction failure (source only). See [parse error handling](#parse-error-handling). |
+| `onParseError` | `'fail' \| 'abort' \| 'drop'` | `'fail'` | How to handle an extraction failure (source only). See [parse error handling](#parse-error-handling). |
 
 **Extract types:**
 - `text` / `innerText` / `textContent`: Plain text content (strips HTML tags, removes `<style>` and `<script>`)
@@ -1360,7 +1367,7 @@ When multiple accounts are configured, select one per adapter call with the `acc
 | `limit` | `number` | | Maximum messages per fetch |
 | `pollIntervalMs` | `number` | | Poll interval in ms (default: IMAP IDLE) |
 | `account` | `string` | | Named account from context config (uses default if omitted) |
-| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle a per-message MIME parse failure. See [parse error handling](#parse-error-handling). Pre-#187 behaviour was equivalent to `'skip'` but logged at debug; the new `'fail'` default routes failures through `.error()` and marks the malformed message Seen so it does not retry forever. |
+| `onParseError` | `'fail' \| 'abort' \| 'drop'` | `'fail'` | How to handle a per-message MIME parse failure. See [parse error handling](#parse-error-handling). Pre-#187 behaviour was equivalent to silent `'drop'` (logged at debug, no event); the new `'fail'` default routes failures through `.error()` and marks the malformed message Seen so it does not retry forever. Set `onParseError: 'drop'` to keep lossy-ingest semantics with structured `exchange:dropped` observability. |
 
 **Client options (`MailClientOptions`):**
 

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -743,6 +743,36 @@ import { mcp } from "@routecraft/mcp-adapter";
 
 **Exported types:** `PseudoAdapter<R>`, `PseudoFactory<Opts>`, `PseudoKeyedFactory<Opts>`, `PseudoOptions`, `PseudoKeyedOptions`
 
+## Parse error handling
+
+Source adapters that convert raw bytes into a structured body (`json`, `html`, `csv`, `jsonl`, `mail`) accept a uniform `onParseError` option that controls what happens when parsing fails (malformed JSON, structurally-invalid CSV row, broken MIME, etc.). The default is `'fail'`.
+
+| Value | Behaviour | Use case |
+|-------|-----------|----------|
+| `'fail'` (default) | The exchange fails inside the pipeline. The route's `.error()` handler is invoked with an `RC5016` error, or `exchange:failed` fires when no handler is set. Streaming adapters (`csv` chunked, `jsonl` chunked, `mail`) continue to the next item. | Per-item observability with stream continuation. |
+| `'abort'` | The source aborts on the first parse failure. No exchange is created; the subscribe promise rejects and `context:error` fires. | Atomic-load semantics where partial data is unacceptable. |
+| `'skip'` | The malformed item is silently dropped. A `warn`-level log is emitted. No exchange is created. Streaming adapters continue. | Lossy upstreams (scraping, public feeds) where malformed items are expected. |
+
+```ts
+// Default: route per-line parse errors through .error(), keep streaming.
+craft()
+  .from(jsonl({ path: './events.jsonl', chunked: true }))
+  .error((err, exchange) => {
+    log.warn({ err, line: exchange.headers['routecraft.jsonl.line'] }, 'bad line');
+    return null;
+  })
+  .filter((e) => e.body != null)
+  .to(db());
+
+// Stop the stream on the first malformed row (atomic-import semantics).
+craft().from(csv({ path: './daily.csv', chunked: true, onParseError: 'abort' })).to(load());
+
+// Silently drop unparseable mail messages.
+craft().from(mail('INBOX', { onParseError: 'skip' })).to(process());
+```
+
+Internally, `'fail'` mode defers parsing to a synthetic first pipeline step injected by the runtime, so `exchange:started` fires before parsing runs. This is what lets the route's `.error()` handler catch parse failures without the source aborting.
+
 ## File adapters
 
 ### file
@@ -883,6 +913,7 @@ Parse and format JSON data, or read/write JSON files.
 | `indent` / `space` | `number` | `0` | JSON formatting spaces (destination only) |
 | `reviver` | `(key, value) => unknown` | -- | JSON.parse reviver (source only) |
 | `replacer` | `(key, value) => unknown` | -- | JSON.stringify replacer (destination only) |
+| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle a parse failure (source only). See [parse error handling](#parse-error-handling). |
 
 **Exported types:** `JsonAdapter`, `JsonFileAdapter`, `JsonOptions`, `JsonTransformerOptions`, `JsonFileOptions`
 
@@ -961,10 +992,11 @@ npm install papaparse
 | `mode` | `'write' \| 'append'` | `'write'` | File operation mode (destination only) |
 | `createDirs` | `boolean` | `false` | Create parent directories (destination only) |
 | `chunked` | `boolean` | `false` | Emit one exchange per row instead of entire array (source only) |
+| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle a row parse failure (source only). See [parse error handling](#parse-error-handling). |
 
 **Behavior:**
 - **Source** (default): Emits entire CSV as array of records (objects if `header: true`, arrays if `header: false`)
-- **Source** (`chunked: true`): Emits one exchange per row with `CSV_ROW` (1-based row number) and `CSV_PATH` headers. Returns `Source` only (no `Destination`). Parse errors throw and are handled by the route's error handler.
+- **Source** (`chunked: true`): Emits one exchange per row with `CSV_ROW` (1-based row number) and `CSV_PATH` headers. Returns `Source` only (no `Destination`). With `onParseError: 'fail'` (default) malformed rows are routed through the route's `.error()` handler and the stream continues; `'abort'` reverts to fail-fast on the first bad row; `'skip'` silently drops the row.
 - **Destination**: Writes exchange body (array of objects/arrays) as CSV. For `mode: 'append'`, skips header row if file exists
 
 ```ts
@@ -1031,6 +1063,7 @@ Read and write [JSON Lines](https://jsonlines.org/) files (one JSON object per l
 | `encoding` | `BufferEncoding` | `'utf-8'` | Text encoding |
 | `chunked` | `boolean` | `false` | Emit one exchange per line instead of a single array |
 | `reviver` | `(key, value) => unknown` | - | Reviver function passed to `JSON.parse` |
+| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle a line parse failure. See [parse error handling](#parse-error-handling). |
 
 **Destination options (`JsonlDestinationOptions`):**
 
@@ -1044,7 +1077,7 @@ Read and write [JSON Lines](https://jsonlines.org/) files (one JSON object per l
 
 **Behavior:**
 - **Source** (default): Reads file, splits lines, parses each as JSON, emits `T[]` array. Empty lines are skipped.
-- **Source** (`chunked: true`): Emits one `T` exchange per line with `JSONL_LINE` (1-based) and `JSONL_PATH` headers. Returns `Source` only (no `Destination`). Parse errors throw and are handled by the route's error handler.
+- **Source** (`chunked: true`): Emits one `T` exchange per line with `JSONL_LINE` (1-based) and `JSONL_PATH` headers. Returns `Source` only (no `Destination`). With `onParseError: 'fail'` (default) malformed lines are routed through the route's `.error()` handler and the stream continues; `'abort'` aborts on the first bad line; `'skip'` silently drops the line.
 - **Destination**: Stringifies body to `JSON.stringify(body) + '\n'`. Array bodies write one line per element. Default mode is append.
 
 **Chunked headers:**
@@ -1147,6 +1180,7 @@ All transformer options above, plus:
 | `mode` | `'read' \| 'write' \| 'append'` | `'read'` for source, `'write'` for destination | File operation mode |
 | `encoding` | `BufferEncoding` | `'utf-8'` | Text encoding |
 | `createDirs` | `boolean` | `false` | Create parent directories (destination only) |
+| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle an extraction failure (source only). See [parse error handling](#parse-error-handling). |
 
 **Extract types:**
 - `text` / `innerText` / `textContent`: Plain text content (strips HTML tags, removes `<style>` and `<script>`)
@@ -1326,6 +1360,7 @@ When multiple accounts are configured, select one per adapter call with the `acc
 | `limit` | `number` | | Maximum messages per fetch |
 | `pollIntervalMs` | `number` | | Poll interval in ms (default: IMAP IDLE) |
 | `account` | `string` | | Named account from context config (uses default if omitted) |
+| `onParseError` | `'fail' \| 'abort' \| 'skip'` | `'fail'` | How to handle a per-message MIME parse failure. See [parse error handling](#parse-error-handling). Pre-#187 behaviour was equivalent to `'skip'` but logged at debug; the new `'fail'` default routes failures through `.error()` and marks the malformed message Seen so it does not retry forever. |
 
 **Client options (`MailClientOptions`):**
 

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -1367,7 +1367,7 @@ When multiple accounts are configured, select one per adapter call with the `acc
 | `limit` | `number` | | Maximum messages per fetch |
 | `pollIntervalMs` | `number` | | Poll interval in ms (default: IMAP IDLE) |
 | `account` | `string` | | Named account from context config (uses default if omitted) |
-| `onParseError` | `'fail' \| 'abort' \| 'drop'` | `'fail'` | How to handle a per-message MIME parse failure. See [parse error handling](#parse-error-handling). Pre-#187 behaviour was equivalent to silent `'drop'` (logged at debug, no event); the new `'fail'` default routes failures through `.error()` and marks the malformed message Seen so it does not retry forever. Set `onParseError: 'drop'` to keep lossy-ingest semantics with structured `exchange:dropped` observability. |
+| `onParseError` | `'fail' \| 'abort' \| 'drop'` | `'fail'` | How to handle a per-message MIME parse failure. See [parse error handling](#parse-error-handling). All three modes mark the malformed message Seen so it does not refetch forever. `'fail'` routes the failure through the route's `.error()` handler (or `exchange:failed` if no handler is set). `'drop'` does NOT invoke `.error()`; it emits `exchange:dropped` with `reason: 'parse-failed'` so subscribers can count parse drops as a structured event without scraping logs. Pre-#187 behaviour was equivalent to a silent `'drop'` (logged at debug, no event); set `onParseError: 'drop'` to keep lossy-ingest semantics with structured observability. |
 
 **Client options (`MailClientOptions`):**
 

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -228,7 +228,7 @@ A source adapter that converts raw bytes into a structured body (json, html, csv
 - Switch `onParseError` per adapter to control behaviour:
   - `'fail'` (default): the exchange fails; the route handles it. Streaming sources continue to the next item.
   - `'abort'`: the source aborts on the first parse failure (atomic-load semantics).
-  - `'skip'`: the bad item is silently dropped with a warn log (lossy ingest).
+  - `'drop'`: the bad item fires `exchange:dropped` with `reason: 'parse-failed'` (lossy ingest with structured observability).
 - For CSV chunked, inspect the row number on the captured error to identify the malformed row.
 
 ## RC9901

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -28,6 +28,7 @@ The `retryable` property indicates whether the [`retry`](/docs/reference/operati
 | [RC5013](#rc5013) | Adapter | Rate limited | Yes |
 | [RC5014](#rc5014) | Adapter | Resource not found | No |
 | [RC5015](#rc5015) | Adapter | Permission denied | No |
+| [RC5016](#rc5016) | Adapter | Source payload parse failed | No |
 | [RC9901](#rc9901) | Runtime | Unknown error | Yes |
 
 ---
@@ -215,6 +216,20 @@ Access control or IAM denied the operation (e.g. 403).
 
 **Suggestion**  
 Check access control, IAM, and scopes.
+
+## RC5016
+Source payload parse failed
+
+**Why it happens**  
+A source adapter that converts raw bytes into a structured body (json, html, csv, jsonl, mail) could not parse the input. With the default `onParseError: 'fail'`, the adapter defers parsing to the route's pipeline so the failure is observable per exchange and the route's `.error()` handler can recover. Causes include malformed JSON, structurally-invalid CSV rows (mismatched columns), broken HTML matching, or malformed MIME.
+
+**Suggestion**  
+- Wire `.error()` on the route to log, repair, or quarantine the bad payload, then return a fallback value to keep the pipeline alive.
+- Switch `onParseError` per adapter to control behaviour:
+  - `'fail'` (default): the exchange fails; the route handles it. Streaming sources continue to the next item.
+  - `'abort'`: the source aborts on the first parse failure (atomic-load semantics).
+  - `'skip'`: the bad item is silently dropped with a warn log (lossy ingest).
+- For CSV chunked, inspect the row number on the captured error to identify the malformed row.
 
 ## RC9901
 Unknown error

--- a/apps/routecraft.dev/src/app/docs/reference/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/events/page.md
@@ -112,6 +112,36 @@ After a split, each child exchange emits its own `exchange:started`. When aggreg
 | `route:{routeId}:operation:error:recovered` | Handler succeeded | `{ routeId, exchangeId, correlationId }` |
 | `route:{routeId}:operation:error:failed` | Handler also failed | `{ routeId, exchangeId, correlationId, error }` |
 
+### Source-parse operations
+
+Parsing source adapters (`json`, `html`, `csv`, `jsonl`, `mail`) defer parsing
+to a synthetic first pipeline step so parse failures become normal pipeline
+events. The synthetic step appears in the standard `step:*` events with
+`operation: "parse"`.
+
+| Event | When it fires | Details |
+| --- | --- | --- |
+| `route:{routeId}:step:started` (`operation: "parse"`) | Synthetic parse step begins, before any user step | `{ routeId, exchangeId, correlationId, operation: "parse", adapter: "parse" }` |
+| `route:{routeId}:step:completed` (`operation: "parse"`) | Parse succeeded; user steps run next | `{ ..., duration }` |
+| `route:{routeId}:step:failed` (`operation: "parse"`) | Parse threw `RC5016` | `{ ..., error }` |
+
+What follows depends on the adapter's `onParseError` mode:
+
+- `'fail'` (default) → `exchange:failed` (or `error:caught` if a route `.error()` handler recovers).
+- `'abort'` → `exchange:failed` for the bad item, then the source aborts and `context:error` fires.
+- `'drop'` → `exchange:dropped` with `reason: "parse-failed"` (no `step:failed` fires; the parse step catches and drops cleanly).
+
+Subscribe with a glob to count source parse failures across all routes:
+
+```ts
+ctx.on('route:*:step:failed', ({ details }) => {
+  if (details.operation === 'parse') metrics.increment('source.parse.failed');
+});
+ctx.on('route:*:exchange:dropped', ({ details }) => {
+  if (details.reason === 'parse-failed') metrics.increment('source.parse.dropped');
+});
+```
+
 ## Plugin events
 
 Plugin events are scoped to a plugin ID.

--- a/packages/routecraft/src/adapters/csv/source.ts
+++ b/packages/routecraft/src/adapters/csv/source.ts
@@ -57,7 +57,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
           message: CsvRow,
           headers?: ExchangeHeaders,
           parse?: (raw: unknown) => unknown | Promise<unknown>,
-          parseFailureMode?: "fail" | "abort" | "drop",
+          parseFailureMode?: OnParseError,
         ) => Promise<import("../../exchange.ts").Exchange>,
         abortController,
         { header, delimiter, quoteChar, skipEmptyLines },
@@ -85,7 +85,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
           message: CsvData,
           headers?: ExchangeHeaders,
           parse?: (raw: unknown) => unknown | Promise<unknown>,
-          parseFailureMode?: "fail" | "abort" | "drop",
+          parseFailureMode?: OnParseError,
         ) => Promise<import("../../exchange.ts").Exchange>;
 
         const parseFn = (raw: unknown): CsvData => {
@@ -128,7 +128,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
       message: CsvRow,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
-      parseFailureMode?: "fail" | "abort" | "drop",
+      parseFailureMode?: OnParseError,
     ) => Promise<import("../../exchange.ts").Exchange>,
     abortController: AbortController,
     parseOptions: {

--- a/packages/routecraft/src/adapters/csv/source.ts
+++ b/packages/routecraft/src/adapters/csv/source.ts
@@ -5,7 +5,11 @@ import { HeadersKeys, type ExchangeHeaders } from "../../exchange.ts";
 import { file } from "../file/index.ts";
 import { ensurePapaparse } from "./shared.ts";
 import { throwFileError } from "../shared/line-reader.ts";
-import { DEFAULT_ON_PARSE_ERROR, type OnParseError } from "../shared/parse.ts";
+import {
+  DEFAULT_ON_PARSE_ERROR,
+  isParseError,
+  type OnParseError,
+} from "../shared/parse.ts";
 import type { CraftContext } from "../../context.ts";
 
 /**
@@ -110,10 +114,22 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
           parseFn,
           onParseError,
         );
-        if (onParseError === "abort") {
-          return await promise;
-        }
-        return await promise.catch(() => undefined as never);
+        // 'abort' is parse-specific: only RC5016 should tear down the
+        // source. A downstream destination error must NOT propagate as
+        // an abort signal even when onParseError === 'abort'.
+        return await promise.catch((err: unknown) => {
+          if (onParseError === "abort" && isParseError(err)) throw err;
+          if (onParseError !== "abort") return undefined as never;
+          // Non-parse failure under 'abort': log and swallow so the
+          // file source keeps reading. (For non-chunked there is only
+          // one exchange so this case is rare; we still keep abort
+          // narrow.)
+          context.logger.debug(
+            { err, path: filePath, adapter: "csv" },
+            "csv adapter: non-parse pipeline failure under 'abort'; not aborting source",
+          );
+          return undefined as never;
+        });
       },
       abortController,
       onReady,
@@ -224,17 +240,16 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
               if (!aborted) parser.resume();
             })
             .catch((err) => {
-              if (onParseError === "abort") {
-                // Abort the stream and reject the subscribe promise so
-                // the source dies. The route boundary already emitted
-                // exchange:failed for this row.
+              // 'abort' is parse-specific: only RC5016 should tear
+              // down the stream. A downstream destination error must
+              // NOT abort even when onParseError === 'abort'; the
+              // route boundary has already emitted exchange:failed
+              // and we just continue.
+              if (onParseError === "abort" && isParseError(err)) {
                 parser.abort();
                 settle(() => reject(err));
                 return;
               }
-              // 'fail' or 'drop': route boundary has already emitted the
-              // appropriate lifecycle event (exchange:failed or
-              // exchange:dropped); just keep the stream flowing.
               context.logger.debug(
                 { err, path: filePath, row: currentRow, adapter: "csv" },
                 "csv adapter: pipeline failed for row; continuing",

--- a/packages/routecraft/src/adapters/csv/source.ts
+++ b/packages/routecraft/src/adapters/csv/source.ts
@@ -5,10 +5,22 @@ import { HeadersKeys, type ExchangeHeaders } from "../../exchange.ts";
 import { file } from "../file/index.ts";
 import { ensurePapaparse } from "./shared.ts";
 import { throwFileError } from "../shared/line-reader.ts";
+import { DEFAULT_ON_PARSE_ERROR, type OnParseError } from "../shared/parse.ts";
+import { logger } from "../../logger.ts";
 
 /**
- * CsvSourceAdapter reads CSV files and parses them to arrays of objects.
- * When chunked is true, emits one exchange per row.
+ * CsvSourceAdapter reads CSV files and parses them via PapaParse.
+ *
+ * Non-chunked: emits a single exchange whose body is the full parsed array.
+ * Chunked: streams rows from disk and emits one exchange per row with
+ * `CSV_ROW` and `CSV_PATH` headers; uses `parser.pause()` /
+ * `parser.resume()` around each handler call for backpressure.
+ *
+ * Per-row parse failures are routed by the `onParseError` option (default
+ * `'fail'`). With `'fail'` in chunked mode the parse runs as a synthetic
+ * first pipeline step so the route's `.error()` handler can catch it (or
+ * `exchange:failed` fires) and the source continues to the next row. See
+ * #187.
  */
 export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
   readonly adapterId = "routecraft.adapter.csv";
@@ -29,6 +41,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
       quoteChar = '"',
       skipEmptyLines = true,
       chunked = false,
+      onParseError = DEFAULT_ON_PARSE_ERROR,
     } = this.options;
 
     if (chunked) {
@@ -38,45 +51,81 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
         handler as (
           message: CsvRow,
           headers?: ExchangeHeaders,
+          parse?: (raw: unknown) => unknown | Promise<unknown>,
         ) => Promise<import("../../exchange.ts").Exchange>,
         abortController,
         { header, delimiter, quoteChar, skipEmptyLines },
+        onParseError,
       );
-    } else {
-      const fileAdapter = file({
-        path: this.options.path,
-        encoding: this.options.encoding || "utf-8",
-      });
+      return;
+    }
 
-      await fileAdapter.subscribe(
-        context,
-        async (csvContent: string) => {
-          const parseResult = Papa.parse(csvContent, {
+    const filePath = this.options.path;
+    if (typeof filePath !== "string") {
+      throw new Error(
+        "csv adapter: path must be a string for source mode (dynamic paths are only supported for destinations)",
+      );
+    }
+
+    const fileAdapter = file({
+      path: filePath,
+      encoding: this.options.encoding || "utf-8",
+    });
+
+    await fileAdapter.subscribe(
+      context,
+      async (csvContent: string) => {
+        const rowHandler = handler as (
+          message: CsvData,
+          headers?: ExchangeHeaders,
+          parse?: (raw: unknown) => unknown | Promise<unknown>,
+        ) => Promise<import("../../exchange.ts").Exchange>;
+
+        const parseFn = (raw: unknown): CsvData => {
+          const result = Papa.parse(raw as string, {
             header,
             delimiter,
             quoteChar,
             skipEmptyLines,
           });
-
-          if (parseResult.errors.length > 0) {
-            const firstError = parseResult.errors[0];
+          if (result.errors.length > 0) {
+            const firstError = result.errors[0];
             throw new Error(
               `csv adapter: parse error at row ${firstError.row}: ${firstError.message}`,
             );
           }
+          return result.data as CsvData;
+        };
 
-          return await (
-            handler as (
-              message: CsvData,
-              headers?: ExchangeHeaders,
-            ) => Promise<import("../../exchange.ts").Exchange>
-          )(parseResult.data as CsvData);
-        },
-        abortController,
-        onReady,
-        meta,
-      );
-    }
+        if (onParseError === "fail") {
+          // Defer parse to the pipeline; route.error() catches failures.
+          return await rowHandler(
+            csvContent as unknown as CsvData,
+            undefined,
+            (raw) => parseFn(raw),
+          );
+        }
+
+        // 'abort' or 'skip': parse inline.
+        let data: CsvData;
+        try {
+          data = parseFn(csvContent);
+        } catch (err) {
+          if (onParseError === "skip") {
+            logger.warn(
+              { err, path: filePath, adapter: "csv" },
+              "csv adapter: skipped malformed CSV file (onParseError: 'skip')",
+            );
+            return undefined as never;
+          }
+          throw err;
+        }
+        return await rowHandler(data);
+      },
+      abortController,
+      onReady,
+      meta,
+    );
   };
 
   private async subscribeChunked(
@@ -84,6 +133,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
     handler: (
       message: CsvRow,
       headers?: ExchangeHeaders,
+      parse?: (raw: unknown) => unknown | Promise<unknown>,
     ) => Promise<import("../../exchange.ts").Exchange>,
     abortController: AbortController,
     parseOptions: {
@@ -92,6 +142,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
       quoteChar: string;
       skipEmptyLines: boolean;
     },
+    onParseError: OnParseError,
   ): Promise<void> {
     if (abortController.signal.aborted) return;
 
@@ -145,33 +196,81 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
           }
 
           rowNumber++;
+          const currentRow = rowNumber;
+          const rowErrors = results.errors;
+          const headers: ExchangeHeaders = {
+            [HeadersKeys.CSV_ROW]: currentRow,
+            [HeadersKeys.CSV_PATH]: filePath,
+          } as ExchangeHeaders;
 
-          if (results.errors.length > 0) {
-            const firstError = results.errors[0];
+          // Inline 'abort' handling: row errors abort the source on the
+          // first bad row, matching pre-#187 behaviour.
+          if (rowErrors.length > 0 && onParseError === "abort") {
+            const firstError = rowErrors[0];
             parser.abort();
             settle(() =>
               reject(
                 new Error(
-                  `csv adapter: parse error at row ${rowNumber}: ${firstError.message}`,
+                  `csv adapter: parse error at row ${currentRow}: ${firstError.message}`,
                 ),
               ),
             );
             return;
           }
 
-          parser.pause();
-          const headers: ExchangeHeaders = {
-            [HeadersKeys.CSV_ROW]: rowNumber,
-            [HeadersKeys.CSV_PATH]: filePath,
-          } as ExchangeHeaders;
+          // Inline 'skip' handling: drop the row, continue to the next.
+          if (rowErrors.length > 0 && onParseError === "skip") {
+            logger.warn(
+              {
+                err: rowErrors[0],
+                path: filePath,
+                row: currentRow,
+                adapter: "csv",
+              },
+              "csv adapter: skipped malformed row (onParseError: 'skip')",
+            );
+            return;
+          }
 
-          handler(results.data as CsvRow, headers)
+          parser.pause();
+
+          // For 'fail' (default) and the no-row-error case, defer the
+          // row-error check to the pipeline so route.error() can catch it.
+          // The parse callback receives the row data (or already has it)
+          // and just re-validates the row errors so a malformed row throws
+          // inside the synthetic parse step.
+          const callPromise =
+            onParseError === "fail"
+              ? handler(results.data as CsvRow, headers, (raw) => {
+                  if (rowErrors.length > 0) {
+                    const firstError = rowErrors[0];
+                    throw new Error(
+                      `csv adapter: parse error at row ${currentRow}: ${firstError.message}`,
+                    );
+                  }
+                  return raw as CsvRow;
+                })
+              : handler(results.data as CsvRow, headers);
+
+          callPromise
             .then(() => {
               if (!aborted) {
                 parser.resume();
               }
             })
             .catch((err) => {
+              if (onParseError === "fail") {
+                // Per-row pipeline failure: log and continue. The route's
+                // `.error()` handler (or `exchange:failed` event) has
+                // already fired for this row; we just keep the stream
+                // flowing.
+                logger.debug(
+                  { err, path: filePath, row: currentRow, adapter: "csv" },
+                  "csv adapter: pipeline failed for row; continuing",
+                );
+                if (!aborted) parser.resume();
+                return;
+              }
               parser.abort();
               settle(() => reject(err));
             });

--- a/packages/routecraft/src/adapters/csv/source.ts
+++ b/packages/routecraft/src/adapters/csv/source.ts
@@ -6,7 +6,8 @@ import { file } from "../file/index.ts";
 import { ensurePapaparse } from "./shared.ts";
 import { throwFileError } from "../shared/line-reader.ts";
 import { DEFAULT_ON_PARSE_ERROR, type OnParseError } from "../shared/parse.ts";
-import { logger } from "../../logger.ts";
+import { rcError } from "../../error.ts";
+import type { CraftContext } from "../../context.ts";
 
 /**
  * CsvSourceAdapter reads CSV files and parses them via PapaParse.
@@ -47,6 +48,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
     if (chunked) {
       if (onReady) onReady();
       await this.subscribeChunked(
+        context,
         Papa,
         handler as (
           message: CsvRow,
@@ -90,9 +92,9 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
           });
           if (result.errors.length > 0) {
             const firstError = result.errors[0];
-            throw new Error(
-              `csv adapter: parse error at row ${firstError.row}: ${firstError.message}`,
-            );
+            throw rcError("RC5016", undefined, {
+              message: `csv adapter: parse error at row ${firstError.row}: ${firstError.message}`,
+            });
           }
           return result.data as CsvData;
         };
@@ -112,12 +114,15 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
           data = parseFn(csvContent);
         } catch (err) {
           if (onParseError === "skip") {
-            logger.warn(
+            context.logger.warn(
               { err, path: filePath, adapter: "csv" },
               "csv adapter: skipped malformed CSV file (onParseError: 'skip')",
             );
+            // FileSourceAdapter ignores the resolved value of this callback,
+            // so a no-exchange short-circuit is safe to fudge as `never`.
             return undefined as never;
           }
+          // 'abort': parseFn already wrapped as RC5016.
           throw err;
         }
         return await rowHandler(data);
@@ -129,6 +134,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
   };
 
   private async subscribeChunked(
+    context: CraftContext,
     Papa: ReturnType<typeof ensurePapaparse>,
     handler: (
       message: CsvRow,
@@ -210,9 +216,9 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
             parser.abort();
             settle(() =>
               reject(
-                new Error(
-                  `csv adapter: parse error at row ${currentRow}: ${firstError.message}`,
-                ),
+                rcError("RC5016", undefined, {
+                  message: `csv adapter: parse error at row ${currentRow}: ${firstError.message}`,
+                }),
               ),
             );
             return;
@@ -220,7 +226,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
 
           // Inline 'skip' handling: drop the row, continue to the next.
           if (rowErrors.length > 0 && onParseError === "skip") {
-            logger.warn(
+            context.logger.warn(
               {
                 err: rowErrors[0],
                 path: filePath,
@@ -234,21 +240,18 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
 
           parser.pause();
 
-          // For 'fail' (default) and the no-row-error case, defer the
-          // row-error check to the pipeline so route.error() can catch it.
-          // The parse callback receives the row data (or already has it)
-          // and just re-validates the row errors so a malformed row throws
-          // inside the synthetic parse step.
+          // For 'fail' mode, only attach a parse callback when the row has
+          // errors. Clean rows take the normal handler path with no
+          // synthetic parse step, avoiding `step:started`/`step:completed`
+          // event noise on every valid row.
+          const hasRowErrors = rowErrors.length > 0;
           const callPromise =
-            onParseError === "fail"
-              ? handler(results.data as CsvRow, headers, (raw) => {
-                  if (rowErrors.length > 0) {
-                    const firstError = rowErrors[0];
-                    throw new Error(
-                      `csv adapter: parse error at row ${currentRow}: ${firstError.message}`,
-                    );
-                  }
-                  return raw as CsvRow;
+            onParseError === "fail" && hasRowErrors
+              ? handler(results.data as CsvRow, headers, () => {
+                  const firstError = rowErrors[0];
+                  throw rcError("RC5016", undefined, {
+                    message: `csv adapter: parse error at row ${currentRow}: ${firstError.message}`,
+                  });
                 })
               : handler(results.data as CsvRow, headers);
 
@@ -263,8 +266,9 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
                 // Per-row pipeline failure: log and continue. The route's
                 // `.error()` handler (or `exchange:failed` event) has
                 // already fired for this row; we just keep the stream
-                // flowing.
-                logger.debug(
+                // flowing. Debug-level avoids double-logging what the
+                // route boundary already logged.
+                context.logger.debug(
                   { err, path: filePath, row: currentRow, adapter: "csv" },
                   "csv adapter: pipeline failed for row; continuing",
                 );

--- a/packages/routecraft/src/adapters/csv/source.ts
+++ b/packages/routecraft/src/adapters/csv/source.ts
@@ -6,7 +6,6 @@ import { file } from "../file/index.ts";
 import { ensurePapaparse } from "./shared.ts";
 import { throwFileError } from "../shared/line-reader.ts";
 import { DEFAULT_ON_PARSE_ERROR, type OnParseError } from "../shared/parse.ts";
-import { rcError } from "../../error.ts";
 import type { CraftContext } from "../../context.ts";
 
 /**
@@ -17,11 +16,15 @@ import type { CraftContext } from "../../context.ts";
  * `CSV_ROW` and `CSV_PATH` headers; uses `parser.pause()` /
  * `parser.resume()` around each handler call for backpressure.
  *
- * Per-row parse failures are routed by the `onParseError` option (default
- * `'fail'`). With `'fail'` in chunked mode the parse runs as a synthetic
- * first pipeline step so the route's `.error()` handler can catch it (or
- * `exchange:failed` fires) and the source continues to the next row. See
- * #187.
+ * Per-row parse failures are observable via the events bus:
+ *
+ * | `onParseError` | Lifecycle on bad row (chunked)                                  |
+ * |----------------|-----------------------------------------------------------------|
+ * | `'fail'` (default) | `exchange:failed` (or `error:caught`); next row continues |
+ * | `'abort'`      | `exchange:failed` for the bad row, then source dies (`context:error`) |
+ * | `'drop'`       | `exchange:dropped` (`reason: "parse-failed"`); next row continues |
+ *
+ * See #187.
  */
 export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
   readonly adapterId = "routecraft.adapter.csv";
@@ -54,6 +57,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
           message: CsvRow,
           headers?: ExchangeHeaders,
           parse?: (raw: unknown) => unknown | Promise<unknown>,
+          parseFailureMode?: "fail" | "abort" | "drop",
         ) => Promise<import("../../exchange.ts").Exchange>,
         abortController,
         { header, delimiter, quoteChar, skipEmptyLines },
@@ -81,6 +85,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
           message: CsvData,
           headers?: ExchangeHeaders,
           parse?: (raw: unknown) => unknown | Promise<unknown>,
+          parseFailureMode?: "fail" | "abort" | "drop",
         ) => Promise<import("../../exchange.ts").Exchange>;
 
         const parseFn = (raw: unknown): CsvData => {
@@ -92,40 +97,23 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
           });
           if (result.errors.length > 0) {
             const firstError = result.errors[0];
-            throw rcError("RC5016", undefined, {
-              message: `csv adapter: parse error at row ${firstError.row}: ${firstError.message}`,
-            });
+            throw new Error(
+              `csv adapter: parse error at row ${firstError.row}: ${firstError.message}`,
+            );
           }
           return result.data as CsvData;
         };
 
-        if (onParseError === "fail") {
-          // Defer parse to the pipeline; route.error() catches failures.
-          return await rowHandler(
-            csvContent as unknown as CsvData,
-            undefined,
-            (raw) => parseFn(raw),
-          );
+        const promise = rowHandler(
+          csvContent as unknown as CsvData,
+          undefined,
+          parseFn,
+          onParseError,
+        );
+        if (onParseError === "abort") {
+          return await promise;
         }
-
-        // 'abort' or 'skip': parse inline.
-        let data: CsvData;
-        try {
-          data = parseFn(csvContent);
-        } catch (err) {
-          if (onParseError === "skip") {
-            context.logger.warn(
-              { err, path: filePath, adapter: "csv" },
-              "csv adapter: skipped malformed CSV file (onParseError: 'skip')",
-            );
-            // FileSourceAdapter ignores the resolved value of this callback,
-            // so a no-exchange short-circuit is safe to fudge as `never`.
-            return undefined as never;
-          }
-          // 'abort': parseFn already wrapped as RC5016.
-          throw err;
-        }
-        return await rowHandler(data);
+        return await promise.catch(() => undefined as never);
       },
       abortController,
       onReady,
@@ -140,6 +128,7 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
       message: CsvRow,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
+      parseFailureMode?: "fail" | "abort" | "drop",
     ) => Promise<import("../../exchange.ts").Exchange>,
     abortController: AbortController,
     parseOptions: {
@@ -209,74 +198,48 @@ export class CsvSourceAdapter implements Source<CsvData | CsvRow> {
             [HeadersKeys.CSV_PATH]: filePath,
           } as ExchangeHeaders;
 
-          // Inline 'abort' handling: row errors abort the source on the
-          // first bad row, matching pre-#187 behaviour.
-          if (rowErrors.length > 0 && onParseError === "abort") {
-            const firstError = rowErrors[0];
-            parser.abort();
-            settle(() =>
-              reject(
-                rcError("RC5016", undefined, {
-                  message: `csv adapter: parse error at row ${currentRow}: ${firstError.message}`,
-                }),
-              ),
-            );
-            return;
-          }
-
-          // Inline 'skip' handling: drop the row, continue to the next.
-          if (rowErrors.length > 0 && onParseError === "skip") {
-            context.logger.warn(
-              {
-                err: rowErrors[0],
-                path: filePath,
-                row: currentRow,
-                adapter: "csv",
-              },
-              "csv adapter: skipped malformed row (onParseError: 'skip')",
-            );
-            return;
-          }
-
           parser.pause();
 
-          // For 'fail' mode, only attach a parse callback when the row has
-          // errors. Clean rows take the normal handler path with no
-          // synthetic parse step, avoiding `step:started`/`step:completed`
-          // event noise on every valid row.
+          // Only attach a parse callback when the row actually has errors.
+          // Clean rows take the normal handler path with no synthetic parse
+          // step so we do not emit a no-op `step:started`/`step:completed`
+          // for every valid row in a 1M-row CSV.
           const hasRowErrors = rowErrors.length > 0;
-          const callPromise =
-            onParseError === "fail" && hasRowErrors
-              ? handler(results.data as CsvRow, headers, () => {
+          const callPromise = hasRowErrors
+            ? handler(
+                results.data as CsvRow,
+                headers,
+                () => {
                   const firstError = rowErrors[0];
-                  throw rcError("RC5016", undefined, {
-                    message: `csv adapter: parse error at row ${currentRow}: ${firstError.message}`,
-                  });
-                })
-              : handler(results.data as CsvRow, headers);
+                  throw new Error(
+                    `csv adapter: parse error at row ${currentRow}: ${firstError.message}`,
+                  );
+                },
+                onParseError,
+              )
+            : handler(results.data as CsvRow, headers);
 
           callPromise
             .then(() => {
-              if (!aborted) {
-                parser.resume();
-              }
+              if (!aborted) parser.resume();
             })
             .catch((err) => {
-              if (onParseError === "fail") {
-                // Per-row pipeline failure: log and continue. The route's
-                // `.error()` handler (or `exchange:failed` event) has
-                // already fired for this row; we just keep the stream
-                // flowing. Debug-level avoids double-logging what the
-                // route boundary already logged.
-                context.logger.debug(
-                  { err, path: filePath, row: currentRow, adapter: "csv" },
-                  "csv adapter: pipeline failed for row; continuing",
-                );
-                if (!aborted) parser.resume();
+              if (onParseError === "abort") {
+                // Abort the stream and reject the subscribe promise so
+                // the source dies. The route boundary already emitted
+                // exchange:failed for this row.
+                parser.abort();
+                settle(() => reject(err));
                 return;
               }
-              parser.abort();
-              settle(() => reject(err));
+              // 'fail' or 'drop': route boundary has already emitted the
+              // appropriate lifecycle event (exchange:failed or
+              // exchange:dropped); just keep the stream flowing.
+              context.logger.debug(
+                { err, path: filePath, row: currentRow, adapter: "csv" },
+                "csv adapter: pipeline failed for row; continuing",
+              );
+              if (!aborted) parser.resume();
             });
         },
         complete: () => {

--- a/packages/routecraft/src/adapters/csv/types.ts
+++ b/packages/routecraft/src/adapters/csv/types.ts
@@ -1,4 +1,5 @@
 import type { Exchange } from "../../exchange.ts";
+import type { OnParseError } from "../shared/parse.ts";
 
 export interface CsvOptions {
   /**
@@ -53,6 +54,19 @@ export interface CsvOptions {
    * Default: false
    */
   chunked?: boolean;
+
+  /**
+   * How to handle a Papa Parse row error (chunked mode) or parse error
+   * (non-chunked mode). Default `'fail'`: the exchange fails so the route's
+   * `.error()` handler can catch it (or `exchange:failed` fires); chunked
+   * mode continues to the next row. `'abort'` rethrows out of the source on
+   * the first bad row. `'skip'` silently logs at warn and skips the bad
+   * row. See `OnParseError` for full semantics.
+   *
+   * @default "fail"
+   * @experimental
+   */
+  onParseError?: OnParseError;
 }
 
 export type CsvRow = Record<string, unknown> | string[];

--- a/packages/routecraft/src/adapters/csv/types.ts
+++ b/packages/routecraft/src/adapters/csv/types.ts
@@ -57,11 +57,17 @@ export interface CsvOptions {
 
   /**
    * How to handle a Papa Parse row error (chunked mode) or parse error
-   * (non-chunked mode). Default `'fail'`: the exchange fails so the route's
-   * `.error()` handler can catch it (or `exchange:failed` fires); chunked
-   * mode continues to the next row. `'abort'` rethrows out of the source on
-   * the first bad row. `'skip'` silently logs at warn and skips the bad
-   * row. See `OnParseError` for full semantics.
+   * (non-chunked mode).
+   *
+   * - `'fail'` (default): `exchange:failed` fires for the bad row; the
+   *   route's `.error()` handler can recover; chunked mode continues to
+   *   the next row.
+   * - `'abort'`: `exchange:failed` fires, then the source dies
+   *   (`context:error`).
+   * - `'drop'`: `exchange:dropped` fires with `reason: "parse-failed"`;
+   *   chunked mode continues.
+   *
+   * See `OnParseError` for full semantics.
    *
    * @default "fail"
    * @experimental

--- a/packages/routecraft/src/adapters/html/source.ts
+++ b/packages/routecraft/src/adapters/html/source.ts
@@ -3,7 +3,7 @@ import type { HtmlOptions, HtmlResult } from "./types.ts";
 import type { FileOptions } from "../file/types.ts";
 import { file } from "../file/index.ts";
 import { extractHtml } from "./shared.ts";
-import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
+import { DEFAULT_ON_PARSE_ERROR, isParseError } from "../shared/parse.ts";
 
 /**
  * HtmlSourceAdapter reads HTML from a file and extracts data using CSS selectors.
@@ -55,7 +55,8 @@ export class HtmlSourceAdapter<
     meta,
   ) => {
     const onParseError = this.options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
-    const opts = this.options as HtmlOptions<T, R>;
+    const opts = this.options;
+    const filePath = opts.path as string;
 
     return this.fileAdapter.subscribe(
       context,
@@ -66,10 +67,23 @@ export class HtmlSourceAdapter<
           (raw) => extractHtml(raw as T, opts) as HtmlResult,
           onParseError,
         );
-        if (onParseError === "abort") {
-          return await promise;
-        }
-        return await promise.catch(() => undefined as never);
+        // 'abort' is parse-specific: only RC5016 should tear down the
+        // source. Downstream destination errors must NOT propagate as
+        // an abort signal even when onParseError === 'abort'.
+        return await promise.catch((err: unknown) => {
+          if (onParseError === "abort" && isParseError(err)) throw err;
+          // 'fail' / 'drop' / non-parse failures under 'abort': route
+          // boundary already emitted the appropriate lifecycle event
+          // (exchange:failed or exchange:dropped). Log at debug for
+          // operator parity with jsonl/source.ts and swallow so the
+          // file source keeps reading. The file adapter ignores the
+          // resolved value, so returning undefined is safe.
+          context.logger.debug(
+            { err, path: filePath, adapter: "html" },
+            "html adapter: pipeline failed for file; continuing",
+          );
+          return undefined as never;
+        });
       },
       abortController,
       onReady,

--- a/packages/routecraft/src/adapters/html/source.ts
+++ b/packages/routecraft/src/adapters/html/source.ts
@@ -4,7 +4,7 @@ import type { FileOptions } from "../file/types.ts";
 import { file } from "../file/index.ts";
 import { extractHtml } from "./shared.ts";
 import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
-import { logger } from "../../logger.ts";
+import { rcError } from "../../error.ts";
 
 /**
  * HtmlSourceAdapter reads HTML from a file and extracts data using CSS selectors.
@@ -71,14 +71,20 @@ export class HtmlSourceAdapter<
           result = extractHtml(htmlContent as T, opts) as HtmlResult;
         } catch (err) {
           if (onParseError === "skip") {
-            logger.warn(
+            context.logger.warn(
               { err, path: filePath, adapter: "html" },
               "html adapter: skipped malformed HTML file (onParseError: 'skip')",
             );
+            // FileSourceAdapter ignores the resolved value of this callback,
+            // so a no-exchange short-circuit is safe to fudge as `never`.
             return undefined as never;
           }
-          // 'abort'
-          throw err;
+          // 'abort': wrap as RC5016 so the failure pattern is one error
+          // code regardless of `onParseError` mode.
+          const message = err instanceof Error ? err.message : String(err);
+          throw rcError("RC5016", err, {
+            message: `html adapter: failed to extract HTML: ${message}`,
+          });
         }
         return handler(result);
       },

--- a/packages/routecraft/src/adapters/html/source.ts
+++ b/packages/routecraft/src/adapters/html/source.ts
@@ -4,7 +4,6 @@ import type { FileOptions } from "../file/types.ts";
 import { file } from "../file/index.ts";
 import { extractHtml } from "./shared.ts";
 import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
-import { rcError } from "../../error.ts";
 
 /**
  * HtmlSourceAdapter reads HTML from a file and extracts data using CSS selectors.
@@ -12,8 +11,14 @@ import { rcError } from "../../error.ts";
  *
  * Extraction is deferred to the route's pipeline by passing a `parse`
  * callback to `handler(...)`: the runtime applies it as a synthetic first
- * step so a malformed HTML file becomes a normal pipeline error that the
- * route's `.error()` handler can catch (default `onParseError: 'fail'`).
+ * step so an extraction failure becomes an observable pipeline event.
+ *
+ * | `onParseError` | Lifecycle on extraction failure                                  |
+ * |----------------|------------------------------------------------------------------|
+ * | `'fail'` (default) | `exchange:failed` (or `error:caught` if `.error()` recovers) |
+ * | `'abort'`      | `exchange:failed`, then source rejects and `context:error` fires |
+ * | `'drop'`       | `exchange:dropped` with `reason: "parse-failed"`                 |
+ *
  * See #187.
  */
 export class HtmlSourceAdapter<
@@ -50,43 +55,21 @@ export class HtmlSourceAdapter<
     meta,
   ) => {
     const onParseError = this.options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
-    const filePath = this.options.path as string;
     const opts = this.options as HtmlOptions<T, R>;
 
     return this.fileAdapter.subscribe(
       context,
       async (htmlContent: string) => {
-        if (onParseError === "fail") {
-          // Defer extraction to the pipeline so route.error() can catch it.
-          return await handler(
-            htmlContent as unknown as HtmlResult,
-            undefined,
-            (raw) => extractHtml(raw as T, opts) as HtmlResult,
-          );
+        const promise = handler(
+          htmlContent as unknown as HtmlResult,
+          undefined,
+          (raw) => extractHtml(raw as T, opts) as HtmlResult,
+          onParseError,
+        );
+        if (onParseError === "abort") {
+          return await promise;
         }
-
-        // 'abort' or 'skip': run extraction inline.
-        let result: HtmlResult;
-        try {
-          result = extractHtml(htmlContent as T, opts) as HtmlResult;
-        } catch (err) {
-          if (onParseError === "skip") {
-            context.logger.warn(
-              { err, path: filePath, adapter: "html" },
-              "html adapter: skipped malformed HTML file (onParseError: 'skip')",
-            );
-            // FileSourceAdapter ignores the resolved value of this callback,
-            // so a no-exchange short-circuit is safe to fudge as `never`.
-            return undefined as never;
-          }
-          // 'abort': wrap as RC5016 so the failure pattern is one error
-          // code regardless of `onParseError` mode.
-          const message = err instanceof Error ? err.message : String(err);
-          throw rcError("RC5016", err, {
-            message: `html adapter: failed to extract HTML: ${message}`,
-          });
-        }
-        return handler(result);
+        return await promise.catch(() => undefined as never);
       },
       abortController,
       onReady,

--- a/packages/routecraft/src/adapters/html/source.ts
+++ b/packages/routecraft/src/adapters/html/source.ts
@@ -3,10 +3,18 @@ import type { HtmlOptions, HtmlResult } from "./types.ts";
 import type { FileOptions } from "../file/types.ts";
 import { file } from "../file/index.ts";
 import { extractHtml } from "./shared.ts";
+import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
+import { logger } from "../../logger.ts";
 
 /**
  * HtmlSourceAdapter reads HTML from a file and extracts data using CSS selectors.
  * Only available when path option is provided.
+ *
+ * Extraction is deferred to the route's pipeline by passing a `parse`
+ * callback to `handler(...)`: the runtime applies it as a synthetic first
+ * step so a malformed HTML file becomes a normal pipeline error that the
+ * route's `.error()` handler can catch (default `onParseError: 'fail'`).
+ * See #187.
  */
 export class HtmlSourceAdapter<
   T = unknown,
@@ -41,14 +49,38 @@ export class HtmlSourceAdapter<
     onReady,
     meta,
   ) => {
+    const onParseError = this.options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
+    const filePath = this.options.path as string;
+    const opts = this.options as HtmlOptions<T, R>;
+
     return this.fileAdapter.subscribe(
       context,
       async (htmlContent: string) => {
-        const result = extractHtml(
-          htmlContent as T,
-          this.options as HtmlOptions<T, R>,
-        );
-        return handler(result as HtmlResult);
+        if (onParseError === "fail") {
+          // Defer extraction to the pipeline so route.error() can catch it.
+          return await handler(
+            htmlContent as unknown as HtmlResult,
+            undefined,
+            (raw) => extractHtml(raw as T, opts) as HtmlResult,
+          );
+        }
+
+        // 'abort' or 'skip': run extraction inline.
+        let result: HtmlResult;
+        try {
+          result = extractHtml(htmlContent as T, opts) as HtmlResult;
+        } catch (err) {
+          if (onParseError === "skip") {
+            logger.warn(
+              { err, path: filePath, adapter: "html" },
+              "html adapter: skipped malformed HTML file (onParseError: 'skip')",
+            );
+            return undefined as never;
+          }
+          // 'abort'
+          throw err;
+        }
+        return handler(result);
       },
       abortController,
       onReady,

--- a/packages/routecraft/src/adapters/html/types.ts
+++ b/packages/routecraft/src/adapters/html/types.ts
@@ -60,11 +60,16 @@ export interface HtmlOptions<T = unknown, R = unknown> {
   createDirs?: boolean;
 
   /**
-   * How to handle a `extractHtml` failure on the file content (source mode
-   * only). Default `'fail'`: the exchange fails so the route's `.error()`
-   * handler can catch it (or `exchange:failed` fires). `'abort'` rethrows
-   * out of the source. `'skip'` silently logs at warn and emits no
-   * exchange. See `OnParseError` for full semantics.
+   * How to handle an `extractHtml` failure on the file content (source mode
+   * only).
+   *
+   * - `'fail'` (default): `exchange:failed` fires; the route's `.error()`
+   *   handler can recover.
+   * - `'abort'`: `exchange:failed` fires, then the source dies
+   *   (`context:error`).
+   * - `'drop'`: `exchange:dropped` fires with `reason: "parse-failed"`.
+   *
+   * See `OnParseError` for full semantics.
    *
    * @default "fail"
    * @experimental

--- a/packages/routecraft/src/adapters/html/types.ts
+++ b/packages/routecraft/src/adapters/html/types.ts
@@ -1,4 +1,5 @@
 import type { Exchange } from "../../exchange.ts";
+import type { OnParseError } from "../shared/parse.ts";
 
 export type HtmlResult = string | string[];
 
@@ -57,4 +58,16 @@ export interface HtmlOptions<T = unknown, R = unknown> {
    * Default: false
    */
   createDirs?: boolean;
+
+  /**
+   * How to handle a `extractHtml` failure on the file content (source mode
+   * only). Default `'fail'`: the exchange fails so the route's `.error()`
+   * handler can catch it (or `exchange:failed` fires). `'abort'` rethrows
+   * out of the source. `'skip'` silently logs at warn and emits no
+   * exchange. See `OnParseError` for full semantics.
+   *
+   * @default "fail"
+   * @experimental
+   */
+  onParseError?: OnParseError;
 }

--- a/packages/routecraft/src/adapters/json/source.ts
+++ b/packages/routecraft/src/adapters/json/source.ts
@@ -3,7 +3,7 @@ import type { JsonFileOptions } from "./types.ts";
 import type { FileOptions } from "../file/types.ts";
 import { file } from "../file/index.ts";
 import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
-import { logger } from "../../logger.ts";
+import { rcError } from "../../error.ts";
 
 /**
  * JsonSourceAdapter reads and parses JSON files.
@@ -60,15 +60,20 @@ export class JsonSourceAdapter implements Source<unknown> {
           parsed = JSON.parse(content, reviver as never);
         } catch (err) {
           if (onParseError === "skip") {
-            logger.warn(
+            context.logger.warn(
               { err, path: filePath, adapter: "json" },
               "json adapter: skipped malformed JSON file (onParseError: 'skip')",
             );
+            // FileSourceAdapter ignores the resolved value of this callback,
+            // so a no-exchange short-circuit is safe to fudge as `never`.
             return undefined as never;
           }
-          // 'abort'
+          // 'abort': wrap as RC5016 so the failure pattern is one error
+          // code regardless of `onParseError` mode.
           const message = err instanceof Error ? err.message : String(err);
-          throw new Error(`json adapter: failed to parse JSON: ${message}`);
+          throw rcError("RC5016", err, {
+            message: `json adapter: failed to parse JSON: ${message}`,
+          });
         }
         return await handler(parsed);
       },

--- a/packages/routecraft/src/adapters/json/source.ts
+++ b/packages/routecraft/src/adapters/json/source.ts
@@ -2,7 +2,7 @@ import type { Source, CallableSource } from "../../operations/from.ts";
 import type { JsonFileOptions } from "./types.ts";
 import type { FileOptions } from "../file/types.ts";
 import { file } from "../file/index.ts";
-import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
+import { DEFAULT_ON_PARSE_ERROR, isParseError } from "../shared/parse.ts";
 
 /**
  * JsonSourceAdapter reads and parses JSON files.
@@ -47,6 +47,7 @@ export class JsonSourceAdapter implements Source<unknown> {
   ) => {
     const onParseError = this.options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
     const reviver = this.options.reviver;
+    const filePath = this.options.path as string;
 
     return this.fileAdapter.subscribe(
       context,
@@ -56,6 +57,7 @@ export class JsonSourceAdapter implements Source<unknown> {
         // observe each outcome:
         //   'fail'  -> exchange:failed (or .error() recovers)
         //   'abort' -> exchange:failed, then we rethrow to abort the source
+        //                (only for RC5016; downstream errors are swallowed)
         //   'drop'  -> exchange:dropped with reason "parse-failed"
         const promise = handler(
           content as unknown,
@@ -63,16 +65,20 @@ export class JsonSourceAdapter implements Source<unknown> {
           (raw) => JSON.parse(raw as string, reviver as never),
           onParseError,
         );
-        if (onParseError === "abort") {
-          // Let the rejection propagate so FileSourceAdapter's caller
-          // observes it and the source dies with context:error.
-          return await promise;
-        }
-        // 'fail' and 'drop': swallow the rejection here (it has already
-        // been emitted as exchange:failed or exchange:dropped). Single-
-        // exchange adapter so there is no "next item" to continue to,
-        // but we still need to not propagate the error out of subscribe.
-        return await promise.catch(() => undefined as never);
+        return await promise.catch((err: unknown) => {
+          // 'abort' is parse-specific: only RC5016 should tear down the
+          // source. A downstream destination error must NOT propagate
+          // as an abort signal.
+          if (onParseError === "abort" && isParseError(err)) throw err;
+          // 'fail' / 'drop' / non-parse failures under 'abort': route
+          // boundary already emitted the appropriate lifecycle event.
+          // Log at debug for operator parity with jsonl/source.ts.
+          context.logger.debug(
+            { err, path: filePath, adapter: "json" },
+            "json adapter: pipeline failed for file; continuing",
+          );
+          return undefined as never;
+        });
       },
       abortController,
       onReady,

--- a/packages/routecraft/src/adapters/json/source.ts
+++ b/packages/routecraft/src/adapters/json/source.ts
@@ -2,9 +2,16 @@ import type { Source, CallableSource } from "../../operations/from.ts";
 import type { JsonFileOptions } from "./types.ts";
 import type { FileOptions } from "../file/types.ts";
 import { file } from "../file/index.ts";
+import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
+import { logger } from "../../logger.ts";
 
 /**
  * JsonSourceAdapter reads and parses JSON files.
+ *
+ * Parses are deferred to the route's pipeline by passing a `parse` callback
+ * to `handler(...)`: the runtime applies it as a synthetic first step so a
+ * malformed JSON file becomes a normal pipeline error that the route's
+ * `.error()` handler can catch (default `onParseError: 'fail'`). See #187.
  */
 export class JsonSourceAdapter implements Source<unknown> {
   readonly adapterId = "routecraft.adapter.json.file";
@@ -32,13 +39,34 @@ export class JsonSourceAdapter implements Source<unknown> {
     onReady,
     meta,
   ) => {
+    const onParseError = this.options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
+    const reviver = this.options.reviver;
+    const filePath = this.options.path as string;
+
     return this.fileAdapter.subscribe(
       context,
       async (content: string) => {
+        if (onParseError === "fail") {
+          // Defer parse to the pipeline so route.error() can catch it.
+          return await handler(content as unknown, undefined, (raw) =>
+            JSON.parse(raw as string, reviver as never),
+          );
+        }
+
+        // 'abort' or 'skip': parse inline so we can either throw out of the
+        // source or silently swallow without ever creating an exchange.
         let parsed: unknown;
         try {
-          parsed = JSON.parse(content, this.options.reviver as never);
+          parsed = JSON.parse(content, reviver as never);
         } catch (err) {
+          if (onParseError === "skip") {
+            logger.warn(
+              { err, path: filePath, adapter: "json" },
+              "json adapter: skipped malformed JSON file (onParseError: 'skip')",
+            );
+            return undefined as never;
+          }
+          // 'abort'
           const message = err instanceof Error ? err.message : String(err);
           throw new Error(`json adapter: failed to parse JSON: ${message}`);
         }

--- a/packages/routecraft/src/adapters/json/source.ts
+++ b/packages/routecraft/src/adapters/json/source.ts
@@ -3,15 +3,21 @@ import type { JsonFileOptions } from "./types.ts";
 import type { FileOptions } from "../file/types.ts";
 import { file } from "../file/index.ts";
 import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
-import { rcError } from "../../error.ts";
 
 /**
  * JsonSourceAdapter reads and parses JSON files.
  *
  * Parses are deferred to the route's pipeline by passing a `parse` callback
  * to `handler(...)`: the runtime applies it as a synthetic first step so a
- * malformed JSON file becomes a normal pipeline error that the route's
- * `.error()` handler can catch (default `onParseError: 'fail'`). See #187.
+ * malformed JSON file becomes an observable pipeline event:
+ *
+ * | `onParseError` | Lifecycle on bad JSON                                          |
+ * |----------------|----------------------------------------------------------------|
+ * | `'fail'` (default) | `exchange:failed` (or `error:caught` if `.error()` recovers) |
+ * | `'abort'`      | `exchange:failed`, then source rejects and `context:error` fires |
+ * | `'drop'`       | `exchange:dropped` with `reason: "parse-failed"`               |
+ *
+ * See #187.
  */
 export class JsonSourceAdapter implements Source<unknown> {
   readonly adapterId = "routecraft.adapter.json.file";
@@ -41,41 +47,32 @@ export class JsonSourceAdapter implements Source<unknown> {
   ) => {
     const onParseError = this.options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
     const reviver = this.options.reviver;
-    const filePath = this.options.path as string;
 
     return this.fileAdapter.subscribe(
       context,
       async (content: string) => {
-        if (onParseError === "fail") {
-          // Defer parse to the pipeline so route.error() can catch it.
-          return await handler(content as unknown, undefined, (raw) =>
-            JSON.parse(raw as string, reviver as never),
-          );
+        // All three modes route through the synthetic parse step so the
+        // exchange exists, lifecycle events fire, and the route can
+        // observe each outcome:
+        //   'fail'  -> exchange:failed (or .error() recovers)
+        //   'abort' -> exchange:failed, then we rethrow to abort the source
+        //   'drop'  -> exchange:dropped with reason "parse-failed"
+        const promise = handler(
+          content as unknown,
+          undefined,
+          (raw) => JSON.parse(raw as string, reviver as never),
+          onParseError,
+        );
+        if (onParseError === "abort") {
+          // Let the rejection propagate so FileSourceAdapter's caller
+          // observes it and the source dies with context:error.
+          return await promise;
         }
-
-        // 'abort' or 'skip': parse inline so we can either throw out of the
-        // source or silently swallow without ever creating an exchange.
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(content, reviver as never);
-        } catch (err) {
-          if (onParseError === "skip") {
-            context.logger.warn(
-              { err, path: filePath, adapter: "json" },
-              "json adapter: skipped malformed JSON file (onParseError: 'skip')",
-            );
-            // FileSourceAdapter ignores the resolved value of this callback,
-            // so a no-exchange short-circuit is safe to fudge as `never`.
-            return undefined as never;
-          }
-          // 'abort': wrap as RC5016 so the failure pattern is one error
-          // code regardless of `onParseError` mode.
-          const message = err instanceof Error ? err.message : String(err);
-          throw rcError("RC5016", err, {
-            message: `json adapter: failed to parse JSON: ${message}`,
-          });
-        }
-        return await handler(parsed);
+        // 'fail' and 'drop': swallow the rejection here (it has already
+        // been emitted as exchange:failed or exchange:dropped). Single-
+        // exchange adapter so there is no "next item" to continue to,
+        // but we still need to not propagate the error out of subscribe.
+        return await promise.catch(() => undefined as never);
       },
       abortController,
       onReady,

--- a/packages/routecraft/src/adapters/json/types.ts
+++ b/packages/routecraft/src/adapters/json/types.ts
@@ -1,4 +1,5 @@
 import type { Exchange } from "../../exchange.ts";
+import type { OnParseError } from "../shared/parse.ts";
 
 // Transformer-mode options (current behavior)
 export interface JsonTransformerOptions<T = unknown, R = unknown, V = unknown> {
@@ -68,6 +69,18 @@ export interface JsonFileOptions {
    * JSON.stringify replacer function (destination mode only).
    */
   replacer?: (key: string, value: unknown) => unknown;
+
+  /**
+   * How to handle a `JSON.parse` failure on the file content (source mode
+   * only). Default `'fail'`: the exchange fails so the route's `.error()`
+   * handler can catch it (or `exchange:failed` fires). `'abort'` rethrows
+   * out of the source. `'skip'` silently logs at warn and emits no
+   * exchange. See `OnParseError` for full semantics.
+   *
+   * @default "fail"
+   * @experimental
+   */
+  onParseError?: OnParseError;
 }
 
 export type JsonOptions<T = unknown, R = unknown, V = unknown> =

--- a/packages/routecraft/src/adapters/json/types.ts
+++ b/packages/routecraft/src/adapters/json/types.ts
@@ -72,10 +72,15 @@ export interface JsonFileOptions {
 
   /**
    * How to handle a `JSON.parse` failure on the file content (source mode
-   * only). Default `'fail'`: the exchange fails so the route's `.error()`
-   * handler can catch it (or `exchange:failed` fires). `'abort'` rethrows
-   * out of the source. `'skip'` silently logs at warn and emits no
-   * exchange. See `OnParseError` for full semantics.
+   * only).
+   *
+   * - `'fail'` (default): `exchange:failed` fires; the route's `.error()`
+   *   handler can recover.
+   * - `'abort'`: `exchange:failed` fires, then the source dies
+   *   (`context:error`).
+   * - `'drop'`: `exchange:dropped` fires with `reason: "parse-failed"`.
+   *
+   * See `OnParseError` for full semantics.
    *
    * @default "fail"
    * @experimental

--- a/packages/routecraft/src/adapters/jsonl/source.ts
+++ b/packages/routecraft/src/adapters/jsonl/source.ts
@@ -4,12 +4,16 @@ import type { JsonlSourceOptions } from "./types.ts";
 import { HeadersKeys, type ExchangeHeaders } from "../../exchange.ts";
 import { forEachLine, throwFileError } from "../shared/line-reader.ts";
 import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
-import { logger } from "../../logger.ts";
+import { rcError } from "../../error.ts";
 
 /**
  * JsonlSourceAdapter reads JSON Lines files.
  *
- * Non-chunked: emits a single array of all parsed objects.
+ * Non-chunked: emits a single array of all parsed objects. With
+ * `onParseError: 'fail'` a malformed line fails the entire array (one
+ * `RC5016` covering the file) since non-chunked emits one exchange. Use
+ * chunked mode for per-line `.error()` granularity.
+ *
  * Chunked: emits one exchange per line with `JSONL_LINE` and `JSONL_PATH`
  * headers.
  *
@@ -27,7 +31,7 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
   constructor(private readonly options: JsonlSourceOptions) {}
 
   subscribe: CallableSource<T | T[]> = async (
-    _context,
+    context,
     handler,
     abortController,
     onReady,
@@ -67,12 +71,16 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
             if (onParseError === "fail") {
               // Defer parse to the pipeline; per-line errors flow through
               // route.error() and the source continues to the next line.
+              // The .catch() here only fires AFTER `runSteps` has already
+              // emitted `exchange:failed` (or the route's `.error()` has
+              // run); debug-level is intentional to avoid double-logging
+              // what the route boundary already logged.
               await lineHandler(
                 trimmed as unknown as T,
                 headers,
                 (raw) => JSON.parse(raw as string, reviver) as T,
               ).catch((err) => {
-                logger.debug(
+                context.logger.debug(
                   { err, path: filePath, line: lineNumber, adapter: "jsonl" },
                   "jsonl adapter: pipeline failed for line; continuing",
                 );
@@ -86,14 +94,18 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
               parsed = JSON.parse(trimmed, reviver) as T;
             } catch (err) {
               if (onParseError === "skip") {
-                logger.warn(
+                context.logger.warn(
                   { err, path: filePath, line: lineNumber, adapter: "jsonl" },
                   "jsonl adapter: skipped malformed line (onParseError: 'skip')",
                 );
                 return;
               }
-              // 'abort': rethrow so forEachLine's caller aborts the source.
-              throw err;
+              // 'abort': wrap as RC5016 so the failure pattern is one error
+              // code regardless of `onParseError` mode.
+              const message = err instanceof Error ? err.message : String(err);
+              throw rcError("RC5016", err, {
+                message: `jsonl adapter: failed to parse line ${lineNumber}: ${message}`,
+              });
             }
             await lineHandler(parsed, headers);
           },
@@ -142,14 +154,18 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
         results.push(JSON.parse(trimmed, reviver) as T);
       } catch (err) {
         if (onParseError === "skip") {
-          logger.warn(
+          context.logger.warn(
             { err, path: filePath, line: i + 1, adapter: "jsonl" },
             "jsonl adapter: skipped malformed line (onParseError: 'skip')",
           );
           continue;
         }
-        // 'abort'
-        throw err;
+        // 'abort': wrap as RC5016 so the failure pattern is one error code
+        // regardless of `onParseError` mode.
+        const message = err instanceof Error ? err.message : String(err);
+        throw rcError("RC5016", err, {
+          message: `jsonl adapter: failed to parse line ${i + 1}: ${message}`,
+        });
       }
     }
 

--- a/packages/routecraft/src/adapters/jsonl/source.ts
+++ b/packages/routecraft/src/adapters/jsonl/source.ts
@@ -3,11 +3,21 @@ import type { Source, CallableSource } from "../../operations/from.ts";
 import type { JsonlSourceOptions } from "./types.ts";
 import { HeadersKeys, type ExchangeHeaders } from "../../exchange.ts";
 import { forEachLine, throwFileError } from "../shared/line-reader.ts";
+import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
+import { logger } from "../../logger.ts";
 
 /**
  * JsonlSourceAdapter reads JSON Lines files.
+ *
  * Non-chunked: emits a single array of all parsed objects.
- * Chunked: emits one exchange per line with JSONL_LINE and JSONL_PATH headers.
+ * Chunked: emits one exchange per line with `JSONL_LINE` and `JSONL_PATH`
+ * headers.
+ *
+ * Per-line `JSON.parse` failures are routed by the `onParseError` option
+ * (default `'fail'`). With `'fail'`, the parse runs as a synthetic first
+ * pipeline step so the route's `.error()` handler can catch it (or
+ * `exchange:failed` fires) and the source continues to the next line in
+ * chunked mode. See #187.
  *
  * @beta
  */
@@ -29,6 +39,7 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
       encoding = "utf-8",
       chunked = false,
       reviver,
+      onParseError = DEFAULT_ON_PARSE_ERROR,
     } = this.options;
 
     if (chunked) {
@@ -42,49 +53,107 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
             const trimmed = line.trim();
             if (trimmed === "") return;
 
-            const parsed = JSON.parse(trimmed, reviver) as T;
-
             const headers: ExchangeHeaders = {
               [HeadersKeys.JSONL_LINE]: lineNumber,
               [HeadersKeys.JSONL_PATH]: filePath,
             } as ExchangeHeaders;
 
-            await (
-              handler as (
-                message: T,
-                headers?: ExchangeHeaders,
-              ) => Promise<import("../../exchange.ts").Exchange>
-            )(parsed, headers);
+            const lineHandler = handler as (
+              message: T,
+              headers?: ExchangeHeaders,
+              parse?: (raw: unknown) => unknown | Promise<unknown>,
+            ) => Promise<import("../../exchange.ts").Exchange>;
+
+            if (onParseError === "fail") {
+              // Defer parse to the pipeline; per-line errors flow through
+              // route.error() and the source continues to the next line.
+              await lineHandler(
+                trimmed as unknown as T,
+                headers,
+                (raw) => JSON.parse(raw as string, reviver) as T,
+              ).catch((err) => {
+                logger.debug(
+                  { err, path: filePath, line: lineNumber, adapter: "jsonl" },
+                  "jsonl adapter: pipeline failed for line; continuing",
+                );
+              });
+              return;
+            }
+
+            // 'abort' or 'skip': parse inline.
+            let parsed: T;
+            try {
+              parsed = JSON.parse(trimmed, reviver) as T;
+            } catch (err) {
+              if (onParseError === "skip") {
+                logger.warn(
+                  { err, path: filePath, line: lineNumber, adapter: "jsonl" },
+                  "jsonl adapter: skipped malformed line (onParseError: 'skip')",
+                );
+                return;
+              }
+              // 'abort': rethrow so forEachLine's caller aborts the source.
+              throw err;
+            }
+            await lineHandler(parsed, headers);
           },
         );
       } catch (err) {
         if (abortController.signal.aborted) return;
         throwFileError("jsonl", filePath, err);
       }
-    } else {
-      const content = await fsp
-        .readFile(filePath, { encoding })
-        .catch((err) => throwFileError("jsonl", filePath, err));
-
-      if (abortController.signal.aborted) return;
-
-      const lines = content.split("\n");
-      const results: T[] = [];
-
-      for (let i = 0; i < lines.length; i++) {
-        const trimmed = lines[i].trim();
-        if (trimmed === "") continue;
-        results.push(JSON.parse(trimmed, reviver) as T);
-      }
-
-      await (
-        handler as (
-          message: T[],
-          headers?: ExchangeHeaders,
-        ) => Promise<import("../../exchange.ts").Exchange>
-      )(results);
-
-      if (onReady) onReady();
+      return;
     }
+
+    // Non-chunked: single exchange with the full parsed array.
+    const content = await fsp
+      .readFile(filePath, { encoding })
+      .catch((err) => throwFileError("jsonl", filePath, err));
+
+    if (abortController.signal.aborted) return;
+
+    const lines = content.split("\n");
+    const arrayHandler = handler as (
+      message: T[],
+      headers?: ExchangeHeaders,
+      parse?: (raw: unknown) => unknown | Promise<unknown>,
+    ) => Promise<import("../../exchange.ts").Exchange>;
+
+    if (onParseError === "fail") {
+      // Pass raw non-empty lines; the synthetic parse step parses each one.
+      const rawLines: string[] = [];
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed !== "") rawLines.push(trimmed);
+      }
+      await arrayHandler(rawLines as unknown as T[], undefined, (raw) =>
+        (raw as string[]).map((l) => JSON.parse(l, reviver) as T),
+      );
+      if (onReady) onReady();
+      return;
+    }
+
+    // 'abort' or 'skip': parse inline.
+    const results: T[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const trimmed = lines[i].trim();
+      if (trimmed === "") continue;
+      try {
+        results.push(JSON.parse(trimmed, reviver) as T);
+      } catch (err) {
+        if (onParseError === "skip") {
+          logger.warn(
+            { err, path: filePath, line: i + 1, adapter: "jsonl" },
+            "jsonl adapter: skipped malformed line (onParseError: 'skip')",
+          );
+          continue;
+        }
+        // 'abort'
+        throw err;
+      }
+    }
+
+    await arrayHandler(results);
+    if (onReady) onReady();
   };
 }

--- a/packages/routecraft/src/adapters/jsonl/source.ts
+++ b/packages/routecraft/src/adapters/jsonl/source.ts
@@ -3,7 +3,7 @@ import type { Source, CallableSource } from "../../operations/from.ts";
 import type { JsonlSourceOptions } from "./types.ts";
 import { HeadersKeys, type ExchangeHeaders } from "../../exchange.ts";
 import { forEachLine, throwFileError } from "../shared/line-reader.ts";
-import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
+import { DEFAULT_ON_PARSE_ERROR, type OnParseError } from "../shared/parse.ts";
 
 /**
  * JsonlSourceAdapter reads JSON Lines files.
@@ -69,7 +69,7 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
               message: T,
               headers?: ExchangeHeaders,
               parse?: (raw: unknown) => unknown | Promise<unknown>,
-              parseFailureMode?: "fail" | "abort" | "drop",
+              parseFailureMode?: OnParseError,
             ) => Promise<import("../../exchange.ts").Exchange>;
 
             // Defer parse to the synthetic pipeline step. The mode the
@@ -123,7 +123,7 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
       message: T[],
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
-      parseFailureMode?: "fail" | "abort" | "drop",
+      parseFailureMode?: OnParseError,
     ) => Promise<import("../../exchange.ts").Exchange>;
 
     const rawLines: string[] = [];

--- a/packages/routecraft/src/adapters/jsonl/source.ts
+++ b/packages/routecraft/src/adapters/jsonl/source.ts
@@ -4,7 +4,6 @@ import type { JsonlSourceOptions } from "./types.ts";
 import { HeadersKeys, type ExchangeHeaders } from "../../exchange.ts";
 import { forEachLine, throwFileError } from "../shared/line-reader.ts";
 import { DEFAULT_ON_PARSE_ERROR } from "../shared/parse.ts";
-import { rcError } from "../../error.ts";
 
 /**
  * JsonlSourceAdapter reads JSON Lines files.
@@ -17,11 +16,15 @@ import { rcError } from "../../error.ts";
  * Chunked: emits one exchange per line with `JSONL_LINE` and `JSONL_PATH`
  * headers.
  *
- * Per-line `JSON.parse` failures are routed by the `onParseError` option
- * (default `'fail'`). With `'fail'`, the parse runs as a synthetic first
- * pipeline step so the route's `.error()` handler can catch it (or
- * `exchange:failed` fires) and the source continues to the next line in
- * chunked mode. See #187.
+ * Per-line `JSON.parse` failures are observable via the events bus:
+ *
+ * | `onParseError` | Lifecycle on bad line (chunked)                                  |
+ * |----------------|------------------------------------------------------------------|
+ * | `'fail'` (default) | `exchange:failed` (or `error:caught`); next line continues  |
+ * | `'abort'`      | `exchange:failed` for the bad line, then source dies (`context:error`) |
+ * | `'drop'`       | `exchange:dropped` (`reason: "parse-failed"`); next line continues |
+ *
+ * See #187.
  *
  * @beta
  */
@@ -66,48 +69,36 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
               message: T,
               headers?: ExchangeHeaders,
               parse?: (raw: unknown) => unknown | Promise<unknown>,
+              parseFailureMode?: "fail" | "abort" | "drop",
             ) => Promise<import("../../exchange.ts").Exchange>;
 
-            if (onParseError === "fail") {
-              // Defer parse to the pipeline; per-line errors flow through
-              // route.error() and the source continues to the next line.
-              // The .catch() here only fires AFTER `runSteps` has already
-              // emitted `exchange:failed` (or the route's `.error()` has
-              // run); debug-level is intentional to avoid double-logging
-              // what the route boundary already logged.
-              await lineHandler(
-                trimmed as unknown as T,
-                headers,
-                (raw) => JSON.parse(raw as string, reviver) as T,
-              ).catch((err) => {
-                context.logger.debug(
-                  { err, path: filePath, line: lineNumber, adapter: "jsonl" },
-                  "jsonl adapter: pipeline failed for line; continuing",
-                );
-              });
+            // Defer parse to the synthetic pipeline step. The mode the
+            // runtime uses controls observability:
+            //   'fail'  -> exchange:failed; we .catch() and continue
+            //   'abort' -> exchange:failed; we let the rejection propagate
+            //              out of forEachLine to abort the source
+            //   'drop'  -> exchange:dropped; promise resolves cleanly
+            const promise = lineHandler(
+              trimmed as unknown as T,
+              headers,
+              (raw) => JSON.parse(raw as string, reviver) as T,
+              onParseError,
+            );
+
+            if (onParseError === "abort") {
+              await promise;
               return;
             }
 
-            // 'abort' or 'skip': parse inline.
-            let parsed: T;
-            try {
-              parsed = JSON.parse(trimmed, reviver) as T;
-            } catch (err) {
-              if (onParseError === "skip") {
-                context.logger.warn(
-                  { err, path: filePath, line: lineNumber, adapter: "jsonl" },
-                  "jsonl adapter: skipped malformed line (onParseError: 'skip')",
-                );
-                return;
-              }
-              // 'abort': wrap as RC5016 so the failure pattern is one error
-              // code regardless of `onParseError` mode.
-              const message = err instanceof Error ? err.message : String(err);
-              throw rcError("RC5016", err, {
-                message: `jsonl adapter: failed to parse line ${lineNumber}: ${message}`,
-              });
-            }
-            await lineHandler(parsed, headers);
+            // 'fail' and 'drop': swallow rejection (route boundary already
+            // emitted the lifecycle event). Debug-level avoids
+            // double-logging what runSteps already logged.
+            await promise.catch((err) => {
+              context.logger.debug(
+                { err, path: filePath, line: lineNumber, adapter: "jsonl" },
+                "jsonl adapter: pipeline failed for line; continuing",
+              );
+            });
           },
         );
       } catch (err) {
@@ -117,7 +108,10 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
       return;
     }
 
-    // Non-chunked: single exchange with the full parsed array.
+    // Non-chunked: single exchange with the full parsed array. The
+    // synthetic parse step parses ALL lines as one operation, so a single
+    // bad line fails the whole array. For per-line granularity use
+    // chunked mode.
     const content = await fsp
       .readFile(filePath, { encoding })
       .catch((err) => throwFileError("jsonl", filePath, err));
@@ -129,47 +123,33 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
       message: T[],
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
+      parseFailureMode?: "fail" | "abort" | "drop",
     ) => Promise<import("../../exchange.ts").Exchange>;
 
-    if (onParseError === "fail") {
-      // Pass raw non-empty lines; the synthetic parse step parses each one.
-      const rawLines: string[] = [];
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (trimmed !== "") rawLines.push(trimmed);
-      }
-      await arrayHandler(rawLines as unknown as T[], undefined, (raw) =>
-        (raw as string[]).map((l) => JSON.parse(l, reviver) as T),
-      );
-      if (onReady) onReady();
-      return;
+    const rawLines: string[] = [];
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed !== "") rawLines.push(trimmed);
     }
 
-    // 'abort' or 'skip': parse inline.
-    const results: T[] = [];
-    for (let i = 0; i < lines.length; i++) {
-      const trimmed = lines[i].trim();
-      if (trimmed === "") continue;
-      try {
-        results.push(JSON.parse(trimmed, reviver) as T);
-      } catch (err) {
-        if (onParseError === "skip") {
-          context.logger.warn(
-            { err, path: filePath, line: i + 1, adapter: "jsonl" },
-            "jsonl adapter: skipped malformed line (onParseError: 'skip')",
-          );
-          continue;
-        }
-        // 'abort': wrap as RC5016 so the failure pattern is one error code
-        // regardless of `onParseError` mode.
-        const message = err instanceof Error ? err.message : String(err);
-        throw rcError("RC5016", err, {
-          message: `jsonl adapter: failed to parse line ${i + 1}: ${message}`,
-        });
-      }
+    const promise = arrayHandler(
+      rawLines as unknown as T[],
+      undefined,
+      (raw) => (raw as string[]).map((l) => JSON.parse(l, reviver) as T),
+      onParseError,
+    );
+
+    if (onParseError === "abort") {
+      await promise;
+    } else {
+      await promise.catch((err) => {
+        context.logger.debug(
+          { err, path: filePath, adapter: "jsonl" },
+          "jsonl adapter: pipeline failed; non-chunked emits one exchange",
+        );
+      });
     }
 
-    await arrayHandler(results);
     if (onReady) onReady();
   };
 }

--- a/packages/routecraft/src/adapters/jsonl/source.ts
+++ b/packages/routecraft/src/adapters/jsonl/source.ts
@@ -1,9 +1,17 @@
 import * as fsp from "node:fs/promises";
 import type { Source, CallableSource } from "../../operations/from.ts";
 import type { JsonlSourceOptions } from "./types.ts";
-import { HeadersKeys, type ExchangeHeaders } from "../../exchange.ts";
+import {
+  HeadersKeys,
+  type Exchange,
+  type ExchangeHeaders,
+} from "../../exchange.ts";
 import { forEachLine, throwFileError } from "../shared/line-reader.ts";
-import { DEFAULT_ON_PARSE_ERROR, type OnParseError } from "../shared/parse.ts";
+import {
+  DEFAULT_ON_PARSE_ERROR,
+  isParseError,
+  type OnParseError,
+} from "../shared/parse.ts";
 
 /**
  * JsonlSourceAdapter reads JSON Lines files.
@@ -70,7 +78,7 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
               headers?: ExchangeHeaders,
               parse?: (raw: unknown) => unknown | Promise<unknown>,
               parseFailureMode?: OnParseError,
-            ) => Promise<import("../../exchange.ts").Exchange>;
+            ) => Promise<Exchange>;
 
             // Defer parse to the synthetic pipeline step. The mode the
             // runtime uses controls observability:
@@ -85,15 +93,14 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
               onParseError,
             );
 
-            if (onParseError === "abort") {
-              await promise;
-              return;
-            }
-
-            // 'fail' and 'drop': swallow rejection (route boundary already
-            // emitted the lifecycle event). Debug-level avoids
-            // double-logging what runSteps already logged.
-            await promise.catch((err) => {
+            await promise.catch((err: unknown) => {
+              // 'abort' is parse-specific: only RC5016 should tear
+              // down the source. Downstream destination errors must
+              // NOT propagate as an abort signal.
+              if (onParseError === "abort" && isParseError(err)) throw err;
+              // 'fail' / 'drop' / non-parse failures under 'abort': the
+              // route boundary already emitted the lifecycle event;
+              // debug-level avoids double-logging what runSteps logged.
               context.logger.debug(
                 { err, path: filePath, line: lineNumber, adapter: "jsonl" },
                 "jsonl adapter: pipeline failed for line; continuing",
@@ -103,6 +110,16 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
         );
       } catch (err) {
         if (abortController.signal.aborted) return;
+        // Preserve framework error codes (e.g. RC5016 from `'abort'` mode).
+        // `throwFileError` wraps as `RC5010` which would mask the original
+        // parse-error code, so re-throw RC-bearing errors as-is.
+        if (
+          typeof err === "object" &&
+          err !== null &&
+          "rc" in (err as Record<string, unknown>)
+        ) {
+          throw err;
+        }
         throwFileError("jsonl", filePath, err);
       }
       return;
@@ -124,7 +141,7 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
       parseFailureMode?: OnParseError,
-    ) => Promise<import("../../exchange.ts").Exchange>;
+    ) => Promise<Exchange>;
 
     const rawLines: string[] = [];
     for (const line of lines) {
@@ -139,16 +156,15 @@ export class JsonlSourceAdapter<T = unknown> implements Source<T | T[]> {
       onParseError,
     );
 
-    if (onParseError === "abort") {
-      await promise;
-    } else {
-      await promise.catch((err) => {
-        context.logger.debug(
-          { err, path: filePath, adapter: "jsonl" },
-          "jsonl adapter: pipeline failed; non-chunked emits one exchange",
-        );
-      });
-    }
+    await promise.catch((err: unknown) => {
+      // 'abort' is parse-specific: only RC5016 should tear down the
+      // source. Downstream destination errors must NOT propagate.
+      if (onParseError === "abort" && isParseError(err)) throw err;
+      context.logger.debug(
+        { err, path: filePath, adapter: "jsonl" },
+        "jsonl adapter: pipeline failed; non-chunked emits one exchange",
+      );
+    });
 
     if (onReady) onReady();
   };

--- a/packages/routecraft/src/adapters/jsonl/types.ts
+++ b/packages/routecraft/src/adapters/jsonl/types.ts
@@ -1,4 +1,5 @@
 import type { Exchange } from "../../exchange.ts";
+import type { OnParseError } from "../shared/parse.ts";
 
 export interface JsonlSourceOptions {
   /**
@@ -22,6 +23,19 @@ export interface JsonlSourceOptions {
    * Optional reviver function passed to JSON.parse.
    */
   reviver?: (key: string, value: unknown) => unknown;
+
+  /**
+   * How to handle a `JSON.parse` failure on a line (chunked mode) or any
+   * line of the file (non-chunked mode). Default `'fail'`: the exchange
+   * fails so the route's `.error()` handler can catch it (or
+   * `exchange:failed` fires); chunked mode continues to the next line.
+   * `'abort'` rethrows out of the source on the first bad line. `'skip'`
+   * silently logs at warn and skips the bad line. See `OnParseError`.
+   *
+   * @default "fail"
+   * @experimental
+   */
+  onParseError?: OnParseError;
 }
 
 export interface JsonlDestinationOptions {

--- a/packages/routecraft/src/adapters/jsonl/types.ts
+++ b/packages/routecraft/src/adapters/jsonl/types.ts
@@ -26,11 +26,16 @@ export interface JsonlSourceOptions {
 
   /**
    * How to handle a `JSON.parse` failure on a line (chunked mode) or any
-   * line of the file (non-chunked mode). Default `'fail'`: the exchange
-   * fails so the route's `.error()` handler can catch it (or
-   * `exchange:failed` fires); chunked mode continues to the next line.
-   * `'abort'` rethrows out of the source on the first bad line. `'skip'`
-   * silently logs at warn and skips the bad line. See `OnParseError`.
+   * line of the file (non-chunked mode).
+   *
+   * - `'fail'` (default): `exchange:failed` fires for the bad line; the
+   *   route's `.error()` handler can recover; chunked mode continues.
+   * - `'abort'`: `exchange:failed` fires, then the source dies
+   *   (`context:error`).
+   * - `'drop'`: `exchange:dropped` fires with `reason: "parse-failed"`;
+   *   chunked mode continues.
+   *
+   * See `OnParseError` for full semantics.
    *
    * @default "fail"
    * @experimental

--- a/packages/routecraft/src/adapters/mail/client-manager.ts
+++ b/packages/routecraft/src/adapters/mail/client-manager.ts
@@ -320,6 +320,10 @@ export class MailClientManager {
     if (overrides.body !== undefined) result.body = overrides.body;
     if (overrides.header !== undefined) result.header = overrides.header;
 
+    // Parse-error handling (#187).
+    if (overrides.onParseError !== undefined)
+      result.onParseError = overrides.onParseError;
+
     return result;
   }
 

--- a/packages/routecraft/src/adapters/mail/shared.ts
+++ b/packages/routecraft/src/adapters/mail/shared.ts
@@ -550,6 +550,11 @@ async function parseMessageContent(
  * error through the route's `.error()` handler via the `parse` argument so
  * malformed MIME becomes a normal pipeline error instead of a silent
  * degraded delivery. See #187.
+ *
+ * @internal Module-level registry. Safe globally because each `MailMessage`
+ * is constructed for one and only one fetch cycle, and entries are deleted
+ * by the source loop as soon as they are consumed. WeakMap GC handles any
+ * messages that go unread (e.g. after an abort mid-fetch).
  */
 export const MAIL_PARSE_ERRORS = new WeakMap<MailMessage, Error>();
 
@@ -594,7 +599,6 @@ export async function fetchMessages(
 
     const { simpleParser } = await import("mailparser");
     const verify = options.verify ?? "headers";
-    const onParseError = options.onParseError ?? "fail";
 
     for (const criteria of criteriaSets) {
       let searchQuery: Record<string, unknown> | string = criteria;
@@ -620,18 +624,12 @@ export async function fetchMessages(
           );
         } catch (err) {
           const wrapped = err instanceof Error ? err : new Error(String(err));
-          if (onParseError === "abort") {
-            throw wrapped;
-          }
-          if (onParseError === "skip") {
-            logger?.warn(
-              { err: wrapped, uid: msg.uid, folder },
-              "mail adapter: skipped malformed message (onParseError: 'skip')",
-            );
-            continue;
-          }
-          // 'fail': capture the error and let the source loop route it
-          // through the route's `.error()` handler via the `parse` arg.
+          // 'fail', 'abort', and 'drop' all capture the error so the per-
+          // message lifecycle event fires from the synthetic parse step.
+          // For 'abort' the source loop rethrows after the event fires so
+          // the source still dies; for 'drop' the route emits
+          // `exchange:dropped`; for 'fail' the route's `.error()` handler
+          // catches it. See #187.
           parseError = wrapped;
           content = {};
         }

--- a/packages/routecraft/src/adapters/mail/shared.ts
+++ b/packages/routecraft/src/adapters/mail/shared.ts
@@ -460,8 +460,6 @@ async function parseMessageContent(
   simpleParser: typeof import("mailparser").simpleParser,
   requestedHeaders?: true | string[],
   includeAnalysisHeaders?: boolean,
-  logger?: { debug: (obj: Record<string, unknown>, msg: string) => void },
-  uid?: number,
 ): Promise<{
   text?: string;
   html?: string;
@@ -475,8 +473,10 @@ async function parseMessageContent(
   analysisHeaders?: Record<string, string | string[]>;
 }> {
   if (!source) return {};
-  try {
-    const parsed = await simpleParser(source);
+  // Throws on malformed MIME. Callers decide whether to swallow, route the
+  // error through the route pipeline, or abort (see `onParseError` and #187).
+  const parsed = await simpleParser(source);
+  {
     const content: {
       text?: string;
       html?: string;
@@ -541,17 +541,17 @@ async function parseMessageContent(
       if (Object.keys(analysis).length > 0) content.analysisHeaders = analysis;
     }
     return content;
-  } catch (err) {
-    // Swallow per-message parse failures so one malformed MIME does not abort
-    // the whole fetch. Log at debug so operators can correlate an empty body /
-    // missing sender back to a parse error.
-    logger?.debug(
-      { err: err instanceof Error ? err : new Error(String(err)), uid },
-      "mail adapter failed to parse message source",
-    );
-    return {};
   }
 }
+
+/**
+ * Per-message parse error attached to a `MailMessage` when the source's
+ * `onParseError` is `'fail'`. The mail source loop reads this and routes the
+ * error through the route's `.error()` handler via the `parse` argument so
+ * malformed MIME becomes a normal pipeline error instead of a silent
+ * degraded delivery. See #187.
+ */
+export const MAIL_PARSE_ERRORS = new WeakMap<MailMessage, Error>();
 
 /**
  * Minimal logger shape accepted by `fetchMessages`. Matches the methods used
@@ -594,6 +594,7 @@ export async function fetchMessages(
 
     const { simpleParser } = await import("mailparser");
     const verify = options.verify ?? "headers";
+    const onParseError = options.onParseError ?? "fail";
 
     for (const criteria of criteriaSets) {
       let searchQuery: Record<string, unknown> | string = criteria;
@@ -606,14 +607,34 @@ export async function fetchMessages(
         if (seenUids.has(msg.uid)) continue;
         seenUids.add(msg.uid);
 
-        const content = await parseMessageContent(
-          msg.source,
-          simpleParser,
-          options.includeHeaders,
-          verify !== "off",
-          logger,
-          msg.uid,
-        );
+        let content:
+          | Awaited<ReturnType<typeof parseMessageContent>>
+          | undefined;
+        let parseError: Error | undefined;
+        try {
+          content = await parseMessageContent(
+            msg.source,
+            simpleParser,
+            options.includeHeaders,
+            verify !== "off",
+          );
+        } catch (err) {
+          const wrapped = err instanceof Error ? err : new Error(String(err));
+          if (onParseError === "abort") {
+            throw wrapped;
+          }
+          if (onParseError === "skip") {
+            logger?.warn(
+              { err: wrapped, uid: msg.uid, folder },
+              "mail adapter: skipped malformed message (onParseError: 'skip')",
+            );
+            continue;
+          }
+          // 'fail': capture the error and let the source loop route it
+          // through the route's `.error()` handler via the `parse` arg.
+          parseError = wrapped;
+          content = {};
+        }
 
         const mailMessage = toMailMessage(
           {
@@ -624,6 +645,10 @@ export async function fetchMessages(
           folder,
           content,
         );
+
+        if (parseError) {
+          MAIL_PARSE_ERRORS.set(mailMessage, parseError);
+        }
 
         if (verify !== "off") {
           const analysisHeaders = content.analysisHeaders;

--- a/packages/routecraft/src/adapters/mail/shared.ts
+++ b/packages/routecraft/src/adapters/mail/shared.ts
@@ -476,72 +476,70 @@ async function parseMessageContent(
   // Throws on malformed MIME. Callers decide whether to swallow, route the
   // error through the route pipeline, or abort (see `onParseError` and #187).
   const parsed = await simpleParser(source);
-  {
-    const content: {
-      text?: string;
-      html?: string;
-      attachments?: Array<{
+  const content: {
+    text?: string;
+    html?: string;
+    attachments?: Array<{
+      filename?: string;
+      contentType: string;
+      size: number;
+      content: Buffer;
+    }>;
+    rawHeaders?: Record<string, string | string[]>;
+    analysisHeaders?: Record<string, string | string[]>;
+  } = {};
+  if (parsed.text) content.text = parsed.text;
+  if (typeof parsed.html === "string") content.html = parsed.html;
+  if (parsed.attachments && parsed.attachments.length > 0) {
+    content.attachments = parsed.attachments.map((att) => {
+      const a: {
         filename?: string;
         contentType: string;
         size: number;
         content: Buffer;
-      }>;
-      rawHeaders?: Record<string, string | string[]>;
-      analysisHeaders?: Record<string, string | string[]>;
-    } = {};
-    if (parsed.text) content.text = parsed.text;
-    if (typeof parsed.html === "string") content.html = parsed.html;
-    if (parsed.attachments && parsed.attachments.length > 0) {
-      content.attachments = parsed.attachments.map((att) => {
-        const a: {
-          filename?: string;
-          contentType: string;
-          size: number;
-          content: Buffer;
-        } = {
-          contentType: att.contentType,
-          size: att.size,
-          content: att.content,
-        };
-        if (att.filename) a.filename = att.filename;
-        return a;
-      });
-    }
-    if (requestedHeaders && parsed.headerLines) {
-      const hdrs: Record<string, string | string[]> = {};
-      const wanted =
-        requestedHeaders === true
-          ? null
-          : new Set(requestedHeaders.map((h) => h.toLowerCase()));
-      for (const entry of parsed.headerLines as Array<{
-        key: string;
-        line: string;
-      }>) {
-        if (wanted && !wanted.has(entry.key)) continue;
-        // Extract value portion after "Header-Name: "
-        const colonIdx = entry.line.indexOf(":");
-        const value =
-          colonIdx >= 0 ? entry.line.slice(colonIdx + 1).trim() : entry.line;
-        // Accumulate multi-value headers (e.g. Received) as arrays
-        const existing = hdrs[entry.key];
-        if (existing === undefined) {
-          hdrs[entry.key] = value;
-        } else if (Array.isArray(existing)) {
-          existing.push(value);
-        } else {
-          hdrs[entry.key] = [existing, value];
-        }
-      }
-      if (Object.keys(hdrs).length > 0) content.rawHeaders = hdrs;
-    }
-    if (includeAnalysisHeaders && parsed.headerLines) {
-      const analysis = extractAnalysisHeaders(
-        parsed.headerLines as ReadonlyArray<{ key: string; line: string }>,
-      );
-      if (Object.keys(analysis).length > 0) content.analysisHeaders = analysis;
-    }
-    return content;
+      } = {
+        contentType: att.contentType,
+        size: att.size,
+        content: att.content,
+      };
+      if (att.filename) a.filename = att.filename;
+      return a;
+    });
   }
+  if (requestedHeaders && parsed.headerLines) {
+    const hdrs: Record<string, string | string[]> = {};
+    const wanted =
+      requestedHeaders === true
+        ? null
+        : new Set(requestedHeaders.map((h) => h.toLowerCase()));
+    for (const entry of parsed.headerLines as Array<{
+      key: string;
+      line: string;
+    }>) {
+      if (wanted && !wanted.has(entry.key)) continue;
+      // Extract value portion after "Header-Name: "
+      const colonIdx = entry.line.indexOf(":");
+      const value =
+        colonIdx >= 0 ? entry.line.slice(colonIdx + 1).trim() : entry.line;
+      // Accumulate multi-value headers (e.g. Received) as arrays
+      const existing = hdrs[entry.key];
+      if (existing === undefined) {
+        hdrs[entry.key] = value;
+      } else if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        hdrs[entry.key] = [existing, value];
+      }
+    }
+    if (Object.keys(hdrs).length > 0) content.rawHeaders = hdrs;
+  }
+  if (includeAnalysisHeaders && parsed.headerLines) {
+    const analysis = extractAnalysisHeaders(
+      parsed.headerLines as ReadonlyArray<{ key: string; line: string }>,
+    );
+    if (Object.keys(analysis).length > 0) content.analysisHeaders = analysis;
+  }
+  return content;
 }
 
 /**

--- a/packages/routecraft/src/adapters/mail/source.ts
+++ b/packages/routecraft/src/adapters/mail/source.ts
@@ -87,6 +87,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
       message: MailMessage,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
+      parseFailureMode?: "fail" | "abort" | "drop",
     ) => Promise<Exchange>,
     abortController: AbortController,
     onReady?: () => void,
@@ -148,21 +149,32 @@ export class MailSourceAdapter implements Source<MailMessage> {
     const onAbort = () => releaseClient();
     abortController.signal.addEventListener("abort", onAbort, { once: true });
 
+    // The MIME parse failure mode is decided per-poll-cycle from
+    // resolved options. `'fail'` (default) surfaces malformed messages
+    // through the route's `.error()` handler; `'drop'` emits
+    // `exchange:dropped` with `reason: "parse-failed"`; `'abort'` would
+    // additionally re-throw out of the source loop.
+    const parseFailureMode = resolved.onParseError ?? "fail";
+
     const handlerWithHeaders = (message: MailMessage) => {
       const headers: ExchangeHeaders = {
         [HEADER_MAIL_UID]: message.uid,
         [HEADER_MAIL_FOLDER]: message.folder,
       };
-      // When the message had a MIME parse failure during fetch (and
-      // `onParseError: 'fail'`), route it through the route's `.error()`
-      // handler by surfacing the captured error from the synthetic parse
-      // step. See #187.
+      // When the message had a MIME parse failure during fetch, surface
+      // the captured error from the synthetic parse step so the route
+      // observes it via the configured failure mode. See #187.
       const parseError = MAIL_PARSE_ERRORS.get(message);
       if (parseError) {
         MAIL_PARSE_ERRORS.delete(message);
-        return handler(message, headers, () => {
-          throw parseError;
-        });
+        return handler(
+          message,
+          headers,
+          () => {
+            throw parseError;
+          },
+          parseFailureMode,
+        );
       }
       return handler(message, headers);
     };
@@ -247,6 +259,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
     abortController: AbortController,
     logger?: MailFetchLogger,
   ): Promise<void> {
+    const onParseError = options.onParseError ?? "fail";
     while (!abortController.signal.aborted) {
       const client = clientRef.current;
       if (!client) return;
@@ -262,13 +275,20 @@ export class MailSourceAdapter implements Source<MailMessage> {
           }
         } catch (err) {
           // A parse failure (RC5016) is permanent: retrying will hit the
-          // same malformed MIME forever. Mark Seen anyway so the message
-          // exits the unread set even when no `.error()` handler recovered.
-          // Other handler failures are treated as transient and left
-          // un-Seen for the next cycle to retry.
-          if (markSeenEnabled && isMailParseError(err)) {
-            await markMessagesSeen(client, message.uid, logger);
+          // same malformed MIME forever. Mark Seen so the message exits
+          // the unread set, then re-evaluate based on the configured mode.
+          if (isMailParseError(err)) {
+            if (markSeenEnabled) {
+              await markMessagesSeen(client, message.uid, logger);
+            }
+            // 'abort': rethrow so the source dies (`context:error` fires).
+            // The per-message `exchange:failed` already fired from the
+            // synthetic parse step.
+            if (onParseError === "abort") throw err;
           }
+          // 'fail' / 'drop' / non-parse failures: leave un-Seen for retry
+          // (transient handler errors are expected to recover) unless we
+          // already marked Seen above.
         }
       }
 
@@ -364,6 +384,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
   ): Promise<void> {
     const client = clientRef.current;
     if (!client) return;
+    const onParseError = options.onParseError ?? "fail";
 
     const messages = await fetchMessages(client, options, folder, logger);
     for (const message of messages) {
@@ -375,11 +396,16 @@ export class MailSourceAdapter implements Source<MailMessage> {
         }
       } catch (err) {
         // RC5016 is a permanent MIME parse failure; mark Seen so we don't
-        // re-fetch the same malformed message forever. Other handler
-        // errors are treated as transient and left un-Seen for retry.
-        if (markSeenEnabled && isMailParseError(err)) {
-          await markMessagesSeen(client, message.uid, logger);
+        // re-fetch the same malformed message forever, and rethrow when
+        // the configured mode is `'abort'` so the source dies.
+        if (isMailParseError(err)) {
+          if (markSeenEnabled) {
+            await markMessagesSeen(client, message.uid, logger);
+          }
+          if (onParseError === "abort") throw err;
         }
+        // Non-parse handler errors are treated as transient and left
+        // un-Seen for retry on the next cycle.
       }
     }
   }

--- a/packages/routecraft/src/adapters/mail/source.ts
+++ b/packages/routecraft/src/adapters/mail/source.ts
@@ -4,7 +4,7 @@ import type { Exchange, ExchangeHeaders } from "../../exchange.ts";
 import { rcError } from "../../error.ts";
 import type { MailMessage, MailServerOptions } from "./types.ts";
 import type { MailClientManager } from "./client-manager.ts";
-import type { OnParseError } from "../shared/parse.ts";
+import { DEFAULT_ON_PARSE_ERROR, type OnParseError } from "../shared/parse.ts";
 import {
   getClientManager,
   createImapClient,
@@ -155,7 +155,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
     // through the route's `.error()` handler; `'drop'` emits
     // `exchange:dropped` with `reason: "parse-failed"`; `'abort'` would
     // additionally re-throw out of the source loop.
-    const parseFailureMode = resolved.onParseError ?? "fail";
+    const parseFailureMode = resolved.onParseError ?? DEFAULT_ON_PARSE_ERROR;
 
     const handlerWithHeaders = (message: MailMessage) => {
       const headers: ExchangeHeaders = {
@@ -260,7 +260,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
     abortController: AbortController,
     logger?: MailFetchLogger,
   ): Promise<void> {
-    const onParseError = options.onParseError ?? "fail";
+    const onParseError = options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
     while (!abortController.signal.aborted) {
       const client = clientRef.current;
       if (!client) return;
@@ -392,7 +392,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
   ): Promise<void> {
     const client = clientRef.current;
     if (!client) return;
-    const onParseError = options.onParseError ?? "fail";
+    const onParseError = options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
 
     const messages = await fetchMessages(client, options, folder, logger);
     for (const message of messages) {

--- a/packages/routecraft/src/adapters/mail/source.ts
+++ b/packages/routecraft/src/adapters/mail/source.ts
@@ -4,6 +4,7 @@ import type { Exchange, ExchangeHeaders } from "../../exchange.ts";
 import { rcError } from "../../error.ts";
 import type { MailMessage, MailServerOptions } from "./types.ts";
 import type { MailClientManager } from "./client-manager.ts";
+import type { OnParseError } from "../shared/parse.ts";
 import {
   getClientManager,
   createImapClient,
@@ -87,7 +88,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
       message: MailMessage,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
-      parseFailureMode?: "fail" | "abort" | "drop",
+      parseFailureMode?: OnParseError,
     ) => Promise<Exchange>,
     abortController: AbortController,
     onReady?: () => void,
@@ -269,6 +270,14 @@ export class MailSourceAdapter implements Source<MailMessage> {
       for (const message of messages) {
         if (abortController.signal.aborted) break;
         try {
+          // Mark-Seen-on-success covers two parse-failure paths via the
+          // handler resolving cleanly:
+          //   1. 'drop': synthetic parse step emits exchange:dropped and
+          //      runSteps returns without throwing.
+          //   2. 'fail' with a route .error() handler that recovers: catch
+          //      block sets exchange.body and runSteps returns cleanly.
+          // The catch block below covers the remaining parse-failure paths
+          // ('fail' without handler, 'abort').
           await handler(message);
           if (markSeenEnabled) {
             await markMessagesSeen(client, message.uid, logger);
@@ -286,9 +295,8 @@ export class MailSourceAdapter implements Source<MailMessage> {
             // synthetic parse step.
             if (onParseError === "abort") throw err;
           }
-          // 'fail' / 'drop' / non-parse failures: leave un-Seen for retry
-          // (transient handler errors are expected to recover) unless we
-          // already marked Seen above.
+          // Non-parse handler errors are treated as transient and left
+          // un-Seen for retry on the next cycle.
         }
       }
 

--- a/packages/routecraft/src/adapters/mail/source.ts
+++ b/packages/routecraft/src/adapters/mail/source.ts
@@ -13,6 +13,7 @@ import {
   throwMailConnectionError,
   HEADER_MAIL_UID,
   HEADER_MAIL_FOLDER,
+  MAIL_PARSE_ERRORS,
   type MailFetchLogger,
 } from "./shared.ts";
 
@@ -85,6 +86,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
     handler: (
       message: MailMessage,
       headers?: ExchangeHeaders,
+      parse?: (raw: unknown) => unknown | Promise<unknown>,
     ) => Promise<Exchange>,
     abortController: AbortController,
     onReady?: () => void,
@@ -151,6 +153,17 @@ export class MailSourceAdapter implements Source<MailMessage> {
         [HEADER_MAIL_UID]: message.uid,
         [HEADER_MAIL_FOLDER]: message.folder,
       };
+      // When the message had a MIME parse failure during fetch (and
+      // `onParseError: 'fail'`), route it through the route's `.error()`
+      // handler by surfacing the captured error from the synthetic parse
+      // step. See #187.
+      const parseError = MAIL_PARSE_ERRORS.get(message);
+      if (parseError) {
+        MAIL_PARSE_ERRORS.delete(message);
+        return handler(message, headers, () => {
+          throw parseError;
+        });
+      }
       return handler(message, headers);
     };
 
@@ -247,9 +260,15 @@ export class MailSourceAdapter implements Source<MailMessage> {
           if (markSeenEnabled) {
             await markMessagesSeen(client, message.uid, logger);
           }
-        } catch {
-          // Handler error already logged by the route pipeline. Leave the
-          // message un-Seen so the next poll cycle retries it.
+        } catch (err) {
+          // A parse failure (RC5016) is permanent: retrying will hit the
+          // same malformed MIME forever. Mark Seen anyway so the message
+          // exits the unread set even when no `.error()` handler recovered.
+          // Other handler failures are treated as transient and left
+          // un-Seen for the next cycle to retry.
+          if (markSeenEnabled && isMailParseError(err)) {
+            await markMessagesSeen(client, message.uid, logger);
+          }
         }
       }
 
@@ -354,9 +373,13 @@ export class MailSourceAdapter implements Source<MailMessage> {
         if (markSeenEnabled) {
           await markMessagesSeen(client, message.uid, logger);
         }
-      } catch {
-        // Handler error already logged by the route pipeline. Leave un-Seen
-        // so the next drain cycle (next IDLE wake or next poll tick) retries.
+      } catch (err) {
+        // RC5016 is a permanent MIME parse failure; mark Seen so we don't
+        // re-fetch the same malformed message forever. Other handler
+        // errors are treated as transient and left un-Seen for retry.
+        if (markSeenEnabled && isMailParseError(err)) {
+          await markMessagesSeen(client, message.uid, logger);
+        }
       }
     }
   }
@@ -473,6 +496,20 @@ function validateSourceOptions(
         "drain when new mail arrives. Use pollIntervalMs for predictable drain.",
     );
   }
+}
+
+/**
+ * True if `err` is the framework's parse-error code (`RC5016`). Used by the
+ * mail loops to distinguish permanent MIME parse failures (mark Seen, do not
+ * retry) from transient pipeline failures (leave un-Seen, retry next cycle).
+ * See #187.
+ */
+function isMailParseError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { rc?: unknown }).rc === "RC5016"
+  );
 }
 
 /**

--- a/packages/routecraft/src/adapters/mail/types.ts
+++ b/packages/routecraft/src/adapters/mail/types.ts
@@ -202,16 +202,22 @@ export interface MailServerOptions {
 
   /**
    * How to handle a per-message MIME parse failure (`mailparser`'s
-   * `simpleParser` throwing on malformed input). Default `'fail'`: the
-   * exchange fails so the route's `.error()` handler can catch it (or
-   * `exchange:failed` fires); the poll loop continues to the next message
-   * and leaves the malformed one un-Seen for retry. `'abort'` rethrows out
-   * of the source on the first malformed message. `'skip'` silently logs
-   * at warn and skips the message. See `OnParseError` for full semantics.
+   * `simpleParser` throwing on malformed input). All modes mark the
+   * malformed message as Seen so it does not refetch indefinitely.
    *
-   * Pre-#187 behaviour was equivalent to `'skip'` but logged at debug; that
-   * silent-degrade pattern is no longer the default. Set
-   * `onParseError: 'skip'` and bump your log level to keep the old shape.
+   * - `'fail'` (default): `exchange:failed` fires for the bad message; the
+   *   route's `.error()` handler can catch it; the poll loop continues.
+   * - `'abort'`: `exchange:failed` fires for the bad message, then the
+   *   source rejects and `context:error` fires.
+   * - `'drop'`: `exchange:dropped` fires with `reason: "parse-failed"` and
+   *   the poll loop continues. Use this when malformed mail is expected
+   *   and you want it counted in `exchange:dropped` metrics rather than
+   *   surfaced as route errors.
+   *
+   * Pre-#187 behaviour was equivalent to `'drop'` but logged at debug
+   * with no event; the new `'fail'` default routes the failure through
+   * `.error()` and is observable. Set `onParseError: 'drop'` to keep the
+   * lossy-ingest semantics with proper observability.
    *
    * @default "fail"
    * @experimental

--- a/packages/routecraft/src/adapters/mail/types.ts
+++ b/packages/routecraft/src/adapters/mail/types.ts
@@ -9,6 +9,7 @@
 
 import type { Exchange } from "../../exchange.ts";
 import type { MailSender } from "./analysis.ts";
+import type { OnParseError } from "../shared/parse.ts";
 
 /**
  * Authentication credentials for mail servers.
@@ -198,6 +199,24 @@ export interface MailServerOptions {
    *   not trusted to have verified the chain for you.
    */
   verify?: "off" | "headers" | "strict";
+
+  /**
+   * How to handle a per-message MIME parse failure (`mailparser`'s
+   * `simpleParser` throwing on malformed input). Default `'fail'`: the
+   * exchange fails so the route's `.error()` handler can catch it (or
+   * `exchange:failed` fires); the poll loop continues to the next message
+   * and leaves the malformed one un-Seen for retry. `'abort'` rethrows out
+   * of the source on the first malformed message. `'skip'` silently logs
+   * at warn and skips the message. See `OnParseError` for full semantics.
+   *
+   * Pre-#187 behaviour was equivalent to `'skip'` but logged at debug; that
+   * silent-degrade pattern is no longer the default. Set
+   * `onParseError: 'skip'` and bump your log level to keep the old shape.
+   *
+   * @default "fail"
+   * @experimental
+   */
+  onParseError?: OnParseError;
 }
 
 /**

--- a/packages/routecraft/src/adapters/shared/parse.ts
+++ b/packages/routecraft/src/adapters/shared/parse.ts
@@ -1,0 +1,43 @@
+/**
+ * How a source adapter handles a parse failure on an individual item.
+ *
+ * Source adapters that translate raw bytes into a structured body (json,
+ * html, csv, jsonl, mail) accept this option to control what happens when
+ * the parse step throws.
+ *
+ * @experimental The shape of this option may evolve as more parsing adapters
+ * adopt the contract.
+ */
+export type OnParseError =
+  /**
+   * Default. The exchange fails: the route's `.error()` handler is invoked
+   * with an `RC5016` error, or `exchange:failed` is emitted when no handler
+   * is set. Streaming adapters continue to the next item.
+   *
+   * Use when you want parse failures to be observable per item and the rest
+   * of the source to keep flowing.
+   */
+  | "fail"
+  /**
+   * The source aborts on the first parse failure. No exchange is created;
+   * the subscribe promise rejects and `context:error` fires.
+   *
+   * Use when partial-data is unacceptable and a malformed item should stop
+   * the import (atomic-load semantics).
+   */
+  | "abort"
+  /**
+   * The parse failure is silently dropped. No exchange is created; a
+   * `warn`-level log is emitted. Streaming adapters continue to the next
+   * item.
+   *
+   * Use when malformed items are expected (scraping, lossy upstreams) and
+   * you do not want them to surface as route errors.
+   */
+  | "skip";
+
+/**
+ * Default `OnParseError` value applied when a parsing adapter does not set
+ * one explicitly.
+ */
+export const DEFAULT_ON_PARSE_ERROR: OnParseError = "fail";

--- a/packages/routecraft/src/adapters/shared/parse.ts
+++ b/packages/routecraft/src/adapters/shared/parse.ts
@@ -70,3 +70,22 @@ export const DEFAULT_ON_PARSE_ERROR: OnParseError = "fail";
  * @experimental
  */
 export const PARSE_DROPPED_REASON = "parse-failed";
+
+/**
+ * True if `err` is a Routecraft `RC5016` parse-failure error. Used by
+ * source adapters in `'abort'` mode to discriminate between parse failures
+ * (which should abort the source) and downstream pipeline failures
+ * (destination errors, transform errors, etc.) that should NOT abort -
+ * `'abort'` is documented as parse-specific behaviour.
+ *
+ * Mirrors the `isMailParseError` helper in the mail adapter.
+ *
+ * @experimental
+ */
+export function isParseError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { rc?: unknown }).rc === "RC5016"
+  );
+}

--- a/packages/routecraft/src/adapters/shared/parse.ts
+++ b/packages/routecraft/src/adapters/shared/parse.ts
@@ -5,6 +5,15 @@
  * html, csv, jsonl, mail) accept this option to control what happens when
  * the parse step throws.
  *
+ * All three modes are observable via the events bus, mirroring the
+ * filter / validate operation patterns:
+ *
+ * | Mode    | Lifecycle events fired                       |
+ * |---------|----------------------------------------------|
+ * | `fail`  | `exchange:started` -> `exchange:failed` (or `error:caught` if `.error()` recovers) |
+ * | `abort` | `exchange:started` -> `exchange:failed`, then `context:error` and the source dies |
+ * | `drop`  | `exchange:started` -> `exchange:dropped` (`reason: "parse-failed"`) |
+ *
  * @experimental The shape of this option may evolve as more parsing adapters
  * adopt the contract.
  */
@@ -19,25 +28,45 @@ export type OnParseError =
    */
   | "fail"
   /**
-   * The source aborts on the first parse failure. No exchange is created;
-   * the subscribe promise rejects and `context:error` fires.
+   * The source aborts on the first parse failure. The bad item still emits
+   * `exchange:started` -> `exchange:failed` for per-item observability;
+   * then the source's subscribe promise rejects and `context:error` fires.
    *
    * Use when partial-data is unacceptable and a malformed item should stop
    * the import (atomic-load semantics).
    */
   | "abort"
   /**
-   * The parse failure is silently dropped. No exchange is created; a
-   * `warn`-level log is emitted. Streaming adapters continue to the next
-   * item.
+   * The parse failure is dropped from the pipeline. The synthetic parse
+   * step emits `exchange:started` -> `exchange:dropped` with
+   * `reason: "parse-failed"` (matching `filter` / `validate` drop
+   * semantics). Streaming adapters continue to the next item; no
+   * `exchange:failed` and no `.error()` handler invocation.
    *
    * Use when malformed items are expected (scraping, lossy upstreams) and
-   * you do not want them to surface as route errors.
+   * you want them counted in `exchange:dropped` metrics rather than
+   * surfaced as route errors.
    */
-  | "skip";
+  | "drop";
 
 /**
  * Default `OnParseError` value applied when a parsing adapter does not set
  * one explicitly.
+ *
+ * @experimental Tracks `OnParseError`'s maturity (#187).
  */
 export const DEFAULT_ON_PARSE_ERROR: OnParseError = "fail";
+
+/**
+ * Reason string emitted on `exchange:dropped` when an `onParseError: 'drop'`
+ * source rejects a malformed item. Stable so subscribers can filter:
+ *
+ * ```ts
+ * ctx.on('route:*:exchange:dropped', ({ details }) => {
+ *   if (details.reason === PARSE_DROPPED_REASON) metrics.increment('parse.dropped');
+ * });
+ * ```
+ *
+ * @experimental
+ */
+export const PARSE_DROPPED_REASON = "parse-failed";

--- a/packages/routecraft/src/consumers/batch.ts
+++ b/packages/routecraft/src/consumers/batch.ts
@@ -124,15 +124,24 @@ export class BatchConsumer implements Consumer<BatchOptions> {
     this.channel.setHandler(async (message) => {
       // When a source adapter attaches a `parse` function (see #187), the
       // batch consumer cannot defer it to the synthetic pipeline step that
-      // the simple consumer relies on, because the merged exchange has no
-      // per-item parse function. We pre-parse here and reject this item's
-      // promise on failure. The chunked source's `.catch()` (when
-      // `onParseError: 'fail'`) will continue to the next item.
+      // the simple consumer relies on: the merged batch exchange has no
+      // per-item parse function, so the runtime cannot apply parsing after
+      // batching. We pre-parse here so the batch contains parsed values.
+      //
+      // On parse failure we route the bad item through the pipeline as its
+      // own per-item exchange (handler invoked with the raw message and the
+      // captured parse function so the synthetic parse step throws RC5016).
+      // This preserves `onParseError: 'fail'` semantics: the route's
+      // `.error()` handler fires, `exchange:failed` fires when no handler
+      // is set, and the source's per-item `.catch()` continues. The bad
+      // item is NOT added to the in-progress batch.
       if (message.parse) {
+        const itemParse = message.parse;
+        const rawMessage = message.message;
         try {
-          message.message = await message.parse(message.message);
-        } catch (err) {
-          return Promise.reject(err);
+          message.message = await itemParse(rawMessage);
+        } catch {
+          return handler(rawMessage, message.headers, itemParse);
         }
         delete message.parse;
       }

--- a/packages/routecraft/src/consumers/batch.ts
+++ b/packages/routecraft/src/consumers/batch.ts
@@ -13,6 +13,7 @@ import {
   type ExchangeHeaders,
   type HeaderValue,
 } from "../exchange.ts";
+import { type OnParseError } from "../adapters/shared/parse.ts";
 
 export type BatchOptions = {
   /**
@@ -66,7 +67,7 @@ export class BatchConsumer implements Consumer<BatchOptions> {
       message: unknown,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
-      parseFailureMode?: "fail" | "abort" | "drop",
+      parseFailureMode?: OnParseError,
     ) => Promise<Exchange>,
   ): Promise<void> {
     let batch: Message[] = [];
@@ -142,11 +143,22 @@ export class BatchConsumer implements Consumer<BatchOptions> {
         const rawMessage = message.message;
         try {
           message.message = await itemParse(rawMessage);
-        } catch {
+        } catch (parseErr) {
           // Route the failed item as a per-item exchange so the synthetic
           // parse step fires the correct lifecycle event for the mode
           // (fail/abort -> exchange:failed, drop -> exchange:dropped).
-          return handler(rawMessage, message.headers, itemParse, itemMode);
+          // Pass a closure that throws the captured error rather than
+          // re-invoking `itemParse` on the same input, since user-supplied
+          // parsers may have side effects (logging, metrics, prefetch).
+          // Mirrors the mail adapter's `MAIL_PARSE_ERRORS` pattern.
+          return handler(
+            rawMessage,
+            message.headers,
+            () => {
+              throw parseErr;
+            },
+            itemMode,
+          );
         }
         delete message.parse;
         delete message.parseFailureMode;

--- a/packages/routecraft/src/consumers/batch.ts
+++ b/packages/routecraft/src/consumers/batch.ts
@@ -66,6 +66,7 @@ export class BatchConsumer implements Consumer<BatchOptions> {
       message: unknown,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
+      parseFailureMode?: "fail" | "abort" | "drop",
     ) => Promise<Exchange>,
   ): Promise<void> {
     let batch: Message[] = [];
@@ -137,13 +138,18 @@ export class BatchConsumer implements Consumer<BatchOptions> {
       // item is NOT added to the in-progress batch.
       if (message.parse) {
         const itemParse = message.parse;
+        const itemMode = message.parseFailureMode;
         const rawMessage = message.message;
         try {
           message.message = await itemParse(rawMessage);
         } catch {
-          return handler(rawMessage, message.headers, itemParse);
+          // Route the failed item as a per-item exchange so the synthetic
+          // parse step fires the correct lifecycle event for the mode
+          // (fail/abort -> exchange:failed, drop -> exchange:dropped).
+          return handler(rawMessage, message.headers, itemParse, itemMode);
         }
         delete message.parse;
+        delete message.parseFailureMode;
       }
 
       const promise = new Promise<Exchange>((resolve, reject) => {

--- a/packages/routecraft/src/consumers/batch.ts
+++ b/packages/routecraft/src/consumers/batch.ts
@@ -62,7 +62,11 @@ export class BatchConsumer implements Consumer<BatchOptions> {
   }
 
   async register(
-    handler: (message: unknown, headers?: ExchangeHeaders) => Promise<Exchange>,
+    handler: (
+      message: unknown,
+      headers?: ExchangeHeaders,
+      parse?: (raw: unknown) => unknown | Promise<unknown>,
+    ) => Promise<Exchange>,
   ): Promise<void> {
     let batch: Message[] = [];
     let resolvers: {
@@ -118,6 +122,21 @@ export class BatchConsumer implements Consumer<BatchOptions> {
     };
 
     this.channel.setHandler(async (message) => {
+      // When a source adapter attaches a `parse` function (see #187), the
+      // batch consumer cannot defer it to the synthetic pipeline step that
+      // the simple consumer relies on, because the merged exchange has no
+      // per-item parse function. We pre-parse here and reject this item's
+      // promise on failure. The chunked source's `.catch()` (when
+      // `onParseError: 'fail'`) will continue to the next item.
+      if (message.parse) {
+        try {
+          message.message = await message.parse(message.message);
+        } catch (err) {
+          return Promise.reject(err);
+        }
+        delete message.parse;
+      }
+
       const promise = new Promise<Exchange>((resolve, reject) => {
         batch.push(message);
         resolvers.push({ resolve, reject });

--- a/packages/routecraft/src/consumers/simple.ts
+++ b/packages/routecraft/src/consumers/simple.ts
@@ -2,6 +2,7 @@ import { CraftContext } from "../context.ts";
 import { type RouteDefinition } from "../route.ts";
 import { type ProcessingQueue, type Message, type Consumer } from "../types.ts";
 import { type Exchange, type ExchangeHeaders } from "../exchange.ts";
+import { type OnParseError } from "../adapters/shared/parse.ts";
 
 export class SimpleConsumer implements Consumer<never> {
   constructor(
@@ -16,7 +17,7 @@ export class SimpleConsumer implements Consumer<never> {
       message: unknown,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
-      parseFailureMode?: "fail" | "abort" | "drop",
+      parseFailureMode?: OnParseError,
     ) => Promise<Exchange>,
   ): Promise<void> {
     this.channel.setHandler(async (message) => {

--- a/packages/routecraft/src/consumers/simple.ts
+++ b/packages/routecraft/src/consumers/simple.ts
@@ -12,10 +12,14 @@ export class SimpleConsumer implements Consumer<never> {
   ) {}
 
   async register(
-    handler: (message: unknown, headers?: ExchangeHeaders) => Promise<Exchange>,
+    handler: (
+      message: unknown,
+      headers?: ExchangeHeaders,
+      parse?: (raw: unknown) => unknown | Promise<unknown>,
+    ) => Promise<Exchange>,
   ): Promise<void> {
     this.channel.setHandler(async (message) => {
-      return await handler(message.message, message.headers);
+      return await handler(message.message, message.headers, message.parse);
     });
   }
 }

--- a/packages/routecraft/src/consumers/simple.ts
+++ b/packages/routecraft/src/consumers/simple.ts
@@ -16,10 +16,16 @@ export class SimpleConsumer implements Consumer<never> {
       message: unknown,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
+      parseFailureMode?: "fail" | "abort" | "drop",
     ) => Promise<Exchange>,
   ): Promise<void> {
     this.channel.setHandler(async (message) => {
-      return await handler(message.message, message.headers, message.parse);
+      return await handler(
+        message.message,
+        message.headers,
+        message.parse,
+        message.parseFailureMode,
+      );
     });
   }
 }

--- a/packages/routecraft/src/error.ts
+++ b/packages/routecraft/src/error.ts
@@ -157,7 +157,7 @@ export const RC: Record<RCCode, RCMeta> = {
     category: "Adapter",
     message: "Source payload parse failed",
     suggestion:
-      "Check the input data matches the adapter's expected format (JSON, CSV, JSONL, HTML, MIME). Wire .error() on the route to recover, or set onParseError to 'abort' or 'skip' on the adapter.",
+      "Check the input data matches the adapter's expected format (JSON, CSV, JSONL, HTML, MIME). Wire .error() on the route to recover, or set onParseError to 'abort' (stop the source) or 'drop' (emit exchange:dropped) on the adapter.",
     docs: `${DOCS_BASE}#rc-5016`,
     retryable: false,
   },

--- a/packages/routecraft/src/error.ts
+++ b/packages/routecraft/src/error.ts
@@ -17,6 +17,7 @@ export type RCCode =
   | "RC5013"
   | "RC5014"
   | "RC5015"
+  | "RC5016"
   | "RC9901";
 
 export type RCMeta = {
@@ -150,6 +151,14 @@ export const RC: Record<RCCode, RCMeta> = {
     message: "Permission denied",
     suggestion: "Check access control, IAM, and scopes",
     docs: `${DOCS_BASE}#rc-5015`,
+    retryable: false,
+  },
+  RC5016: {
+    category: "Adapter",
+    message: "Source payload parse failed",
+    suggestion:
+      "Check the input data matches the adapter's expected format (JSON, CSV, JSONL, HTML, MIME). Wire .error() on the route to recover, or set onParseError to 'abort' or 'skip' on the adapter.",
+    docs: `${DOCS_BASE}#rc-5016`,
     retryable: false,
   },
   RC9901: {

--- a/packages/routecraft/src/exchange.ts
+++ b/packages/routecraft/src/exchange.ts
@@ -237,6 +237,15 @@ type ExchangeInternals = {
    * @internal
    */
   parse?: (raw: unknown) => unknown | Promise<unknown>;
+  /**
+   * Optional input-schema validation deferred to run inside the synthetic
+   * parse step. Used when a route has both `.input()` schemas and a
+   * parsing source: validation must see the parsed body, not the raw
+   * bytes. `DefaultRoute` populates this alongside `parse`. See #187.
+   *
+   * @internal
+   */
+  applyValidation?: (exchange: Exchange) => Promise<void>;
 };
 
 /**

--- a/packages/routecraft/src/exchange.ts
+++ b/packages/routecraft/src/exchange.ts
@@ -3,6 +3,7 @@ import { INTERNALS_KEY, BRAND, setBrand, setInternals } from "./brand.ts";
 import { type CraftContext } from "./context.ts";
 import { logger, childBindings } from "./logger.ts";
 import type { Route } from "./route.ts";
+import type { OnParseError } from "./adapters/shared/parse.ts";
 
 /**
  * Types of operations that can be performed on an exchange.
@@ -249,7 +250,7 @@ type ExchangeInternals = {
    *
    * @internal
    */
-  parseFailureMode?: "fail" | "abort" | "drop";
+  parseFailureMode?: OnParseError;
   /**
    * Optional input-schema validation deferred to run inside the synthetic
    * parse step. Used when a route has both `.input()` schemas and a

--- a/packages/routecraft/src/exchange.ts
+++ b/packages/routecraft/src/exchange.ts
@@ -11,6 +11,13 @@ import type { Route } from "./route.ts";
 export enum OperationType {
   /** The exchange was created from a source */
   FROM = "from",
+  /**
+   * Synthetic step inserted by the runtime when a source adapter attaches a
+   * `parse` function to the queued message. Runs `exchange.body = parse(body)`
+   * before any user steps so parse failures flow through the route's normal
+   * error handling instead of aborting the source. See #187.
+   */
+  PARSE = "parse",
   /** The exchange was processed by a processor */
   PROCESS = "process",
   /** The exchange was sent to a destination */
@@ -220,6 +227,16 @@ export type Exchange<T = unknown> = {
 type ExchangeInternals = {
   context: CraftContext;
   route?: Route;
+  /**
+   * Optional parser the runtime applies as a synthetic first pipeline step.
+   * Set by `DefaultRoute` from the queue `Message.parse` when a source
+   * adapter attaches one (see `CallableSource.handler` parse argument and
+   * #187). The runtime clears this after running it so it does not run
+   * twice.
+   *
+   * @internal
+   */
+  parse?: (raw: unknown) => unknown | Promise<unknown>;
 };
 
 /**

--- a/packages/routecraft/src/exchange.ts
+++ b/packages/routecraft/src/exchange.ts
@@ -16,6 +16,8 @@ export enum OperationType {
    * `parse` function to the queued message. Runs `exchange.body = parse(body)`
    * before any user steps so parse failures flow through the route's normal
    * error handling instead of aborting the source. See #187.
+   *
+   * @experimental Tracks `OnParseError`'s maturity.
    */
   PARSE = "parse",
   /** The exchange was processed by a processor */
@@ -237,6 +239,17 @@ type ExchangeInternals = {
    * @internal
    */
   parse?: (raw: unknown) => unknown | Promise<unknown>;
+  /**
+   * How the synthetic parse step should handle a parse failure.
+   * - `"fail"` / `"abort"`: throw `RC5016` so `exchange:failed` fires (and
+   *   for `"abort"` the adapter rethrows out of subscribe).
+   * - `"drop"`: emit `exchange:dropped` with `reason: "parse-failed"`,
+   *   matching filter/validate drop semantics; the pipeline halts cleanly
+   *   without invoking `.error()`. See #187.
+   *
+   * @internal
+   */
+  parseFailureMode?: "fail" | "abort" | "drop";
   /**
    * Optional input-schema validation deferred to run inside the synthetic
    * parse step. Used when a route has both `.input()` schemas and a

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -162,6 +162,11 @@ export {
 export { tagAdapter, factoryArgs } from "./adapters/shared/factory-tag.ts";
 
 export {
+  type OnParseError,
+  DEFAULT_ON_PARSE_ERROR,
+} from "./adapters/shared/parse.ts";
+
+export {
   type Adapter,
   type Consumer,
   type EventName,

--- a/packages/routecraft/src/operations/from.ts
+++ b/packages/routecraft/src/operations/from.ts
@@ -2,6 +2,7 @@ import { type CraftContext } from "../context.ts";
 import { type Exchange, type ExchangeHeaders } from "../exchange.ts";
 import { type RouteDiscovery } from "../route.ts";
 import { type Adapter } from "../types.ts";
+import { type OnParseError } from "../adapters/shared/parse.ts";
 
 /**
  * Metadata the engine passes to a source adapter at subscribe time.
@@ -75,7 +76,7 @@ export type CallableSource<T = unknown> = (
      *
      * @experimental
      */
-    parseFailureMode?: "fail" | "abort" | "drop",
+    parseFailureMode?: OnParseError,
   ) => Promise<Exchange>,
   abortController: AbortController,
   onReady?: () => void,

--- a/packages/routecraft/src/operations/from.ts
+++ b/packages/routecraft/src/operations/from.ts
@@ -31,7 +31,14 @@ export interface SourceMeta {
  * route's `.error()` handler can catch it. Adapters that emit pre-parsed
  * values (direct, simple, cron, timer, event, file) ignore the third argument.
  *
- * @template T - Body type of messages produced by this source
+ * **Type caveat:** when `parse` is supplied, the `message` argument is the
+ * RAW value (e.g. a JSON line string, raw RFC-822 bytes), not the typed `T`.
+ * The exchange body is widened to `unknown` until the synthetic parse step
+ * runs, then narrowed to `T` for downstream user steps. `.error()` handlers
+ * tied to `Exchange<T>` should NOT assume the body is `T` when the failure
+ * came from the parse step itself; they may be looking at raw bytes.
+ *
+ * @template T - Body type of messages produced by this source (after parse)
  */
 export type CallableSource<T = unknown> = (
   context: CraftContext,
@@ -54,6 +61,21 @@ export type CallableSource<T = unknown> = (
      * the contract; see #187.
      */
     parse?: (raw: unknown) => unknown | Promise<unknown>,
+    /**
+     * Decides what the synthetic parse step does on failure:
+     * - `"fail"` (default): throw `RC5016` so `exchange:failed` fires (or
+     *   the route's `.error()` recovers it).
+     * - `"abort"`: same lifecycle as `"fail"` but the source rethrows the
+     *   rejection and dies (`context:error` fires).
+     * - `"drop"`: emit `exchange:dropped` with `reason: "parse-failed"`
+     *   instead of failing; the pipeline halts cleanly without invoking
+     *   `.error()`.
+     *
+     * Adapters set this from their `onParseError` option.
+     *
+     * @experimental
+     */
+    parseFailureMode?: "fail" | "abort" | "drop",
   ) => Promise<Exchange>,
   abortController: AbortController,
   onReady?: () => void,

--- a/packages/routecraft/src/operations/from.ts
+++ b/packages/routecraft/src/operations/from.ts
@@ -23,11 +23,38 @@ export interface SourceMeta {
  * Function form of a source: subscribes to data and invokes the handler for each message.
  * Use with `.from(callableSource)` or adapters that implement Source.
  *
+ * The `handler` callback accepts an optional third argument, `parse`, that the
+ * runtime invokes as a synthetic first pipeline step. Source adapters that
+ * convert raw bytes into a structured body (json, html, csv, jsonl, mail) pass
+ * their parse logic through this argument so a parse failure becomes a normal
+ * pipeline error: the exchange exists, `exchange:started` has fired, and the
+ * route's `.error()` handler can catch it. Adapters that emit pre-parsed
+ * values (direct, simple, cron, timer, event, file) ignore the third argument.
+ *
  * @template T - Body type of messages produced by this source
  */
 export type CallableSource<T = unknown> = (
   context: CraftContext,
-  handler: (message: T, headers?: ExchangeHeaders) => Promise<Exchange>,
+  handler: (
+    message: T,
+    headers?: ExchangeHeaders,
+    /**
+     * Optional parser invoked by the runtime as the first step of the
+     * pipeline, before any user-defined step. The parsed result becomes the
+     * exchange body. Errors thrown here flow through the route's normal
+     * error handling: the route's `.error()` handler is invoked, or
+     * `exchange:failed` fires when no handler is set. Source adapters use
+     * this to defer parse failures so they are observable per exchange.
+     *
+     * Typed as `(raw: unknown) => unknown | Promise<unknown>` because the
+     * runtime cannot statically know the parsed shape; adapters narrow at
+     * the call site since they know their own raw and parsed types.
+     *
+     * @experimental Marked experimental until more parsing adapters adopt
+     * the contract; see #187.
+     */
+    parse?: (raw: unknown) => unknown | Promise<unknown>,
+  ) => Promise<Exchange>,
   abortController: AbortController,
   onReady?: () => void,
   meta?: SourceMeta,

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -21,6 +21,7 @@ import { rcError, RoutecraftError, RC, formatSchemaIssues } from "./error.ts";
 import { isRoutecraftError } from "./brand.ts";
 import { logger, childBindings } from "./logger.ts";
 import { type Source } from "./operations/from.ts";
+import { type OnParseError } from "./adapters/shared/parse.ts";
 import {
   type Adapter,
   type Step,
@@ -158,7 +159,7 @@ const PARSE_DROPPED_REASON = "parse-failed";
  */
 function buildParseStep(
   parse: (raw: unknown) => unknown | Promise<unknown>,
-  failureMode: "fail" | "abort" | "drop",
+  failureMode: OnParseError,
   applyValidation?: (exchange: Exchange) => Promise<void>,
 ): Step<Adapter> {
   return {
@@ -485,7 +486,8 @@ export class DefaultRoute implements Route {
   }
 
   /**
-   * Validate an incoming exchange against the route's `input` schemas.
+   * Validate an incoming exchange against the route's `input` schemas BEFORE
+   * the pipeline runs (no `exchange:started` has fired yet).
    *
    * On success, the exchange body and headers are mutated in place with any
    * validated / coerced values (headers are merged over the originals so
@@ -493,6 +495,12 @@ export class DefaultRoute implements Route {
    * unknowns). On failure, emits `exchange:started` followed by
    * `exchange:dropped` for telemetry and throws an RC5002 error so the
    * source's caller (e.g. a direct channel's `send`) sees the rejection.
+   *
+   * MUST NOT be called after `handler()` has emitted `exchange:started` for
+   * the exchange (e.g. from inside the synthetic parse step). Use
+   * {@link validateInputOrThrow} for that path: it throws RC5002 without
+   * emitting events, so the parse step's `step:failed` -> runSteps catch ->
+   * `exchange:failed` lifecycle stays intact.
    */
   private async applyInputValidation(
     exchange: Exchange,
@@ -515,6 +523,41 @@ export class DefaultRoute implements Route {
         // Merge validated values over the originals in place so caller
         // pass-through keys (correlation IDs, adapter-injected metadata)
         // survive schemas that strip unknowns.
+        Object.assign(exchange.headers, headerValue);
+      }
+    }
+  }
+
+  /**
+   * Same as {@link applyInputValidation} but without emitting any
+   * `exchange:started` / `exchange:dropped` events on failure: just throws
+   * RC5002. Used by the synthetic parse step in `runSteps` so a validation
+   * failure becomes a normal step failure (`step:failed` -> `exchange:failed`)
+   * rather than a duplicate `started` + stray `dropped` followed by a
+   * `failed` (see #187).
+   */
+  private async validateInputOrThrow(
+    exchange: Exchange,
+    schemas: { body?: StandardSchemaV1; headers?: StandardSchemaV1 },
+  ): Promise<void> {
+    if (schemas.body) {
+      const res = await this.validateAgainst(schemas.body, exchange.body);
+      if (!res.ok) {
+        throw rcError("RC5002", new Error(res.message), {
+          message: `Body validation failed for route "${this.definition.id}"`,
+        });
+      }
+      exchange.body = res.value;
+    }
+    if (schemas.headers) {
+      const res = await this.validateAgainst(schemas.headers, exchange.headers);
+      if (!res.ok) {
+        throw rcError("RC5002", new Error(res.message), {
+          message: `Header validation failed for route "${this.definition.id}"`,
+        });
+      }
+      const headerValue = res.value as ExchangeHeaders | undefined;
+      if (headerValue !== undefined) {
         Object.assign(exchange.headers, headerValue);
       }
     }
@@ -715,10 +758,15 @@ export class DefaultRoute implements Route {
             internals.parseFailureMode = parseFailureMode ?? "fail";
             // Validation must run AFTER parse so `.input()` schemas
             // validate the parsed body, not the raw bytes. The synthetic
-            // parse step calls this hook once parse succeeds.
+            // parse step calls this hook once parse succeeds. Use the
+            // non-emitting variant so a validation failure inside the parse
+            // step throws RC5002 cleanly into the step loop's catch path
+            // (which emits `step:failed` and then `exchange:failed`),
+            // without firing duplicate `exchange:started` /
+            // `exchange:dropped` events (see #187).
             if (hasInputSchema) {
               internals.applyValidation = (ex: Exchange) =>
-                this.applyInputValidation(ex, inputSchemas);
+                this.validateInputOrThrow(ex, inputSchemas);
             }
           }
         } else if (hasInputSchema) {

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -21,7 +21,10 @@ import { rcError, RoutecraftError, RC, formatSchemaIssues } from "./error.ts";
 import { isRoutecraftError } from "./brand.ts";
 import { logger, childBindings } from "./logger.ts";
 import { type Source } from "./operations/from.ts";
-import { type OnParseError } from "./adapters/shared/parse.ts";
+import {
+  type OnParseError,
+  PARSE_DROPPED_REASON,
+} from "./adapters/shared/parse.ts";
 import {
   type Adapter,
   type Step,
@@ -120,19 +123,6 @@ export interface RouteDiscovery {
 const PARSE_STEP_ADAPTER: Adapter = { adapterId: "routecraft.parse" };
 
 /**
- * Stable `reason` string emitted on `exchange:dropped` when a parsing source
- * with `onParseError: 'drop'` rejects a malformed item. Mirrors the constant
- * exported from `adapters/shared/parse.ts`. Subscribers can filter on this:
- *
- * ```ts
- * ctx.on('route:*:exchange:dropped', ({ details }) => {
- *   if (details.reason === 'parse-failed') metrics.increment('parse.dropped');
- * });
- * ```
- */
-const PARSE_DROPPED_REASON = "parse-failed";
-
-/**
  * Build a synthetic pipeline step that runs a source-supplied parse function
  * against the exchange body. Inserted by `runSteps` as the first step when a
  * source attaches `parse` to its message; this is what makes parse failures
@@ -216,9 +206,12 @@ function buildParseStep(
         exchange.body = await parse(exchange.body);
       } catch (cause) {
         if (failureMode === "drop") {
-          // Drops are not failures: emit step:completed (the step itself
-          // ran cleanly), then exchange:dropped with a stable reason.
-          emitStepCompleted();
+          // The parse threw, so the step itself failed: emit step:failed
+          // (honest about what happened), then exchange:dropped with a
+          // stable reason (carries the policy decision). Subscribers
+          // counting parse failures see step:failed; subscribers
+          // tracking drop policy see exchange:dropped.
+          emitStepFailed(cause);
           context?.emit(`route:${routeId}:exchange:dropped` as EventName, {
             routeId,
             exchangeId: exchange.id,

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -116,11 +116,7 @@ export interface RouteDiscovery {
  * Synthetic adapter used as the carrier for the parse step. Has no behaviour;
  * the step's `execute` does the work.
  */
-const PARSE_STEP_ADAPTER: Adapter = {
-  adapterId: "routecraft.parse",
-} as Adapter & {
-  adapterId: string;
-};
+const PARSE_STEP_ADAPTER: Adapter = { adapterId: "routecraft.parse" };
 
 /**
  * Build a synthetic pipeline step that runs a source-supplied parse function
@@ -131,9 +127,15 @@ const PARSE_STEP_ADAPTER: Adapter = {
  *
  * Errors are wrapped as `RC5016` so consumers can distinguish parse failures
  * from generic step failures (`RC5001`).
+ *
+ * When `applyValidation` is supplied, it runs immediately after the parse so
+ * route-level `.input()` schemas validate the parsed body, not the raw bytes.
+ * A validation failure throws out of `applyValidation` and is handled by the
+ * step loop's catch path the same way any step error is.
  */
 function buildParseStep(
   parse: (raw: unknown) => unknown | Promise<unknown>,
+  applyValidation?: (exchange: Exchange) => Promise<void>,
 ): Step<Adapter> {
   return {
     operation: OperationType.PARSE,
@@ -148,6 +150,9 @@ function buildParseStep(
         throw rcError("RC5016", cause, {
           message: `Source payload parse failed: ${causeMessage}`,
         });
+      }
+      if (applyValidation) {
+        await applyValidation(exchange);
       }
       // Hand control back to the step loop with the user's pipeline.
       queue.push({ exchange, steps: remainingSteps });
@@ -598,23 +603,32 @@ export class DefaultRoute implements Route {
     // caller (e.g. a direct channel's `send`) sees the validation error.
     this.consumer.register(async (message, headers, parse) => {
       const exchange = this.buildExchange(message, headers);
+      const inputSchemas = this.definition.discovery?.input;
+      const hasInputSchema = !!inputSchemas?.body || !!inputSchemas?.headers;
 
-      // Stash the source-supplied parser on exchange internals so `runSteps`
-      // can apply it as a synthetic first pipeline step. This is what makes
-      // parse errors (e.g. malformed JSONL line, bad CSV row) surface as
-      // normal pipeline errors that the route's `.error()` handler can
-      // catch, rather than aborting the source. See #187.
       if (parse) {
+        // Stash the source-supplied parser on exchange internals so
+        // `runSteps` can apply it as a synthetic first pipeline step. This
+        // is what makes parse errors (e.g. malformed JSONL line, bad CSV
+        // row) surface as normal pipeline errors that the route's
+        // `.error()` handler can catch, rather than aborting the source.
+        // See #187.
         const internals = EXCHANGE_INTERNALS.get(exchange);
         if (internals) {
           internals.parse = parse;
+          // Validation must run AFTER parse so `.input()` schemas validate
+          // the parsed body, not the raw bytes. The synthetic parse step
+          // calls this hook once parse succeeds.
+          if (hasInputSchema) {
+            internals.applyValidation = (ex: Exchange) =>
+              this.applyInputValidation(ex, inputSchemas);
+          }
         }
-      }
-
-      const inputSchemas = this.definition.discovery?.input;
-      if (inputSchemas?.body || inputSchemas?.headers) {
+      } else if (hasInputSchema) {
+        // No parse: run validation eagerly (preserves existing behaviour).
         await this.applyInputValidation(exchange, inputSchemas);
       }
+
       return this.handler(exchange);
     });
 
@@ -786,15 +800,17 @@ export class DefaultRoute implements Route {
     // `.error()` handler is invoked, or `exchange:failed` fires.
     const internals = EXCHANGE_INTERNALS.get(exchange);
     const sourceParse = internals?.parse;
+    const sourceValidate = internals?.applyValidation;
     if (internals && sourceParse) {
       // Clear so parse never runs twice on the same exchange (e.g. if the
       // exchange is forwarded back through the queue).
       delete internals.parse;
+      delete internals.applyValidation;
     }
 
     const userSteps = [...this.definition.steps];
     const initialSteps: Step<Adapter>[] = sourceParse
-      ? [buildParseStep(sourceParse), ...userSteps]
+      ? [buildParseStep(sourceParse, sourceValidate), ...userSteps]
       : userSteps;
 
     const queue: { exchange: Exchange; steps: Step<Adapter>[] }[] = [

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -119,41 +119,137 @@ export interface RouteDiscovery {
 const PARSE_STEP_ADAPTER: Adapter = { adapterId: "routecraft.parse" };
 
 /**
+ * Stable `reason` string emitted on `exchange:dropped` when a parsing source
+ * with `onParseError: 'drop'` rejects a malformed item. Mirrors the constant
+ * exported from `adapters/shared/parse.ts`. Subscribers can filter on this:
+ *
+ * ```ts
+ * ctx.on('route:*:exchange:dropped', ({ details }) => {
+ *   if (details.reason === 'parse-failed') metrics.increment('parse.dropped');
+ * });
+ * ```
+ */
+const PARSE_DROPPED_REASON = "parse-failed";
+
+/**
  * Build a synthetic pipeline step that runs a source-supplied parse function
  * against the exchange body. Inserted by `runSteps` as the first step when a
- * source attaches `parse` to its message; ensures parse failures flow through
- * the route's normal error-handling machinery (`.error()` handler,
- * `exchange:failed`) instead of aborting the source. See #187.
+ * source attaches `parse` to its message; this is what makes parse failures
+ * observable as normal pipeline events (rather than aborting the source).
+ * See #187.
  *
- * Errors are wrapped as `RC5016` so consumers can distinguish parse failures
- * from generic step failures (`RC5001`).
+ * Behaviour on parse failure depends on `failureMode`:
+ * - `"fail"` / `"abort"`: throw `RC5016` so `exchange:failed` fires (or the
+ *   route's `.error()` handler recovers). The adapter's caller distinguishes
+ *   `"abort"` by re-throwing the rejection out of subscribe.
+ * - `"drop"`: emit `exchange:dropped` with `reason: "parse-failed"` (matching
+ *   filter / validate drop semantics) and halt the pipeline cleanly without
+ *   invoking `.error()`.
  *
- * When `applyValidation` is supplied, it runs immediately after the parse so
- * route-level `.input()` schemas validate the parsed body, not the raw bytes.
- * A validation failure throws out of `applyValidation` and is handled by the
- * step loop's catch path the same way any step error is.
+ * When `applyValidation` is supplied, it runs immediately after a successful
+ * parse so route-level `.input()` schemas validate the parsed body, not the
+ * raw bytes. Validation failure throws out of `applyValidation` and is
+ * handled by the step loop's catch path like any step error.
+ *
+ * The step manages its own `step:started` / `step:completed` / `step:failed`
+ * lifecycle events (`skipStepEvents: true`) so we can emit `step:completed`
+ * for the drop case (drops are not failures) without the route loop
+ * double-emitting.
  */
 function buildParseStep(
   parse: (raw: unknown) => unknown | Promise<unknown>,
+  failureMode: "fail" | "abort" | "drop",
   applyValidation?: (exchange: Exchange) => Promise<void>,
 ): Step<Adapter> {
   return {
     operation: OperationType.PARSE,
     label: "parse",
     adapter: PARSE_STEP_ADAPTER,
+    skipStepEvents: true,
     async execute(exchange, remainingSteps, queue) {
+      const internals = EXCHANGE_INTERNALS.get(exchange);
+      const context = internals?.context;
+      const route = internals?.route;
+      const routeId =
+        route?.definition.id ??
+        (exchange.headers[HeadersKeys.ROUTE_ID] as string);
+      const correlationId = exchange.headers[
+        HeadersKeys.CORRELATION_ID
+      ] as string;
+      const stepStart = Date.now();
+
+      const emitStepStarted = () => {
+        context?.emit(`route:${routeId}:step:started` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          operation: "parse",
+          adapter: "parse",
+        });
+      };
+      const emitStepCompleted = () => {
+        context?.emit(`route:${routeId}:step:completed` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          operation: "parse",
+          adapter: "parse",
+          duration: Date.now() - stepStart,
+        });
+      };
+      const emitStepFailed = (err: unknown) => {
+        context?.emit(`route:${routeId}:step:failed` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          operation: "parse",
+          adapter: "parse",
+          duration: Date.now() - stepStart,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      };
+
+      emitStepStarted();
+
       try {
         exchange.body = await parse(exchange.body);
       } catch (cause) {
+        if (failureMode === "drop") {
+          // Drops are not failures: emit step:completed (the step itself
+          // ran cleanly), then exchange:dropped with a stable reason.
+          emitStepCompleted();
+          context?.emit(`route:${routeId}:exchange:dropped` as EventName, {
+            routeId,
+            exchangeId: exchange.id,
+            correlationId,
+            reason: PARSE_DROPPED_REASON,
+            exchange,
+          });
+          // Mark dropped so the route engine does not emit
+          // exchange:completed for this exchange.
+          exchange.headers["routecraft.dropped"] = true;
+          return;
+        }
+        // 'fail' / 'abort': throw RC5016 so the step loop's catch path
+        // emits exchange:failed (or invokes the route's `.error()`).
+        emitStepFailed(cause);
         const causeMessage =
           cause instanceof Error ? cause.message : String(cause);
         throw rcError("RC5016", cause, {
           message: `Source payload parse failed: ${causeMessage}`,
         });
       }
+
       if (applyValidation) {
-        await applyValidation(exchange);
+        try {
+          await applyValidation(exchange);
+        } catch (cause) {
+          emitStepFailed(cause);
+          throw cause;
+        }
       }
+
+      emitStepCompleted();
       // Hand control back to the step loop with the user's pipeline.
       queue.push({ exchange, steps: remainingSteps });
     },
@@ -601,36 +697,38 @@ export class DefaultRoute implements Route {
     // validation without per-adapter wiring. On failure the engine emits
     // `exchange:dropped` for telemetry and re-throws so the source's own
     // caller (e.g. a direct channel's `send`) sees the validation error.
-    this.consumer.register(async (message, headers, parse) => {
-      const exchange = this.buildExchange(message, headers);
-      const inputSchemas = this.definition.discovery?.input;
-      const hasInputSchema = !!inputSchemas?.body || !!inputSchemas?.headers;
+    this.consumer.register(
+      async (message, headers, parse, parseFailureMode) => {
+        const exchange = this.buildExchange(message, headers);
+        const inputSchemas = this.definition.discovery?.input;
+        const hasInputSchema = !!inputSchemas?.body || !!inputSchemas?.headers;
 
-      if (parse) {
-        // Stash the source-supplied parser on exchange internals so
-        // `runSteps` can apply it as a synthetic first pipeline step. This
-        // is what makes parse errors (e.g. malformed JSONL line, bad CSV
-        // row) surface as normal pipeline errors that the route's
-        // `.error()` handler can catch, rather than aborting the source.
-        // See #187.
-        const internals = EXCHANGE_INTERNALS.get(exchange);
-        if (internals) {
-          internals.parse = parse;
-          // Validation must run AFTER parse so `.input()` schemas validate
-          // the parsed body, not the raw bytes. The synthetic parse step
-          // calls this hook once parse succeeds.
-          if (hasInputSchema) {
-            internals.applyValidation = (ex: Exchange) =>
-              this.applyInputValidation(ex, inputSchemas);
+        if (parse) {
+          // Stash the source-supplied parser on exchange internals so
+          // `runSteps` can apply it as a synthetic first pipeline step.
+          // This is what makes parse errors surface as normal pipeline
+          // events the route can observe (`.error()` for `'fail'`,
+          // `exchange:dropped` for `'drop'`). See #187.
+          const internals = EXCHANGE_INTERNALS.get(exchange);
+          if (internals) {
+            internals.parse = parse;
+            internals.parseFailureMode = parseFailureMode ?? "fail";
+            // Validation must run AFTER parse so `.input()` schemas
+            // validate the parsed body, not the raw bytes. The synthetic
+            // parse step calls this hook once parse succeeds.
+            if (hasInputSchema) {
+              internals.applyValidation = (ex: Exchange) =>
+                this.applyInputValidation(ex, inputSchemas);
+            }
           }
+        } else if (hasInputSchema) {
+          // No parse: run validation eagerly (preserves existing behaviour).
+          await this.applyInputValidation(exchange, inputSchemas);
         }
-      } else if (hasInputSchema) {
-        // No parse: run validation eagerly (preserves existing behaviour).
-        await this.applyInputValidation(exchange, inputSchemas);
-      }
 
-      return this.handler(exchange);
-    });
+        return this.handler(exchange);
+      },
+    );
 
     let emitted = false;
     const onReady = () => {
@@ -663,7 +761,7 @@ export class DefaultRoute implements Route {
     };
     return activeSource.subscribe(
       this.context,
-      (message, headers, parse) => {
+      (message, headers, parse, parseFailureMode) => {
         onReady(); // fallback: fire before first message if adapter never called it
         return this.messageChannel.enqueue({
           message,
@@ -671,6 +769,7 @@ export class DefaultRoute implements Route {
           ...(parse
             ? {
                 parse: parse as (raw: unknown) => unknown | Promise<unknown>,
+                parseFailureMode: parseFailureMode ?? "fail",
               }
             : {}),
         });
@@ -801,16 +900,21 @@ export class DefaultRoute implements Route {
     const internals = EXCHANGE_INTERNALS.get(exchange);
     const sourceParse = internals?.parse;
     const sourceValidate = internals?.applyValidation;
+    const sourceFailureMode = internals?.parseFailureMode ?? "fail";
     if (internals && sourceParse) {
       // Clear so parse never runs twice on the same exchange (e.g. if the
       // exchange is forwarded back through the queue).
       delete internals.parse;
+      delete internals.parseFailureMode;
       delete internals.applyValidation;
     }
 
     const userSteps = [...this.definition.steps];
     const initialSteps: Step<Adapter>[] = sourceParse
-      ? [buildParseStep(sourceParse, sourceValidate), ...userSteps]
+      ? [
+          buildParseStep(sourceParse, sourceFailureMode, sourceValidate),
+          ...userSteps,
+        ]
       : userSteps;
 
     const queue: { exchange: Exchange; steps: Step<Adapter>[] }[] = [

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -113,6 +113,49 @@ export interface RouteDiscovery {
 }
 
 /**
+ * Synthetic adapter used as the carrier for the parse step. Has no behaviour;
+ * the step's `execute` does the work.
+ */
+const PARSE_STEP_ADAPTER: Adapter = {
+  adapterId: "routecraft.parse",
+} as Adapter & {
+  adapterId: string;
+};
+
+/**
+ * Build a synthetic pipeline step that runs a source-supplied parse function
+ * against the exchange body. Inserted by `runSteps` as the first step when a
+ * source attaches `parse` to its message; ensures parse failures flow through
+ * the route's normal error-handling machinery (`.error()` handler,
+ * `exchange:failed`) instead of aborting the source. See #187.
+ *
+ * Errors are wrapped as `RC5016` so consumers can distinguish parse failures
+ * from generic step failures (`RC5001`).
+ */
+function buildParseStep(
+  parse: (raw: unknown) => unknown | Promise<unknown>,
+): Step<Adapter> {
+  return {
+    operation: OperationType.PARSE,
+    label: "parse",
+    adapter: PARSE_STEP_ADAPTER,
+    async execute(exchange, remainingSteps, queue) {
+      try {
+        exchange.body = await parse(exchange.body);
+      } catch (cause) {
+        const causeMessage =
+          cause instanceof Error ? cause.message : String(cause);
+        throw rcError("RC5016", cause, {
+          message: `Source payload parse failed: ${causeMessage}`,
+        });
+      }
+      // Hand control back to the step loop with the user's pipeline.
+      queue.push({ exchange, steps: remainingSteps });
+    },
+  };
+}
+
+/**
  * Configuration for a route: source, steps, and consumer.
  *
  * Describes how data flows from a source through processing steps to destinations.
@@ -553,8 +596,21 @@ export class DefaultRoute implements Route {
     // validation without per-adapter wiring. On failure the engine emits
     // `exchange:dropped` for telemetry and re-throws so the source's own
     // caller (e.g. a direct channel's `send`) sees the validation error.
-    this.consumer.register(async (message, headers) => {
+    this.consumer.register(async (message, headers, parse) => {
       const exchange = this.buildExchange(message, headers);
+
+      // Stash the source-supplied parser on exchange internals so `runSteps`
+      // can apply it as a synthetic first pipeline step. This is what makes
+      // parse errors (e.g. malformed JSONL line, bad CSV row) surface as
+      // normal pipeline errors that the route's `.error()` handler can
+      // catch, rather than aborting the source. See #187.
+      if (parse) {
+        const internals = EXCHANGE_INTERNALS.get(exchange);
+        if (internals) {
+          internals.parse = parse;
+        }
+      }
+
       const inputSchemas = this.definition.discovery?.input;
       if (inputSchemas?.body || inputSchemas?.headers) {
         await this.applyInputValidation(exchange, inputSchemas);
@@ -593,11 +649,16 @@ export class DefaultRoute implements Route {
     };
     return activeSource.subscribe(
       this.context,
-      (message, headers) => {
+      (message, headers, parse) => {
         onReady(); // fallback: fire before first message if adapter never called it
         return this.messageChannel.enqueue({
           message,
           headers: headers ?? {},
+          ...(parse
+            ? {
+                parse: parse as (raw: unknown) => unknown | Promise<unknown>,
+              }
+            : {}),
         });
       },
       this.abortController,
@@ -718,8 +779,26 @@ export class DefaultRoute implements Route {
     dropped: boolean;
     error?: unknown;
   }> {
+    // If the source adapter attached a `parse` function (see #187), prepend
+    // a synthetic step that runs it before any user-defined steps. The step
+    // throws an `RC5016` error on parse failure, which then flows through
+    // the same error-handler path as any other step error: the route's
+    // `.error()` handler is invoked, or `exchange:failed` fires.
+    const internals = EXCHANGE_INTERNALS.get(exchange);
+    const sourceParse = internals?.parse;
+    if (internals && sourceParse) {
+      // Clear so parse never runs twice on the same exchange (e.g. if the
+      // exchange is forwarded back through the queue).
+      delete internals.parse;
+    }
+
+    const userSteps = [...this.definition.steps];
+    const initialSteps: Step<Adapter>[] = sourceParse
+      ? [buildParseStep(sourceParse), ...userSteps]
+      : userSteps;
+
     const queue: { exchange: Exchange; steps: Step<Adapter>[] }[] = [
-      { exchange: exchange, steps: [...this.definition.steps] },
+      { exchange: exchange, steps: initialSteps },
     ];
 
     let lastProcessedExchange: Exchange = exchange;

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -90,17 +90,22 @@ export type ConsumerType<T extends Consumer, O = unknown> = new (
  *   `exchange.body = await parse(exchange.body)` inside the same try/catch
  *   that handles step errors, so a parse failure flows through the route's
  *   `errorHandler` and `exchange:failed` event path. See
- *   `adapters/shared/parse.ts` for the `OnParseError` semantics that adapters
- *   use to decide whether to set `parse` (= `'fail'`) or handle the error
- *   inline (`'abort'` / `'skip'`).
+ *   `adapters/shared/parse.ts` for the `OnParseError` semantics.
+ * @property parseFailureMode - Decides how the synthetic parse step handles
+ *   a thrown parse error. `"fail"` (default) and `"abort"` throw `RC5016`
+ *   so `exchange:failed` fires; `"drop"` instead emits `exchange:dropped`
+ *   with `reason: "parse-failed"`. Adapters set this from their
+ *   `onParseError` option; the source loop additionally rethrows for
+ *   `"abort"` so the source dies. See #187.
  *
- * @experimental The `parse` field is part of the parse-error-handling work
- * in #187. Its shape may evolve as more parsing adapters adopt the contract.
+ * @experimental The `parse`/`parseFailureMode` fields are part of the
+ * parse-error-handling work in #187. Their shape may evolve.
  */
 export type Message = {
   message: unknown;
   headers?: ExchangeHeaders;
   parse?: (raw: unknown) => unknown | Promise<unknown>;
+  parseFailureMode?: "fail" | "abort" | "drop";
 };
 
 export interface Consumer<O = unknown> {
@@ -125,6 +130,7 @@ export interface Consumer<O = unknown> {
       message: unknown,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
+      parseFailureMode?: "fail" | "abort" | "drop",
     ) => Promise<Exchange>,
   ): void;
 }

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -3,6 +3,7 @@ import { type OperationType } from "./exchange.ts";
 import { type CraftContext } from "./context.ts";
 import { type RouteDefinition } from "./route.ts";
 import { type Route } from "./route.ts";
+import { type OnParseError } from "./adapters/shared/parse.ts";
 
 /**
  * Base interface for all adapters (sources, destinations, transformers, filters, etc.).
@@ -105,7 +106,7 @@ export type Message = {
   message: unknown;
   headers?: ExchangeHeaders;
   parse?: (raw: unknown) => unknown | Promise<unknown>;
-  parseFailureMode?: "fail" | "abort" | "drop";
+  parseFailureMode?: OnParseError;
 };
 
 export interface Consumer<O = unknown> {
@@ -130,7 +131,7 @@ export interface Consumer<O = unknown> {
       message: unknown,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
-      parseFailureMode?: "fail" | "abort" | "drop",
+      parseFailureMode?: OnParseError,
     ) => Promise<Exchange>,
   ): void;
 }

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -76,9 +76,31 @@ export type ConsumerType<T extends Consumer, O = unknown> = new (
   options: O,
 ) => T;
 
+/**
+ * Internal envelope flowing from a source adapter to its consumer through the
+ * route's processing queue.
+ *
+ * @property message - Raw payload as the adapter handed it to `handler(...)`.
+ *   When `parse` is set this is typically the unparsed bytes/string; when
+ *   `parse` is unset this is the already-parsed value used directly as the
+ *   exchange body.
+ * @property headers - Optional exchange headers attached by the adapter.
+ * @property parse - Optional parser the runtime invokes as a synthetic first
+ *   step before any user-defined steps run. When provided, the runtime sets
+ *   `exchange.body = await parse(exchange.body)` inside the same try/catch
+ *   that handles step errors, so a parse failure flows through the route's
+ *   `errorHandler` and `exchange:failed` event path. See
+ *   `adapters/shared/parse.ts` for the `OnParseError` semantics that adapters
+ *   use to decide whether to set `parse` (= `'fail'`) or handle the error
+ *   inline (`'abort'` / `'skip'`).
+ *
+ * @experimental The `parse` field is part of the parse-error-handling work
+ * in #187. Its shape may evolve as more parsing adapters adopt the contract.
+ */
 export type Message = {
   message: unknown;
   headers?: ExchangeHeaders;
+  parse?: (raw: unknown) => unknown | Promise<unknown>;
 };
 
 export interface Consumer<O = unknown> {
@@ -90,9 +112,20 @@ export interface Consumer<O = unknown> {
    * Register the route handler. At runtime, message and the returned exchange's body
    * are untyped (unknown). The builder chain is typed; narrow or assert in the handler
    * if you need to access body fields.
+   *
+   * The optional `parse` argument is forwarded by the consumer when the
+   * source adapter attached one to the queued `Message`. The route
+   * captures it on the exchange internals so `runSteps` can apply it as a
+   * synthetic first pipeline step. Consumers that merge multiple messages
+   * (e.g. batch) parse items eagerly during enqueue and pass a `parse`-less
+   * call here.
    */
   register(
-    handler: (message: unknown, headers?: ExchangeHeaders) => Promise<Exchange>,
+    handler: (
+      message: unknown,
+      headers?: ExchangeHeaders,
+      parse?: (raw: unknown) => unknown | Promise<unknown>,
+    ) => Promise<Exchange>,
   ): void;
 }
 

--- a/packages/routecraft/test/batch.test.ts
+++ b/packages/routecraft/test/batch.test.ts
@@ -80,4 +80,84 @@ describe("BatchConsumer", () => {
       waitTime: 50,
     });
   });
+
+  /**
+   * @case Parse failures route through the registered handler with the parse fn (#187)
+   * @preconditions Batch consumer; enqueue one item with a failing parse and one with a passing parse
+   * @expectedResult Bad item invokes the registered handler with raw message + parse fn + parseFailureMode; good item is added to the batch and flushed normally with the parsed value
+   */
+  test("routes parse failures through the registered handler instead of swallowing them", async () => {
+    const ctx = new CraftContext();
+    const queue = new InMemoryProcessingQueue<Message>();
+    const consumer = new BatchConsumer(
+      ctx,
+      createRouteDefinition("batched-parse"),
+      queue,
+      { size: 10, time: 50 },
+    );
+
+    type HandlerCall = {
+      message: unknown;
+      parseProvided: boolean;
+      mode: string | undefined;
+    };
+    const calls: HandlerCall[] = [];
+
+    await consumer.register(async (message, _headers, parse, mode) => {
+      calls.push({
+        message,
+        parseProvided: typeof parse === "function",
+        mode,
+      });
+      return {
+        id: "exchange-id",
+        body: message,
+        headers: {},
+        logger: ctx.logger,
+      } as Exchange;
+    });
+
+    // Enqueue a good item first so the batch starts.
+    const goodPromise = queue.enqueue({
+      message: '{"id":1}',
+      headers: {},
+      parse: (raw) => JSON.parse(raw as string),
+      parseFailureMode: "fail",
+    });
+
+    // Enqueue a bad item: pre-parse will throw and the consumer must
+    // route through the registered handler with the parse fn so the
+    // synthetic parse step (in the real route runtime) can fire RC5016.
+    const badPromise = queue.enqueue({
+      message: "not-json",
+      headers: {},
+      parse: (raw) => JSON.parse(raw as string),
+      parseFailureMode: "fail",
+    });
+
+    // The bad item is routed immediately as its own per-item exchange:
+    // the batch consumer calls handler(rawMessage, headers, parse, mode).
+    await badPromise;
+    expect(
+      calls.some(
+        (c) =>
+          c.message === "not-json" &&
+          c.parseProvided === true &&
+          c.mode === "fail",
+      ),
+    ).toBe(true);
+
+    // The good item stays in the batch until the timer fires.
+    await vi.advanceTimersByTimeAsync(50);
+    await goodPromise;
+    expect(
+      calls.some(
+        (c) =>
+          // After pre-parse the merged batch body is the parsed array.
+          Array.isArray(c.message) &&
+          c.message.length === 1 &&
+          (c.message[0] as { id?: number }).id === 1,
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/routecraft/test/csv-chunked.test.ts
+++ b/packages/routecraft/test/csv-chunked.test.ts
@@ -243,34 +243,44 @@ describe("CSV Adapter - Chunked Mode", () => {
   });
 
   /**
-   * @case onParseError: 'skip' silently drops malformed rows
-   * @preconditions CSV chunked mode with malformed row and onParseError: 'skip'
-   * @expectedResult Only valid rows reach the spy; no error events
+   * @case onParseError: 'drop' emits exchange:dropped for malformed rows
+   * @preconditions CSV chunked with malformed row and onParseError: 'drop'
+   * @expectedResult Only valid rows reach the spy; exchange:dropped fires with reason "parse-failed"
    */
-  test("onParseError: 'skip' silently drops malformed rows", async () => {
-    const filePath = path.join(tmpDir, "skip.csv");
+  test("onParseError: 'drop' emits exchange:dropped for malformed rows", async () => {
+    const filePath = path.join(tmpDir, "drop.csv");
     await fsp.writeFile(filePath, "a,b,c\n1,2,3\n4,5\n6,7,8\n", "utf-8");
 
     const s = spy();
+    const dropped: { reason: string }[] = [];
 
     t = await testContext()
       .routes(
         craft()
-          .id("csv-chunked-skip")
+          .id("csv-chunked-drop")
           .from(
             csv({
               path: filePath,
               header: true,
               chunked: true,
-              onParseError: "skip",
+              onParseError: "drop",
             }),
           )
           .to(s),
       )
       .build();
 
+    t.ctx.on(
+      "route:csv-chunked-drop:exchange:dropped" as never,
+      ((payload: { details: { reason: string } }) => {
+        dropped.push({ reason: payload.details.reason });
+      }) as never,
+    );
+
     await t.ctx.start();
 
     expect(s.received.length).toBe(2);
+    expect(dropped.length).toBeGreaterThanOrEqual(1);
+    expect(dropped[0].reason).toBe("parse-failed");
   });
 });

--- a/packages/routecraft/test/csv-chunked.test.ts
+++ b/packages/routecraft/test/csv-chunked.test.ts
@@ -207,4 +207,70 @@ describe("CSV Adapter - Chunked Mode", () => {
     expect(received.length).toBeGreaterThanOrEqual(3);
     expect(received.length).toBeLessThan(50);
   }, 10000);
+
+  /**
+   * @case Default 'fail' mode routes per-row parse errors through .error() and continues
+   * @preconditions CSV chunked mode with a row Papa flags as malformed
+   * @expectedResult error handler invoked with RC5016, valid rows still reach the spy
+   */
+  test("default 'fail' routes per-row parse errors through .error() and continues", async () => {
+    const filePath = path.join(tmpDir, "mixed.csv");
+    // Mismatched column counts force PapaParse to flag a row error.
+    await fsp.writeFile(filePath, "a,b,c\n1,2,3\n4,5\n6,7,8\n", "utf-8");
+
+    const s = spy();
+    const errors: unknown[] = [];
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("csv-chunked-fail")
+          .error((err) => {
+            errors.push(err);
+            return undefined;
+          })
+          .from(csv({ path: filePath, header: true, chunked: true }))
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect((errors[0] as { rc?: string }).rc).toBe("RC5016");
+    // Two valid rows still flow through; the malformed one is caught by .error().
+    expect(s.received.length).toBe(2);
+  });
+
+  /**
+   * @case onParseError: 'skip' silently drops malformed rows
+   * @preconditions CSV chunked mode with malformed row and onParseError: 'skip'
+   * @expectedResult Only valid rows reach the spy; no error events
+   */
+  test("onParseError: 'skip' silently drops malformed rows", async () => {
+    const filePath = path.join(tmpDir, "skip.csv");
+    await fsp.writeFile(filePath, "a,b,c\n1,2,3\n4,5\n6,7,8\n", "utf-8");
+
+    const s = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("csv-chunked-skip")
+          .from(
+            csv({
+              path: filePath,
+              header: true,
+              chunked: true,
+              onParseError: "skip",
+            }),
+          )
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    expect(s.received.length).toBe(2);
+  });
 });

--- a/packages/routecraft/test/csv.test.ts
+++ b/packages/routecraft/test/csv.test.ts
@@ -404,4 +404,116 @@ Alice,30
       expect(adapter.adapterId).toBe("routecraft.adapter.csv");
     });
   });
+
+  describe("source mode - non-chunked onParseError", () => {
+    /**
+     * @case Default 'fail' routes parse error through .error()
+     * @preconditions Non-chunked CSV with malformed row count, default onParseError
+     * @expectedResult .error() handler invoked with RC5016; spy receives nothing
+     */
+    test("default 'fail' routes parse error through .error()", async () => {
+      const filePath = path.join(tmpDir, "bad.csv");
+      // Mismatched columns force a Papa parse error.
+      await fsp.writeFile(filePath, "a,b,c\n1,2\n", "utf-8");
+
+      const s = spy();
+      const errors: { rc?: string }[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("csv-non-chunked-fail")
+            .error((err) => {
+              errors.push(err as { rc?: string });
+              return undefined;
+            })
+            .from(csv({ path: filePath, header: true }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errors.length).toBe(1);
+      expect(errors[0].rc).toBe("RC5016");
+      expect(s.received.length).toBe(0);
+    });
+
+    /**
+     * @case 'abort' emits exchange:failed then context:error
+     * @preconditions Non-chunked CSV with malformed row, onParseError: 'abort'
+     * @expectedResult Per-item exchange:failed fires; context:error fires
+     */
+    test("'abort' emits exchange:failed then context:error", async () => {
+      const filePath = path.join(tmpDir, "bad.csv");
+      await fsp.writeFile(filePath, "a,b,c\n1,2\n", "utf-8");
+
+      const s = spy();
+      const failed: { error: unknown }[] = [];
+      const ctxErrs: { error: unknown }[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("csv-non-chunked-abort")
+            .from(csv({ path: filePath, header: true, onParseError: "abort" }))
+            .to(s),
+        )
+        .build();
+
+      t.ctx.on(
+        "route:csv-non-chunked-abort:exchange:failed" as never,
+        ((payload: { details: { error: unknown } }) => {
+          failed.push({ error: payload.details.error });
+        }) as never,
+      );
+      t.ctx.on("context:error", (payload) => {
+        ctxErrs.push({ error: payload.details.error });
+      });
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(failed.length).toBe(1);
+      expect((failed[0].error as { rc?: string }).rc).toBe("RC5016");
+      expect(ctxErrs.length).toBeGreaterThanOrEqual(1);
+    });
+
+    /**
+     * @case 'drop' emits exchange:dropped on parse failure
+     * @preconditions Non-chunked CSV with malformed row, onParseError: 'drop'
+     * @expectedResult exchange:dropped fires with reason 'parse-failed'; spy receives nothing
+     */
+    test("'drop' emits exchange:dropped on parse failure", async () => {
+      const filePath = path.join(tmpDir, "bad.csv");
+      await fsp.writeFile(filePath, "a,b,c\n1,2\n", "utf-8");
+
+      const s = spy();
+      const dropped: { reason: string }[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("csv-non-chunked-drop")
+            .from(csv({ path: filePath, header: true, onParseError: "drop" }))
+            .to(s),
+        )
+        .build();
+
+      t.ctx.on(
+        "route:csv-non-chunked-drop:exchange:dropped" as never,
+        ((payload: { details: { reason: string } }) => {
+          dropped.push({ reason: payload.details.reason });
+        }) as never,
+      );
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(dropped.length).toBe(1);
+      expect(dropped[0].reason).toBe("parse-failed");
+      expect(s.received.length).toBe(0);
+    });
+  });
 });

--- a/packages/routecraft/test/html.test.ts
+++ b/packages/routecraft/test/html.test.ts
@@ -524,4 +524,151 @@ describe("HTML Adapter", () => {
       expect(fileContent).toBe(htmlContent);
     });
   });
+
+  describe("source-mode onParseError handling", () => {
+    let tempDir: string;
+    let testFile: string;
+
+    /**
+     * @case Default 'fail' routes extraction failure through .error()
+     * @preconditions HTML source with extract: 'attr' but no attr option (extractHtml throws)
+     * @expectedResult .error() handler invoked with RC5016; spy receives nothing
+     */
+    test("default 'fail' routes extraction failure through .error()", async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "html-parse-test-"));
+      testFile = path.join(tempDir, "page.html");
+      await fs.writeFile(
+        testFile,
+        "<html><body><a href='/x'>x</a></body></html>",
+      );
+
+      const s = spy();
+      const errors: { rc?: string }[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-source-fail")
+            .error((err) => {
+              errors.push(err as { rc?: string });
+              return undefined;
+            })
+            .from(
+              html({
+                path: testFile,
+                selector: "a",
+                extract: "attr",
+                // attr intentionally omitted so extractHtml throws.
+              }),
+            )
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errors.length).toBe(1);
+      expect(errors[0].rc).toBe("RC5016");
+      expect(s.received.length).toBe(0);
+    });
+
+    /**
+     * @case 'drop' mode emits exchange:dropped on extraction failure
+     * @preconditions HTML source with malformed extract config and onParseError: 'drop'
+     * @expectedResult exchange:dropped fires with reason 'parse-failed'; no .error() invocation
+     */
+    test("'drop' emits exchange:dropped on extraction failure", async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "html-parse-test-"));
+      testFile = path.join(tempDir, "page.html");
+      await fs.writeFile(
+        testFile,
+        "<html><body><a href='/x'>x</a></body></html>",
+      );
+
+      const s = spy();
+      const dropped: { reason: string }[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-source-drop")
+            .from(
+              html({
+                path: testFile,
+                selector: "a",
+                extract: "attr",
+                onParseError: "drop",
+              }),
+            )
+            .to(s),
+        )
+        .build();
+
+      t.ctx.on(
+        "route:html-source-drop:exchange:dropped" as never,
+        ((payload: { details: { reason: string } }) => {
+          dropped.push({ reason: payload.details.reason });
+        }) as never,
+      );
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(dropped.length).toBe(1);
+      expect(dropped[0].reason).toBe("parse-failed");
+      expect(s.received.length).toBe(0);
+    });
+
+    /**
+     * @case 'abort' emits per-item exchange:failed before context:error
+     * @preconditions HTML source with extraction failure and onParseError: 'abort'
+     * @expectedResult exchange:failed fires for the item; context:error fires
+     */
+    test("'abort' emits exchange:failed then context:error", async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "html-parse-test-"));
+      testFile = path.join(tempDir, "page.html");
+      await fs.writeFile(
+        testFile,
+        "<html><body><a href='/x'>x</a></body></html>",
+      );
+
+      const s = spy();
+      const failed: { error: unknown }[] = [];
+      const ctxErrs: { error: unknown }[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-source-abort")
+            .from(
+              html({
+                path: testFile,
+                selector: "a",
+                extract: "attr",
+                onParseError: "abort",
+              }),
+            )
+            .to(s),
+        )
+        .build();
+
+      t.ctx.on(
+        "route:html-source-abort:exchange:failed" as never,
+        ((payload: { details: { error: unknown } }) => {
+          failed.push({ error: payload.details.error });
+        }) as never,
+      );
+      t.ctx.on("context:error", (payload) => {
+        ctxErrs.push({ error: payload.details.error });
+      });
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(failed.length).toBe(1);
+      expect((failed[0].error as { rc?: string }).rc).toBe("RC5016");
+      expect(ctxErrs.length).toBeGreaterThanOrEqual(1);
+    });
+  });
 });

--- a/packages/routecraft/test/html.test.ts
+++ b/packages/routecraft/test/html.test.ts
@@ -529,6 +529,16 @@ describe("HTML Adapter", () => {
     let tempDir: string;
     let testFile: string;
 
+    afterEach(async () => {
+      if (tempDir) {
+        try {
+          await fs.rm(tempDir, { recursive: true, force: true });
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    });
+
     /**
      * @case Default 'fail' routes extraction failure through .error()
      * @preconditions HTML source with extract: 'attr' but no attr option (extractHtml throws)

--- a/packages/routecraft/test/json.test.ts
+++ b/packages/routecraft/test/json.test.ts
@@ -335,7 +335,7 @@ describe("JSON Adapter", () => {
     /**
      * @case Invalid JSON file aborts source with onParseError: 'abort'
      * @preconditions File contains invalid JSON; onParseError: 'abort'
-     * @expectedResult Error thrown with "failed to parse" message via context:error
+     * @expectedResult RC5016 surfaces via context:error and the source dies
      */
     test("invalid JSON file aborts source with onParseError: 'abort'", async () => {
       await fs.writeFile(testFilePath, "{ invalid json }");

--- a/packages/routecraft/test/json.test.ts
+++ b/packages/routecraft/test/json.test.ts
@@ -299,11 +299,11 @@ describe("JSON Adapter", () => {
     });
 
     /**
-     * @case Invalid JSON in file throws error
-     * @preconditions File contains invalid JSON
-     * @expectedResult Error thrown with "failed to parse" message
+     * @case Invalid JSON file routes parse error through pipeline (default 'fail')
+     * @preconditions File contains invalid JSON; route has no .error() handler
+     * @expectedResult exchange:failed event fires with RC5016, no exchange reaches the spy
      */
-    test("invalid JSON file throws error", async () => {
+    test("invalid JSON file routes parse error through pipeline", async () => {
       await fs.writeFile(testFilePath, "{ invalid json }");
 
       const s = spy();
@@ -313,6 +313,45 @@ describe("JSON Adapter", () => {
           craft()
             .id("json-source-invalid")
             .from(json({ path: testFilePath }) as unknown as Source<unknown>)
+            .to(s),
+        )
+        .build();
+
+      const errSpy = vi.fn();
+      t.ctx.on("context:error", errSpy);
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+      // Default 'fail' routes the parse error through the pipeline; with no
+      // .error() handler the failure surfaces via context:error.
+      expect(errSpy).toHaveBeenCalled();
+      const errorPayload = errSpy.mock.calls[0][0];
+      const error = errorPayload.details.error;
+      expect(error.rc).toBe("RC5016");
+      // The parse failure happened inside the pipeline, so the spy never
+      // received an exchange.
+      expect(s.received).toHaveLength(0);
+    });
+
+    /**
+     * @case Invalid JSON file aborts source with onParseError: 'abort'
+     * @preconditions File contains invalid JSON; onParseError: 'abort'
+     * @expectedResult Error thrown with "failed to parse" message via context:error
+     */
+    test("invalid JSON file aborts source with onParseError: 'abort'", async () => {
+      await fs.writeFile(testFilePath, "{ invalid json }");
+
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("json-source-invalid-abort")
+            .from(
+              json({
+                path: testFilePath,
+                onParseError: "abort",
+              }) as unknown as Source<unknown>,
+            )
             .to(s),
         )
         .build();

--- a/packages/routecraft/test/json.test.ts
+++ b/packages/routecraft/test/json.test.ts
@@ -363,7 +363,8 @@ describe("JSON Adapter", () => {
       expect(errSpy).toHaveBeenCalled();
       const errorPayload = errSpy.mock.calls[0][0];
       const error = errorPayload.details.error;
-      expect(error.message).toMatch(/failed to parse JSON/);
+      // Abort surfaces RC5016 from the synthetic parse step.
+      expect(error.rc).toBe("RC5016");
     });
 
     /**

--- a/packages/routecraft/test/jsonl.test.ts
+++ b/packages/routecraft/test/jsonl.test.ts
@@ -93,7 +93,7 @@ describe("JSONL Adapter", () => {
     /**
      * @case Aborts source on parse error when onParseError is 'abort'
      * @preconditions JSONL file with invalid JSON on line 2 and onParseError: 'abort'
-     * @expectedResult subscribe promise rejects with the parse error
+     * @expectedResult Per-item exchange:failed fires, then context:error with RC5016
      */
     test("aborts source on parse error with onParseError: 'abort'", async () => {
       const filePath = path.join(tmpDir, "bad.jsonl");
@@ -103,15 +103,36 @@ describe("JSONL Adapter", () => {
         "utf-8",
       );
 
-      const adapter = jsonl({ path: filePath, onParseError: "abort" });
+      const s = spy();
+      const failed: { error: unknown }[] = [];
 
-      await expect(
-        adapter.subscribe(
-          {} as any,
-          async () => ({}) as any,
-          new AbortController(),
-        ),
-      ).rejects.toThrow(/not-json/);
+      t = await testContext()
+        .routes(
+          craft()
+            .id("jsonl-non-chunked-abort")
+            .from(jsonl({ path: filePath, onParseError: "abort" }))
+            .to(s),
+        )
+        .build();
+
+      t.ctx.on(
+        "route:jsonl-non-chunked-abort:exchange:failed" as never,
+        ((payload: { details: { error: unknown } }) => {
+          failed.push({ error: payload.details.error });
+        }) as never,
+      );
+
+      const ctxErrSpy: { error: unknown }[] = [];
+      t.ctx.on("context:error", (payload) => {
+        ctxErrSpy.push({ error: payload.details.error });
+      });
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(failed.length).toBe(1);
+      expect((failed[0].error as { rc?: string }).rc).toBe("RC5016");
+      expect(ctxErrSpy.length).toBeGreaterThanOrEqual(1);
     });
 
     /**
@@ -272,25 +293,45 @@ describe("JSONL Adapter", () => {
     /**
      * @case Chunked mode aborts source on parse error with onParseError: 'abort'
      * @preconditions JSONL file with invalid JSON, chunked mode, onParseError: 'abort'
-     * @expectedResult subscribe promise rejects with the parse error
+     * @expectedResult Per-line exchange:failed fires, then context:error with RC5016
      */
     test("aborts chunked source on parse error with onParseError: 'abort'", async () => {
       const filePath = path.join(tmpDir, "bad-chunked.jsonl");
-      await fsp.writeFile(filePath, '{"ok":1}\nnot-json', "utf-8");
+      await fsp.writeFile(filePath, '{"ok":1}\nnot-json\n{"ok":2}', "utf-8");
 
-      const adapter = jsonl({
-        path: filePath,
-        chunked: true,
-        onParseError: "abort",
+      const s = spy();
+      const failed: { error: unknown }[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("jsonl-chunked-abort")
+            .from(
+              jsonl({ path: filePath, chunked: true, onParseError: "abort" }),
+            )
+            .to(s),
+        )
+        .build();
+
+      t.ctx.on(
+        "route:jsonl-chunked-abort:exchange:failed" as never,
+        ((payload: { details: { error: unknown } }) => {
+          failed.push({ error: payload.details.error });
+        }) as never,
+      );
+
+      const ctxErrSpy: { error: unknown }[] = [];
+      t.ctx.on("context:error", (payload) => {
+        ctxErrSpy.push({ error: payload.details.error });
       });
 
-      await expect(
-        adapter.subscribe(
-          {} as any,
-          async () => ({}) as any,
-          new AbortController(),
-        ),
-      ).rejects.toThrow(/not-json/);
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Per-item exchange:failed fired for the bad line BEFORE the source died.
+      expect(failed.length).toBe(1);
+      expect((failed[0].error as { rc?: string }).rc).toBe("RC5016");
+      expect(ctxErrSpy.length).toBeGreaterThanOrEqual(1);
     });
 
     /**
@@ -330,12 +371,12 @@ describe("JSONL Adapter", () => {
     });
 
     /**
-     * @case Chunked mode 'skip' silently drops malformed lines and continues
-     * @preconditions JSONL file with bad lines and onParseError: 'skip'
-     * @expectedResult Only valid lines reach the spy; no error events fire
+     * @case Chunked mode 'drop' emits exchange:dropped for malformed lines and continues
+     * @preconditions JSONL file with bad lines and onParseError: 'drop'
+     * @expectedResult Valid lines reach the spy; exchange:dropped fires with reason "parse-failed"
      */
-    test("onParseError: 'skip' drops malformed lines silently", async () => {
-      const filePath = path.join(tmpDir, "skip-chunked.jsonl");
+    test("onParseError: 'drop' emits exchange:dropped for malformed lines", async () => {
+      const filePath = path.join(tmpDir, "drop-chunked.jsonl");
       await fsp.writeFile(
         filePath,
         '{"id":1}\nnot-json\n{"id":2}\nbroken{\n{"id":3}',
@@ -343,17 +384,25 @@ describe("JSONL Adapter", () => {
       );
 
       const s = spy();
+      const dropped: { reason: string }[] = [];
 
       t = await testContext()
         .routes(
           craft()
-            .id("jsonl-chunked-skip")
+            .id("jsonl-chunked-drop")
             .from(
-              jsonl({ path: filePath, chunked: true, onParseError: "skip" }),
+              jsonl({ path: filePath, chunked: true, onParseError: "drop" }),
             )
             .to(s),
         )
         .build();
+
+      t.ctx.on(
+        "route:jsonl-chunked-drop:exchange:dropped" as never,
+        ((payload: { details: { reason: string } }) => {
+          dropped.push({ reason: payload.details.reason });
+        }) as never,
+      );
 
       await t.ctx.start();
 
@@ -361,6 +410,8 @@ describe("JSONL Adapter", () => {
       expect(s.received[0].body).toEqual({ id: 1 });
       expect(s.received[1].body).toEqual({ id: 2 });
       expect(s.received[2].body).toEqual({ id: 3 });
+      expect(dropped.length).toBeGreaterThanOrEqual(2);
+      expect(dropped[0].reason).toBe("parse-failed");
     });
   });
 

--- a/packages/routecraft/test/jsonl.test.ts
+++ b/packages/routecraft/test/jsonl.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, afterEach, beforeEach } from "vitest";
+import { z } from "zod";
 import { testContext, spy, type TestContext } from "@routecraft/testing";
 import { craft, simple, jsonl, HeadersKeys } from "@routecraft/routecraft";
 import * as fsp from "node:fs/promises";
@@ -412,6 +413,109 @@ describe("JSONL Adapter", () => {
       expect(s.received[2].body).toEqual({ id: 3 });
       expect(dropped.length).toBeGreaterThanOrEqual(2);
       expect(dropped[0].reason).toBe("parse-failed");
+    });
+  });
+
+  describe("source mode - parse + .input() schema", () => {
+    /**
+     * @case Valid JSONL line passes input validation against the parsed body
+     * @preconditions Chunked JSONL with valid lines, route has .input(zodSchema)
+     * @expectedResult The schema sees the parsed object (not the raw line); spy receives the validated body
+     */
+    test(".input() schema validates the parsed body, not the raw line", async () => {
+      const filePath = path.join(tmpDir, "valid-input.jsonl");
+      await fsp.writeFile(
+        filePath,
+        '{"id":1,"name":"Alice"}\n{"id":2,"name":"Bob"}',
+        "utf-8",
+      );
+
+      const schema = z.object({
+        id: z.number(),
+        name: z.string(),
+      });
+
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("jsonl-input-valid")
+            .input({ body: schema })
+            .from(jsonl({ path: filePath, chunked: true }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      expect(s.received).toHaveLength(2);
+      expect(s.received[0].body).toEqual({ id: 1, name: "Alice" });
+      expect(s.received[1].body).toEqual({ id: 2, name: "Bob" });
+    });
+
+    /**
+     * @case Input validation failure on a parsed body emits exchange:failed once (no duplicate started/dropped)
+     * @preconditions Chunked JSONL with parsed body that violates schema
+     * @expectedResult Exactly one exchange:started, one exchange:failed (RC5002), zero exchange:dropped per bad item
+     */
+    test("input validation failure inside parse step emits clean lifecycle (no duplicate started/dropped)", async () => {
+      const filePath = path.join(tmpDir, "schema-fail.jsonl");
+      await fsp.writeFile(
+        filePath,
+        '{"id":"not-a-number"}\n{"id":42}',
+        "utf-8",
+      );
+
+      const schema = z.object({ id: z.number() });
+
+      const s = spy();
+      const started: string[] = [];
+      const failed: { error: { rc?: string } }[] = [];
+      const dropped: { reason: string }[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("jsonl-input-bad")
+            .input({ body: schema })
+            .from(jsonl({ path: filePath, chunked: true }))
+            .to(s),
+        )
+        .build();
+
+      t.ctx.on(
+        "route:jsonl-input-bad:exchange:started" as never,
+        ((payload: { details: { exchangeId: string } }) => {
+          started.push(payload.details.exchangeId);
+        }) as never,
+      );
+      t.ctx.on(
+        "route:jsonl-input-bad:exchange:failed" as never,
+        ((payload: { details: { error: { rc?: string } } }) => {
+          failed.push({ error: payload.details.error });
+        }) as never,
+      );
+      t.ctx.on(
+        "route:jsonl-input-bad:exchange:dropped" as never,
+        ((payload: { details: { reason: string } }) => {
+          dropped.push({ reason: payload.details.reason });
+        }) as never,
+      );
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Two lines processed: one bad (validation fails), one good.
+      // Each line gets exactly one exchange:started.
+      expect(started).toHaveLength(2);
+      // The bad line fails with RC5002; no spurious exchange:dropped fired.
+      expect(failed).toHaveLength(1);
+      expect(failed[0].error.rc).toBe("RC5002");
+      expect(dropped).toHaveLength(0);
+      // The good line still reaches the destination.
+      expect(s.received).toHaveLength(1);
+      expect(s.received[0].body).toEqual({ id: 42 });
     });
   });
 

--- a/packages/routecraft/test/jsonl.test.ts
+++ b/packages/routecraft/test/jsonl.test.ts
@@ -134,6 +134,7 @@ describe("JSONL Adapter", () => {
       expect(failed.length).toBe(1);
       expect((failed[0].error as { rc?: string }).rc).toBe("RC5016");
       expect(ctxErrSpy.length).toBeGreaterThanOrEqual(1);
+      expect((ctxErrSpy[0].error as { rc?: string }).rc).toBe("RC5016");
     });
 
     /**
@@ -333,6 +334,7 @@ describe("JSONL Adapter", () => {
       expect(failed.length).toBe(1);
       expect((failed[0].error as { rc?: string }).rc).toBe("RC5016");
       expect(ctxErrSpy.length).toBeGreaterThanOrEqual(1);
+      expect((ctxErrSpy[0].error as { rc?: string }).rc).toBe("RC5016");
     });
 
     /**
@@ -411,8 +413,11 @@ describe("JSONL Adapter", () => {
       expect(s.received[0].body).toEqual({ id: 1 });
       expect(s.received[1].body).toEqual({ id: 2 });
       expect(s.received[2].body).toEqual({ id: 3 });
-      expect(dropped.length).toBeGreaterThanOrEqual(2);
+      // Two malformed lines, two structured drop events, both with the
+      // stable parse-failed reason.
+      expect(dropped).toHaveLength(2);
       expect(dropped[0].reason).toBe("parse-failed");
+      expect(dropped[1].reason).toBe("parse-failed");
     });
   });
 

--- a/packages/routecraft/test/jsonl.test.ts
+++ b/packages/routecraft/test/jsonl.test.ts
@@ -91,11 +91,11 @@ describe("JSONL Adapter", () => {
     });
 
     /**
-     * @case Throws on parse error
-     * @preconditions JSONL file with invalid JSON on line 2
-     * @expectedResult Error with line number in message
+     * @case Aborts source on parse error when onParseError is 'abort'
+     * @preconditions JSONL file with invalid JSON on line 2 and onParseError: 'abort'
+     * @expectedResult subscribe promise rejects with the parse error
      */
-    test("throws on parse error", async () => {
+    test("aborts source on parse error with onParseError: 'abort'", async () => {
       const filePath = path.join(tmpDir, "bad.jsonl");
       await fsp.writeFile(
         filePath,
@@ -103,7 +103,7 @@ describe("JSONL Adapter", () => {
         "utf-8",
       );
 
-      const adapter = jsonl({ path: filePath });
+      const adapter = jsonl({ path: filePath, onParseError: "abort" });
 
       await expect(
         adapter.subscribe(
@@ -270,15 +270,19 @@ describe("JSONL Adapter", () => {
     });
 
     /**
-     * @case Chunked mode throws on parse error
-     * @preconditions JSONL file with invalid JSON, chunked mode
-     * @expectedResult Error is thrown
+     * @case Chunked mode aborts source on parse error with onParseError: 'abort'
+     * @preconditions JSONL file with invalid JSON, chunked mode, onParseError: 'abort'
+     * @expectedResult subscribe promise rejects with the parse error
      */
-    test("throws on parse error in chunked mode", async () => {
+    test("aborts chunked source on parse error with onParseError: 'abort'", async () => {
       const filePath = path.join(tmpDir, "bad-chunked.jsonl");
       await fsp.writeFile(filePath, '{"ok":1}\nnot-json', "utf-8");
 
-      const adapter = jsonl({ path: filePath, chunked: true });
+      const adapter = jsonl({
+        path: filePath,
+        chunked: true,
+        onParseError: "abort",
+      });
 
       await expect(
         adapter.subscribe(
@@ -287,6 +291,76 @@ describe("JSONL Adapter", () => {
           new AbortController(),
         ),
       ).rejects.toThrow(/not-json/);
+    });
+
+    /**
+     * @case Chunked mode default 'fail' routes parse error to .error() and continues
+     * @preconditions JSONL file with one bad line between two good lines, route has .error() handler
+     * @expectedResult error handler invoked once with RC5016, both good lines reach the spy
+     */
+    test("default 'fail' routes per-line parse errors through .error() and continues", async () => {
+      const filePath = path.join(tmpDir, "mixed-chunked.jsonl");
+      await fsp.writeFile(filePath, '{"id":1}\nnot-json\n{"id":2}', "utf-8");
+
+      const s = spy();
+      const errors: unknown[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("jsonl-chunked-fail-routes")
+            .error((err) => {
+              errors.push(err);
+              return undefined;
+            })
+            .from(jsonl({ path: filePath, chunked: true }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      expect(errors).toHaveLength(1);
+      expect((errors[0] as { rc?: string }).rc).toBe("RC5016");
+      // Two valid lines reach the destination; the bad line stopped at the
+      // synthetic parse step inside the pipeline.
+      expect(s.received).toHaveLength(2);
+      expect(s.received[0].body).toEqual({ id: 1 });
+      expect(s.received[1].body).toEqual({ id: 2 });
+    });
+
+    /**
+     * @case Chunked mode 'skip' silently drops malformed lines and continues
+     * @preconditions JSONL file with bad lines and onParseError: 'skip'
+     * @expectedResult Only valid lines reach the spy; no error events fire
+     */
+    test("onParseError: 'skip' drops malformed lines silently", async () => {
+      const filePath = path.join(tmpDir, "skip-chunked.jsonl");
+      await fsp.writeFile(
+        filePath,
+        '{"id":1}\nnot-json\n{"id":2}\nbroken{\n{"id":3}',
+        "utf-8",
+      );
+
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("jsonl-chunked-skip")
+            .from(
+              jsonl({ path: filePath, chunked: true, onParseError: "skip" }),
+            )
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      expect(s.received).toHaveLength(3);
+      expect(s.received[0].body).toEqual({ id: 1 });
+      expect(s.received[1].body).toEqual({ id: 2 });
+      expect(s.received[2].body).toEqual({ id: 3 });
     });
   });
 

--- a/packages/routecraft/test/mail.test.ts
+++ b/packages/routecraft/test/mail.test.ts
@@ -1506,6 +1506,145 @@ describe("Mail Adapter", () => {
 
       await expect(t.test()).rejects.toMatchObject({ rc: "RC5003" });
     });
+
+    /**
+     * @case Default 'fail' routes MIME parse failures through .error() and marks Seen
+     * @preconditions simpleParser throws on a fetched message; route has .error() handler
+     * @expectedResult .error() invoked with RC5016; markSeen called for the bad UID
+     */
+    test("onParseError default 'fail' routes MIME parse failures through .error()", async () => {
+      const { simpleParser } = await import("mailparser");
+      (simpleParser as any).mockRejectedValueOnce(new Error("malformed MIME"));
+      mockMessageFlagsAdd.mockReset();
+      mockMessageFlagsAdd.mockResolvedValue(undefined);
+
+      mockFetch.mockImplementationOnce(() => ({
+        async *[Symbol.asyncIterator]() {
+          yield {
+            uid: 99,
+            flags: new Set([]),
+            envelope: { messageId: "<bad@test.com>" },
+            source: Buffer.from("garbage"),
+          };
+        },
+      }));
+
+      const s = spy();
+      const errors: { rc?: string }[] = [];
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("mail-parse-fail")
+            .error((err) => {
+              errors.push(err as { rc?: string });
+              return undefined;
+            })
+            .from(mail("INBOX", { pollIntervalMs: 5, unseen: true }))
+            .to(s),
+        )
+        .build();
+
+      const startPromise = t.ctx.start();
+      await new Promise((r) => setTimeout(r, 20));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(errors.length).toBe(1);
+      expect(errors[0].rc).toBe("RC5016");
+      // Mark Seen so the malformed message does not refetch forever.
+      expect(mockMessageFlagsAdd).toHaveBeenCalledWith(
+        "99",
+        ["\\Seen"],
+        expect.anything(),
+      );
+    });
+
+    /**
+     * @case 'drop' mode emits exchange:dropped for malformed MIME
+     * @preconditions simpleParser throws; onParseError: 'drop'
+     * @expectedResult exchange:dropped fires with reason 'parse-failed'; markSeen called
+     */
+    test("onParseError 'drop' emits exchange:dropped for malformed MIME", async () => {
+      const { simpleParser } = await import("mailparser");
+      (simpleParser as any).mockRejectedValueOnce(new Error("malformed MIME"));
+      mockMessageFlagsAdd.mockReset();
+      mockMessageFlagsAdd.mockResolvedValue(undefined);
+
+      mockFetch.mockImplementationOnce(() => ({
+        async *[Symbol.asyncIterator]() {
+          yield {
+            uid: 100,
+            flags: new Set([]),
+            envelope: { messageId: "<drop@test.com>" },
+            source: Buffer.from("garbage"),
+          };
+        },
+      }));
+
+      const s = spy();
+      const dropped: { reason: string }[] = [];
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("mail-parse-drop")
+            .from(
+              mail("INBOX", {
+                pollIntervalMs: 5,
+                unseen: true,
+                onParseError: "drop",
+              }),
+            )
+            .to(s),
+        )
+        .build();
+
+      t.ctx.on(
+        "route:mail-parse-drop:exchange:dropped" as never,
+        ((payload: { details: { reason: string } }) => {
+          dropped.push({ reason: payload.details.reason });
+        }) as never,
+      );
+
+      const startPromise = t.ctx.start();
+      await new Promise((r) => setTimeout(r, 20));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(dropped.length).toBe(1);
+      expect(dropped[0].reason).toBe("parse-failed");
+      expect(mockMessageFlagsAdd).toHaveBeenCalledWith(
+        "100",
+        ["\\Seen"],
+        expect.anything(),
+      );
+      expect(s.received.length).toBe(0);
+    });
   });
 
   describe("buildSearchCriteriaSets", () => {


### PR DESCRIPTION
Source adapters that convert raw bytes to a structured body (json, html,
csv, jsonl, mail) previously parsed before calling the route handler, so
parse failures bypassed the route's .error() handler entirely and (for
streaming sources) aborted the source on the first malformed item. This
moves parsing into the pipeline so the route's .error() handler can catch
parse failures per exchange, and adds a uniform onParseError option for
controlling behaviour.

The runtime adds an experimental third argument to CallableSource.handler,
parse, that adapters use to pass their parser. The runtime applies it as a
synthetic first pipeline step so exchange:started fires before parse runs
and a parse failure flows through the same error-handler path as any other
step error. Adapters that don't parse (direct, simple, cron, timer, event,
file, mcp) ignore the new argument.

Each parsing adapter accepts onParseError: 'fail' | 'abort' | 'skip',
default 'fail':
- 'fail': exchange fails inside the pipeline; route.error() catches it (or
  exchange:failed fires); streaming adapters continue to the next item.
- 'abort': source aborts on first parse failure (legacy fail-fast).
- 'skip': item silently dropped, log at warn; streaming adapters continue.

A new error code RC5016 distinguishes parse failures from generic step
errors. Mail's previous silent-degrade behaviour (return MailMessage{} on
malformed MIME) is replaced by the new flow; existing routes that relied
on it can opt back in with onParseError: 'skip'. Mail also marks Seen on
parse failure to prevent infinite re-fetch of permanently-malformed
messages.

The batch consumer pre-parses items during enqueue (per-item rejections
propagate to the source's catch); only simple consumer routes parse
errors through the synthetic pipeline step.

BREAKING CHANGES:
- json, html, csv, jsonl, mail: parse failures now route through
  route.error() by default instead of throwing out of the source. Existing
  behaviour requires onParseError: 'abort'.
- mail: malformed MIME no longer silently delivers an empty MailMessage;
  set onParseError: 'skip' to preserve the old behaviour.
- csv chunked: row errors that previously aborted the stream now route
  through .error() and continue. Set onParseError: 'abort' to revert.

https://claude.ai/code/session_019Ru7NrfyYtWZmFyuzL1wNq

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes source-level parse errors for `json`, `html`, `csv`, `jsonl`, and `mail` through the route pipeline so `.error()` can handle them (closes #187). Adds a synthetic `parse` step with `RC5016` and a uniform `onParseError` option (`'fail'` default, `'abort'`, `'drop'`) for clear, per-item observability.

- **Bug Fixes**
  - `'abort'` now only stops the source on true parse failures (`RC5016`); other step errors don’t abort.
  - `'drop'` emits `step:failed` for the parse and `exchange:dropped` with reason `parse-failed`.
  - Batch consumer routes parse failures via the registered handler using the captured parser; bad items aren’t added to the batch.
  - Input validation runs after the parse step; schemas see the parsed body and events aren’t duplicated.
  - `jsonl` preserves framework error codes (doesn’t wrap `RC5016`), and adapters use `DEFAULT_ON_PARSE_ERROR` consistently.

- **Migration**
  - Replace `onParseError: 'skip'` with `'drop'` (now emits `exchange:dropped` with reason `parse-failed`).
  - To keep legacy fail-fast behavior, set `onParseError: 'abort'` on `json`, `html`, `csv`, `jsonl`, or `mail`.
  - If you relied on mail’s empty-message fallback, set `onParseError: 'drop'`.
  - Update tests/event subscribers for the new `parse` step and `RC5016` on parse failures.

<sup>Written for commit 386de2f32da8b7972a9d4c63f4f08a17a7f32ab6. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/272?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

