### PR TITLE
feat(core)!: dual-mode wrapper pattern with .error() as the first wrapper (closes #140)

### DIFF
--- a/.standards/README.md
+++ b/.standards/README.md
@@ -15,6 +15,7 @@ Internal development standards for Routecraft contributors (human and AI). These
 | [Type Safety Registries](./type-safety-registries.md) | Declaration-merging registries for typed adapters and endpoints; codegen direction |
 | [Testing](./testing.md) | Runner conventions, JSDoc-on-every-test, helpers from `@routecraft/testing`, lifecycle pattern, assertion patterns |
 | [CI/CD](./ci-cd.md) | PR gates, hook policy, peer-dependency rules, optional peer dependencies, release flow |
+| [Resilience Wrappers](./resilience-wrappers.md) | Dual-mode wrapper pattern (`.error()` and future `.retry()`/`.timeout()`/`.cache()`/...), authoring contract, stacking + cascade rules |
 
 ## Related
 

--- a/.standards/resilience-wrappers.md
+++ b/.standards/resilience-wrappers.md
@@ -82,22 +82,22 @@ on it for free by rethrowing on unrecoverable failure.
 
 A new wrapper takes about 50 lines plus builder glue. Subclass
 `WrapperStep<T>` from `packages/routecraft/src/operations/wrapper.ts`
-and implement `runInner(exchange)`:
+and implement `runInner(exchange, innerQueue)`:
 
 ```ts
 export class TimeoutWrapperStep<T extends Adapter = Adapter>
   extends WrapperStep<T>
 {
-  private innerPushed: { exchange: Exchange; steps: Step<Adapter>[] }[] = [];
-
   constructor(inner: Step<T>, private readonly ms: number) {
     super(inner);
   }
 
-  protected override async runInner(exchange: Exchange): Promise<WrapperOutcome> {
-    this.innerPushed = [];
-    const innerPromise = this.inner.execute(exchange, [], this.innerPushed);
-    const result = await Promise.race([
+  protected override async runInner(
+    exchange: Exchange,
+    innerQueue: { exchange: Exchange; steps: Step<Adapter>[] }[],
+  ): Promise<WrapperOutcome> {
+    const innerPromise = this.inner.execute(exchange, [], innerQueue);
+    return await Promise.race([
       innerPromise.then(() => "ok" as const),
       sleep(this.ms).then(() => {
         throw rcError("RC5012", undefined, {
@@ -105,14 +105,15 @@ export class TimeoutWrapperStep<T extends Adapter = Adapter>
         });
       }),
     ]);
-    return result;
-  }
-
-  protected override drainInnerQueue() {
-    return this.innerPushed;
   }
 }
 ```
+
+Key contract points:
+
+- `runInner` receives a per-execution `innerQueue` array as its second parameter. Pass it as the third argument to `this.inner.execute(exchange, [], innerQueue)` so the inner step's pushes (e.g. `split` children) flow back through the buffer.
+- The buffer is owned by the template's `execute()` and lives only for one call. Never store it on `this`; doing so leaks state across concurrent exchanges hitting the same step instance.
+- Throwing from `runInner` propagates out so the route's outer catch in `runSteps` cascades to the route-level handler (or default error path). Wrappers do not need to re-emit `step:failed` themselves; the template emits it via try/catch.
 
 Then add the dual-mode method on the builder:
 
@@ -183,7 +184,8 @@ accordingly.
 ## 8. `.standards` checklist for a new wrapper
 
 - [ ] New `XWrapperStep` extends `WrapperStep`, implements
-      `runInner` and `drainInnerQueue`.
+      `runInner(exchange, innerQueue)` (no instance state for the
+      queue; pass `innerQueue` straight to `this.inner.execute`).
 - [ ] Dual-mode `.x(...)` builder method on `StepBuilderBase` (step
       scope) with an override on `RouteBuilder` for the pre-from
       path.

--- a/.standards/resilience-wrappers.md
+++ b/.standards/resilience-wrappers.md
@@ -1,0 +1,220 @@
+# Resilience Wrappers
+
+Authoring contract for "dual-mode wrapper" operations: a single builder
+method (`.error()`, future `.retry()` / `.timeout()` / `.cache()` /
+`.circuitBreaker()` / `.throttle()` / `.delay()`) that applies at
+either route scope (when staged before `.from()`) or step scope (when
+chained after `.from()`).
+
+The pattern is shared so every future resilience operation has the
+same mental model, ESLint behaviour, docs layout, and observability.
+
+---
+
+## 1. Operation categories
+
+Three categories cover every operation in the framework:
+
+| Category | Position | Examples |
+|----------|----------|----------|
+| Route-only | Before `.from()` only. Configures the route. | `.id()`, `.batch()`, `.title()`, `.description()`, `.input()`, `.output()` |
+| Dual-mode wrapper | Same method, position decides scope. | `.error()`, future `.retry()`, `.timeout()`, `.cache()`, `.circuitBreaker()`, `.throttle()`, `.delay()` |
+| Pipeline | After `.from()` only. Already enforced by the builder type system. | `.transform()`, `.to()`, `.process()`, `.enrich()`, `.split()`, `.aggregate()`, `.tap()`, `.filter()`, `.validate()`, `.choice()`, `.header()` |
+
+## 2. Dual-mode contract
+
+A dual-mode wrapper exposes one method on the builder. Position decides
+scope:
+
+- **Before `.from()`**: route scope. The wrapper applies to the entire
+  pipeline. Wired into `RouteDefinition` (or the equivalent feature
+  bag); the runtime applies it at the route boundary.
+- **After `.from()`**: step scope. The wrapper attaches to the
+  immediately next step. Wired by pushing a factory onto the
+  builder's pending-wrapper stack; the next call to `pushStep` folds
+  the stack around the step.
+
+The handler signature is identical in both positions. Each scope
+preserves the builder's body type parameter so a wrapped step does not
+break inference for downstream `.to(...)` / `.transform(...)`.
+
+## 3. Stacking order
+
+Multiple wrappers stack outside-in in declaration order. The
+first-declared wrapper is the outermost.
+
+```ts
+.from(source)
+.retry({ attempts: 3 })   // outer
+.timeout({ ms: 5_000 })   // middle
+.error(handleAuthFailure) // inner
+.to(http({ url }))
+```
+
+Resolves to `retry(timeout(error(http(...))))`. `error` runs first
+(closest to the inner step); if it rethrows, `timeout` sees that
+throw; if `timeout` fires its own deadline, `retry` decides whether to
+re-attempt the whole stack.
+
+The stack is cleared on every push. A wrapper attaches to exactly one
+step.
+
+## 4. Cascade rule (handler failure)
+
+When a step-scope handler itself throws (or the wrapper otherwise
+cannot recover), it must rethrow. The runtime cascade is:
+
+1. Outer wrappers in the same step's stack get a chance to handle the
+   rethrow (e.g. retry will re-attempt; the rethrow is just one
+   attempt's failure).
+2. After all step-scope wrappers exhaust, the route-level handler
+   (when set) runs, exactly as if the inner step had thrown directly.
+3. If no route-level handler exists, the default error path fires:
+   `route:<id>:error` + `context:error` + `exchange:failed`.
+4. The route is **not** stopped. The next exchange processes
+   normally.
+
+The runtime path is the existing outer catch in
+`packages/routecraft/src/route.ts`'s `runSteps`. Wrappers piggyback
+on it for free by rethrowing on unrecoverable failure.
+
+## 5. Implementation skeleton
+
+A new wrapper takes about 50 lines plus builder glue. Subclass
+`WrapperStep<T>` from `packages/routecraft/src/operations/wrapper.ts`
+and implement `runInner(exchange)`:
+
+```ts
+export class TimeoutWrapperStep<T extends Adapter = Adapter>
+  extends WrapperStep<T>
+{
+  private innerPushed: { exchange: Exchange; steps: Step<Adapter>[] }[] = [];
+
+  constructor(inner: Step<T>, private readonly ms: number) {
+    super(inner);
+  }
+
+  protected override async runInner(exchange: Exchange): Promise<WrapperOutcome> {
+    this.innerPushed = [];
+    const innerPromise = this.inner.execute(exchange, [], this.innerPushed);
+    const result = await Promise.race([
+      innerPromise.then(() => "ok" as const),
+      sleep(this.ms).then(() => {
+        throw rcError("RC5012", undefined, {
+          message: `Step "${this.label}" exceeded ${this.ms}ms timeout`,
+        });
+      }),
+    ]);
+    return result;
+  }
+
+  protected override drainInnerQueue() {
+    return this.innerPushed;
+  }
+}
+```
+
+Then add the dual-mode method on the builder:
+
+```ts
+// step-builder-base.ts (step-scope-only on this base)
+timeout(opts: { ms: number }): this {
+  this.pendingStepWrappers.push(
+    (inner) => new TimeoutWrapperStep(inner, opts.ms),
+  );
+  return this;
+}
+```
+
+And override on `RouteBuilder` for the dual-mode behaviour:
+
+```ts
+override timeout(opts: { ms: number }): this {
+  if (this.currentRoute === undefined) {
+    // pre-from: stage as route-level
+    this.pendingOptions = { ...(this.pendingOptions ?? {}), timeout: opts };
+    return this;
+  }
+  // post-from: delegate to base for step-scope wrap
+  return super.timeout(opts);
+}
+```
+
+Route-scope wiring depends on the operation's semantics. For
+`.timeout()` it might apply at the consumer boundary; for `.cache()`
+it wraps the whole pipeline; for `.circuitBreaker()` it integrates
+with the consumer's backpressure (see "When a wrapper is not enough"
+below).
+
+## 6. Observability
+
+Every dual-mode wrapper emits scope-aware lifecycle events:
+
+| Event | When | Bindings |
+|-------|------|----------|
+| `route:<id>:<wrapper>:invoked` | Wrapper observed a failure or precondition that triggered its behaviour. | `routeId`, `exchangeId`, `correlationId`, `originalError` (or precondition payload), `failedOperation`, `scope: "route" \| "step"`, `stepLabel?` |
+| `route:<id>:<wrapper>:recovered` | Wrapper produced a value that lets the pipeline continue. | Same plus `recoveryStrategy`. |
+| `route:<id>:<wrapper>:failed` | Wrapper rethrew (or otherwise gave up). | Same. |
+
+For `.error()` the wrapper emits the existing `error-handler:*` set.
+A new wrapper picks its own family (e.g. `retry:*`, `timeout:*`,
+`cache:*`).
+
+Wildcard subscribers (`route:*:error-handler:*`,
+`route:*:retry:*`) keep matching; the new `scope` and `stepLabel`
+fields are additive.
+
+## 7. When a wrapper is not enough
+
+Some resilience patterns need consumer-layer integration that pure
+step wrapping cannot provide:
+
+| Pattern | Wrapper covers | Wrapper does NOT cover |
+|---------|-----------------|------------------------|
+| Step-level `.circuitBreaker()` | Trip on N consecutive step failures, fail-fast subsequent calls. | Pausing the consumer during cooldown. |
+| Route-level `.circuitBreaker()` | NOT well-served by a wrapper alone. | Pausing the source consumer (HTTP / queue / cron) during cooldown so backpressure flows back to the caller / queue. |
+| Route-level `.throttle()` (rate limit on the consumer) | NOT well-served by a wrapper alone. | Token-bucket at the consumer. |
+
+These need a paired `Consumer` integration (a consumer that observes
+breaker / throttle state and pauses pulling). Track this constraint
+in the new operation's issue and scope its acceptance criteria
+accordingly.
+
+## 8. `.standards` checklist for a new wrapper
+
+- [ ] New `XWrapperStep` extends `WrapperStep`, implements
+      `runInner` and `drainInnerQueue`.
+- [ ] Dual-mode `.x(...)` builder method on `StepBuilderBase` (step
+      scope) with an override on `RouteBuilder` for the pre-from
+      path.
+- [ ] Route-scope wiring documented (where the runtime applies it).
+- [ ] Events: `x:invoked`, `x:recovered`, `x:failed` with
+      `scope: "route" | "step"` and `stepLabel?`.
+- [ ] Tests covering: step-scope happy path, step-scope failure,
+      stacked wrappers, handler-failure cascade to route-level, no
+      route handler default path, builder body type preserved across
+      the wrapper.
+- [ ] Docs updated: `docs/introduction/operations`,
+      `docs/advanced/error-handling` (or equivalent),
+      `docs/reference/operations`, `docs/reference/events`.
+- [ ] No em-dashes in docs, JSDoc, comments, or written output.
+- [ ] `@experimental` on the new exports until a second wrapper has
+      shipped.
+- [ ] Conventional Commits.
+
+## 9. Cross-references
+
+- `#187` (source-level parse error recovery): once parsing moves into
+  the pipeline, `.error()` wraps the parse step to get "log and skip
+  bad rows, continue processing" as a composable pattern.
+- `#139` (Circuit Breaker): see "When a wrapper is not enough"; the
+  step-scope side is a wrapper, the route-scope side needs consumer
+  integration.
+- `#112` (Cache): pure wrapper at both scopes; first wrapper after
+  `.error()` to validate the pattern at scale.
+- `WrapperStep` source: `packages/routecraft/src/operations/wrapper.ts`.
+- `ErrorWrapperStep` source:
+  `packages/routecraft/src/operations/error-wrapper.ts`.
+- Builder hook source:
+  `packages/routecraft/src/step-builder-base.ts`
+  (`pendingStepWrappers`, `applyPendingWrappers`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Detailed coding standards for contributors live in `.standards/`:
 - [Type Safety Registries](.standards/type-safety-registries.md) -- declaration-merging registries for typed adapters and endpoints
 - [Testing](.standards/testing.md) -- runner conventions, JSDoc-on-every-test, helpers, lifecycle, assertion patterns
 - [CI/CD](.standards/ci-cd.md) -- PR gates, hook policy, peer-dependency rules, release flow
+- [Resilience Wrappers](.standards/resilience-wrappers.md) -- dual-mode wrapper pattern (`.error()` and future resilience ops), authoring contract
 
 ## Merge Checklist
 

--- a/apps/routecraft.dev/src/app/docs/advanced/error-handling/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/error-handling/page.md
@@ -94,6 +94,49 @@ If you only need to log or return a static fallback, you do not need `forward` a
 })
 ```
 
+## Step-scope handlers
+
+`.error()` is dual-mode. Chained AFTER `.from()` it wraps the **immediately next step** instead of the whole route. On wrapped-step success the pipeline continues unchanged. On wrapped-step failure the handler runs, its return value replaces `exchange.body`, and the pipeline continues with the next step.
+
+```ts
+craft()
+  .id('resilient-pipeline')
+  .from(timer({ intervalMs: 60_000 }))
+  .transform(prepareRequest)
+  .error((err) => ({ fallback: true, reason: String(err) }))
+  .to(http({ url: 'https://flaky.api/endpoint' }))
+  .to(database())
+```
+
+Reads as: "if `http(...)` throws, swallow it and continue to `database` with `{ fallback: true, reason: ... }` as the body". Subsequent steps see the recovery as if the step had succeeded.
+
+The handler signature is identical to the route-scope form: `(error, exchange, forward) => unknown | Promise<unknown>`.
+
+### Combined route + step handlers
+
+Step handlers are local recovery; route handlers are the safety net. Use both:
+
+```ts
+craft()
+  .id('with-safety-net')
+  .error((err, ex, forward) => forward('errors.catchall', ex.body))   // route scope
+  .from(timer({ intervalMs: 60_000 }))
+  .transform(prepareRequest)
+  .error((err) => ({ fallback: true }))                               // step scope
+  .to(http({ url: 'https://flaky.api/endpoint' }))
+  .to(database())
+```
+
+The step handler recovers `http` failures silently. If it ever throws, the route handler takes over and forwards to `errors.catchall`.
+
+### Cascade rule
+
+When a step handler itself throws, the wrapper rethrows. The route handler (when set) catches it; otherwise the default path fires (`route:*:error`, `context:error`, `exchange:failed`). The route is NOT stopped.
+
+### Scope only the next step
+
+A wrapper attaches to exactly one step. `.error(h).transform(a).transform(b)` does NOT cover `b` (or the `to()` after it); only `a`. Add another `.error(...)` before each step you want to wrap.
+
 ## When the error handler itself throws
 
 If your `.error()` handler throws, the context takes over:

--- a/apps/routecraft.dev/src/app/docs/reference/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/events/page.md
@@ -114,6 +114,8 @@ After a split, each child exchange emits its own `exchange:started`. When aggreg
 
 `scope` is `"route"` for the catch-all set via `.error()` BEFORE `.from()`, and `"step"` for a wrapper attached AFTER `.from()`. `stepLabel` is the label of the wrapped step when `scope === "step"`. Wildcard subscribers (`route:*:error-handler:*`) keep matching.
 
+| Event | When it fires | Details |
+| --- | --- | --- |
 | `route:{routeId}:operation:error:invoked` | Reserved for the planned `.onError()` operation | `{ routeId, exchangeId, correlationId }` |
 | `route:{routeId}:operation:error:recovered` | Reserved for the planned `.onError()` operation | `{ routeId, exchangeId, correlationId }` |
 | `route:{routeId}:operation:error:failed` | Reserved for the planned `.onError()` operation | `{ routeId, exchangeId, correlationId, error }` |

--- a/apps/routecraft.dev/src/app/docs/reference/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/events/page.md
@@ -108,9 +108,15 @@ After a split, each child exchange emits its own `exchange:started`. When aggreg
 
 | Event | When it fires | Details |
 | --- | --- | --- |
-| `route:{routeId}:operation:error:invoked` | `.onError()` handler called | `{ routeId, exchangeId, correlationId }` |
-| `route:{routeId}:operation:error:recovered` | Handler succeeded | `{ routeId, exchangeId, correlationId }` |
-| `route:{routeId}:operation:error:failed` | Handler also failed | `{ routeId, exchangeId, correlationId, error }` |
+| `route:{routeId}:error-handler:invoked` | A `.error()` handler runs (route or step scope) | `{ routeId, exchangeId, correlationId, originalError, failedOperation, scope: "route" \| "step", stepLabel? }` |
+| `route:{routeId}:error-handler:recovered` | Handler returned a value; pipeline continues (step scope) or replaces body (route scope) | Same plus `recoveryStrategy` |
+| `route:{routeId}:error-handler:failed` | Handler itself threw; rethrows for the next layer (route scope or default error path) | Same |
+
+`scope` is `"route"` for the catch-all set via `.error()` BEFORE `.from()`, and `"step"` for a wrapper attached AFTER `.from()`. `stepLabel` is the label of the wrapped step when `scope === "step"`. Wildcard subscribers (`route:*:error-handler:*`) keep matching.
+
+| `route:{routeId}:operation:error:invoked` | Reserved for the planned `.onError()` operation | `{ routeId, exchangeId, correlationId }` |
+| `route:{routeId}:operation:error:recovered` | Reserved for the planned `.onError()` operation | `{ routeId, exchangeId, correlationId }` |
+| `route:{routeId}:operation:error:failed` | Reserved for the planned `.onError()` operation | `{ routeId, exchangeId, correlationId, error }` |
 
 ### Source-parse operations
 

--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -20,7 +20,7 @@ DSL operators with signatures and examples. {% .lead %}
 |-----------|----------|-------------|
 | [`id`](#id) | Route | Set the unique identifier for the route |
 | [`batch`](#batch) | Route | Process exchanges in batches instead of one at a time |
-| [`error`](#error) | Route | Configure route-level error handling |
+| [`error`](#error) | Route + Wrapper | Configure error handling. Before `.from()` it catches every step (route scope); after `.from()` it wraps the next step and the pipeline continues after recovery (step scope). |
 | [`from`](#from) | Route | Define the source of data for the capability |
 | [`retry`](#retry) | Wrapper | Retry the next operation on failure {% badge color="purple" %}planned{% /badge %} |
 | [`throttle`](#throttle) | Wrapper | Rate limit the next operation {% badge color="purple" %}planned{% /badge %} |
@@ -48,7 +48,7 @@ DSL operators with signatures and examples. {% .lead %}
 
 ## Route operations
 
-Route operations configure the capability itself. `id`, `batch`, and `error` go before `from()` -- if called after an existing route, they are staged for the next `from()`. `from()` defines the source and creates the capability.
+Route operations configure the capability itself. `id`, `batch`, and route-scope `error` go before `from()`; if called after an existing route, they are staged for the next `from()`. `from()` defines the source and creates the capability. `error` is dual-mode: when chained AFTER `from()` it becomes a step-scope wrapper around the next step (see the [`error`](#error) section below).
 
 ### id
 
@@ -164,6 +164,44 @@ craft()
 2. **Context level**: Fallback for unhandled errors via `context.on('error', handler)`
 
 **Note about tap errors:** Tap operations emit errors to the route error handler via events. The main exchange continues (tap is fire-and-forget), but the error is observable for logging and monitoring.
+
+#### Step scope (after `.from()`)
+
+`.error()` is dual-mode. Chained AFTER `.from()` it becomes a **wrapper** around the immediately next step instead of a route-level catch-all. On wrapped-step success the pipeline continues unchanged. On wrapped-step failure the handler runs, its return value replaces `exchange.body`, and the pipeline continues with the next step. Subsequent steps see the recovery as if nothing went wrong.
+
+```ts
+// Recover from one flaky call, keep processing
+craft()
+  .id('resilient-pipeline')
+  .from(timer({ intervalMs: 60_000 }))
+  .transform(prepareRequest)
+  .error((err) => ({ fallback: true, reason: String(err) }))
+  .to(http({ url: 'https://flaky.api/endpoint' }))
+  .to(database())
+```
+
+The handler signature is identical in both positions: `(error, exchange, forward) => unknown | Promise<unknown>`.
+
+**Cascade rule.** When a step-scope handler itself throws, the wrapper rethrows. The route-scope handler (when set) catches it; otherwise the default error path fires (`route:*:error`, `context:error`, `exchange:failed`). The route is NOT stopped.
+
+```ts
+craft()
+  .id('with-safety-net')
+  .error((err, ex, forward) => forward('errors.catchall', ex.body))  // route scope
+  .from(timer({ intervalMs: 60_000 }))
+  .transform(prepareRequest)
+  .error((err) => ({ fallback: true }))                              // step scope
+  .to(http({ url: 'https://flaky.api/endpoint' }))
+  .to(database())
+```
+
+The step-scope handler recovers `http` failures silently. If it ever throws, the route-scope handler takes over and forwards to `errors.catchall`.
+
+**Stacking.** Multiple wrappers stack outside-in in declaration order. The first-declared wrapper is the outermost. (Until a second public wrapper ships, this only matters when manually composing wrappers in tests.)
+
+**Scope only the next step.** A wrapper attaches to exactly one step. `.error(h).transform(a).transform(b)` does NOT cover `b` (or `to()` after it); only `a`. Add another `.error(...)` before each step you want to wrap.
+
+For the architectural pattern wrappers follow, see [`.standards/resilience-wrappers.md`](https://github.com/routecraftjs/routecraft/blob/main/.standards/resilience-wrappers.md).
 
 **Note about direct destinations:** Direct destinations with their own routes have their own error handlers. Errors in direct destinations are handled by their route's error handler, not the calling route.
 

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -553,9 +553,12 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    * wrapper pattern. See `.standards/resilience-wrappers.md`.
    */
   override error(handler: ErrorHandler): this {
-    if (this.currentRoute === undefined) {
-      // Pre-`.from()`: stage as the route-level catch-all (existing
-      // behaviour). The base-class wrapper stack stays empty.
+    if (this.currentRoute === undefined || this.pendingOptions !== undefined) {
+      // Pre-`.from()` for the FIRST route, OR staging for the NEXT
+      // route in a chained `craft().id(a).from(...).to(...).id(b)
+      // .error(h)...` pattern. In both cases `.error()` configures
+      // route-scope behaviour for the route currently being staged
+      // by `pendingOptions`. The base-class wrapper stack stays empty.
       this.pendingOptions = {
         ...(this.pendingOptions ?? {}),
         errorHandler: handler,
@@ -563,8 +566,9 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       logger.trace("Staging route-scope error handler for next route");
       return this;
     }
-    // Post-`.from()`: delegate to the base-class step-scope path so
-    // the next pushed step is wrapped in `ErrorWrapperStep`.
+    // Post-`.from()` on the current route: delegate to the base-class
+    // step-scope path so the next pushed step is wrapped in
+    // `ErrorWrapperStep`.
     return super.error(handler);
   }
 

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -374,6 +374,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    * ```
    */
   id(id: string): this {
+    this.assertNoPendingWrappers("id");
     this.pendingOptions = { ...(this.pendingOptions ?? {}), id };
     logger.trace({ route: id }, "Staging route id for next route");
     return this;
@@ -596,6 +597,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   from<T>(source: Source<T> | CallableSource<T>): RouteBuilder<T>;
   from<T>(source: Source<unknown> | CallableSource<unknown>): RouteBuilder<T>;
   from<T>(source: Source<T> | CallableSource<T>): RouteBuilder<T> {
+    this.assertNoPendingWrappers("from");
     const id = this.pendingOptions?.id ?? randomUUID();
     const consumer = this.pendingOptions?.consumer ?? {
       type: SimpleConsumer as unknown as ConsumerType<Consumer>,
@@ -838,8 +840,30 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
         message: `Route metadata staged but never consumed by .from().`,
       });
     }
+    this.assertNoPendingWrappers("build");
     logger.trace({ routeCount: this.routes.length }, "Building routes");
     return this.routes;
+  }
+
+  /**
+   * Throw when a step-scope wrapper (`.error()`, future `.retry()` /
+   * `.timeout()` / `.cache()`) was staged but the user is starting a
+   * new route or finalising the build without consuming it. A wrapper
+   * attaches to the immediately next pipeline step; if no step
+   * follows on the current route, the wrapper would silently leak
+   * into the next route's first step. Symmetric with the existing
+   * "metadata staged but never consumed" rule.
+   *
+   * @internal
+   */
+  private assertNoPendingWrappers(method: string): void {
+    if (this.pendingStepWrappers.length > 0) {
+      throw rcError("RC2001", undefined, {
+        message:
+          `Wrapper(s) staged via .error() (or future .retry() / .timeout() / .cache()) but no step followed before .${method}(). ` +
+          `A wrapper attaches to the immediately next pipeline step; orphaning one (or letting it leak into the next route) is almost always a mistake.`,
+      });
+    }
   }
 }
 

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -504,34 +504,68 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   }
 
   /**
-   * Define a catch-all error handler for unhandled errors in the route's step pipeline.
+   * Attach an error handler. Dual-mode based on position relative to
+   * `.from()`:
    *
-   * Must be called before `.from()`. When any step throws an unhandled error, this handler
-   * is invoked instead of the default log-and-swallow behavior. The pipeline does not resume
-   * after the handler runs; its return value becomes the route's final exchange body.
+   * - **Before `.from()`** (route scope): stages a catch-all for the
+   *   route's pipeline. When any step throws an unhandled error the
+   *   handler runs and the pipeline does NOT resume; the handler's
+   *   return value becomes the route's final exchange body.
+   * - **After `.from()`** (step scope): wraps the immediately next
+   *   step. When that step throws the handler runs, its return value
+   *   replaces `exchange.body`, and the pipeline continues with the
+   *   next step. Subsequent steps see the recovery as if nothing went
+   *   wrong.
    *
-   * @param handler - Receives the error, the exchange at the point of failure, and a `forward`
-   *   function to delegate to another route via the direct adapter.
+   * The handler signature is identical in both positions
+   * (`(error, exchange, forward) => unknown`). When a step-scope
+   * handler itself throws, the wrapper rethrows so a route-scope
+   * handler (when set) catches it; otherwise the default error path
+   * fires (`route:*:error`, `context:error`, `exchange:failed`). The
+   * route is NOT stopped.
+   *
+   * @param handler - Receives the error, the exchange at the point of
+   *   failure, and a `forward` function to delegate to another route
+   *   via the direct adapter.
    * @returns This builder for chaining
    *
-   * @example
-   * ```typescript
+   * @example Route-scope catch-all
+   * ```ts
    * craft()
    *   .id('process-orders')
-   *   .error((error, exchange, forward) => {
-   *     return forward('error-route', { reason: error.message })
-   *   })
+   *   .error((err, ex, forward) => forward('error-route', { reason: String(err) }))
    *   .from(timer({ intervalMs: 60000 }))
    *   .to(dangerousDestination)
    * ```
+   *
+   * @example Step-scope recovery (pipeline continues)
+   * ```ts
+   * craft()
+   *   .id('resilient-pipeline')
+   *   .from(timer({ intervalMs: 60000 }))
+   *   .transform(prepareRequest)
+   *   .error((err) => ({ fallback: true, reason: String(err) }))
+   *   .to(http({ url: 'https://flaky.api/endpoint' }))
+   *   .to(database())
+   * ```
+   *
+   * @experimental Step-scope behaviour ships with the dual-mode
+   * wrapper pattern. See `.standards/resilience-wrappers.md`.
    */
-  error(handler: ErrorHandler): this {
-    this.pendingOptions = {
-      ...(this.pendingOptions ?? {}),
-      errorHandler: handler,
-    };
-    logger.trace("Staging error handler for next route");
-    return this;
+  override error(handler: ErrorHandler): this {
+    if (this.currentRoute === undefined) {
+      // Pre-`.from()`: stage as the route-level catch-all (existing
+      // behaviour). The base-class wrapper stack stays empty.
+      this.pendingOptions = {
+        ...(this.pendingOptions ?? {}),
+        errorHandler: handler,
+      };
+      logger.trace("Staging route-scope error handler for next route");
+      return this;
+    }
+    // Post-`.from()`: delegate to the base-class step-scope path so
+    // the next pushed step is wrapped in `ErrorWrapperStep`.
+    return super.error(handler);
   }
 
   /**
@@ -623,11 +657,12 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    */
   protected override pushStep<T extends Adapter>(step: Step<T>): void {
     const route = this.requireSource();
+    const wrapped = this.applyPendingWrappers(step);
     logger.trace(
-      { operation: step.operation, route: route.id },
+      { operation: wrapped.operation, route: route.id },
       "Adding step to route",
     );
-    route.steps.push(step);
+    route.steps.push(wrapped);
   }
 
   /**

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -91,6 +91,9 @@ export {
   replace,
 } from "./operations/enrich.ts";
 
+export { WrapperStep, type WrapperOutcome } from "./operations/wrapper.ts";
+export { ErrorWrapperStep } from "./operations/error-wrapper.ts";
+
 export {
   ContextBuilder,
   craft,
@@ -171,6 +174,7 @@ export {
   type Consumer,
   type EventName,
   type EventHandler,
+  type Step,
 } from "./types.ts";
 
 export { SimpleConsumer } from "./consumers/simple.ts";

--- a/packages/routecraft/src/operations/choice.ts
+++ b/packages/routecraft/src/operations/choice.ts
@@ -101,7 +101,7 @@ export class BranchBuilder<Current = unknown> extends StepBuilderBase<Current> {
   private readonly steps: Step<Adapter>[] = [];
 
   protected override pushStep<T extends Adapter>(step: Step<T>): void {
-    this.steps.push(step);
+    this.steps.push(this.applyPendingWrappers(step));
   }
 
   /**

--- a/packages/routecraft/src/operations/error-wrapper.ts
+++ b/packages/routecraft/src/operations/error-wrapper.ts
@@ -5,6 +5,7 @@ import {
   HeadersKeys,
 } from "../exchange.ts";
 import { rcError, RoutecraftError } from "../error.ts";
+import { isRoutecraftError } from "../brand.ts";
 import type { ErrorHandler } from "../route.ts";
 import type { Adapter, EventName, Step } from "../types.ts";
 import { WrapperStep, type WrapperOutcome } from "./wrapper.ts";
@@ -67,7 +68,20 @@ export class ErrorWrapperStep<
     try {
       await this.inner.execute(exchange, [], innerQueue);
       return "ok";
-    } catch (innerError) {
+    } catch (rawInnerError) {
+      // Normalise the thrown value to `RoutecraftError` so the
+      // step-scope handler receives the same shape the route-scope
+      // handler does (route.ts's `processError` does the same).
+      // Handlers that branch on `error.rc` / `error.meta.message`
+      // work in both positions without special-casing.
+      const innerError: RoutecraftError = isRoutecraftError(rawInnerError)
+        ? (rawInnerError as RoutecraftError)
+        : rcError("RC5001", rawInnerError, {
+            message:
+              rawInnerError instanceof Error
+                ? rawInnerError.message
+                : String(rawInnerError),
+          });
       const routeId = route?.definition.id;
       if (route && context && routeId) {
         context.emit(`route:${routeId}:error-handler:invoked` as EventName, {

--- a/packages/routecraft/src/operations/error-wrapper.ts
+++ b/packages/routecraft/src/operations/error-wrapper.ts
@@ -41,11 +41,6 @@ import { WrapperStep, type WrapperOutcome } from "./wrapper.ts";
 export class ErrorWrapperStep<
   T extends Adapter = Adapter,
 > extends WrapperStep<T> {
-  private innerPushed: {
-    exchange: Exchange;
-    steps: Step<Adapter>[];
-  }[] = [];
-
   constructor(
     inner: Step<T>,
     private readonly handler: ErrorHandler,
@@ -55,6 +50,7 @@ export class ErrorWrapperStep<
 
   protected override async runInner(
     exchange: Exchange,
+    innerQueue: { exchange: Exchange; steps: Step<Adapter>[] }[],
   ): Promise<WrapperOutcome> {
     const route = getExchangeRoute(exchange);
     const context = getExchangeContext(exchange);
@@ -63,12 +59,13 @@ export class ErrorWrapperStep<
       HeadersKeys.CORRELATION_ID
     ] as string;
 
-    // Run the inner step against a private queue so we can capture
-    // pushes (for split / choice / etc.) and re-relay them with
-    // remainingSteps in the template method on success or recovery.
-    this.innerPushed = [];
+    // Run the inner step against the per-execution `innerQueue` so we
+    // can capture pushes (for split / choice / etc.) and let the
+    // template method re-relay them with `remainingSteps`. The buffer
+    // is owned by a single `execute()` invocation, so concurrent
+    // exchanges through the same step instance never alias state.
     try {
-      await this.inner.execute(exchange, [], this.innerPushed);
+      await this.inner.execute(exchange, [], innerQueue);
       return "ok";
     } catch (innerError) {
       const routeId = route?.definition.id;
@@ -97,10 +94,11 @@ export class ErrorWrapperStep<
         const recovered = await this.handler(innerError, exchange, forward);
         exchange.body = recovered;
         // The recovery replaced the body; subsequent pipeline steps
-        // see the new value. No inner-pushed children survive a
-        // failure, so clear the buffer to let the template method
-        // route the (single) recovered exchange forward.
-        this.innerPushed = [];
+        // see the new value. Drop any partial pushes the failed inner
+        // step made before throwing so the template method routes the
+        // single recovered exchange forward, not the half-finished
+        // children.
+        innerQueue.length = 0;
 
         if (route && context && routeId) {
           context.emit(
@@ -142,12 +140,5 @@ export class ErrorWrapperStep<
             });
       }
     }
-  }
-
-  protected override drainInnerQueue(): {
-    exchange: Exchange;
-    steps: Step<Adapter>[];
-  }[] {
-    return this.innerPushed;
   }
 }

--- a/packages/routecraft/src/operations/error-wrapper.ts
+++ b/packages/routecraft/src/operations/error-wrapper.ts
@@ -1,0 +1,153 @@
+import {
+  type Exchange,
+  getExchangeContext,
+  getExchangeRoute,
+  HeadersKeys,
+} from "../exchange.ts";
+import { rcError, RoutecraftError } from "../error.ts";
+import type { ErrorHandler } from "../route.ts";
+import type { Adapter, EventName, Step } from "../types.ts";
+import { WrapperStep, type WrapperOutcome } from "./wrapper.ts";
+
+/**
+ * Step-scope `.error()` handler. Wraps a single step. On wrapped-step
+ * success the pipeline continues unchanged; on wrapped-step failure
+ * the user-supplied handler runs, its return value replaces
+ * `exchange.body`, and the pipeline continues with the next step.
+ *
+ * Mirrors the route-level `errorHandler` semantics (`(err, exchange,
+ * forward) => unknown`), but bound to one step instead of the whole
+ * pipeline. The handler receives the same `forward` callable as the
+ * route-level handler, so a step-scope handler can delegate recovery
+ * to a direct route the same way:
+ *
+ * ```ts
+ * .error((err, ex, forward) => forward('errors.dlq', ex.body))
+ * .to(http({ url: 'https://flaky.api/x' }))
+ * ```
+ *
+ * If the handler itself throws, the wrapper rethrows so the route's
+ * outer catch in `runSteps` fires the route-level handler when one is
+ * defined, or the default `route:*:error` / `context:error` /
+ * `exchange:failed` path otherwise. The route is NOT stopped.
+ *
+ * Emits scope-aware lifecycle events:
+ * - `route:<id>:error-handler:invoked`  ({ scope: "step", stepLabel })
+ * - `route:<id>:error-handler:recovered` on handler success
+ * - `route:<id>:error-handler:failed`    on handler throw (rethrown)
+ *
+ * @experimental Surfaced via the dual-mode `.error()` builder method.
+ */
+export class ErrorWrapperStep<
+  T extends Adapter = Adapter,
+> extends WrapperStep<T> {
+  private innerPushed: {
+    exchange: Exchange;
+    steps: Step<Adapter>[];
+  }[] = [];
+
+  constructor(
+    inner: Step<T>,
+    private readonly handler: ErrorHandler,
+  ) {
+    super(inner);
+  }
+
+  protected override async runInner(
+    exchange: Exchange,
+  ): Promise<WrapperOutcome> {
+    const route = getExchangeRoute(exchange);
+    const context = getExchangeContext(exchange);
+    const stepLabel = this.label ?? String(this.operation);
+    const correlationId = exchange.headers[
+      HeadersKeys.CORRELATION_ID
+    ] as string;
+
+    // Run the inner step against a private queue so we can capture
+    // pushes (for split / choice / etc.) and re-relay them with
+    // remainingSteps in the template method on success or recovery.
+    this.innerPushed = [];
+    try {
+      await this.inner.execute(exchange, [], this.innerPushed);
+      return "ok";
+    } catch (innerError) {
+      const routeId = route?.definition.id;
+      if (route && context && routeId) {
+        context.emit(`route:${routeId}:error-handler:invoked` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          originalError: innerError,
+          failedOperation: stepLabel,
+          scope: "step",
+          stepLabel,
+        });
+      }
+
+      try {
+        const forward = route?.getForward();
+        if (!forward) {
+          // Should not happen in normal pipelines (route is always
+          // bound), but fail loudly rather than silently mis-recover.
+          throw rcError("RC5001", innerError, {
+            message:
+              "Step-scope .error() handler ran without a route binding; cannot build forward()",
+          });
+        }
+        const recovered = await this.handler(innerError, exchange, forward);
+        exchange.body = recovered;
+        // The recovery replaced the body; subsequent pipeline steps
+        // see the new value. No inner-pushed children survive a
+        // failure, so clear the buffer to let the template method
+        // route the (single) recovered exchange forward.
+        this.innerPushed = [];
+
+        if (route && context && routeId) {
+          context.emit(
+            `route:${routeId}:error-handler:recovered` as EventName,
+            {
+              routeId,
+              exchangeId: exchange.id,
+              correlationId,
+              originalError: innerError,
+              failedOperation: stepLabel,
+              recoveryStrategy: "step-error-handler",
+              scope: "step",
+              stepLabel,
+            },
+          );
+        }
+        return "recovered";
+      } catch (handlerError) {
+        if (route && context && routeId) {
+          context.emit(`route:${routeId}:error-handler:failed` as EventName, {
+            routeId,
+            exchangeId: exchange.id,
+            correlationId,
+            originalError: innerError,
+            failedOperation: stepLabel,
+            recoveryStrategy: "step-error-handler",
+            scope: "step",
+            stepLabel,
+          });
+        }
+        // Rethrow so `runSteps` cascades to the route-level handler
+        // (or the default error path when none is set). Wrap raw
+        // throws in `RoutecraftError` for consistent observability;
+        // pass-through if already an RoutecraftError.
+        throw handlerError instanceof RoutecraftError
+          ? handlerError
+          : rcError("RC5001", handlerError, {
+              message: `Step-scope .error() handler for "${stepLabel}" threw`,
+            });
+      }
+    }
+  }
+
+  protected override drainInnerQueue(): {
+    exchange: Exchange;
+    steps: Step<Adapter>[];
+  }[] {
+    return this.innerPushed;
+  }
+}

--- a/packages/routecraft/src/operations/wrapper.ts
+++ b/packages/routecraft/src/operations/wrapper.ts
@@ -1,4 +1,5 @@
 import type { Adapter, EventName, Step } from "../types.ts";
+import { getAdapterLabel } from "../types.ts";
 import {
   type Exchange,
   getExchangeContext,
@@ -151,6 +152,7 @@ export abstract class WrapperStep<
     const route = getExchangeRoute(exchange);
     const context = getExchangeContext(exchange);
     const stepLabel = this.label ?? String(this.operation);
+    const adapterLabel = getAdapterLabel(this.adapter);
     const correlationId = exchange.headers[
       HeadersKeys.CORRELATION_ID
     ] as string;
@@ -169,6 +171,7 @@ export abstract class WrapperStep<
         exchangeId: exchange.id,
         correlationId,
         operation: stepLabel,
+        ...(adapterLabel ? { adapter: adapterLabel } : {}),
       });
     }
 
@@ -191,6 +194,7 @@ export abstract class WrapperStep<
           exchangeId: exchange.id,
           correlationId,
           operation: stepLabel,
+          ...(adapterLabel ? { adapter: adapterLabel } : {}),
           duration: Date.now() - stepStart,
           error: err instanceof Error ? err.message : String(err),
         });
@@ -204,6 +208,7 @@ export abstract class WrapperStep<
         exchangeId: exchange.id,
         correlationId,
         operation: stepLabel,
+        ...(adapterLabel ? { adapter: adapterLabel } : {}),
         duration: Date.now() - stepStart,
       });
     }

--- a/packages/routecraft/src/operations/wrapper.ts
+++ b/packages/routecraft/src/operations/wrapper.ts
@@ -4,7 +4,29 @@ import {
   getExchangeContext,
   getExchangeRoute,
   HeadersKeys,
+  OperationType,
 } from "../exchange.ts";
+import { rcError } from "../error.ts";
+
+/**
+ * Operation kinds that resilience wrappers cannot safely wrap. Validated
+ * at construction time by {@link WrapperStep} so misuse fails when the
+ * route is built, not at first dispatch.
+ *
+ * - `aggregate`: reads sibling exchanges from the shared route queue
+ *   via `queue.splice(...)`. The wrapper hands inner an isolated
+ *   per-execution buffer, so an aggregator inside a wrapper would only
+ *   ever see the current exchange.
+ * - `split`: emits children synchronously then may throw mid-stream;
+ *   recovery would silently truncate already-emitted children. Wrap
+ *   the steps DOWNSTREAM of `.split()` instead.
+ *
+ * @internal
+ */
+const NON_WRAPPABLE_OPERATIONS: ReadonlySet<OperationType> = new Set([
+  OperationType.AGGREGATE,
+  OperationType.SPLIT,
+]);
 
 /**
  * Outcome of {@link WrapperStep.runInner}. Subclasses use it to tell the
@@ -66,6 +88,14 @@ export abstract class WrapperStep<
   readonly skipStepEvents = true;
 
   constructor(protected readonly inner: Step<T>) {
+    if (NON_WRAPPABLE_OPERATIONS.has(inner.operation)) {
+      throw rcError("RC5003", undefined, {
+        message:
+          `Wrapper operations (e.g. .error(), future .retry() / .timeout() / .cache()) cannot wrap "${inner.operation}" steps. ` +
+          `Aggregate reads siblings from the shared route queue and split emits children synchronously; both have semantics ` +
+          `that conflict with per-execution wrapper isolation. Wrap the steps downstream of split / before aggregate instead.`,
+      });
+    }
     this.operation = inner.operation;
     this.adapter = inner.adapter;
     if (inner.label !== undefined) this.label = inner.label;
@@ -124,9 +154,16 @@ export abstract class WrapperStep<
     const correlationId = exchange.headers[
       HeadersKeys.CORRELATION_ID
     ] as string;
+    const routeId = route?.definition.id;
+    // The wrapper only emits step lifecycle events when the inner
+    // step does NOT manage its own. Steps with `skipStepEvents = true`
+    // (filter, choice, split, aggregate, choice's halt, child
+    // wrappers in a stack) emit their own pair, so the wrapper must
+    // stay silent to avoid duplicates.
+    const innerOwnsEvents = this.inner.skipStepEvents === true;
+    const shouldEmitEvents = !innerOwnsEvents && route && context && routeId;
 
-    if (route && context) {
-      const routeId = route.definition.id;
+    if (shouldEmitEvents) {
       context.emit(`route:${routeId}:step:started` as EventName, {
         routeId,
         exchangeId: exchange.id,
@@ -140,10 +177,28 @@ export abstract class WrapperStep<
     // exchanges flowing through the same step instance don't share
     // state.
     const innerQueue: { exchange: Exchange; steps: Step<Adapter>[] }[] = [];
-    await this.runInner(exchange, innerQueue);
+    try {
+      await this.runInner(exchange, innerQueue);
+    } catch (err) {
+      // Emit step:failed before propagating so observers see a
+      // balanced started → failed pair. This matters for stacked
+      // wrappers where an inner wrapper threw and an outer wrapper
+      // recovers; without this, the inner wrapper's started event
+      // would never have a closing event.
+      if (shouldEmitEvents) {
+        context.emit(`route:${routeId}:step:failed` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          operation: stepLabel,
+          duration: Date.now() - stepStart,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      throw err;
+    }
 
-    if (route && context) {
-      const routeId = route.definition.id;
+    if (shouldEmitEvents) {
       context.emit(`route:${routeId}:step:completed` as EventName, {
         routeId,
         exchangeId: exchange.id,
@@ -153,11 +208,18 @@ export abstract class WrapperStep<
       });
     }
 
-    // Relay any children the inner step pushed (e.g. `split` children)
-    // with `remainingSteps` reattached. When the inner step did not
-    // push (the common case for transform / to / process / header /
-    // tap / filter / validate), push the mutated exchange directly.
+    // Relay any children the inner step pushed (e.g. `split` children
+    // when the wrapper is downstream of one) with `remainingSteps`
+    // reattached. When the inner step did not push:
+    // - If the inner intentionally dropped the exchange (filter
+    //   reject, choice unmatched, halt all set `routecraft.dropped`),
+    //   leave it dropped. Re-pushing would resurrect the drop and run
+    //   subsequent steps on a logically-removed exchange.
+    // - Otherwise push the mutated exchange so the rest of the
+    //   pipeline runs (the common case for transform / to / process /
+    //   header / tap / validate).
     if (innerQueue.length === 0) {
+      if (exchange.headers["routecraft.dropped"] === true) return;
       queue.push({ exchange, steps: remainingSteps });
       return;
     }

--- a/packages/routecraft/src/operations/wrapper.ts
+++ b/packages/routecraft/src/operations/wrapper.ts
@@ -1,0 +1,171 @@
+import type { Adapter, EventName, Step } from "../types.ts";
+import {
+  type Exchange,
+  getExchangeContext,
+  getExchangeRoute,
+  HeadersKeys,
+} from "../exchange.ts";
+
+/**
+ * Outcome of {@link WrapperStep.runInner}. Subclasses use it to tell the
+ * template method whether the inner step ran cleanly (`"ok"`) or threw
+ * and was recovered by the wrapper (`"recovered"`). In both cases the
+ * pipeline continues with `remainingSteps`.
+ *
+ * Subclasses signal a hard failure by throwing instead of returning;
+ * the template method lets that propagate so `runSteps` cascades to the
+ * route-level error handler (or the default `route:*:error` path when
+ * none is set).
+ *
+ * @internal
+ */
+export type WrapperOutcome = "ok" | "recovered";
+
+/**
+ * Abstract base for "dual-mode wrapper" operations: a single concept
+ * (`.error()`, future `.retry()`, `.timeout()`, `.cache()`, ...) that
+ * applies at either route scope (when staged before `.from()`) or step
+ * scope (when chained after `.from()`). The route-scope path is wired
+ * by the builder via existing fields on `RouteDefinition`. The
+ * step-scope path is wired by wrapping the *immediately next* step in a
+ * concrete `WrapperStep` subclass.
+ *
+ * Subclasses implement {@link WrapperStep.runInner}: run the inner
+ * step, decide whether to surface its result (`"ok"`), recover from a
+ * failure (`"recovered"`), or rethrow (signals an unrecoverable error
+ * for `runSteps` to handle).
+ *
+ * The template `execute()` handles the boilerplate: emitting the
+ * inner step's `step:started` / `step:completed` events with the inner
+ * label (so the wrapper is observationally invisible), then forwarding
+ * `exchange` to the rest of the pipeline by pushing
+ * `{ exchange, steps: remainingSteps }` onto the queue.
+ *
+ * @experimental Public surface is the dual-mode `.error()` builder
+ * method (see {@link RouteBuilder.error}); the `WrapperStep` class is
+ * exposed for forward-compat as wrapper authors land additional
+ * operations (retry, cache, timeout, circuit breaker, etc.).
+ */
+export abstract class WrapperStep<
+  T extends Adapter = Adapter,
+> implements Step<T> {
+  /**
+   * Operation kind delegated from the inner step so observers see the
+   * wrapped operation's identity, not a generic "wrapper".
+   */
+  readonly operation: Step<T>["operation"];
+  /** Adapter delegated from the inner step. */
+  readonly adapter: T;
+  /** Display label delegated from the inner step. */
+  readonly label?: string;
+  /**
+   * The wrapper emits its own `step:started` / `step:completed` events
+   * with the inner step's label, so `runSteps` must not emit a generic
+   * pair around the wrapper.
+   */
+  readonly skipStepEvents = true;
+
+  constructor(protected readonly inner: Step<T>) {
+    this.operation = inner.operation;
+    this.adapter = inner.adapter;
+    if (inner.label !== undefined) this.label = inner.label;
+  }
+
+  /**
+   * Run the inner step with whatever extra behaviour the subclass adds.
+   * Return `"ok"` when the inner step succeeded normally, or
+   * `"recovered"` when the wrapper handled a failure and the pipeline
+   * should continue with `exchange.body` set by the recovery path.
+   * Throw to signal the wrapper could not recover; `runSteps` will then
+   * fall through to the route-level error handler (or fail the
+   * exchange when none is set).
+   *
+   * @param exchange Live exchange to feed to the inner step.
+   * @returns Outcome that determines whether the pipeline continues.
+   */
+  protected abstract runInner(exchange: Exchange): Promise<WrapperOutcome>;
+
+  /**
+   * Template method called by `runSteps`. Emits the inner step's
+   * lifecycle events with the inner label, delegates to
+   * {@link runInner}, and forwards the exchange (or any child
+   * exchanges the inner pushed) to the rest of the pipeline on
+   * success or recovery. Wrapper-specific failure events are emitted
+   * by the subclass before it rethrows.
+   *
+   * When the inner step pushes child exchanges (e.g. `split`), each
+   * child is re-pushed onto the real queue with `remainingSteps`
+   * appended so children continue through the rest of the pipeline.
+   * When the inner step does not push (e.g. `to`, `transform`,
+   * `process`), the wrapper pushes the mutated exchange itself.
+   */
+  async execute(
+    exchange: Exchange,
+    remainingSteps: Step<Adapter>[],
+    queue: { exchange: Exchange; steps: Step<Adapter>[] }[],
+  ): Promise<void> {
+    const route = getExchangeRoute(exchange);
+    const context = getExchangeContext(exchange);
+    const stepLabel = this.label ?? String(this.operation);
+    const correlationId = exchange.headers[
+      HeadersKeys.CORRELATION_ID
+    ] as string;
+
+    if (route && context) {
+      const routeId = route.definition.id;
+      context.emit(`route:${routeId}:step:started` as EventName, {
+        routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        operation: stepLabel,
+      });
+    }
+
+    const stepStart = Date.now();
+    await this.runInner(exchange);
+
+    if (route && context) {
+      const routeId = route.definition.id;
+      context.emit(`route:${routeId}:step:completed` as EventName, {
+        routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        operation: stepLabel,
+        duration: Date.now() - stepStart,
+      });
+    }
+
+    // The subclass calls `inner.execute(exchange, [], innerQueue)` so
+    // it can capture per-call outcome; relay any pushed children here
+    // with `remainingSteps` reattached. When the inner step did not
+    // push (the common case for transform / to / process / header /
+    // tap / filter / validate), push the mutated exchange directly.
+    const inner = this.drainInnerQueue();
+    if (inner.length === 0) {
+      queue.push({ exchange, steps: remainingSteps });
+      return;
+    }
+    for (const item of inner) {
+      queue.push({
+        exchange: item.exchange,
+        steps: [...item.steps, ...remainingSteps],
+      });
+    }
+  }
+
+  /**
+   * Hand the inner queue captured by {@link runInner} back to the
+   * template method. Subclasses that delegate to a private inner
+   * queue must override this; the default returns an empty array,
+   * which works for subclasses that pass the real queue to the inner
+   * step directly.
+   *
+   * @internal
+   */
+  protected drainInnerQueue(): {
+    exchange: Exchange;
+    steps: Step<Adapter>[];
+  }[] {
+    return [];
+  }
+}

--- a/packages/routecraft/src/operations/wrapper.ts
+++ b/packages/routecraft/src/operations/wrapper.ts
@@ -80,10 +80,24 @@ export abstract class WrapperStep<
    * fall through to the route-level error handler (or fail the
    * exchange when none is set).
    *
+   * `innerQueue` is a per-execution buffer the subclass passes to
+   * `inner.execute(exchange, [], innerQueue)`. Any items the inner
+   * step pushes (e.g. `split` children) are captured here; the
+   * template method then re-relays them to the real queue with
+   * `remainingSteps` reattached. The buffer is local to a single
+   * `execute()` call, so the same step instance can serve concurrent
+   * exchanges without state leakage. Subclasses must clear the buffer
+   * on a recovered failure to avoid leaking the failed inner's
+   * partial pushes into the recovered path.
+   *
    * @param exchange Live exchange to feed to the inner step.
+   * @param innerQueue Per-execution buffer for inner-pushed children.
    * @returns Outcome that determines whether the pipeline continues.
    */
-  protected abstract runInner(exchange: Exchange): Promise<WrapperOutcome>;
+  protected abstract runInner(
+    exchange: Exchange,
+    innerQueue: { exchange: Exchange; steps: Step<Adapter>[] }[],
+  ): Promise<WrapperOutcome>;
 
   /**
    * Template method called by `runSteps`. Emits the inner step's
@@ -122,7 +136,11 @@ export abstract class WrapperStep<
     }
 
     const stepStart = Date.now();
-    await this.runInner(exchange);
+    // Per-execution buffer; passed to runInner so concurrent
+    // exchanges flowing through the same step instance don't share
+    // state.
+    const innerQueue: { exchange: Exchange; steps: Step<Adapter>[] }[] = [];
+    await this.runInner(exchange, innerQueue);
 
     if (route && context) {
       const routeId = route.definition.id;
@@ -135,37 +153,19 @@ export abstract class WrapperStep<
       });
     }
 
-    // The subclass calls `inner.execute(exchange, [], innerQueue)` so
-    // it can capture per-call outcome; relay any pushed children here
+    // Relay any children the inner step pushed (e.g. `split` children)
     // with `remainingSteps` reattached. When the inner step did not
     // push (the common case for transform / to / process / header /
     // tap / filter / validate), push the mutated exchange directly.
-    const inner = this.drainInnerQueue();
-    if (inner.length === 0) {
+    if (innerQueue.length === 0) {
       queue.push({ exchange, steps: remainingSteps });
       return;
     }
-    for (const item of inner) {
+    for (const item of innerQueue) {
       queue.push({
         exchange: item.exchange,
         steps: [...item.steps, ...remainingSteps],
       });
     }
-  }
-
-  /**
-   * Hand the inner queue captured by {@link runInner} back to the
-   * template method. Subclasses that delegate to a private inner
-   * queue must override this; the default returns an empty array,
-   * which works for subclasses that pass the real queue to the inner
-   * step directly.
-   *
-   * @internal
-   */
-  protected drainInnerQueue(): {
-    exchange: Exchange;
-    steps: Step<Adapter>[];
-  }[] {
-    return [];
   }
 }

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -351,6 +351,17 @@ export interface Route<T = unknown> {
    * @internal
    */
   trackTask(promise: Promise<unknown>): void;
+
+  /**
+   * Build a forward function the route uses to delegate from an
+   * error / fallback handler to another route via the direct adapter.
+   * Exposed so step-scope `WrapperStep` subclasses can hand the same
+   * callable to a user-supplied handler as the route-level pipeline
+   * does.
+   *
+   * @internal
+   */
+  getForward(): ForwardFn;
 }
 
 /**
@@ -1105,6 +1116,20 @@ export class DefaultRoute implements Route {
         );
 
         if (this.definition.errorHandler) {
+          // Route-scope error-handler events. Step-scope wrappers
+          // emit the same set with `scope: "step"` and `stepLabel`.
+          this.context.emit(
+            `route:${this.definition.id}:error-handler:invoked` as const,
+            {
+              routeId: this.definition.id,
+              exchangeId: exchange.id,
+              correlationId,
+              originalError: err,
+              failedOperation: stepLabel,
+              scope: "route",
+            },
+          );
+
           try {
             const forward = this.buildForward();
             const result = await this.definition.errorHandler(
@@ -1124,6 +1149,18 @@ export class DefaultRoute implements Route {
                 exchange,
               },
             );
+            this.context.emit(
+              `route:${this.definition.id}:error-handler:recovered` as const,
+              {
+                routeId: this.definition.id,
+                exchangeId: exchange.id,
+                correlationId,
+                originalError: err,
+                failedOperation: stepLabel,
+                recoveryStrategy: "route-error-handler",
+                scope: "route",
+              },
+            );
           } catch (handlerError) {
             const handlerErr = this.processError(stepLabel, handlerError);
             exchange.logger.error(
@@ -1133,6 +1170,18 @@ export class DefaultRoute implements Route {
                 context: "error handler",
               },
               handlerErr.meta.message,
+            );
+            this.context.emit(
+              `route:${this.definition.id}:error-handler:failed` as const,
+              {
+                routeId: this.definition.id,
+                exchangeId: exchange.id,
+                correlationId,
+                originalError: err,
+                failedOperation: stepLabel,
+                recoveryStrategy: "route-error-handler",
+                scope: "route",
+              },
             );
             // Error handler rethrew -- route-level + context-level error
             this.context.emit(
@@ -1251,6 +1300,20 @@ export class DefaultRoute implements Route {
       dropped,
       error: stepError,
     };
+  }
+
+  /**
+   * Build a forward function that sends a payload to another route via the direct adapter.
+   *
+   * Exposed (`@internal`) so step-scope `WrapperStep` subclasses can hand
+   * the same forward callable to a user-supplied error / fallback handler
+   * as the route-level pipeline does. Resolve via
+   * `getExchangeRoute(exchange).getForward()`.
+   *
+   * @returns A forward function
+   */
+  getForward(): ForwardFn {
+    return this.buildForward();
   }
 
   /**

--- a/packages/routecraft/src/step-builder-base.ts
+++ b/packages/routecraft/src/step-builder-base.ts
@@ -17,6 +17,7 @@ import {
   type EnrichMergeShape,
   type EnrichAggregatorOption,
 } from "./operations/enrich.ts";
+import { ErrorWrapperStep } from "./operations/error-wrapper.ts";
 import {
   type Processor,
   type CallableProcessor,
@@ -34,7 +35,19 @@ import {
   ValidateStep,
 } from "./operations/validate.ts";
 import { HeaderStep } from "./operations/header.ts";
+import type { ErrorHandler } from "./route.ts";
 import { PUSH_STEP } from "./dsl-symbol.ts";
+
+/**
+ * Builder hook that wraps a single step in a "dual-mode wrapper"
+ * (e.g. `.error()`, future `.retry()` / `.timeout()` / `.cache()`).
+ * Pushed onto {@link StepBuilderBase}'s pending wrapper stack when the
+ * builder method runs in step scope; folded around the next pushed
+ * step inside {@link StepBuilderBase.applyPendingWrappers}.
+ *
+ * @internal
+ */
+export type StepWrapperFactory = <T extends Adapter>(inner: Step<T>) => Step<T>;
 
 // Type-only imports to avoid a runtime cycle. The `Retyped` conditional below
 // resolves `this` into the concrete subclass typed at `NewT`; the value side
@@ -92,14 +105,77 @@ export type Retyped<This, NewT> =
  */
 export abstract class StepBuilderBase<Current = unknown> {
   /**
+   * Stack of step-scope wrapper factories declared since the last
+   * pushed step, in declaration order. Folded around the next pushed
+   * step by {@link applyPendingWrappers}; the first-declared wrapper
+   * is outermost (`.retry().timeout().process(slow)` means
+   * `retry(timeout(process))`). Cleared after each push.
+   *
+   * @internal
+   */
+  protected pendingStepWrappers: StepWrapperFactory[] = [];
+
+  /**
+   * Fold any wrappers staged since the last push around `step`,
+   * returning the (possibly wrapped) step that subclasses should hand
+   * to their target collection. Clears the stack on every call so a
+   * wrapper attaches to exactly one step.
+   *
+   * @internal
+   */
+  protected applyPendingWrappers<T extends Adapter>(step: Step<T>): Step<T> {
+    if (this.pendingStepWrappers.length === 0) return step;
+    let wrapped: Step<Adapter> = step as Step<Adapter>;
+    for (let i = this.pendingStepWrappers.length - 1; i >= 0; i--) {
+      const factory = this.pendingStepWrappers[i]!;
+      wrapped = factory(wrapped);
+    }
+    this.pendingStepWrappers = [];
+    return wrapped as unknown as Step<T>;
+  }
+
+  /**
    * Append a step to the builder's pipeline. Implemented by each subclass
    * to route the step into the right collection (current route definition
    * vs. branch step array). Subclass-specific validation (e.g.
-   * `RouteBuilder.requireSource`) lives in the implementation.
+   * `RouteBuilder.requireSource`) lives in the implementation. Subclasses
+   * MUST run `step` through {@link applyPendingWrappers} so dual-mode
+   * wrappers (`.error()`, future `.retry()`, etc.) attach to the right
+   * step.
    *
    * @param step - The step to append
    */
   protected abstract pushStep<T extends Adapter>(step: Step<T>): void;
+
+  /**
+   * Attach an error handler to the next step. When the wrapped step
+   * throws, the handler runs with `(err, exchange, forward)` (same
+   * shape as the route-level handler), its return value replaces
+   * `exchange.body`, and the pipeline continues with the next step.
+   *
+   * On `RouteBuilder`, this method is dual-mode: when called BEFORE
+   * `.from()` it stages a route-level catch-all (existing behaviour);
+   * when called AFTER `.from()` it wraps the next step. On
+   * `BranchBuilder`, it is always step-scope.
+   *
+   * If the handler itself throws, the wrapper rethrows so the
+   * route-level handler (when set) catches it; otherwise the route's
+   * default error path fires (`route:*:error`, `context:error`,
+   * `exchange:failed`). The route is NOT stopped.
+   *
+   * Stacks left-to-right: `.error(h1).error(h2).to(dest)` produces
+   * `h1` outermost wrapping `h2` wrapping `dest`. `h2` runs first; if
+   * it rethrows, `h1` gets a chance.
+   *
+   * @experimental Step-scope behaviour ships with the dual-mode
+   * wrapper pattern (see `.standards/resilience-wrappers.md`).
+   */
+  error(handler: ErrorHandler): this {
+    this.pendingStepWrappers.push(
+      (inner) => new ErrorWrapperStep(inner, handler),
+    );
+    return this;
+  }
 
   /**
    * Return `this` re-typed to the concrete subclass at a new body type.

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -513,6 +513,14 @@ type RouteEventDetails<S extends string> =
                                     correlationId: string;
                                     originalError: unknown;
                                     failedOperation: string;
+                                    /**
+                                     * `"route"` for the route-level (`.error()` before `.from()`)
+                                     * catch-all handler; `"step"` for a wrapper-scope handler
+                                     * attached to a single step (`.error()` after `.from()`).
+                                     */
+                                    scope?: "route" | "step";
+                                    /** Step label when `scope === "step"`. */
+                                    stepLabel?: string;
                                   }
                                 : S extends "error-handler:recovered"
                                   ? {
@@ -522,6 +530,10 @@ type RouteEventDetails<S extends string> =
                                       originalError: unknown;
                                       failedOperation: string;
                                       recoveryStrategy: string;
+                                      /** See `error-handler:invoked.scope`. */
+                                      scope?: "route" | "step";
+                                      /** Step label when `scope === "step"`. */
+                                      stepLabel?: string;
                                     }
                                   : S extends "error-handler:failed"
                                     ? {
@@ -531,6 +543,10 @@ type RouteEventDetails<S extends string> =
                                         originalError: unknown;
                                         failedOperation: string;
                                         recoveryStrategy?: string;
+                                        /** See `error-handler:invoked.scope`. */
+                                        scope?: "route" | "step";
+                                        /** Step label when `scope === "step"`. */
+                                        stepLabel?: string;
                                       }
                                     : // Choice operation
                                       S extends "operation:choice:matched"

--- a/packages/routecraft/test/step-error.test.ts
+++ b/packages/routecraft/test/step-error.test.ts
@@ -1,0 +1,313 @@
+import { describe, test, expect, afterEach, vi } from "vitest";
+import { testContext, spy, type TestContext } from "@routecraft/testing";
+import {
+  craft,
+  direct,
+  ErrorWrapperStep,
+  simple,
+  WrapperStep,
+  type Step,
+  type Adapter,
+  type Exchange,
+} from "@routecraft/routecraft";
+
+describe(".error() step scope: dual-mode wrapper", () => {
+  let t: TestContext | undefined;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Step-scope handler recovers a single failure and the pipeline continues
+   * @preconditions .from(...).transform(throws).error(recover).to(sink)
+   * @expectedResult Sink receives the handler's return; route reports zero errors
+   */
+  test("step-scope recovery continues the pipeline", async () => {
+    const sink = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("step-recovers")
+          .from(simple("input"))
+          .error(() => ({ recovered: true }))
+          .transform(() => {
+            throw new Error("boom");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(t.errors).toHaveLength(0);
+    expect(sink.received).toHaveLength(1);
+    expect(sink.received[0].body).toEqual({ recovered: true });
+  });
+
+  /**
+   * @case Wrapper attaches to the immediately next step only
+   * @preconditions .error(h).transform(ok).transform(throw); h does NOT cover the second transform
+   * @expectedResult Route's default error path fires; sink not reached
+   */
+  test("wrapper covers only the next step, not later steps", async () => {
+    const sink = spy();
+    const handler = vi.fn(() => ({ shouldNotRun: true }));
+    t = await testContext()
+      .routes(
+        craft()
+          .id("scope-only-next")
+          .from(simple("input"))
+          .error(handler)
+          .transform((b) => `${b}-ok`)
+          .transform(() => {
+            throw new Error("from-second");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    // Handler not invoked because the throw happened on the unwrapped second transform.
+    expect(handler).not.toHaveBeenCalled();
+    expect(sink.received).toHaveLength(0);
+    expect(t.errors[0]?.message).toMatch(/from-second/);
+  });
+
+  /**
+   * @case Stacked wrappers fold outside-in (first declared is outermost)
+   * @preconditions Two synthetic wrappers stacked; outer rethrows test marker, inner unused
+   * @expectedResult Outer wrapper observes the inner wrapper's adapter (its `inner` is the inner wrapper)
+   */
+  test("stacked step wrappers fold outside-in", async () => {
+    // Two minimal trace wrappers that just record their own position in the stack.
+    const calls: string[] = [];
+    class TraceWrapperOuter extends WrapperStep {
+      protected override async runInner(exchange: Exchange): Promise<"ok"> {
+        calls.push("outer-before");
+        await this.inner.execute(exchange, [], []);
+        calls.push("outer-after");
+        return "ok";
+      }
+    }
+    class TraceWrapperInner extends WrapperStep {
+      protected override async runInner(exchange: Exchange): Promise<"ok"> {
+        calls.push("inner-before");
+        await this.inner.execute(exchange, [], []);
+        calls.push("inner-after");
+        return "ok";
+      }
+    }
+
+    // Hand-build: outer wraps inner wraps the to step. We can't easily
+    // express "stack two wrapper factories" through the public builder
+    // until a second public wrapper ships, so wire the wrap chain
+    // directly via the builder's pending stack via a thin helper.
+    const sink = spy();
+    type WrapBuilder = {
+      pendingStepWrappers: Array<(s: Step<Adapter>) => Step<Adapter>>;
+    };
+    const builder = craft().id("stacked-wrappers").from(simple("hi"));
+    (builder as unknown as WrapBuilder).pendingStepWrappers.push(
+      (inner) => new TraceWrapperOuter(inner),
+    );
+    (builder as unknown as WrapBuilder).pendingStepWrappers.push(
+      (inner) => new TraceWrapperInner(inner),
+    );
+
+    t = await testContext().routes(builder.to(sink)).build();
+    await t.test();
+
+    // Outer surrounds inner: outer-before, inner-before, inner-after, outer-after.
+    expect(calls).toEqual([
+      "outer-before",
+      "inner-before",
+      "inner-after",
+      "outer-after",
+    ]);
+    expect(sink.received).toHaveLength(1);
+  });
+
+  /**
+   * @case Step handler throws; route-level handler catches the rethrow
+   * @preconditions Route .error(routeHandler) before .from(); step .error(throws) after
+   * @expectedResult Route handler invoked with the (wrapped) handler error; pipeline halts after route handler (existing semantics)
+   */
+  test("step handler throw escalates to route handler", async () => {
+    const routeHandler = vi.fn(() => ({ caughtAtRoute: true }));
+    const sink = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("escalate-to-route")
+          .error(routeHandler)
+          .from(simple("input"))
+          .error(() => {
+            throw new Error("step-handler-failure");
+          })
+          .transform(() => {
+            throw new Error("step-failure");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(routeHandler).toHaveBeenCalledTimes(1);
+    expect(t.errors).toHaveLength(0);
+  });
+
+  /**
+   * @case Step handler throws with no route-level handler; default error path fires
+   * @preconditions No route-level .error(); step .error(throws); transform throws
+   * @expectedResult t.errors records the failure; route is NOT stopped (next exchange still processes)
+   */
+  test("step handler throw without route handler hits default path", async () => {
+    const sink = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("escalate-no-route")
+          .from(simple("input"))
+          .error(() => {
+            throw new Error("step-handler-failure");
+          })
+          .transform(() => {
+            throw new Error("step-failure");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(t.errors[0]?.message).toMatch(
+      /step-handler-failure|step-failure|threw/i,
+    );
+    expect(sink.received).toHaveLength(0);
+  });
+
+  /**
+   * @case Step handler uses forward() to delegate recovery to a direct route
+   * @preconditions DLQ direct route registered; step handler returns forward(dlq, payload)
+   * @expectedResult DLQ receives the payload; pipeline continues with forward()'s return as the body
+   */
+  test("step handler can forward() to a direct route", async () => {
+    const dlqSink = spy();
+    const sink = spy();
+    t = await testContext()
+      .routes([
+        craft().id("dlq").from(direct()).to(dlqSink),
+        craft()
+          .id("with-step-forward")
+          .from(simple("input"))
+          .error((err, _ex, forward) => forward("dlq", { reason: String(err) }))
+          .transform(() => {
+            throw new Error("boom");
+          })
+          .to(sink),
+      ])
+      .build();
+
+    await t.test();
+    expect(dlqSink.received).toHaveLength(1);
+    expect(dlqSink.received[0].body).toMatchObject({
+      reason: expect.stringMatching(/boom/),
+    });
+    expect(sink.received).toHaveLength(1);
+  });
+
+  /**
+   * @case Combined route + step handlers; happy path through the step recovery
+   * @preconditions Route .error() set; step .error() set; only step throws
+   * @expectedResult Step handler runs; route handler is never invoked
+   */
+  test("step handler short-circuits the route handler on success", async () => {
+    const routeHandler = vi.fn(() => ({ shouldNotRun: true }));
+    const sink = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("step-wins")
+          .error(routeHandler)
+          .from(simple("input"))
+          .error(() => ({ stepRecovered: true }))
+          .transform(() => {
+            throw new Error("step-failure");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(routeHandler).not.toHaveBeenCalled();
+    expect(sink.received[0].body).toEqual({ stepRecovered: true });
+  });
+
+  /**
+   * @case error-handler events carry scope and stepLabel for step-scope wrappers
+   * @preconditions Subscriber to route:*:error-handler:* before t.test()
+   * @expectedResult invoked + recovered events both carry scope: "step" and a stepLabel
+   */
+  test("error-handler events carry scope and stepLabel for step scope", async () => {
+    const events: Array<{ name: string; details: unknown }> = [];
+    t = await testContext()
+      .routes(
+        craft()
+          .id("event-scope")
+          .from(simple("input"))
+          .error(() => "recovered")
+          .transform(() => {
+            throw new Error("boom");
+          })
+          .to(spy()),
+      )
+      .build();
+
+    t.ctx.on(
+      "route:event-scope:error-handler:invoked" as never,
+      ({ details }: { details: unknown }) => {
+        events.push({ name: "invoked", details });
+      },
+    );
+    t.ctx.on(
+      "route:event-scope:error-handler:recovered" as never,
+      ({ details }: { details: unknown }) => {
+        events.push({ name: "recovered", details });
+      },
+    );
+
+    await t.test();
+    expect(events.map((e) => e.name)).toEqual(["invoked", "recovered"]);
+    for (const e of events) {
+      const d = e.details as {
+        scope?: string;
+        stepLabel?: string;
+        failedOperation?: string;
+      };
+      expect(d.scope).toBe("step");
+      expect(d.stepLabel).toBeDefined();
+    }
+  });
+
+  /**
+   * @case Wrapper exposes the inner step's identity
+   * @preconditions Construct an ErrorWrapperStep around a known inner step
+   * @expectedResult operation/adapter/label fields delegate to the inner step
+   */
+  test("wrapper delegates operation/adapter/label to its inner step", () => {
+    const handler = vi.fn();
+    const innerSpy: Step<Adapter> = {
+      operation: "transform" as Step<Adapter>["operation"],
+      adapter: { kind: "fake" } as unknown as Adapter,
+      label: "fake-step",
+      async execute(): Promise<void> {
+        // never called in this test
+      },
+    };
+    const wrapped = new ErrorWrapperStep(innerSpy, handler);
+    expect(wrapped.operation).toBe(innerSpy.operation);
+    expect(wrapped.adapter).toBe(innerSpy.adapter);
+    expect(wrapped.label).toBe("fake-step");
+    expect(wrapped.skipStepEvents).toBe(true);
+  });
+});

--- a/packages/routecraft/test/step-error.test.ts
+++ b/packages/routecraft/test/step-error.test.ts
@@ -296,33 +296,61 @@ describe(".error() step scope: dual-mode wrapper", () => {
   });
 
   /**
-   * @case Concurrent exchanges through the same step instance do not share state
-   * @preconditions Single .error() wrapper around a slow transform; fire many exchanges in parallel
-   * @expectedResult Every recovered body equals the handler's return; no cross-talk between exchanges
+   * @case Concurrent execute() calls on one wrapper instance do not share inner-queue state
+   * @preconditions Single ErrorWrapperStep instance; fire 10 concurrent execute() calls with overlapping inner work
+   * @expectedResult Each call's inner-pushed children land in the right per-call queue; no cross-talk
    */
-  test("concurrent exchanges through one wrapper instance do not alias state", async () => {
-    const sink = spy();
-    const handler = vi.fn((err) => `recovered-from-${(err as Error).message}`);
-    t = await testContext()
-      .routes(
-        craft()
-          .id("concurrent-wrapper")
-          .from(simple("payload"))
-          .error(handler)
-          .transform(async (body) => {
-            // Stagger the failure so multiple exchanges interleave inside the wrapper.
-            await new Promise((r) => setTimeout(r, 1));
-            throw new Error(`boom-${body as string}`);
-          })
-          .to(sink),
-      )
-      .build();
+  test("concurrent execute() calls share no per-execution buffer state", async () => {
+    // Hand-build a wrapper unit test (no testContext) to avoid the
+    // start/stop race that would come from calling `t.test()` in
+    // parallel on a single TestContext. The bug we want to detect is
+    // wrapper-internal: per-execution buffers must not leak across
+    // concurrent calls into the same instance.
 
-    // Fire several exchanges through the single wrapper instance.
-    await Promise.all(Array.from({ length: 10 }, () => t!.test()));
-    expect(sink.received.length).toBeGreaterThanOrEqual(10);
-    for (const ex of sink.received) {
-      expect(ex.body).toBe("recovered-from-boom-payload");
+    // Fake inner step that yields the event loop then pushes ONE
+    // child whose body identifies the originating exchange. If the
+    // wrapper aliases per-instance state, a child will end up in the
+    // wrong outer queue.
+    const innerStep: Step<Adapter> = {
+      operation: "transform" as Step<Adapter>["operation"],
+      adapter: { adapterId: "fake.inner" } as unknown as Adapter,
+      async execute(
+        exchange: Exchange,
+        _remainingSteps: Step<Adapter>[],
+        queue: { exchange: Exchange; steps: Step<Adapter>[] }[],
+      ): Promise<void> {
+        // Yield so multiple execute() invocations interleave.
+        await new Promise((r) => setTimeout(r, 1));
+        queue.push({ exchange, steps: [] });
+      },
+    };
+    const wrapper = new ErrorWrapperStep(innerStep, () => "unused");
+
+    const N = 10;
+    const outerQueues: {
+      exchange: Exchange;
+      steps: Step<Adapter>[];
+    }[][] = Array.from({ length: N }, () => []);
+
+    // Build N synthetic exchanges, identifiable by body.
+    const exchanges: Exchange[] = Array.from({ length: N }, (_, i) => ({
+      id: `ex-${i}`,
+      body: `payload-${i}`,
+      headers: {} as Record<string, unknown>,
+      logger: { warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    })) as unknown as Exchange[];
+
+    await Promise.all(
+      exchanges.map((ex, i) => wrapper.execute(ex, [], outerQueues[i]!)),
+    );
+
+    // Every outer queue should contain exactly the originating
+    // exchange's child. If the per-execution buffer leaked, one of
+    // these would be wrong or zero / two.
+    for (let i = 0; i < N; i++) {
+      const queue = outerQueues[i]!;
+      expect(queue).toHaveLength(1);
+      expect(queue[0]!.exchange.body).toBe(`payload-${i}`);
     }
   });
 
@@ -531,6 +559,116 @@ describe(".error() step scope: dual-mode wrapper", () => {
     expect(events).toContain("failed:transform");
     expect(sink.received).toHaveLength(1);
     expect(sink.received[0].body).toBe("outer-recovered");
+  });
+
+  /**
+   * @case Staged wrapper that's never consumed before .id() throws
+   * @preconditions craft().id(a).from(x).to(y).error(h).id(b)... - wrapper staged but no step follows
+   * @expectedResult RC2001 thrown at .id() so the leak surfaces at build time
+   */
+  test("wrapper staged but never consumed throws at next .id()", () => {
+    expect(() => {
+      craft()
+        .id("a")
+        .from(simple("x"))
+        .to(spy())
+        .error(() => "leaked")
+        .id("b");
+    }).toThrow(/wrapper.*staged|never consumed|orphan/i);
+  });
+
+  /**
+   * @case Staged wrapper that's never consumed before .from() throws
+   * @preconditions Chained route shortcut (no .id() between routes); wrapper leaked from first route
+   * @expectedResult RC2001 thrown at .from()
+   */
+  test("wrapper staged but never consumed throws at next .from()", () => {
+    expect(() => {
+      craft()
+        .id("a")
+        .from(simple("x"))
+        .to(spy())
+        .error(() => "leaked")
+        .from(simple("y"));
+    }).toThrow(/wrapper.*staged|never consumed|orphan/i);
+  });
+
+  /**
+   * @case Staged wrapper that's never consumed before .build() throws
+   * @preconditions craft().id(a).from(x).to(y).error(h) - last call is the wrapper, no step after
+   * @expectedResult RC2001 thrown at .build()
+   */
+  test("wrapper staged but never consumed throws at .build()", () => {
+    expect(() => {
+      craft()
+        .id("a")
+        .from(simple("x"))
+        .to(spy())
+        .error(() => "leaked")
+        .build();
+    }).toThrow(/wrapper.*staged|never consumed|orphan/i);
+  });
+
+  /**
+   * @case Step-scope handler receives a normalised RoutecraftError
+   * @preconditions Inner throws a plain Error; handler captures the error it receives
+   * @expectedResult Handler receives a RoutecraftError (rc/meta), not the raw Error
+   */
+  test("step-scope handler receives a normalised RoutecraftError", async () => {
+    let captured: unknown;
+    const sink = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("normalised-error")
+          .from(simple("input"))
+          .error((err) => {
+            captured = err;
+            return "ok";
+          })
+          .transform(() => {
+            throw new Error("raw-throw");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(captured).toBeDefined();
+    const c = captured as { rc?: string; meta?: { message?: string } };
+    expect(c.rc).toBe("RC5001");
+    expect(c.meta?.message).toMatch(/raw-throw/);
+  });
+
+  /**
+   * @case Wrapper-emitted step events carry the adapter label
+   * @preconditions Subscriber on step:started for a wrapped to() step
+   * @expectedResult The emitted detail object includes an `adapter` field
+   */
+  test("wrapper events carry adapter metadata", async () => {
+    const adapters: unknown[] = [];
+    const sink = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("adapter-meta")
+          .from(simple("input"))
+          .error(() => "fallback")
+          .transform((b) => `t-${b as string}`)
+          .to(sink),
+      )
+      .build();
+
+    t.ctx.on(
+      "route:adapter-meta:step:started" as never,
+      ({ details }: { details: { operation: string; adapter?: string } }) => {
+        if (details.operation === "transform") adapters.push(details.adapter);
+      },
+    );
+
+    await t.test();
+    expect(adapters).toHaveLength(1);
+    expect(adapters[0]).toBeDefined();
   });
 
   /**

--- a/packages/routecraft/test/step-error.test.ts
+++ b/packages/routecraft/test/step-error.test.ts
@@ -83,17 +83,23 @@ describe(".error() step scope: dual-mode wrapper", () => {
     // Two minimal trace wrappers that just record their own position in the stack.
     const calls: string[] = [];
     class TraceWrapperOuter extends WrapperStep {
-      protected override async runInner(exchange: Exchange): Promise<"ok"> {
+      protected override async runInner(
+        exchange: Exchange,
+        innerQueue: { exchange: Exchange; steps: Step<Adapter>[] }[],
+      ): Promise<"ok"> {
         calls.push("outer-before");
-        await this.inner.execute(exchange, [], []);
+        await this.inner.execute(exchange, [], innerQueue);
         calls.push("outer-after");
         return "ok";
       }
     }
     class TraceWrapperInner extends WrapperStep {
-      protected override async runInner(exchange: Exchange): Promise<"ok"> {
+      protected override async runInner(
+        exchange: Exchange,
+        innerQueue: { exchange: Exchange; steps: Step<Adapter>[] }[],
+      ): Promise<"ok"> {
         calls.push("inner-before");
-        await this.inner.execute(exchange, [], []);
+        await this.inner.execute(exchange, [], innerQueue);
         calls.push("inner-after");
         return "ok";
       }
@@ -287,6 +293,67 @@ describe(".error() step scope: dual-mode wrapper", () => {
       expect(d.scope).toBe("step");
       expect(d.stepLabel).toBeDefined();
     }
+  });
+
+  /**
+   * @case Concurrent exchanges through the same step instance do not share state
+   * @preconditions Single .error() wrapper around a slow transform; fire many exchanges in parallel
+   * @expectedResult Every recovered body equals the handler's return; no cross-talk between exchanges
+   */
+  test("concurrent exchanges through one wrapper instance do not alias state", async () => {
+    const sink = spy();
+    const handler = vi.fn((err) => `recovered-from-${(err as Error).message}`);
+    t = await testContext()
+      .routes(
+        craft()
+          .id("concurrent-wrapper")
+          .from(simple("payload"))
+          .error(handler)
+          .transform(async (body) => {
+            // Stagger the failure so multiple exchanges interleave inside the wrapper.
+            await new Promise((r) => setTimeout(r, 1));
+            throw new Error(`boom-${body as string}`);
+          })
+          .to(sink),
+      )
+      .build();
+
+    // Fire several exchanges through the single wrapper instance.
+    await Promise.all(Array.from({ length: 10 }, () => t!.test()));
+    expect(sink.received.length).toBeGreaterThanOrEqual(10);
+    for (const ex of sink.received) {
+      expect(ex.body).toBe("recovered-from-boom-payload");
+    }
+  });
+
+  /**
+   * @case Chained-routes: `.error()` between routes stages route-scope for the next route
+   * @preconditions craft().id(a).from(...).to(...).id(b).error(h).from(...) - error follows id but precedes from
+   * @expectedResult When route b throws, h runs (route-scope catch-all), not a step-scope wrapper
+   */
+  test("chained-route .error() after .id() stages route-scope for the next route", async () => {
+    const sink = spy();
+    const handlerB = vi.fn(() => ({ caughtAtRouteB: true }));
+    t = await testContext()
+      .routes(
+        craft()
+          .id("a")
+          .from(simple("ok-a"))
+          .to(spy())
+          .id("b")
+          .error(handlerB)
+          .from(simple("ok-b"))
+          .transform(() => {
+            throw new Error("b-failure");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(handlerB).toHaveBeenCalledTimes(1);
+    // Route-scope: pipeline halts after handler. Sink not reached.
+    expect(sink.received).toHaveLength(0);
   });
 
   /**

--- a/packages/routecraft/test/step-error.test.ts
+++ b/packages/routecraft/test/step-error.test.ts
@@ -357,6 +357,183 @@ describe(".error() step scope: dual-mode wrapper", () => {
   });
 
   /**
+   * @case Wrapping `aggregate` is rejected at builder time
+   * @preconditions craft().error(h).aggregate(...) - aggregator can't observe siblings inside a wrapper
+   * @expectedResult RC5003 thrown synchronously at construction; no route runs
+   */
+  test("wrapping aggregate throws at builder time", async () => {
+    expect(() => {
+      // Build the chain as `unknown` so we don't fight the
+      // aggregator's generic inference for code that never runs;
+      // we only want to assert the construction-time throw.
+      const builder = craft()
+        .id("wrap-agg")
+        .from(simple([1, 2]))
+        .split()
+        .error(() => 0) as unknown as { aggregate: (fn: unknown) => unknown };
+      (
+        builder.aggregate(() => undefined) as unknown as {
+          build: () => unknown;
+        }
+      ).build();
+    }).toThrow(/cannot wrap.*aggregate|wrap.*split/i);
+  });
+
+  /**
+   * @case Wrapping `split` is rejected at builder time
+   * @preconditions craft().error(h).split(...) - split's children are emitted synchronously and recovery would truncate
+   * @expectedResult RC5003 thrown synchronously at construction
+   */
+  test("wrapping split throws at builder time", async () => {
+    expect(() => {
+      craft()
+        .id("wrap-split")
+        .from(simple([1, 2, 3]))
+        .error(() => 0)
+        .split()
+        .to(spy())
+        .build();
+    }).toThrow(/cannot wrap.*split/i);
+  });
+
+  /**
+   * @case Wrapping a step that drops the exchange preserves the drop
+   * @preconditions Wrapper around a filter that rejects every input; sink after the wrapper
+   * @expectedResult Sink never receives the dropped exchange; routecraft.dropped flows through
+   */
+  test("wrapped filter that rejects keeps the drop (no resurrection)", async () => {
+    const sink = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("wrap-filter-drop")
+          .from(simple("input"))
+          .error(() => "should-not-recover")
+          .filter(() => false)
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    // Filter rejected the exchange. The wrapper must not re-inject it.
+    expect(sink.received).toHaveLength(0);
+  });
+
+  /**
+   * @case Wrapping a `skipStepEvents = true` step does not duplicate step events
+   * @preconditions Wrapper around `tap()` (which has skipStepEvents = true) with a subscriber
+   * @expectedResult Exactly one step:started for the tap operation, not two
+   */
+  test("wrapping a skipStepEvents step does not double-emit lifecycle events", async () => {
+    const tapSink = spy();
+    const sink = spy();
+    const startedEvents: unknown[] = [];
+    t = await testContext()
+      .routes(
+        craft()
+          .id("no-double-events")
+          .from(simple("input"))
+          .error(() => "fallback")
+          .tap(tapSink)
+          .to(sink),
+      )
+      .build();
+
+    t.ctx.on(
+      "route:no-double-events:step:started" as never,
+      ({ details }: { details: unknown }) => {
+        const d = details as { operation?: string };
+        if (d.operation === "tap") startedEvents.push(details);
+      },
+    );
+
+    await t.test();
+    expect(startedEvents).toHaveLength(1);
+  });
+
+  /**
+   * @case Stacked wrapper emits step:failed when its inner runInner throws
+   * @preconditions Outer wrapper recovers; inner wrapper's runInner throws
+   * @expectedResult Inner wrapper emits step:started + step:failed; no orphan started without a closing event
+   */
+  test("stacked wrapper emits step:failed on cascade for balanced events", async () => {
+    const events: string[] = [];
+    // Custom outer wrapper that recovers the inner failure.
+    class RecoveringOuter extends WrapperStep {
+      protected override async runInner(
+        exchange: Exchange,
+        innerQueue: { exchange: Exchange; steps: Step<Adapter>[] }[],
+      ): Promise<"ok" | "recovered"> {
+        try {
+          await this.inner.execute(exchange, [], innerQueue);
+          return "ok";
+        } catch {
+          // Swallow inner's throw so the test asserts the inner's step events.
+          (exchange as { body?: unknown }).body = "outer-recovered";
+          innerQueue.length = 0;
+          return "recovered";
+        }
+      }
+    }
+    // Inner wrapper that always throws (forces the cascade).
+    class ThrowingInner extends WrapperStep {
+      protected override async runInner(): Promise<"ok"> {
+        throw new Error("inner-failed");
+      }
+    }
+
+    const sink = spy();
+    type WrapBuilder = {
+      pendingStepWrappers: Array<(s: Step<Adapter>) => Step<Adapter>>;
+    };
+    const builder = craft().id("balanced-events").from(simple("hi"));
+    // Stage wrappers so the NEXT step gets wrapped. We then add a
+    // transform (which becomes the wrapped inner) and an unwrapped
+    // `to(sink)` after, so the recovered exchange flows past the
+    // wrapper and reaches the sink.
+    (builder as unknown as WrapBuilder).pendingStepWrappers.push(
+      (inner) => new RecoveringOuter(inner),
+    );
+    (builder as unknown as WrapBuilder).pendingStepWrappers.push(
+      (inner) => new ThrowingInner(inner),
+    );
+
+    t = await testContext()
+      .routes(builder.transform((b) => `pre-${b as string}`).to(sink))
+      .build();
+    t.ctx.on(
+      "route:balanced-events:step:started" as never,
+      ({ details }: { details: { operation: string } }) => {
+        events.push(`started:${details.operation}`);
+      },
+    );
+    t.ctx.on(
+      "route:balanced-events:step:failed" as never,
+      ({ details }: { details: { operation: string } }) => {
+        events.push(`failed:${details.operation}`);
+      },
+    );
+    t.ctx.on(
+      "route:balanced-events:step:completed" as never,
+      ({ details }: { details: { operation: string } }) => {
+        events.push(`completed:${details.operation}`);
+      },
+    );
+
+    await t.test();
+
+    // The inner wrapper (whose inner is the transform step) emits
+    // started and then failed when its runInner throws. The outer
+    // wrapper does NOT emit started/completed because its inner is a
+    // wrapper (skipStepEvents = true), so events are balanced and not
+    // duplicated. The unwrapped to(sink) runs after recovery.
+    expect(events).toContain("started:transform");
+    expect(events).toContain("failed:transform");
+    expect(sink.received).toHaveLength(1);
+    expect(sink.received[0].body).toBe("outer-recovered");
+  });
+
+  /**
    * @case Wrapper exposes the inner step's identity
    * @preconditions Construct an ErrorWrapperStep around a known inner step
    * @expectedResult operation/adapter/label fields delegate to the inner step


### PR DESCRIPTION
## Summary

Introduces a reusable `WrapperStep<T>` abstract base so future resilience operations (`retry`, `cache`, `timeout`, `circuitBreaker`, `throttle`, `delay`) ship as a small subclass plus a one-liner on the builder. `.error()` becomes the first concrete subclass and graduates from route-only to dual-mode.

Closes #140.

> Stacked on top of #265 (#187). Will re-target `main` once #265 merges.

## Position decides scope

- **Before `.from()`** (route scope, unchanged): catches every step in the pipeline; pipeline halts after the handler runs.
- **After `.from()`** (step scope, new): wraps the immediately next step. On failure the handler runs, its return value replaces `exchange.body`, and the pipeline continues with the next step.

```ts
craft()
  .id('resilient-pipeline')
  .from(timer({ intervalMs: 60_000 }))
  .transform(prepareRequest)
  .error((err) => ({ fallback: true, reason: String(err) }))   // step scope
  .to(http({ url: 'https://flaky.api/endpoint' }))
  .to(database())
```

The handler signature is identical in both positions.

## Cascade rule

When a step-scope handler throws, the wrapper rethrows so the route-scope handler (when set) catches it; otherwise the default error path fires (`route:*:error`, `context:error`, `exchange:failed`). The route is NOT stopped.

## What landed

**Code:**
- `packages/routecraft/src/operations/wrapper.ts` (new): abstract `WrapperStep<T>`. Template method delegates `operation`/`adapter`/`label` to the inner step, emits inner-labelled `step:*` events, captures inner-pushed children via a private queue + `drainInnerQueue()` hook so split/choice survive wrapping with `remainingSteps` reattached.
- `packages/routecraft/src/operations/error-wrapper.ts` (new): `ErrorWrapperStep<T>`. Mirrors route-level error semantics, exposes the same `forward` callable, emits scope-aware `error-handler:*` events with `scope: "step"` and `stepLabel`.
- `packages/routecraft/src/route.ts`: promote `buildForward()` to `getForward(): ForwardFn` (`@internal`) so wrappers can build the same callable. Also emit `error-handler:*` events at the route-level path (with `scope: "route"`); previously typed but not emitted.
- `packages/routecraft/src/step-builder-base.ts`: `pendingStepWrappers` stack + `applyPendingWrappers()` fold + step-scope `.error()` method on the shared base.
- `packages/routecraft/src/builder.ts`: `RouteBuilder.error()` becomes dual-mode (pre-from stages route-level; post-from delegates to base). `pushStep` runs every step through `applyPendingWrappers`.
- `packages/routecraft/src/operations/choice.ts`: `BranchBuilder.pushStep` runs through `applyPendingWrappers` too, so `.error()` works inside branch builders.
- `packages/routecraft/src/types.ts`: extend `error-handler:*` event detail types with `scope?` and `stepLabel?`.
- `packages/routecraft/src/index.ts`: re-export `WrapperStep`, `WrapperOutcome`, `ErrorWrapperStep`, and `Step`.

**Tests:** `packages/routecraft/test/step-error.test.ts` (9 cases):
1. Step-scope recovery continues the pipeline.
2. Wrapper covers only the next step, not later steps.
3. Stacked step wrappers fold outside-in (first-declared outermost).
4. Step handler throw escalates to route handler.
5. Step handler throw without route handler hits the default path; route is not stopped.
6. Step handler can `forward()` to a direct route.
7. Step handler short-circuits the route handler on success.
8. `error-handler:*` events carry `scope` and `stepLabel` for step scope.
9. Wrapper delegates `operation`/`adapter`/`label`/`skipStepEvents` to its inner step.

**Standards:** `.standards/resilience-wrappers.md` with the authoring contract, stacking rules, cascade rule, observability shape, and "when a wrapper is not enough" notes (route-level circuit breaker needs consumer-layer backpressure, etc.). Linked from `CLAUDE.md` and `.standards/README.md`.

**Docs:**
- `docs/reference/operations`: `.error()` reclassified as dual-mode + new step-scope subsection.
- `docs/advanced/error-handling`: full step-scope walkthrough + combined route + step example + cascade rule + scope rule.
- `docs/reference/events`: `scope` and `stepLabel` documented on `error-handler:*`; existing `:operation:error:*` set re-labelled as reserved for the planned `.onError()` operation.

## Why "!"

Type-only widening on the `.error()` signature; existing call sites are unaffected. Route-level behaviour unchanged. The "!" marker is defensive: the `Route` interface gains a public `getForward()` method, which is technically a structural change for anyone implementing `Route` directly (very rare).

## Verification

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm test` (999 pass / 1 skipped)

## Test plan

- [ ] Re-target `main` once #265 merges
- [ ] Reviewer confirms cascade behaviour matches the existing route-level `.error()` semantics
- [ ] Confirms wrapper invisibility (inner step's label still shows in `step:*` events)
- [ ] Sanity-check that `BranchBuilder` step-scope `.error()` works inside `.choice(b => b.error(...).to(...))`

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dual‑mode wrapper pattern and makes `.error()` work at both route and step scope with safe recovery, wrapper stacking, and scope‑aware events. Also adds guardrails to prevent wrapper leaks, improves event payloads, and normalizes step‑scope errors; closes #140.

- **New Features**
  - `.error()` is dual‑mode: before `.from()` it catches the whole route; after `.from()` it wraps the next step, sets `exchange.body` on recovery, then continues. Wrappers stack outside‑in, are invisible in `step:*` events, work inside `choice`, and emit `error-handler:*` with `scope` and `stepLabel`.
  - Reusable `WrapperStep` base and `ErrorWrapperStep` concrete wrapper; exports `WrapperStep`, `WrapperOutcome`, `ErrorWrapperStep`, and `Step`.
  - Builder/runtime: `pendingStepWrappers` + `applyPendingWrappers` wrap the next step in both `RouteBuilder` and `BranchBuilder`; route now emits `error-handler:*` for route scope, and `Route` exposes `getForward()` for handlers.

- **Bug Fixes**
  - Correctly treats chained-route `.error()` staged between routes as route‑scope; prevents wrapper‑stack leaks by throwing RC2001 at `.id()`, `.from()`, or `.build()` when a staged wrapper wasn’t consumed.
  - Fixes per‑execution concurrency by using a local inner queue; wrapper no longer resurrects dropped exchanges; avoids duplicate `step:*` events when the inner has `skipStepEvents`; emits `step:failed` on cascade for balanced lifecycle events.
  - Wrapper‑emitted `step:*` events include adapter metadata; step‑scope handlers receive a normalized `RoutecraftError`.
  - Rejects wrapping `split`/`aggregate` at build time with RC5003.

<sup>Written for commit 3044aad8fdb97374c4f0d359b2b9c73fd3fdd569. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/273?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

