### PR TITLE
feat(ai)!: agent event-system unification (context bus for decisions; onDelta for tokens)

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/events/page.md
@@ -120,6 +120,30 @@ After a split, each child exchange emits its own `exchange:started`. When aggreg
 | `route:{routeId}:operation:error:recovered` | Reserved for the planned `.onError()` operation | `{ routeId, exchangeId, correlationId }` |
 | `route:{routeId}:operation:error:failed` | Reserved for the planned `.onError()` operation | `{ routeId, exchangeId, correlationId, error }` |
 
+### Agent operations
+
+Emitted by `agent()` destinations. These are the **coarse decision events** — broadcast to every subscriber, no opt-in needed. For token-level streaming use `AgentOptions.onDelta` instead (a separate per-call channel).
+
+| Event | When it fires | Details |
+| --- | --- | --- |
+| `route:{routeId}:agent:tool:invoked` | Agent decided to call a tool (input validated, before guard) | `{ routeId, exchangeId, correlationId, toolCallId, toolName, input }` |
+| `route:{routeId}:agent:tool:result` | Tool handler returned a value | `{ routeId, exchangeId, correlationId, toolCallId, toolName, output, duration }` |
+| `route:{routeId}:agent:tool:error` | Tool handler / guard / input validation threw | `{ routeId, exchangeId, correlationId, toolCallId, toolName, error, duration }` |
+| `route:{routeId}:agent:finished` | Agent dispatch returned a consolidated result | `{ routeId, exchangeId, correlationId, finishReason, inputTokens?, outputTokens?, totalTokens? }` |
+| `route:{routeId}:agent:error` | Provider / transport error during dispatch | `{ routeId, exchangeId, correlationId, error }` |
+
+Wildcard subscriptions (`route:*:agent:tool:*`, `route:*:agent:finished`) work for cross-cutting telemetry, dashboards, and TUIs.
+
+```ts
+ctx.on('route:*:agent:tool:invoked', ({ details }) => {
+  log.info({ tool: details.toolName, input: details.input }, 'Agent called tool');
+});
+
+ctx.on('route:*:agent:finished', ({ details }) => {
+  metrics.histogram('agent.tokens.total', details.totalTokens ?? 0);
+});
+```
+
 ### Source-parse operations
 
 Parsing source adapters (`json`, `html`, `csv`, `jsonl`, `mail`) defer parsing

--- a/apps/routecraft.dev/src/app/docs/reference/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/events/page.md
@@ -122,7 +122,7 @@ After a split, each child exchange emits its own `exchange:started`. When aggreg
 
 ### Agent operations
 
-Emitted by `agent()` destinations. These are the **coarse decision events** — broadcast to every subscriber, no opt-in needed. For token-level streaming use `AgentOptions.onDelta` instead (a separate per-call channel).
+Emitted by `agent()` destinations. These are the **coarse decision events**: broadcast to every subscriber, no opt-in needed. For token-level streaming use `AgentOptions.onDelta` instead (a separate per-call channel).
 
 | Event | When it fires | Details |
 | --- | --- | --- |

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -649,9 +649,9 @@ agentPlugin({
 
 Agent model references use the `"providerId:modelName"` format and resolve against the LLM provider registry populated by `llmPlugin`. **You must install `llmPlugin` with the relevant providers.** This is intentional: provider credentials live in one place, and agents reference them by id. There is no inline-credentials escape hatch on `agent({...})`; centralised wiring via `llmPlugin` is the only path.
 
-#### Step cap (`maxSteps`)
+#### Turn cap (`maxTurns`)
 
-The Vercel AI SDK's tool-calling loop runs until the model returns a final text response or a stop condition fires. Each iteration is one step (one model call plus the resulting tool calls / results). The agent caps step count to **8 by default**; override per agent via `maxSteps:` or context-wide via `defaultOptions.maxSteps`. When the cap fires the SDK returns whatever text the model produced last; downstream logic should treat truncated output as a possible outcome.
+The Vercel AI SDK's tool-calling loop runs until the model returns a final text response or a stop condition fires. Each iteration is one **turn** (one model call plus the resulting tool calls / results). The agent caps turn count to **8 by default**; override per agent via `maxTurns:` or context-wide via `defaultOptions.maxTurns`. When the cap fires the SDK returns whatever text the model produced last; downstream logic should treat truncated output as a possible outcome.
 
 #### Human-in-the-loop (today: blocking; tomorrow: durable)
 
@@ -678,43 +678,69 @@ A blocking tool handler today looks like:
 
 When the durable epic lands, the same handler migrates by replacing the blocking await with `throw new SuspendError({ reason: "awaiting-human-approval" })` and consuming the resume callback in a separate route. The runtime contract (return value, schema, `FnHandlerContext`) stays identical.
 
-#### Streaming (`onEvent`)
+#### Observability: two channels
 
-Set `onEvent` on an agent to stream tokens, tool calls, and finish reasons live as the model generates them. Internally the dispatch switches from `generateText` to `streamText`; externally the destination still returns a consolidated `AgentResult` once the stream drains, so downstream pipeline ops are unaffected.
+Agents emit on two distinct channels with different shapes and use cases:
+
+**1. Context bus** (`ctx.on('route:*:agent:*', ...)`): coarse decision events. Broadcast to every subscriber. Use for telemetry, dashboards, audit trails, TUIs. Always emitted; no opt-in needed.
+
+| Event | Fields | When |
+|---|---|---|
+| `route:<id>:agent:tool:invoked` | `toolCallId`, `toolName`, `input` | Agent decided to call a tool. |
+| `route:<id>:agent:tool:result` | `toolCallId`, `toolName`, `output`, `duration` | Tool handler returned successfully. |
+| `route:<id>:agent:tool:error` | `toolCallId`, `toolName`, `error`, `duration` | Tool handler / guard / input validation threw. |
+| `route:<id>:agent:finished` | `finishReason`, `inputTokens?`, `outputTokens?`, `totalTokens?` | Agent dispatch returned a consolidated result. |
+| `route:<id>:agent:error` | `error` | Provider / transport error during dispatch. |
+
+All events also carry `routeId`, `exchangeId`, `correlationId`. Wildcard subscriptions (`route:*:agent:tool:*`) work as expected.
+
+```ts
+ctx.on("route:*:agent:tool:invoked", ({ details }) => {
+  console.log(`[${details.routeId}] tool ${details.toolName} called with`, details.input);
+});
+
+ctx.on("route:*:agent:finished", ({ details }) => {
+  metrics.increment("agent.calls.total", { route: details.routeId });
+  metrics.histogram("agent.tokens.total", details.totalTokens ?? 0);
+});
+```
+
+**2. `onDelta` callback** (per-dispatch, opt-in): token-level deltas, directed delivery, back-pressure-aware. Use for streaming tokens to a chat UI / SSE / WebSocket where you want to render text as the model writes it.
 
 ```ts
 agent({
   model: "openai:gpt-4o",
   system: "Be helpful.",
   tools: tools(["search"]),
-  onEvent: (event) => {
-    if (event.type === "text-delta") sse.send({ data: event.text });
-    if (event.type === "tool-call") sse.send({ data: `calling ${event.toolName}` });
+  onDelta: (delta) => {
+    sse.send({ data: delta.text, type: delta.type });
   },
 })
 ```
 
-Event shapes (discriminated union, exported as `AgentEvent`):
+Setting `onDelta` switches dispatch from `generateText` to `streamText`; externally the destination still returns a consolidated `AgentResult` once the stream drains.
+
+`AgentDelta` is a narrow discriminated union:
 
 | Type | Fields | When |
 |---|---|---|
 | `text-delta` | `text` | Each token (or token chunk) emitted by the model. |
 | `reasoning-delta` | `text` | Provider reasoning text (Anthropic extended thinking, OpenAI o1). Useful for "thinking..." UI. |
-| `tool-call` | `toolCallId`, `toolName`, `input` | Model decided to call a tool. `input` is the validated args. |
-| `tool-result` | `toolCallId`, `toolName`, `output` | Tool handler returned a value. |
-| `tool-error` | `toolCallId`, `toolName`, `error` | Handler, guard, or input validation threw. |
-| `step-finish` | `finishReason`, `usage?` | One step (model call + tools) ended. |
-| `finish` | `finishReason`, `usage?` | The whole dispatch ended. |
-| `error` | `error` | Provider or transport error surfaced through the stream. |
 
 Behaviour notes:
 
-- **Listener errors are contained.** A throw inside `onEvent` is caught and logged; the dispatch keeps running and the consolidated `AgentResult` still reaches downstream ops.
-- **Async listeners are awaited.** Returning a `Promise` from `onEvent` applies back-pressure to the stream, which is what you want when forwarding to a slow consumer (database, remote SSE channel).
-- **Stream errors still throw.** Provider errors surface as an `error` event AND propagate out of the dispatch promise, so failure handling matches the non-streaming path.
-- **Per-agent only.** `onEvent` is not part of `defaultOptions` because event sinks are typically request-scoped (a per-connection SSE channel). For observability across all agents, use a telemetry plugin.
+- **Listener errors are contained.** A throw inside `onDelta` is caught and logged; the dispatch keeps running and the consolidated `AgentResult` still reaches downstream ops.
+- **Async listeners are awaited.** Returning a `Promise` from `onDelta` applies back-pressure to the stream, which is what you want when forwarding to a slow consumer (database, remote SSE channel).
+- **Stream errors still throw.** Provider errors propagate out of the dispatch promise; the `agent:error` context event also fires. Failure handling matches the non-streaming path.
+- **Per-agent only.** `onDelta` is not part of `defaultOptions` because delta sinks are typically request-scoped.
 
-The 90% use case is forwarding tokens into an HTTP SSE response so a UI updates as the model writes.
+For named agents that share a definition across requests, accept `onDelta` at the call site:
+
+```ts
+.to(agent("summariser", { onDelta: (d) => sse.send(d.text) }))
+```
+
+The 90% use case is forwarding tokens into an HTTP SSE response so a UI updates as the model writes. For everything else (per-tool observability, finish reasons, total usage, errors) use the context bus.
 
 ### Typed fn ids (`FnRegistry`)
 

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -150,7 +150,10 @@ export function agent(
         ...(perCall ? { perCall } : {}),
       }),
       agent,
-      factoryArgs(arg),
+      // Preserve both args so `mockAdapter()` and other testing-hook
+      // introspection see the per-call overrides supplied at the
+      // call site (e.g. a per-request `onDelta`).
+      perCall ? factoryArgs(arg, perCall) : factoryArgs(arg),
     );
   }
   validateAgentOptions(arg);

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -5,7 +5,10 @@ import {
   tagAdapter,
 } from "@routecraft/routecraft";
 import { parseProviderModel } from "../llm/shared.ts";
-import { AgentDestinationAdapter } from "./destination.ts";
+import {
+  AgentDestinationAdapter,
+  type AgentByNameOverrides,
+} from "./destination.ts";
 import { isToolSelection } from "./tools/selection.ts";
 import type { AgentOptions, AgentResult } from "./types.ts";
 
@@ -127,7 +130,12 @@ export function validateAgentOptions(options: AgentOptions): void {
 export function agent(options: AgentOptions): Destination<unknown, AgentResult>;
 export function agent(name: string): Destination<unknown, AgentResult>;
 export function agent(
+  name: string,
+  perCall: AgentByNameOverrides,
+): Destination<unknown, AgentResult>;
+export function agent(
   arg: AgentOptions | string,
+  perCall?: AgentByNameOverrides,
 ): Destination<unknown, AgentResult> {
   if (typeof arg === "string") {
     if (arg.trim() === "") {
@@ -136,7 +144,11 @@ export function agent(
       });
     }
     return tagAdapter(
-      new AgentDestinationAdapter({ kind: "by-name", name: arg }),
+      new AgentDestinationAdapter({
+        kind: "by-name",
+        name: arg,
+        ...(perCall ? { perCall } : {}),
+      }),
       agent,
       factoryArgs(arg),
     );

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -7,11 +7,16 @@ import {
   type Exchange,
 } from "@routecraft/routecraft";
 import { resolveModel, resolvePrompt } from "../llm/shared.ts";
-import { AgentSession, buildUserPrompt } from "./session.ts";
+import {
+  AgentSession,
+  buildUserPrompt,
+  dispatchIdentityFrom,
+} from "./session.ts";
 import {
   ADAPTER_AGENT_DEFAULT_OPTIONS,
   ADAPTER_AGENT_REGISTRY,
 } from "./store.ts";
+import type { AgentDeltaListener } from "./events.ts";
 import type { ResolvedTool } from "./tools/selection.ts";
 import type {
   AgentDefaultOptions,
@@ -23,10 +28,32 @@ import type {
 const AGENT_REGISTRY_STORE_DESCRIPTION =
   ADAPTER_AGENT_REGISTRY.description ?? "routecraft.adapter.agent.registry";
 
+/**
+ * Per-call overrides accepted by the by-name `agent("name", { ... })`
+ * factory. Constrained to fields that are inherently request-scoped
+ * (the SSE / WebSocket / TUI consumer for `onDelta` is not known at
+ * registration time). Anything else (model, system, tools, output)
+ * stays authoritative on the registered options.
+ *
+ * @experimental
+ */
+export interface AgentByNameOverrides {
+  /**
+   * Per-request token-delta listener. Mirrors `AgentOptions.onDelta`
+   * but lives at the call site so each dispatch can stream into its
+   * own consumer without cross-talk.
+   */
+  onDelta?: AgentDeltaListener;
+}
+
 /** Discriminated state: inline options or a registry name. */
 export type AgentBinding =
   | { kind: "inline"; options: AgentOptions }
-  | { kind: "by-name"; name: string };
+  | {
+      kind: "by-name";
+      name: string;
+      perCall?: AgentByNameOverrides;
+    };
 
 /**
  * Agent destination adapter. Resolves agent options (inline or
@@ -81,6 +108,12 @@ export class AgentDestinationAdapter implements Destination<
       });
     }
 
+    const route = getExchangeRoute(exchange);
+    const dispatchIdentity = dispatchIdentityFrom(
+      exchange,
+      route?.definition.id,
+    );
+
     const session = new AgentSession({
       options: merged,
       modelConfig: config,
@@ -89,6 +122,7 @@ export class AgentDestinationAdapter implements Destination<
       user,
       system,
       context,
+      dispatchIdentity,
     });
 
     // Thread the route's abort signal through so the agent dispatch
@@ -96,14 +130,20 @@ export class AgentDestinationAdapter implements Destination<
     // route or context shuts down. Falls back to a never-firing
     // signal when the exchange has no route binding (rare; mostly
     // synthetic exchanges in tests).
-    const abortSignal =
-      getExchangeRoute(exchange)?.signal ?? new AbortController().signal;
+    const abortSignal = route?.signal ?? new AbortController().signal;
 
-    // Streaming is selected by the presence of `onEvent`. The
-    // consolidated AgentResult is returned in both paths, so
+    // Streaming is selected by the presence of `onDelta` on the
+    // merged options or as a per-call override at the by-name call
+    // site. Per-call wins because it's request-scoped (e.g. a
+    // specific SSE channel for THIS dispatch).
+    const onDelta =
+      this.binding.kind === "by-name"
+        ? (this.binding.perCall?.onDelta ?? merged.onDelta)
+        : merged.onDelta;
+    // The consolidated AgentResult is returned in both paths, so
     // downstream pipeline ops are unaffected by the choice.
-    if (merged.onEvent !== undefined) {
-      return await session.runStream(abortSignal, merged.onEvent);
+    if (onDelta !== undefined) {
+      return await session.runStream(abortSignal, onDelta);
     }
     return await session.runUntilDone(abortSignal);
   }
@@ -187,8 +227,8 @@ function mergeWithDefaults(
   if (out.tools === undefined && defaults.tools !== undefined) {
     out.tools = defaults.tools;
   }
-  if (out.maxSteps === undefined && defaults.maxSteps !== undefined) {
-    out.maxSteps = defaults.maxSteps;
+  if (out.maxTurns === undefined && defaults.maxTurns !== undefined) {
+    out.maxTurns = defaults.maxTurns;
   }
   return out;
 }

--- a/packages/ai/src/agent/events.ts
+++ b/packages/ai/src/agent/events.ts
@@ -1,84 +1,51 @@
-import type { LlmUsage } from "../llm/types.ts";
-
 /**
- * Discriminated union of events emitted by a streaming agent dispatch.
- * Forwarded to the user-supplied `AgentOptions.onEvent` listener while
- * the model + tool-calling loop runs. The set is a normalised subset of
- * the Vercel AI SDK's `streamText` full-stream parts; low-level parts
- * (text-start, text-end, tool-input-* deltas, abort) are filtered out
- * so the routecraft surface stays stable across SDK versions.
+ * Token-level delta emitted while a streaming agent dispatch writes
+ * its response. Forwarded to the user-supplied `AgentOptions.onDelta`
+ * listener as the model emits tokens.
+ *
+ * `AgentDelta` is INTENTIONALLY narrow: it covers only token-level
+ * incremental updates that need a directed, back-pressure-aware
+ * delivery channel (the canonical case is forwarding to a single
+ * SSE / WebSocket / TUI consumer). Coarse decision events (tool-call,
+ * tool-result, step-finished, finished) live on the context bus
+ * (`route:<id>:agent:*`) where they're broadcast to every subscriber
+ * without per-call wiring.
  *
  * @experimental
  */
-export type AgentEvent =
+export type AgentDelta =
   /** Incremental text from the model. Concatenate to render tokens live. */
   | { type: "text-delta"; text: string }
   /**
    * Incremental reasoning text from the provider (Anthropic extended
    * thinking, OpenAI o1). Useful for "thinking..." UI; safe to ignore.
    */
-  | { type: "reasoning-delta"; text: string }
-  /** Model decided to call a tool. `input` is the validated args. */
-  | {
-      type: "tool-call";
-      toolCallId: string;
-      toolName: string;
-      input: unknown;
-    }
-  /** Tool handler returned successfully. `output` is the handler's return value. */
-  | {
-      type: "tool-result";
-      toolCallId: string;
-      toolName: string;
-      output: unknown;
-    }
-  /** Tool handler (or guard, or input validation) threw. */
-  | {
-      type: "tool-error";
-      toolCallId: string;
-      toolName: string;
-      error: unknown;
-    }
-  /**
-   * One step of the loop ended (a model call + any tool calls + their
-   * results). Emitted before the next step begins, and once before
-   * `finish` for the final step.
-   */
-  | {
-      type: "step-finish";
-      finishReason: string;
-      usage?: LlmUsage;
-    }
-  /** The whole dispatch ended. Final consolidated result is returned by the destination. */
-  | {
-      type: "finish";
-      finishReason: string;
-      usage?: LlmUsage;
-    }
-  /** Provider or transport error surfaced through the stream. */
-  | { type: "error"; error: unknown };
+  | { type: "reasoning-delta"; text: string };
 
 /**
- * Listener for streaming agent dispatches. Set on `AgentOptions.onEvent`
- * to receive events. Async listeners are awaited so back-pressure on a
- * slow consumer (e.g. an SSE channel) propagates into the stream.
+ * Listener for streaming agent dispatches. Set on
+ * `AgentOptions.onDelta` to receive token-level deltas. Async
+ * listeners are awaited so back-pressure on a slow consumer (e.g. an
+ * SSE channel) propagates into the stream.
  *
  * Throws inside the listener are caught and logged; they do not abort
  * the agent dispatch.
  *
  * @experimental
  */
-export type AgentEventListener = (event: AgentEvent) => void | Promise<void>;
+export type AgentDeltaListener = (delta: AgentDelta) => void | Promise<void>;
 
 /**
  * Convert a Vercel AI SDK `streamText` full-stream part into an
- * `AgentEvent`. Returns `null` for parts that have no public-surface
- * equivalent (text-start/end markers, tool-input-* deltas, abort, raw
- * provider parts, etc.).
+ * `AgentDelta`. Returns `null` for parts that have no public-surface
+ * equivalent on the delta channel (text-start/end markers,
+ * tool-input-* deltas, abort, raw provider parts, AND tool-call /
+ * tool-result / finish-step / finish / error parts that now flow
+ * through the context bus instead).
  *
  * @internal
  */
-export function normalizeStreamPart(part: unknown): AgentEvent | null {
+export function normalizeStreamDelta(part: unknown): AgentDelta | null {
   if (part === null || typeof part !== "object") return null;
   const p = part as Record<string, unknown>;
   const type = p["type"];
@@ -93,48 +60,6 @@ export function normalizeStreamPart(part: unknown): AgentEvent | null {
       if (text === undefined || text.length === 0) return null;
       return { type: "reasoning-delta", text };
     }
-    case "tool-call": {
-      const toolCallId = readString(p, "toolCallId");
-      const toolName = readString(p, "toolName");
-      if (toolCallId === undefined || toolName === undefined) return null;
-      const input = p["input"] ?? p["args"];
-      return { type: "tool-call", toolCallId, toolName, input };
-    }
-    case "tool-result": {
-      const toolCallId = readString(p, "toolCallId");
-      const toolName = readString(p, "toolName");
-      if (toolCallId === undefined || toolName === undefined) return null;
-      const output = p["output"] ?? p["result"];
-      return { type: "tool-result", toolCallId, toolName, output };
-    }
-    case "tool-error": {
-      const toolCallId = readString(p, "toolCallId");
-      const toolName = readString(p, "toolName");
-      if (toolCallId === undefined || toolName === undefined) return null;
-      return {
-        type: "tool-error",
-        toolCallId,
-        toolName,
-        error: p["error"],
-      };
-    }
-    case "finish-step": {
-      const finishReason = readString(p, "finishReason") ?? "unknown";
-      const usage = readUsage(p["usage"]);
-      return usage
-        ? { type: "step-finish", finishReason, usage }
-        : { type: "step-finish", finishReason };
-    }
-    case "finish": {
-      const finishReason = readString(p, "finishReason") ?? "unknown";
-      const usage = readUsage(p["totalUsage"]) ?? readUsage(p["usage"]);
-      return usage
-        ? { type: "finish", finishReason, usage }
-        : { type: "finish", finishReason };
-    }
-    case "error": {
-      return { type: "error", error: p["error"] };
-    }
     default:
       return null;
   }
@@ -146,15 +71,4 @@ function readString(
 ): string | undefined {
   const v = obj[key];
   return typeof v === "string" ? v : undefined;
-}
-
-function readUsage(value: unknown): LlmUsage | undefined {
-  if (value === null || typeof value !== "object") return undefined;
-  const u = value as Record<string, unknown>;
-  const out: LlmUsage = {};
-  if (typeof u["inputTokens"] === "number") out.inputTokens = u["inputTokens"];
-  if (typeof u["outputTokens"] === "number")
-    out.outputTokens = u["outputTokens"];
-  if (typeof u["totalTokens"] === "number") out.totalTokens = u["totalTokens"];
-  return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -1,6 +1,10 @@
 export { agent } from "./agent.ts";
-export { AgentDestinationAdapter, type AgentBinding } from "./destination.ts";
-export type { AgentEvent, AgentEventListener } from "./events.ts";
+export {
+  AgentDestinationAdapter,
+  type AgentBinding,
+  type AgentByNameOverrides,
+} from "./destination.ts";
+export type { AgentDelta, AgentDeltaListener } from "./events.ts";
 export { agentPlugin, type AgentPluginOptions } from "./plugin.ts";
 export {
   ADAPTER_AGENT_DEFAULT_OPTIONS,

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -41,9 +41,14 @@ export function dispatchIdentityFrom(
   routeId: string | undefined,
 ): AgentDispatchIdentity | undefined {
   if (routeId === undefined) return undefined;
+  // The framework runtime sets `routecraft.correlation_id` on every
+  // exchange that flows through a real route. Synthetic exchanges
+  // (mostly tests) may lack it; fall back to the exchange id so the
+  // emitted events still carry a stable, non-empty `correlationId`.
+  const corr = exchange.headers[HeadersKeys.CORRELATION_ID];
   return {
     exchangeId: exchange.id,
-    correlationId: exchange.headers[HeadersKeys.CORRELATION_ID] as string,
+    correlationId: typeof corr === "string" ? corr : exchange.id,
     routeId,
   };
 }
@@ -145,7 +150,7 @@ export class AgentSession {
    * `streamText`: each normalised token-level delta is forwarded to
    * `onDelta` while the loop runs, and the consolidated
    * {@link AgentResult} is returned once the stream drains. Coarse
-   * decision events (tool-call, tool-result, turn-finished, finished,
+   * decision events (tool-call, tool-result, finished,
    * error) flow on the context bus regardless of whether `onDelta`
    * is set; see `route:<id>:agent:*` events.
    *
@@ -197,11 +202,11 @@ export class AgentSession {
     const id = this.input.dispatchIdentity;
     const ctx = this.input.context;
     if (!id || !ctx) return;
-    const finishReason =
-      readString(
-        (result.raw as Record<string, unknown> | undefined) ?? {},
-        "finishReason",
-      ) ?? "unknown";
+    // Both runGenerate (sync) and runStreamGenerate (after awaiting
+    // the SDK Promise) populate `result.finishReason` as a normalised
+    // string. Falls back to "unknown" only when the provider didn't
+    // report one.
+    const finishReason = result.finishReason ?? "unknown";
     ctx.emit(`route:${id.routeId}:agent:finished` as EventName, {
       routeId: id.routeId,
       exchangeId: id.exchangeId,
@@ -294,14 +299,6 @@ export class AgentSession {
 async function buildStopWhen(maxTurns: number): Promise<unknown> {
   const { stepCountIs } = await import("ai");
   return stepCountIs(maxTurns);
-}
-
-function readString(
-  obj: Record<string, unknown>,
-  key: string,
-): string | undefined {
-  const v = obj[key];
-  return typeof v === "string" ? v : undefined;
 }
 
 function toAgentResult(result: LlmResult): AgentResult {

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -1,9 +1,14 @@
-import type { CraftContext, Exchange } from "@routecraft/routecraft";
+import {
+  HeadersKeys,
+  type CraftContext,
+  type EventName,
+  type Exchange,
+} from "@routecraft/routecraft";
 import { callLlm, streamLlm } from "../llm/providers/index.ts";
 import { resolvePrompt, resolveUserPromptDefault } from "../llm/shared.ts";
 import type { LlmModelConfig, LlmResult } from "../llm/types.ts";
 import { toAiOutputSpec } from "../llm/structured-output.ts";
-import type { AgentEventListener } from "./events.ts";
+import type { AgentDeltaListener } from "./events.ts";
 import { buildVercelTools } from "./tool-bridge.ts";
 import type { ResolvedTool } from "./tools/selection.ts";
 import type {
@@ -12,10 +17,41 @@ import type {
   AgentResult,
 } from "./types.ts";
 
+/**
+ * Identity of the exchange driving the current dispatch. Used to emit
+ * `route:<routeId>:agent:*` events on the context bus with stable
+ * `exchangeId` / `correlationId` / `routeId` fields.
+ *
+ * @internal
+ */
+export interface AgentDispatchIdentity {
+  exchangeId: string;
+  correlationId: string;
+  routeId: string;
+}
+
+/**
+ * Extract the dispatch identity from an exchange. Returns `undefined`
+ * for synthetic exchanges that have no route binding (mostly tests).
+ *
+ * @internal
+ */
+export function dispatchIdentityFrom(
+  exchange: Exchange<unknown>,
+  routeId: string | undefined,
+): AgentDispatchIdentity | undefined {
+  if (routeId === undefined) return undefined;
+  return {
+    exchangeId: exchange.id,
+    correlationId: exchange.headers[HeadersKeys.CORRELATION_ID] as string,
+    routeId,
+  };
+}
+
 /** Default sampling settings; aligned with the LLM destination defaults. */
 const DEFAULT_TEMPERATURE = 0;
 const DEFAULT_MAX_TOKENS = 1024;
-const DEFAULT_MAX_STEPS = 8;
+const DEFAULT_MAX_TURNS = 8;
 
 /**
  * Resolved agent inputs ready for dispatch. Computed once by the
@@ -40,6 +76,12 @@ export interface AgentSessionInput {
   readonly system: string;
   /** Optional context reference passed to tool handlers. */
   readonly context: CraftContext | undefined;
+  /**
+   * Dispatch identity used to emit `route:<routeId>:agent:*` events
+   * on the context bus. Undefined for synthetic exchanges with no
+   * route binding.
+   */
+  readonly dispatchIdentity: AgentDispatchIdentity | undefined;
 }
 
 /**
@@ -75,56 +117,128 @@ export class AgentSession {
   async runUntilDone(abortSignal: AbortSignal): Promise<AgentResult> {
     const { modelConfig, modelName, system, user, output, toolExtras } =
       await this.prepare(abortSignal);
-    const result = await callLlm({
-      config: modelConfig,
-      modelId: modelName,
-      options: {
-        temperature: DEFAULT_TEMPERATURE,
-        maxTokens: DEFAULT_MAX_TOKENS,
-      },
-      system,
-      user,
-      abortSignal,
-      ...(output !== undefined ? { output } : {}),
-      ...toolExtras,
-    });
-    return toAgentResult(result);
+    try {
+      const result = await callLlm({
+        config: modelConfig,
+        modelId: modelName,
+        options: {
+          temperature: DEFAULT_TEMPERATURE,
+          maxTokens: DEFAULT_MAX_TOKENS,
+        },
+        system,
+        user,
+        abortSignal,
+        ...(output !== undefined ? { output } : {}),
+        ...toolExtras,
+      });
+      this.emitFinished(result);
+      return toAgentResult(result);
+    } catch (err) {
+      this.emitError(err);
+      throw err;
+    }
   }
 
   /**
    * Run the streaming tool-calling loop. Same setup as
    * {@link AgentSession.runUntilDone}, but the dispatch goes through
-   * `streamText`: each normalised event is forwarded to `onEvent`
-   * while the loop runs, and the consolidated {@link AgentResult} is
-   * returned once the stream drains.
+   * `streamText`: each normalised token-level delta is forwarded to
+   * `onDelta` while the loop runs, and the consolidated
+   * {@link AgentResult} is returned once the stream drains. Coarse
+   * decision events (tool-call, tool-result, turn-finished, finished,
+   * error) flow on the context bus regardless of whether `onDelta`
+   * is set; see `route:<id>:agent:*` events.
    *
    * Listener errors are caught and logged inside the LLM-provider
    * layer; they never abort the dispatch. Stream-level errors
-   * (provider failure, network error) are surfaced as an "error"
-   * event AND propagate by rejecting this promise, so callers handle
-   * failure exactly like the sync path.
+   * (provider failure, network error) are surfaced both as an
+   * `agent:error` context event AND propagate by rejecting this
+   * promise, so callers handle failure exactly like the sync path.
    */
   async runStream(
     abortSignal: AbortSignal,
-    onEvent: AgentEventListener,
+    onDelta: AgentDeltaListener,
   ): Promise<AgentResult> {
     const { modelConfig, modelName, system, user, output, toolExtras } =
       await this.prepare(abortSignal);
-    const result = await streamLlm({
-      config: modelConfig,
-      modelId: modelName,
-      options: {
-        temperature: DEFAULT_TEMPERATURE,
-        maxTokens: DEFAULT_MAX_TOKENS,
-      },
-      system,
-      user,
-      abortSignal,
-      onEvent,
-      ...(output !== undefined ? { output } : {}),
-      ...toolExtras,
+    try {
+      const result = await streamLlm({
+        config: modelConfig,
+        modelId: modelName,
+        options: {
+          temperature: DEFAULT_TEMPERATURE,
+          maxTokens: DEFAULT_MAX_TOKENS,
+        },
+        system,
+        user,
+        abortSignal,
+        onDelta,
+        ...(output !== undefined ? { output } : {}),
+        ...toolExtras,
+      });
+      this.emitFinished(result);
+      return toAgentResult(result);
+    } catch (err) {
+      this.emitError(err);
+      throw err;
+    }
+  }
+
+  /**
+   * Emit `route:<id>:agent:finished` on the context bus once the
+   * dispatch returns a consolidated result. Carries finish reason
+   * and total token usage so observability consumers can wire
+   * dashboards / metrics / billing without subscribing to per-token
+   * deltas.
+   *
+   * @internal
+   */
+  private emitFinished(result: LlmResult): void {
+    const id = this.input.dispatchIdentity;
+    const ctx = this.input.context;
+    if (!id || !ctx) return;
+    const finishReason =
+      readString(
+        (result.raw as Record<string, unknown> | undefined) ?? {},
+        "finishReason",
+      ) ?? "unknown";
+    ctx.emit(`route:${id.routeId}:agent:finished` as EventName, {
+      routeId: id.routeId,
+      exchangeId: id.exchangeId,
+      correlationId: id.correlationId,
+      finishReason,
+      ...(result.usage?.inputTokens !== undefined && {
+        inputTokens: result.usage.inputTokens,
+      }),
+      ...(result.usage?.outputTokens !== undefined && {
+        outputTokens: result.usage.outputTokens,
+      }),
+      ...(result.usage?.totalTokens !== undefined && {
+        totalTokens: result.usage.totalTokens,
+      }),
     });
-    return toAgentResult(result);
+  }
+
+  /**
+   * Emit `route:<id>:agent:error` on the context bus when the
+   * dispatch promise rejects (provider failure, transport error, an
+   * unhandled tool throw cascading through the SDK). The error
+   * still propagates by rethrow; this just gives observability
+   * subscribers a chance to record the failure without wrapping
+   * every dispatch site.
+   *
+   * @internal
+   */
+  private emitError(err: unknown): void {
+    const id = this.input.dispatchIdentity;
+    const ctx = this.input.context;
+    if (!id || !ctx) return;
+    ctx.emit(`route:${id.routeId}:agent:error` as EventName, {
+      routeId: id.routeId,
+      exchangeId: id.exchangeId,
+      correlationId: id.correlationId,
+      error: err,
+    });
   }
 
   /**
@@ -145,15 +259,28 @@ export class AgentSession {
       | { tools: Record<string, unknown>; stopWhen: unknown }
       | Record<string, never>;
   }> {
-    const { options, modelConfig, modelName, tools, user, system, context } =
-      this.input;
-    const vercelTools = await buildVercelTools(tools, context, abortSignal);
+    const {
+      options,
+      modelConfig,
+      modelName,
+      tools,
+      user,
+      system,
+      context,
+      dispatchIdentity,
+    } = this.input;
+    const vercelTools = await buildVercelTools(
+      tools,
+      context,
+      abortSignal,
+      dispatchIdentity,
+    );
     const toolExtras =
       Object.keys(vercelTools).length > 0
         ? {
             tools: vercelTools,
             stopWhen: await buildStopWhen(
-              options.maxSteps ?? DEFAULT_MAX_STEPS,
+              options.maxTurns ?? DEFAULT_MAX_TURNS,
             ),
           }
         : {};
@@ -164,9 +291,17 @@ export class AgentSession {
   }
 }
 
-async function buildStopWhen(maxSteps: number): Promise<unknown> {
+async function buildStopWhen(maxTurns: number): Promise<unknown> {
   const { stepCountIs } = await import("ai");
-  return stepCountIs(maxSteps);
+  return stepCountIs(maxTurns);
+}
+
+function readString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = obj[key];
+  return typeof v === "string" ? v : undefined;
 }
 
 function toAgentResult(result: LlmResult): AgentResult {

--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   logger as frameworkLogger,
   type CraftContext,
@@ -76,7 +77,10 @@ export async function buildVercelTools(
           ...baseCtx,
           abortSignal: callOpts?.abortSignal ?? baseCtx.abortSignal,
         };
-        const toolCallId = callOpts?.toolCallId ?? "";
+        // The Vercel SDK passes a unique toolCallId per invocation;
+        // synthesise one when absent so invoked → result events still
+        // correlate (a shared empty-string id would alias every call).
+        const toolCallId = callOpts?.toolCallId ?? randomUUID();
         const start = Date.now();
 
         if (ctx && dispatchIdentity) {

--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -1,9 +1,11 @@
 import {
   logger as frameworkLogger,
   type CraftContext,
+  type EventName,
 } from "@routecraft/routecraft";
 import { toAiInputSchema } from "../llm/structured-output.ts";
 import type { FnHandlerContext } from "../fn/types.ts";
+import type { AgentDispatchIdentity } from "./session.ts";
 import type { ResolvedTool } from "./tools/selection.ts";
 
 /**
@@ -12,10 +14,16 @@ import type { ResolvedTool } from "./tools/selection.ts";
  * for `generateText({ tools })`.
  *
  * Each resulting tool runs:
- * 1. The optional guard (registered via `tools([{ name, guard }])` or
+ * 1. Emit `route:<routeId>:agent:tool:invoked` on the context bus so
+ *    cross-cutting observability (telemetry, dashboards, audit) sees
+ *    the call before the handler runs.
+ * 2. The optional guard (registered via `tools([{ name, guard }])` or
  *    `tools([{ tagged, guard }])`). Throwing inside the guard surfaces
- *    back to the model as a tool error so the model can self-correct.
- * 2. The underlying handler with `(input, fnHandlerContext)`.
+ *    back to the model as a tool error so the model can self-correct;
+ *    the wrapper emits `agent:tool:error` before rethrowing.
+ * 3. The underlying handler with `(input, fnHandlerContext)`. On
+ *    success the wrapper emits `agent:tool:result`; on throw it
+ *    emits `agent:tool:error` and rethrows.
  *
  * Schema validation is delegated to the SDK: when the model's tool-call
  * args fail to match `inputSchema`, the SDK reports a tool error to
@@ -28,6 +36,7 @@ export async function buildVercelTools(
   resolved: ResolvedTool[],
   ctx: CraftContext | undefined,
   abortSignal: AbortSignal,
+  dispatchIdentity?: AgentDispatchIdentity,
 ): Promise<Record<string, unknown>> {
   if (resolved.length === 0)
     return Object.create(null) as Record<string, unknown>;
@@ -67,8 +76,58 @@ export async function buildVercelTools(
           ...baseCtx,
           abortSignal: callOpts?.abortSignal ?? baseCtx.abortSignal,
         };
-        if (guard) await guard(input, callCtx);
-        return await handler(input, callCtx);
+        const toolCallId = callOpts?.toolCallId ?? "";
+        const start = Date.now();
+
+        if (ctx && dispatchIdentity) {
+          ctx.emit(
+            `route:${dispatchIdentity.routeId}:agent:tool:invoked` as EventName,
+            {
+              routeId: dispatchIdentity.routeId,
+              exchangeId: dispatchIdentity.exchangeId,
+              correlationId: dispatchIdentity.correlationId,
+              toolCallId,
+              toolName: r.name,
+              input,
+            },
+          );
+        }
+
+        try {
+          if (guard) await guard(input, callCtx);
+          const output = await handler(input, callCtx);
+          if (ctx && dispatchIdentity) {
+            ctx.emit(
+              `route:${dispatchIdentity.routeId}:agent:tool:result` as EventName,
+              {
+                routeId: dispatchIdentity.routeId,
+                exchangeId: dispatchIdentity.exchangeId,
+                correlationId: dispatchIdentity.correlationId,
+                toolCallId,
+                toolName: r.name,
+                output,
+                duration: Date.now() - start,
+              },
+            );
+          }
+          return output;
+        } catch (err) {
+          if (ctx && dispatchIdentity) {
+            ctx.emit(
+              `route:${dispatchIdentity.routeId}:agent:tool:error` as EventName,
+              {
+                routeId: dispatchIdentity.routeId,
+                exchangeId: dispatchIdentity.exchangeId,
+                correlationId: dispatchIdentity.correlationId,
+                toolCallId,
+                toolName: r.name,
+                error: err,
+                duration: Date.now() - start,
+              },
+            );
+          }
+          throw err;
+        }
       },
     });
   }

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -1,6 +1,6 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { LlmModelId, LlmPromptSource, LlmUsage } from "../llm/types.ts";
-import type { AgentEventListener } from "./events.ts";
+import type { AgentDeltaListener } from "./events.ts";
 import type { ToolSelection } from "./tools/selection.ts";
 
 /**
@@ -48,12 +48,13 @@ export interface AgentDefaultOptions {
   tools?: ToolSelection;
 
   /**
-   * Default cap on tool-call steps for the Vercel AI SDK loop, applied
-   * to agents that omit `maxSteps`. Each step is one model call (which
-   * may emit any number of tool calls) plus the resulting tool results.
-   * Resolves to `stopWhen: stepCountIs(maxSteps)` at dispatch.
+   * Default cap on tool-calling turns for the Vercel AI SDK loop,
+   * applied to agents that omit `maxTurns`. Each turn is one model
+   * call (which may emit any number of tool calls) plus the resulting
+   * tool results. Resolves to `stopWhen: stepCountIs(maxTurns)` at
+   * dispatch.
    */
-  maxSteps?: number;
+  maxTurns?: number;
 }
 
 /**
@@ -117,33 +118,36 @@ export interface AgentOptions {
   output?: StandardSchemaV1;
 
   /**
-   * Cap on tool-call steps for the Vercel AI SDK loop. Each step is
-   * one model call (which may emit any number of tool calls) plus the
-   * resulting tool results. Resolves to `stopWhen: stepCountIs(n)` at
-   * dispatch. Defaults to 8 when neither the agent nor
-   * `defaultOptions.maxSteps` supplies a value.
+   * Cap on tool-calling turns for the Vercel AI SDK loop. Each turn
+   * is one model call (which may emit any number of tool calls) plus
+   * the resulting tool results. Resolves to `stopWhen: stepCountIs(n)`
+   * at dispatch. Defaults to 8 when neither the agent nor
+   * `defaultOptions.maxTurns` supplies a value.
    */
-  maxSteps?: number;
+  maxTurns?: number;
 
   /**
-   * Listener invoked for each event emitted while the model + tool
-   * loop runs. Setting this switches the dispatch from `generateText`
-   * to `streamText` under the hood; the destination still returns a
-   * consolidated {@link AgentResult} once the stream drains, so
-   * downstream pipeline ops are unaffected.
+   * Listener invoked for each token-level delta emitted while the
+   * model writes its response. Setting this switches the dispatch
+   * from `generateText` to `streamText` under the hood; the
+   * destination still returns a consolidated {@link AgentResult}
+   * once the stream drains, so downstream pipeline ops are
+   * unaffected.
    *
-   * Use for live UI updates (SSE, WebSocket, console). For server-side
-   * persistence or telemetry without a streamed UI, use the regular
-   * (non-streaming) dispatch and read `AgentResult` directly.
+   * Use for live UI updates (SSE, WebSocket, console "type-out"
+   * effect). For coarse observability (tool calls, step finishes,
+   * total usage), subscribe to the `route:<id>:agent:*` events on
+   * the context bus instead; those fire whether or not `onDelta`
+   * is set.
    *
    * Listener errors are caught and logged, never propagate into the
    * dispatch. Async listeners are awaited so back-pressure on a slow
    * consumer flows back into the stream.
    *
-   * Per-agent only; not part of `defaultOptions` because event sinks
+   * Per-agent only; not part of `defaultOptions` because delta sinks
    * are typically request-scoped (e.g. a per-connection SSE channel).
    */
-  onEvent?: AgentEventListener;
+  onDelta?: AgentDeltaListener;
 }
 
 /**

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -129,8 +129,9 @@ export {
 export type {
   AgentBinding,
   AgentDefaultOptions,
-  AgentEvent,
-  AgentEventListener,
+  AgentByNameOverrides,
+  AgentDelta,
+  AgentDeltaListener,
   AgentOptions,
   AgentPluginOptions,
   AgentRegisteredOptions,

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -1,6 +1,6 @@
 import { logger as frameworkLogger } from "@routecraft/routecraft";
-import type { AgentEventListener } from "../../agent/events.ts";
-import { normalizeStreamPart } from "../../agent/events.ts";
+import type { AgentDeltaListener } from "../../agent/events.ts";
+import { normalizeStreamDelta } from "../../agent/events.ts";
 import type {
   LlmModelConfig,
   LlmOptionsMerged,
@@ -171,18 +171,18 @@ export async function callLlm(params: CallLlmParams): Promise<LlmResult> {
 /**
  * Streaming counterpart to {@link callLlm}. Resolves the language model
  * for the configured provider, calls Vercel's `streamText`, forwards
- * each normalised stream event to `onEvent`, and finally returns the
- * consolidated {@link LlmResult} once the stream drains.
+ * each normalised token-level delta to `onDelta`, and finally returns
+ * the consolidated {@link LlmResult} once the stream drains.
  *
  * Used by the agent destination when the user supplies
- * `AgentOptions.onEvent`. Exposed at the LLM-provider layer so the
+ * `AgentOptions.onDelta`. Exposed at the LLM-provider layer so the
  * provider plumbing (model resolution, option mapping, reasoning
  * extraction) stays in one place.
  */
 export async function streamLlm(
-  params: CallLlmParams & { onEvent: AgentEventListener },
+  params: CallLlmParams & { onDelta: AgentDeltaListener },
 ): Promise<LlmResult> {
-  const { config, modelId, options, system, user, onEvent } = params;
+  const { config, modelId, options, system, user, onDelta } = params;
   const model = await resolveLanguageModel(config, modelId);
   return runStreamGenerate(
     model,
@@ -190,7 +190,7 @@ export async function streamLlm(
     system,
     user,
     buildExtras(params),
-    onEvent,
+    onDelta,
   );
 }
 
@@ -401,14 +401,15 @@ async function runGenerate(
 
 /**
  * Shared `streamText` invocation. Iterates the SDK's `fullStream`,
- * forwards each normalised event to `onEvent`, then awaits the
+ * forwards each token-level delta to `onDelta`, then awaits the
  * consolidated values (text, usage, reasoning, optional structured
  * output) once the stream drains.
  *
  * Listener errors are caught and logged; they do not abort the
- * dispatch. Stream errors surface via an "error" event AND propagate
- * out of `await result.text`, so the dispatch fails normally after
- * the listener has been informed.
+ * dispatch. Stream errors propagate out of `await result.text`, so
+ * the dispatch fails normally; coarse decision events (tool calls,
+ * finish) are emitted on the context bus by the agent session, not
+ * here.
  *
  * @internal
  */
@@ -418,21 +419,21 @@ async function runStreamGenerate(
   system: string,
   user: string,
   extras: ProviderExtras,
-  onEvent: AgentEventListener,
+  onDelta: AgentDeltaListener,
 ): Promise<LlmResult> {
   const { streamText } = await import("ai");
   const params = buildSdkParams(model, options, system, user, extras);
   const result = streamText(params as Parameters<typeof streamText>[0]);
 
   for await (const part of result.fullStream) {
-    const event = normalizeStreamPart(part);
-    if (event === null) continue;
+    const delta = normalizeStreamDelta(part);
+    if (delta === null) continue;
     try {
-      await onEvent(event);
+      await onDelta(delta);
     } catch (err) {
       frameworkLogger.warn(
         { err },
-        "agent.onEvent listener threw; ignoring and continuing stream",
+        "agent.onDelta listener threw; ignoring and continuing stream",
       );
     }
   }

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -396,6 +396,9 @@ async function runGenerate(
   if (parsed !== undefined) out.output = parsed;
   const reasoning = readReasoning(result);
   if (reasoning) out.reasoning = reasoning;
+  // generateText resolves finishReason synchronously on the result.
+  const finishReason = (result as { finishReason?: unknown }).finishReason;
+  if (typeof finishReason === "string") out.finishReason = finishReason;
   return out;
 }
 
@@ -460,6 +463,14 @@ async function runStreamGenerate(
     (result as { output?: PromiseLike<unknown> }).output,
   );
   if (structured !== undefined) out.output = structured;
+  // streamText exposes finishReason as a Promise that resolves once
+  // the loop terminates; await it so callers (e.g. the agent
+  // session emitting `agent:finished`) see a normalised string
+  // instead of a Promise.
+  const finishReason = await safeAwait<string | undefined>(
+    (result as { finishReason?: PromiseLike<string | undefined> }).finishReason,
+  );
+  if (typeof finishReason === "string") out.finishReason = finishReason;
   return out;
 }
 

--- a/packages/ai/src/llm/types.ts
+++ b/packages/ai/src/llm/types.ts
@@ -162,6 +162,14 @@ export interface LlmResult {
   reasoning?: string;
   /** Token usage for the last step. Same shape as AI SDK usage. */
   usage?: LlmUsage;
+  /**
+   * Reason the model loop terminated (`"stop"`, `"length"`, `"tool-calls"`,
+   * etc.). Populated by both the sync (`generateText`) and streaming
+   * (`streamText`) paths. The streaming path awaits the SDK's
+   * `result.finishReason` Promise before resolving so callers always
+   * see a normalised string value.
+   */
+  finishReason?: string;
   /** Full generateText() result for advanced use (debugging, response metadata). */
   raw?: unknown;
 }

--- a/packages/ai/test/agent-bus-events.test.ts
+++ b/packages/ai/test/agent-bus-events.test.ts
@@ -40,7 +40,7 @@ vi.mock("../src/llm/providers/index.ts", () => ({
       return {
         text: "stubbed-response",
         usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-        raw: { finishReason: "stop" },
+        finishReason: "stop",
       };
     },
   ),
@@ -67,7 +67,7 @@ vi.mock("../src/llm/providers/index.ts", () => ({
       return {
         text: "ok",
         usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        raw: { finishReason: "stop" },
+        finishReason: "stop",
       };
     },
   ),

--- a/packages/ai/test/agent-bus-events.test.ts
+++ b/packages/ai/test/agent-bus-events.test.ts
@@ -1,0 +1,274 @@
+import { describe, test, expect, afterEach, vi, beforeEach } from "vitest";
+import { craft, simple } from "@routecraft/routecraft";
+import { testContext, type TestContext } from "@routecraft/testing";
+import { z } from "zod";
+import {
+  agent,
+  agentPlugin,
+  defaultFns,
+  llmPlugin,
+  tools,
+  type AgentDelta,
+} from "../src/index.ts";
+import type { LlmResult } from "../src/llm/types.ts";
+
+// Mock the LLM dispatcher so the test stays hermetic. The mock
+// invokes one of the registered tools so we can assert on the
+// agent:tool:* events emitted by tool-bridge, then returns a
+// consolidated result so agent:finished can fire.
+vi.mock("../src/llm/providers/index.ts", () => ({
+  callLlm: vi.fn(
+    async (params: {
+      tools?: Record<
+        string,
+        { execute: (input: unknown, opts: unknown) => Promise<unknown> }
+      >;
+    }): Promise<LlmResult> => {
+      // If the agent has tools, drive a single tool call so the
+      // wrapper emits invoked + result.
+      const toolMap = params.tools;
+      if (toolMap) {
+        const [name, t] = Object.entries(toolMap)[0]!;
+        await t.execute(
+          {},
+          {
+            toolCallId: `call-${name}-1`,
+            abortSignal: new AbortController().signal,
+          },
+        );
+      }
+      return {
+        text: "stubbed-response",
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        raw: { finishReason: "stop" },
+      };
+    },
+  ),
+  streamLlm: vi.fn(
+    async (params: {
+      onDelta: (d: AgentDelta) => void | Promise<void>;
+      tools?: Record<
+        string,
+        { execute: (input: unknown, opts: unknown) => Promise<unknown> }
+      >;
+    }): Promise<LlmResult> => {
+      const toolMap = params.tools;
+      if (toolMap) {
+        const [name, t] = Object.entries(toolMap)[0]!;
+        await t.execute(
+          {},
+          {
+            toolCallId: `call-${name}-1`,
+            abortSignal: new AbortController().signal,
+          },
+        );
+      }
+      await params.onDelta({ type: "text-delta", text: "ok" });
+      return {
+        text: "ok",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        raw: { finishReason: "stop" },
+      };
+    },
+  ),
+}));
+
+describe("agent context-bus events", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case agent:tool:invoked / result fire on the context bus when a tool is called
+   * @preconditions Agent with one tool; mocked callLlm drives one tool call
+   * @expectedResult Subscriber on route:*:agent:tool:* receives invoked + result events with stable fields
+   */
+  test("tool:invoked + tool:result emitted on context bus", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({ functions: { ...defaultFns } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("with-tool")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "Be helpful.",
+              model: "anthropic:claude-opus-4-7",
+              tools: tools(["currentTime"]),
+            }),
+          ),
+      )
+      .build();
+
+    const events: Array<{ name: string; details: unknown }> = [];
+    t.ctx.on(
+      "route:with-tool:agent:tool:invoked" as never,
+      ({ details }: { details: unknown }) => {
+        events.push({ name: "invoked", details });
+      },
+    );
+    t.ctx.on(
+      "route:with-tool:agent:tool:result" as never,
+      ({ details }: { details: unknown }) => {
+        events.push({ name: "result", details });
+      },
+    );
+
+    await t.test();
+
+    expect(events.map((e) => e.name)).toEqual(["invoked", "result"]);
+    const invoked = events[0]!.details as Record<string, unknown>;
+    expect(invoked["routeId"]).toBe("with-tool");
+    expect(invoked["toolName"]).toBe("currentTime");
+    expect(invoked["toolCallId"]).toBe("call-currentTime-1");
+    const result = events[1]!.details as Record<string, unknown>;
+    expect(result["toolName"]).toBe("currentTime");
+    expect(result["duration"]).toBeTypeOf("number");
+  });
+
+  /**
+   * @case agent:tool:error fires when a tool handler throws
+   * @preconditions Agent with one tool whose handler throws; mocked SDK drives a call
+   * @expectedResult Subscriber receives invoked + error events; result NOT emitted
+   */
+  test("tool:error emitted on context bus when handler throws", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({
+            functions: {
+              boomTool: {
+                description: "Always throws",
+                input: z.object({}),
+                handler: async () => {
+                  throw new Error("tool-boom");
+                },
+              },
+            },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("with-throwing-tool")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              tools: tools(["boomTool"]),
+            }),
+          ),
+      )
+      .build();
+
+    const events: string[] = [];
+    t.ctx.on("route:with-throwing-tool:agent:tool:invoked" as never, () => {
+      events.push("invoked");
+    });
+    t.ctx.on("route:with-throwing-tool:agent:tool:result" as never, () => {
+      events.push("result");
+    });
+    t.ctx.on("route:with-throwing-tool:agent:tool:error" as never, () => {
+      events.push("error");
+    });
+
+    await t.test();
+
+    expect(events).toEqual(["invoked", "error"]);
+  });
+
+  /**
+   * @case agent:finished fires after the dispatch returns
+   * @preconditions Agent without tools; happy-path LLM call
+   * @expectedResult Subscriber receives one finished event with usage and finishReason
+   */
+  test("agent:finished emitted with usage and finishReason", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("simple-agent")
+          .from(simple("hi"))
+          .to(agent({ system: "x", model: "anthropic:claude-opus-4-7" })),
+      )
+      .build();
+
+    const finished: unknown[] = [];
+    t.ctx.on(
+      "route:simple-agent:agent:finished" as never,
+      ({ details }: { details: unknown }) => {
+        finished.push(details);
+      },
+    );
+
+    await t.test();
+
+    expect(finished).toHaveLength(1);
+    const d = finished[0] as Record<string, unknown>;
+    expect(d["routeId"]).toBe("simple-agent");
+    expect(d["finishReason"]).toBe("stop");
+    expect(d["inputTokens"]).toBe(10);
+    expect(d["outputTokens"]).toBe(5);
+    expect(d["totalTokens"]).toBe(15);
+  });
+
+  /**
+   * @case Per-call onDelta on agent("name", { onDelta }) is forwarded to the streaming path
+   * @preconditions Registered agent + by-name dispatch with per-call onDelta override
+   * @expectedResult Listener receives the mock's text-delta; streamLlm path was used
+   */
+  test("by-name agent accepts per-call onDelta override", async () => {
+    const deltas: AgentDelta[] = [];
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({
+            agents: {
+              namedAgent: {
+                description: "Test named agent",
+                model: "anthropic:claude-opus-4-7",
+                system: "Be helpful.",
+              },
+            },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("uses-named")
+          .from(simple("hi"))
+          .to(
+            agent("namedAgent", {
+              onDelta: (d) => {
+                deltas.push(d);
+              },
+            }),
+          ),
+      )
+      .build();
+
+    await t.test();
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toEqual({ type: "text-delta", text: "ok" });
+  });
+});

--- a/packages/ai/test/agent-events.test.ts
+++ b/packages/ai/test/agent-events.test.ts
@@ -1,26 +1,26 @@
 import { describe, test, expect } from "vitest";
-import { normalizeStreamPart } from "../src/agent/events.ts";
+import { normalizeStreamDelta } from "../src/agent/events.ts";
 
-describe("normalizeStreamPart: Vercel SDK part to AgentEvent", () => {
+describe("normalizeStreamDelta: Vercel SDK part to AgentDelta", () => {
   /**
-   * @case Plain text deltas map 1:1 onto text-delta events
+   * @case Plain text deltas map 1:1 onto text-delta deltas
    * @preconditions Part of shape { type: "text-delta", text }
    * @expectedResult Returns { type: "text-delta", text }
    */
   test("text-delta passes through", () => {
-    expect(normalizeStreamPart({ type: "text-delta", text: "hi" })).toEqual({
+    expect(normalizeStreamDelta({ type: "text-delta", text: "hi" })).toEqual({
       type: "text-delta",
       text: "hi",
     });
   });
 
   /**
-   * @case Empty text deltas are dropped (would emit a no-op event)
+   * @case Empty text deltas are dropped (would emit a no-op delta)
    * @preconditions Part with empty text
    * @expectedResult null (filtered)
    */
   test("empty text-delta is filtered", () => {
-    expect(normalizeStreamPart({ type: "text-delta", text: "" })).toBeNull();
+    expect(normalizeStreamDelta({ type: "text-delta", text: "" })).toBeNull();
   });
 
   /**
@@ -30,7 +30,7 @@ describe("normalizeStreamPart: Vercel SDK part to AgentEvent", () => {
    */
   test("text-delta accepts legacy `textDelta` field", () => {
     expect(
-      normalizeStreamPart({ type: "text-delta", textDelta: "legacy" }),
+      normalizeStreamDelta({ type: "text-delta", textDelta: "legacy" }),
     ).toEqual({ type: "text-delta", text: "legacy" });
   });
 
@@ -41,7 +41,7 @@ describe("normalizeStreamPart: Vercel SDK part to AgentEvent", () => {
    */
   test("reasoning-delta passes through", () => {
     expect(
-      normalizeStreamPart({ type: "reasoning-delta", text: "musing" }),
+      normalizeStreamDelta({ type: "reasoning-delta", text: "musing" }),
     ).toEqual({ type: "reasoning-delta", text: "musing" });
   });
 
@@ -52,123 +52,53 @@ describe("normalizeStreamPart: Vercel SDK part to AgentEvent", () => {
    */
   test("reasoning-delta accepts legacy `delta` field", () => {
     expect(
-      normalizeStreamPart({ type: "reasoning-delta", delta: "musing-legacy" }),
+      normalizeStreamDelta({ type: "reasoning-delta", delta: "musing-legacy" }),
     ).toEqual({ type: "reasoning-delta", text: "musing-legacy" });
   });
 
   /**
-   * @case Tool calls carry id, name, and validated input
-   * @preconditions Part of shape { type: "tool-call", toolCallId, toolName, input }
-   * @expectedResult Returns the same shape with `input` (not `args`)
+   * @case Coarse decision parts (tool-call, tool-result, tool-error) are filtered out
+   * @preconditions Parts that previously routed through the delta channel
+   * @expectedResult null - those parts now flow on the context bus instead
    */
-  test("tool-call maps cleanly", () => {
+  test("coarse decision parts are filtered (now on context bus)", () => {
     expect(
-      normalizeStreamPart({
+      normalizeStreamDelta({
         type: "tool-call",
         toolCallId: "c1",
         toolName: "echo",
         input: { msg: "hi" },
       }),
-    ).toEqual({
-      type: "tool-call",
-      toolCallId: "c1",
-      toolName: "echo",
-      input: { msg: "hi" },
-    });
-  });
-
-  /**
-   * @case Tool result carries handler return value
-   * @preconditions Part of shape { type: "tool-result", toolCallId, toolName, output }
-   * @expectedResult Returns the same shape with `output` (not `result`)
-   */
-  test("tool-result maps cleanly", () => {
+    ).toBeNull();
     expect(
-      normalizeStreamPart({
+      normalizeStreamDelta({
         type: "tool-result",
         toolCallId: "c1",
         toolName: "echo",
-        output: "echoed hi",
+        output: "ok",
       }),
-    ).toEqual({
-      type: "tool-result",
-      toolCallId: "c1",
-      toolName: "echo",
-      output: "echoed hi",
-    });
-  });
-
-  /**
-   * @case Tool error carries the thrown value
-   * @preconditions Part of shape { type: "tool-error", toolCallId, toolName, error }
-   * @expectedResult Returns the same shape
-   */
-  test("tool-error maps cleanly", () => {
-    const err = new Error("boom");
+    ).toBeNull();
     expect(
-      normalizeStreamPart({
+      normalizeStreamDelta({
         type: "tool-error",
         toolCallId: "c1",
         toolName: "echo",
-        error: err,
+        error: new Error("boom"),
       }),
-    ).toEqual({
-      type: "tool-error",
-      toolCallId: "c1",
-      toolName: "echo",
-      error: err,
-    });
-  });
-
-  /**
-   * @case Step finish carries reason and optional usage
-   * @preconditions Part with finishReason and usage
-   * @expectedResult Returns step-finish with same fields
-   */
-  test("finish-step maps to step-finish with usage", () => {
+    ).toBeNull();
     expect(
-      normalizeStreamPart({
+      normalizeStreamDelta({
         type: "finish-step",
         finishReason: "tool-calls",
-        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
       }),
-    ).toEqual({
-      type: "step-finish",
-      finishReason: "tool-calls",
-      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-    });
-  });
-
-  /**
-   * @case Final finish prefers totalUsage when present
-   * @preconditions Part with totalUsage
-   * @expectedResult Returns finish with usage from totalUsage
-   */
-  test("finish prefers totalUsage over usage", () => {
+    ).toBeNull();
     expect(
-      normalizeStreamPart({
+      normalizeStreamDelta({
         type: "finish",
         finishReason: "stop",
-        totalUsage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
       }),
-    ).toEqual({
-      type: "finish",
-      finishReason: "stop",
-      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
-    });
-  });
-
-  /**
-   * @case Error events surface to the listener
-   * @preconditions Part of shape { type: "error", error }
-   * @expectedResult Returns { type: "error", error }
-   */
-  test("error passes through", () => {
-    const err = { code: "ECONNRESET" };
-    expect(normalizeStreamPart({ type: "error", error: err })).toEqual({
-      type: "error",
-      error: err,
-    });
+    ).toBeNull();
+    expect(normalizeStreamDelta({ type: "error", error: {} })).toBeNull();
   });
 
   /**
@@ -177,16 +107,16 @@ describe("normalizeStreamPart: Vercel SDK part to AgentEvent", () => {
    * @expectedResult null
    */
   test("low-level SDK parts are filtered out", () => {
-    expect(normalizeStreamPart({ type: "text-start", id: "0" })).toBeNull();
-    expect(normalizeStreamPart({ type: "text-end", id: "0" })).toBeNull();
+    expect(normalizeStreamDelta({ type: "text-start", id: "0" })).toBeNull();
+    expect(normalizeStreamDelta({ type: "text-end", id: "0" })).toBeNull();
     expect(
-      normalizeStreamPart({ type: "tool-input-start", id: "x" }),
+      normalizeStreamDelta({ type: "tool-input-start", id: "x" }),
     ).toBeNull();
     expect(
-      normalizeStreamPart({ type: "tool-input-delta", id: "x", delta: "{" }),
+      normalizeStreamDelta({ type: "tool-input-delta", id: "x", delta: "{" }),
     ).toBeNull();
-    expect(normalizeStreamPart({ type: "abort" })).toBeNull();
-    expect(normalizeStreamPart({ type: "raw", payload: {} })).toBeNull();
+    expect(normalizeStreamDelta({ type: "abort" })).toBeNull();
+    expect(normalizeStreamDelta({ type: "raw", payload: {} })).toBeNull();
   });
 
   /**
@@ -195,9 +125,9 @@ describe("normalizeStreamPart: Vercel SDK part to AgentEvent", () => {
    * @expectedResult null for each
    */
   test("non-object input returns null", () => {
-    expect(normalizeStreamPart(null)).toBeNull();
-    expect(normalizeStreamPart(undefined)).toBeNull();
-    expect(normalizeStreamPart("text")).toBeNull();
-    expect(normalizeStreamPart(42)).toBeNull();
+    expect(normalizeStreamDelta(null)).toBeNull();
+    expect(normalizeStreamDelta(undefined)).toBeNull();
+    expect(normalizeStreamDelta("text")).toBeNull();
+    expect(normalizeStreamDelta(42)).toBeNull();
   });
 });

--- a/packages/ai/test/agent-runtime.test.ts
+++ b/packages/ai/test/agent-runtime.test.ts
@@ -115,11 +115,11 @@ describe("agent runtime: tool wiring through callLlm", () => {
   });
 
   /**
-   * @case maxSteps shorthand resolves to a stopWhen value
-   * @preconditions agent.maxSteps = 3
+   * @case maxTurns shorthand resolves to a stopWhen value
+   * @preconditions agent.maxTurns = 3
    * @expectedResult callLlm receives a stopWhen (we don't unpack the SDK helper's shape; presence is enough)
    */
-  test("maxSteps shorthand produces a stopWhen", async () => {
+  test("maxTurns shorthand produces a stopWhen", async () => {
     t = await testContext()
       .with({
         plugins: [
@@ -129,14 +129,14 @@ describe("agent runtime: tool wiring through callLlm", () => {
       })
       .routes(
         craft()
-          .id("maxsteps")
+          .id("maxturns")
           .from(simple("hi"))
           .to(
             agent({
               system: "x",
               model: "anthropic:claude-opus-4-7",
               tools: tools(["currentTime"]),
-              maxSteps: 3,
+              maxTurns: 3,
             }),
           ),
       )

--- a/packages/ai/test/agent-streaming.test.ts
+++ b/packages/ai/test/agent-streaming.test.ts
@@ -4,17 +4,17 @@ import { spy, testContext, type TestContext } from "@routecraft/testing";
 import {
   agent,
   llmPlugin,
-  type AgentEvent,
+  type AgentDelta,
   type AgentResult,
 } from "../src/index.ts";
 import type { LlmResult } from "../src/llm/types.ts";
 
 // Mock both LLM dispatch paths so the streaming tests stay hermetic.
-// `streamLlm` synthesises a small event stream (text-delta x2 +
-// finish), forwards it to `onEvent`, and returns a consolidated
-// LlmResult mirroring what the real provider would build after the
-// stream drains. `callLlm` stays available for the non-streaming
-// regression check.
+// `streamLlm` synthesises a small token stream (text-delta x2),
+// forwards it to `onDelta`, and returns a consolidated LlmResult
+// mirroring what the real provider would build after the stream
+// drains. Coarse decision events (tool-call, tool-result, finished,
+// error) flow on the context bus and are tested separately.
 vi.mock("../src/llm/providers/index.ts", () => ({
   callLlm: vi.fn(
     async (): Promise<LlmResult> => ({
@@ -24,26 +24,21 @@ vi.mock("../src/llm/providers/index.ts", () => ({
   ),
   streamLlm: vi.fn(
     async ({
-      onEvent,
+      onDelta,
     }: {
-      onEvent: (e: AgentEvent) => void | Promise<void>;
+      onDelta: (d: AgentDelta) => void | Promise<void>;
     }): Promise<LlmResult> => {
       // Mirror the real runStreamGenerate: listener throws are caught
       // and logged so a noisy consumer doesn't break the dispatch.
-      const safe = async (e: AgentEvent) => {
+      const safe = async (d: AgentDelta) => {
         try {
-          await onEvent(e);
+          await onDelta(d);
         } catch {
           // swallow, mirrors frameworkLogger.warn in the real path
         }
       };
       await safe({ type: "text-delta", text: "Hel" });
       await safe({ type: "text-delta", text: "lo" });
-      await safe({
-        type: "finish",
-        finishReason: "stop",
-        usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
-      });
       return {
         text: "Hello",
         usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
@@ -56,7 +51,7 @@ import { callLlm, streamLlm } from "../src/llm/providers/index.ts";
 const callLlmMock = callLlm as unknown as ReturnType<typeof vi.fn>;
 const streamLlmMock = streamLlm as unknown as ReturnType<typeof vi.fn>;
 
-describe("agent streaming: onEvent → streamLlm wiring", () => {
+describe("agent streaming: onDelta -> streamLlm wiring", () => {
   let t: TestContext | undefined;
 
   beforeEach(() => {
@@ -70,11 +65,11 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
   });
 
   /**
-   * @case Agent without onEvent uses the synchronous path
-   * @preconditions Inline agent with no `onEvent`
+   * @case Agent without onDelta uses the synchronous path
+   * @preconditions Inline agent with no `onDelta`
    * @expectedResult callLlm called once; streamLlm not called
    */
-  test("no onEvent → callLlm, not streamLlm", async () => {
+  test("no onDelta -> callLlm, not streamLlm", async () => {
     t = await testContext()
       .with({
         plugins: [
@@ -100,12 +95,12 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
   });
 
   /**
-   * @case Agent with onEvent triggers the streaming path
-   * @preconditions Inline agent with `onEvent` callback
+   * @case Agent with onDelta triggers the streaming path
+   * @preconditions Inline agent with `onDelta` callback
    * @expectedResult streamLlm called once; callLlm not called
    */
-  test("onEvent present → streamLlm, not callLlm", async () => {
-    const events: AgentEvent[] = [];
+  test("onDelta present -> streamLlm, not callLlm", async () => {
+    const deltas: AgentDelta[] = [];
     t = await testContext()
       .with({
         plugins: [
@@ -120,8 +115,8 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
             agent({
               system: "Be helpful.",
               model: "anthropic:claude-opus-4-7",
-              onEvent: (e) => {
-                events.push(e);
+              onDelta: (d) => {
+                deltas.push(d);
               },
             }),
           ),
@@ -134,12 +129,12 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
   });
 
   /**
-   * @case Listener receives every emitted event in order
-   * @preconditions onEvent collects all events into an array
-   * @expectedResult Events seen are [text-delta "Hel", text-delta "lo", finish]
+   * @case Listener receives every emitted delta in order
+   * @preconditions onDelta collects all deltas into an array
+   * @expectedResult Deltas seen are [text-delta "Hel", text-delta "lo"]
    */
-  test("listener receives events in dispatch order", async () => {
-    const events: AgentEvent[] = [];
+  test("listener receives deltas in dispatch order", async () => {
+    const deltas: AgentDelta[] = [];
     t = await testContext()
       .with({
         plugins: [
@@ -148,14 +143,14 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
       })
       .routes(
         craft()
-          .id("event-order")
+          .id("delta-order")
           .from(simple("hi"))
           .to(
             agent({
               system: "x",
               model: "anthropic:claude-opus-4-7",
-              onEvent: (e) => {
-                events.push(e);
+              onDelta: (d) => {
+                deltas.push(d);
               },
             }),
           ),
@@ -163,10 +158,9 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
       .build();
 
     await t.test();
-    expect(events).toHaveLength(3);
-    expect(events[0]).toEqual({ type: "text-delta", text: "Hel" });
-    expect(events[1]).toEqual({ type: "text-delta", text: "lo" });
-    expect(events[2]).toMatchObject({ type: "finish", finishReason: "stop" });
+    expect(deltas).toHaveLength(2);
+    expect(deltas[0]).toEqual({ type: "text-delta", text: "Hel" });
+    expect(deltas[1]).toEqual({ type: "text-delta", text: "lo" });
   });
 
   /**
@@ -190,7 +184,7 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
             agent({
               system: "x",
               model: "anthropic:claude-opus-4-7",
-              onEvent: () => {},
+              onDelta: () => {},
             }),
           )
           .to(sink),
@@ -209,8 +203,8 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
 
   /**
    * @case Throwing listener does not abort the dispatch
-   * @preconditions onEvent throws on the first text-delta
-   * @expectedResult Dispatch completes, AgentResult body still consolidated, subsequent events still attempted
+   * @preconditions onDelta throws on every call
+   * @expectedResult Dispatch completes, AgentResult body still consolidated
    */
   test("listener throw is contained; dispatch completes", async () => {
     let received = 0;
@@ -229,7 +223,7 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
             agent({
               system: "x",
               model: "anthropic:claude-opus-4-7",
-              onEvent: () => {
+              onDelta: () => {
                 received++;
                 throw new Error("listener boom");
               },
@@ -240,21 +234,18 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
       .build();
 
     await t.test();
-    // The mocked streamLlm awaits onEvent in a try/catch (mirrors the
-    // real implementation), so all 3 events are still attempted and
-    // the consolidated AgentResult still flows downstream.
-    expect(received).toBe(3);
+    expect(received).toBe(2);
     const body = sink.received[0].body as AgentResult;
     expect(body.text).toBe("Hello");
   });
 
   /**
    * @case Async listener is awaited so back-pressure flows back into the stream
-   * @preconditions onEvent returns a Promise that resolves after a tick
-   * @expectedResult All events delivered before the dispatch resolves
+   * @preconditions onDelta returns a Promise that resolves after a tick
+   * @expectedResult All deltas delivered before the dispatch resolves; ordering preserved
    */
   test("async listener is awaited", async () => {
-    const events: AgentEvent[] = [];
+    const deltas: AgentDelta[] = [];
     t = await testContext()
       .with({
         plugins: [
@@ -269,9 +260,9 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
             agent({
               system: "x",
               model: "anthropic:claude-opus-4-7",
-              onEvent: async (e) => {
+              onDelta: async (d) => {
                 await new Promise((r) => setTimeout(r, 1));
-                events.push(e);
+                deltas.push(d);
               },
             }),
           ),
@@ -279,11 +270,8 @@ describe("agent streaming: onEvent → streamLlm wiring", () => {
       .build();
 
     await t.test();
-    expect(events).toHaveLength(3);
-    // Awaiting an async listener must preserve dispatch order; without
-    // back-pressure the events would interleave.
-    expect(events[0]).toEqual({ type: "text-delta", text: "Hel" });
-    expect(events[1]).toEqual({ type: "text-delta", text: "lo" });
-    expect(events[2]).toMatchObject({ type: "finish", finishReason: "stop" });
+    expect(deltas).toHaveLength(2);
+    expect(deltas[0]).toEqual({ type: "text-delta", text: "Hel" });
+    expect(deltas[1]).toEqual({ type: "text-delta", text: "lo" });
   });
 });

--- a/packages/ai/test/stream-llm.test.ts
+++ b/packages/ai/test/stream-llm.test.ts
@@ -5,11 +5,14 @@ import { logger as frameworkLogger } from "@routecraft/routecraft";
 // re-implementation in agent-streaming.test.ts) is exercised end to
 // end. The mock provides a minimal `streamText` whose `fullStream`
 // yields a controlled sequence and whose consolidation accessors
-// resolve as Promises.
+// resolve as Promises. Two text-deltas plus a coarse `finish` part
+// (which is now filtered out by `normalizeStreamDelta`); the test
+// asserts that only the deltas drive `onDelta` invocations.
 vi.mock("ai", () => ({
   streamText: vi.fn(() => ({
     fullStream: (async function* () {
-      yield { type: "text-delta", text: "ok" };
+      yield { type: "text-delta", text: "o" };
+      yield { type: "text-delta", text: "k" };
       yield { type: "finish", finishReason: "stop" };
     })(),
     text: Promise.resolve("ok"),
@@ -45,32 +48,33 @@ describe("streamLlm: production listener-error containment", () => {
 
   /**
    * @case A throwing listener does not reject the dispatch
-   * @preconditions onEvent throws synchronously on every invocation
+   * @preconditions onDelta throws synchronously on every invocation
    * @expectedResult Promise resolves with the consolidated LlmResult; warn called per throw
    */
-  test("throwing onEvent does not abort dispatch", async () => {
+  test("throwing onDelta does not abort dispatch", async () => {
     const result = await streamLlm({
       config: { provider: "anthropic", apiKey: "sk-test" },
       modelId: "claude-test",
       options: { temperature: 0, maxTokens: 64 },
       system: "x",
       user: "y",
-      onEvent: () => {
+      onDelta: () => {
         throw new Error("listener boom");
       },
     });
     expect(result.text).toBe("ok");
-    // 2 events normalised → 2 listener invocations → 2 warn entries.
+    // 2 deltas (the finish part is filtered) -> 2 listener
+    // invocations -> 2 warn entries.
     expect(warnSpy).toHaveBeenCalledTimes(2);
-    expect(warnSpy.mock.calls[0]?.[1]).toMatch(/agent\.onEvent listener threw/);
+    expect(warnSpy.mock.calls[0]?.[1]).toMatch(/agent\.onDelta listener threw/);
   });
 
   /**
-   * @case Listener that throws on the first event still receives the second
-   * @preconditions onEvent throws on the first call, succeeds on the rest
-   * @expectedResult Both events are delivered (catch lives per-event, not per-stream)
+   * @case Listener that throws on the first delta still receives the second
+   * @preconditions onDelta throws on the first call, succeeds on the rest
+   * @expectedResult Both deltas are delivered (catch lives per-delta, not per-stream)
    */
-  test("subsequent events still delivered after a listener throw", async () => {
+  test("subsequent deltas still delivered after a listener throw", async () => {
     let calls = 0;
     await streamLlm({
       config: { provider: "anthropic", apiKey: "sk-test" },
@@ -78,7 +82,7 @@ describe("streamLlm: production listener-error containment", () => {
       options: { temperature: 0, maxTokens: 64 },
       system: "x",
       user: "y",
-      onEvent: () => {
+      onDelta: () => {
         calls++;
         if (calls === 1) throw new Error("first-only");
       },

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -289,6 +289,13 @@ export type StepEventName =
  * - `route:<routeId>:error-handler:recovered` - Error handler succeeded
  * - `route:<routeId>:error-handler:failed` - Error handler also failed
  *
+ * **Agent events** (emitted by `agent()` destinations):
+ * - `route:<routeId>:agent:tool:invoked` - Agent decided to call a tool
+ * - `route:<routeId>:agent:tool:result` - Tool handler returned a value
+ * - `route:<routeId>:agent:tool:error` - Tool handler / guard / input validation threw
+ * - `route:<routeId>:agent:finished` - Agent dispatch ended (final usage available)
+ * - `route:<routeId>:agent:error` - Provider / transport error during dispatch
+ *
  * @example
  * ```typescript
  * ctx.on('route:*:batch:flushed', ({ details }) => {
@@ -311,7 +318,12 @@ export type SpecialEventName =
   | `route:${string}:error-handler:recovered`
   | `route:${string}:error-handler:failed`
   | `route:${string}:operation:choice:matched`
-  | `route:${string}:operation:choice:unmatched`;
+  | `route:${string}:operation:choice:unmatched`
+  | `route:${string}:agent:tool:invoked`
+  | `route:${string}:agent:tool:result`
+  | `route:${string}:agent:tool:error`
+  | `route:${string}:agent:finished`
+  | `route:${string}:agent:error`;
 
 /**
  * Authentication events.
@@ -563,52 +575,99 @@ type RouteEventDetails<S extends string> =
                                             exchangeId: string;
                                             correlationId: string;
                                           }
-                                        : // Step errors (multi-segment suffix)
-                                          S extends `step:${string}:error:caught`
+                                        : // Agent events
+                                          S extends "agent:tool:invoked"
                                           ? {
-                                              error: unknown;
-                                              route?: Route;
-                                              exchange?: Exchange<unknown>;
-                                              operation: string;
+                                              routeId: string;
+                                              exchangeId: string;
+                                              correlationId: string;
+                                              toolCallId: string;
+                                              toolName: string;
+                                              input: unknown;
                                             }
-                                          : S extends `step:${string}:error`
+                                          : S extends "agent:tool:result"
                                             ? {
-                                                error: unknown;
-                                                route?: Route;
-                                                exchange?: Exchange<unknown>;
-                                                operation: string;
+                                                routeId: string;
+                                                exchangeId: string;
+                                                correlationId: string;
+                                                toolCallId: string;
+                                                toolName: string;
+                                                output: unknown;
+                                                duration: number;
                                               }
-                                            : // Route errors
-                                              S extends "error:caught"
+                                            : S extends "agent:tool:error"
                                               ? {
+                                                  routeId: string;
+                                                  exchangeId: string;
+                                                  correlationId: string;
+                                                  toolCallId: string;
+                                                  toolName: string;
                                                   error: unknown;
-                                                  route?: Route;
-                                                  exchange?: Exchange<unknown>;
+                                                  duration: number;
                                                 }
-                                              : S extends "error"
+                                              : S extends "agent:finished"
                                                 ? {
-                                                    error: unknown;
-                                                    route?: Route;
-                                                    exchange?: Exchange<unknown>;
+                                                    routeId: string;
+                                                    exchangeId: string;
+                                                    correlationId: string;
+                                                    finishReason: string;
+                                                    inputTokens?: number;
+                                                    outputTokens?: number;
+                                                    totalTokens?: number;
                                                   }
-                                                : // Route lifecycle (must be last to avoid matching multi-segment suffixes)
-                                                  S extends
-                                                      | "registered"
-                                                      | "starting"
-                                                      | "started"
-                                                  ? { route: Route }
-                                                  : S extends "stopping"
+                                                : S extends "agent:error"
+                                                  ? {
+                                                      routeId: string;
+                                                      exchangeId: string;
+                                                      correlationId: string;
+                                                      error: unknown;
+                                                    }
+                                                  : // Step errors (multi-segment suffix)
+                                                    S extends `step:${string}:error:caught`
                                                     ? {
-                                                        route: Route;
-                                                        reason?: unknown;
+                                                        error: unknown;
+                                                        route?: Route;
                                                         exchange?: Exchange<unknown>;
+                                                        operation: string;
                                                       }
-                                                    : S extends "stopped"
+                                                    : S extends `step:${string}:error`
                                                       ? {
-                                                          route: Route;
+                                                          error: unknown;
+                                                          route?: Route;
                                                           exchange?: Exchange<unknown>;
+                                                          operation: string;
                                                         }
-                                                      : never;
+                                                      : // Route errors
+                                                        S extends "error:caught"
+                                                        ? {
+                                                            error: unknown;
+                                                            route?: Route;
+                                                            exchange?: Exchange<unknown>;
+                                                          }
+                                                        : S extends "error"
+                                                          ? {
+                                                              error: unknown;
+                                                              route?: Route;
+                                                              exchange?: Exchange<unknown>;
+                                                            }
+                                                          : // Route lifecycle (must be last to avoid matching multi-segment suffixes)
+                                                            S extends
+                                                                | "registered"
+                                                                | "starting"
+                                                                | "started"
+                                                            ? { route: Route }
+                                                            : S extends "stopping"
+                                                              ? {
+                                                                  route: Route;
+                                                                  reason?: unknown;
+                                                                  exchange?: Exchange<unknown>;
+                                                                }
+                                                              : S extends "stopped"
+                                                                ? {
+                                                                    route: Route;
+                                                                    exchange?: Exchange<unknown>;
+                                                                  }
+                                                                : never;
 
 /** Detail types for `plugin:<pluginId>:<suffix>` events. */
 type PluginEventDetails<S extends string> = S extends


### PR DESCRIPTION
## Summary

Splits agent observability into two channels with intentional boundaries, replacing the monolithic `onEvent` callback. The `onEvent`-as-everything design conflated three concerns (cross-cutting telemetry, per-decision events, token streams) into one mechanism, which was awkward for TUIs/dashboards (couldn't subscribe globally) and for named agents (couldn't stream tokens to a per-request consumer).

## What changes

**1. Coarse decision events on the context bus** (broadcast, wildcard-subscribable, telemetry-friendly):

| Event | Use |
|---|---|
| `route:<id>:agent:tool:invoked` | Agent decided to call a tool. `{ toolCallId, toolName, input }`. |
| `route:<id>:agent:tool:result` | Tool returned a value. `{ toolCallId, toolName, output, duration }`. |
| `route:<id>:agent:tool:error` | Tool / guard / input validation threw. `{ toolCallId, toolName, error, duration }`. |
| `route:<id>:agent:finished` | Dispatch returned. `{ finishReason, inputTokens?, outputTokens?, totalTokens? }`. |
| `route:<id>:agent:error` | Provider / transport error. `{ error }`. |

Wildcard subscriptions work: `ctx.on("route:*:agent:tool:*", ...)` or `ctx.on("route:*:agent:finished", ...)` for cross-cutting telemetry.

**2. Token-level deltas on a per-call directed channel** (back-pressure aware, single consumer):

```ts
.to(agent({
  model: "openai:gpt-4o",
  onDelta: (delta) => sse.send({ data: delta.text, type: delta.type }),
}))
```

`AgentDelta` is now narrow: `text-delta | reasoning-delta`. Coarse events that used to flow through here (tool-call, finish, error) now go on the context bus where they belong.

## API renames (all `@experimental`, no migration shim)

| Before | After |
|---|---|
| `AgentEvent` | `AgentDelta` |
| `AgentEventListener` | `AgentDeltaListener` |
| `AgentOptions.onEvent` | `AgentOptions.onDelta` |
| `normalizeStreamPart` | `normalizeStreamDelta` |
| `AgentOptions.maxSteps` | `AgentOptions.maxTurns` |
| `AgentDefaultOptions.maxSteps` | `AgentDefaultOptions.maxTurns` |

`maxTurns` aligns with Claude's external naming; "turns" are the natural unit of agent-loop progress.

## By-name agent per-call overrides (closes a real gap)

Streaming a registered agent's tokens to a per-request consumer was previously impossible — `onEvent` was on `AgentOptions` and the by-name form `agent("name")` resolved registered options without accepting per-call overrides.

```ts
// Now possible:
.to(agent("summariser", { onDelta: (d) => sse.send(d.text) }))
```

Constrained to `onDelta` only — overriding model/system/tools per-call would defeat the purpose of named agents. New `AgentByNameOverrides` interface; third overload on `agent()`; `AgentBinding.kind === "by-name"` carries an optional `perCall` field.

## Implementation

- `AgentSession` gains `dispatchIdentity` (`routeId` / `exchangeId` / `correlationId`), threaded from destination via `dispatchIdentityFrom`.
- `tool-bridge.ts` wraps each tool's `execute()` with `invoked` / `result` / `error` emissions using the dispatch identity for stable IDs.
- `session.ts.runUntilDone` and `runStream` wrap the LLM call in try/catch so `agent:finished` (success) and `agent:error` (throw) always fire.
- `runStreamGenerate` provider helper now forwards only deltas; coarse parts (finish-step, finish, error) are no longer translated into the delta channel.

## Tests

4 new in `agent-bus-events.test.ts`:
- `tool:invoked` + `tool:result` emitted with stable fields and duration.
- `tool:error` emitted on handler throw; `result` not emitted.
- `agent:finished` emitted with finish reason and token usage.
- Per-call `onDelta` on `agent("name", { onDelta })` is forwarded.

Existing `agent-streaming.test.ts` rewritten for the narrowed `onDelta` surface (deltas only). `agent-events.test.ts` asserts coarse parts are filtered (now bus-side).

Suite: **1010 pass / 1 skipped** (was 1006, +4).

## Verification

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm test`

## Test plan

- [ ] Reviewer confirms the two-channel mental model (broadcast vs directed) is the right line.
- [ ] Reviewer reads the new "Observability: two channels" section in `docs/reference/plugins/page.md`.
- [ ] CI green.

## Follow-ups (intentionally out of scope)

- `agent:turn:finished` events (per-turn observability, requires per-step iteration in both paths). Quick follow-up.
- `telemetry()` plugin auto-instrumenting tool calls as child spans of the agent step (consumes the new bus events).

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies agent observability into two channels: coarse decision events now emit on the context bus, and token streaming uses a new per-call `onDelta`. Enables per-request streaming for named agents and renames `maxSteps` to `maxTurns`.

- **New Features**
  - Context bus events: `route:<id>:agent:tool:invoked`, `:tool:result`, `:tool:error`, `:finished`, `:error` (with `routeId`, `exchangeId`, `correlationId`).
  - `onDelta` (per-dispatch, back-pressure aware) emits only `text-delta` and `reasoning-delta`.
  - Named agents accept per-call `onDelta`: `agent("summariser", { onDelta })`.
  - Renames: `onEvent` → `onDelta`, `AgentEvent*` → `AgentDelta*`, `normalizeStreamPart` → `normalizeStreamDelta`, `maxSteps` → `maxTurns`.

- **Bug Fixes**
  - `agent:finished.finishReason` is correct on streaming runs (awaits provider value; also exposed on `LlmResult`).
  - By-name `agent("name", { onDelta })` preserves per-call overrides in factory args for introspection/testing.
  - `dispatchIdentityFrom` falls back to `exchange.id` when `correlationId` is missing.
  - Tools emit unique `toolCallId` when the SDK omits it (uses `randomUUID()`), preserving invoked→result/error correlation.

<sup>Written for commit beb21e6513f0d7782bb502a0a0480413f7d10aa7. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/275?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

