### PR TITLE
feat(ai)!: agent enhancements (toolCalls, validate, skills+agents loaders, FnHandlerContext narrowing)

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -742,6 +742,34 @@ For named agents that share a definition across requests, accept `onDelta` at th
 
 The 90% use case is forwarding tokens into an HTTP SSE response so a UI updates as the model writes. For everything else (per-tool observability, finish reasons, total usage, errors) use the context bus.
 
+#### Asserting on agent behaviour (`AgentResult.toolCalls`)
+
+For programmatic assertions ("the agent must have replied via `replyEmail`, otherwise escalate"), inspect `AgentResult.toolCalls` in a downstream `.process()` step. The list pairs each tool call with its return value or thrown error in invocation order; combine with step-scope `.error()` for fallback routing:
+
+```ts
+craft()
+  .id("inbox-bot")
+  .from(mail({ account: "support" }))
+  .to(agent({
+    system: "Reply to the customer via replyEmail. If you cannot answer, leave it unanswered.",
+    tools: tools(["replyEmail"]),
+  }))
+  .error((err, ex, forward) => {
+    // Agent did not reply via tool; escalate to a human inbox
+    return forward("escalate-to-human", ex.body);
+  })
+  .process((ex) => {
+    const r = ex.body as AgentResult;
+    const replied = r.toolCalls?.some(
+      (c) => c.toolName === "replyEmail" && !c.error,
+    );
+    if (!replied) throw new Error("Agent finished without sending a reply");
+    return r;
+  })
+```
+
+The context bus events (`route:*:agent:tool:*`) are the live observation channel for the same calls; `toolCalls` on the result is the synchronous post-hoc view a pipeline step can branch on. Use the bus for telemetry / dashboards / TUIs; use `toolCalls` for assertions and routing.
+
 ### Typed fn ids (`FnRegistry`)
 
 For compile-time autocomplete of fn ids in the agent `tools: [...]` field (follow-up story), populate the `FnRegistry` marker interface via declaration merging in your project:

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "@routecraft/routecraft": "workspace:^0.5.0",
     "@standard-schema/spec": "^1.1.0",
-    "ai": "^6.0.168"
+    "ai": "^6.0.168",
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.71",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@routecraft/routecraft": "workspace:^0.5.0",
     "@standard-schema/spec": "^1.1.0",
-    "ai": "^6.0.168",
-    "yaml": "^2.8.0"
+    "ai": "^6.0.168"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.71",
@@ -39,6 +38,7 @@
     "jose": "^6.2.2",
     "ollama-ai-provider-v2": "^3.5.0",
     "vitest": "^4.1.4",
+    "yaml": "^2.8.0",
     "zod": "^4.3.6"
   },
   "peerDependencies": {
@@ -50,7 +50,8 @@
     "@openrouter/ai-sdk-provider": "^2.2.3",
     "@routecraft/routecraft": "*",
     "express": "^5.0.0",
-    "ollama-ai-provider-v2": "^3.3.1"
+    "ollama-ai-provider-v2": "^3.3.1",
+    "yaml": "^2.8.0"
   },
   "keywords": [
     "routecraft",
@@ -90,6 +91,9 @@
       "optional": true
     },
     "ollama-ai-provider-v2": {
+      "optional": true
+    },
+    "yaml": {
       "optional": true
     }
   }

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -122,6 +122,7 @@ export class AgentDestinationAdapter implements Destination<
       user,
       system,
       context,
+      exchange,
       dispatchIdentity,
     });
 

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -16,6 +16,7 @@ import {
   ADAPTER_AGENT_DEFAULT_OPTIONS,
   ADAPTER_AGENT_REGISTRY,
 } from "./store.ts";
+import { ADAPTER_SKILL_REGISTRY, type Skill } from "../skill/types.ts";
 import type { AgentDeltaListener } from "./events.ts";
 import type { ResolvedTool } from "./tools/selection.ts";
 import type {
@@ -96,17 +97,18 @@ export class AgentDestinationAdapter implements Destination<
     // System accepts the same string-or-function shape as `llm({ system })`,
     // so resolve it against the exchange here. The session then receives a
     // plain string, matching what the provider layer expects.
-    const system = resolvePrompt(merged.system, exchange);
+    const baseSystem = resolvePrompt(merged.system, exchange);
     // Mirror the construction-time check (validateAgentOptions) so a
     // function-form `system` resolver can't silently drop the prompt at
     // dispatch by returning an empty string.
-    if (system.trim() === "") {
+    if (baseSystem.trim() === "") {
       throw rcError("RC5003", undefined, {
         message:
           `Agent: "system" resolved to an empty string. ` +
           `When "system" is a function, it must return a non-empty string for the incoming exchange.`,
       });
     }
+    const system = appendSkillsToSystem(baseSystem, merged.skills, context);
 
     const route = getExchangeRoute(exchange);
     const dispatchIdentity = dispatchIdentityFrom(
@@ -256,4 +258,53 @@ function resolveAgentTools(
     });
   }
   return options.tools.resolve(context);
+}
+
+/**
+ * Build the final system prompt by concatenating the resolved skill
+ * content (when the agent declared `skills: ["name", ...]`) onto the
+ * agent's own system prompt. Each skill is wrapped in a heading so the
+ * model can see the skill name and its boundary in context.
+ *
+ * Throws `RC5003` when a referenced skill name is not registered,
+ * when an agent declares `skills` but no skills are registered at all,
+ * or when the agent has no live context to look up skills against.
+ *
+ * @internal
+ */
+function appendSkillsToSystem(
+  baseSystem: string,
+  skills: string[] | undefined,
+  context: CraftContext | undefined,
+): string {
+  if (!skills || skills.length === 0) return baseSystem;
+  if (!context) {
+    throw rcError("RC5003", undefined, {
+      message: `Agent: cannot resolve "skills" without a CraftContext.`,
+    });
+  }
+  const registry = context.getStore(
+    ADAPTER_SKILL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
+  ) as Map<string, Skill> | undefined;
+  if (!registry || registry.size === 0) {
+    throw rcError("RC5003", undefined, {
+      message: `Agent: declared "skills" (${skills.map((s) => `"${s}"`).join(", ")}) but no skills are registered in this context. Install agentPlugin({ skills }) with the relevant entries.`,
+    });
+  }
+  const parts: string[] = [baseSystem];
+  for (const name of skills) {
+    const skill = registry.get(name);
+    if (!skill) {
+      const known = [...registry.keys()].sort();
+      throw rcError("RC5003", undefined, {
+        message:
+          `Agent: unknown skill "${name}". ` +
+          (known.length > 0
+            ? `Known skill names: ${known.map((k) => `"${k}"`).join(", ")}.`
+            : `No skills are registered in this context.`),
+      });
+    }
+    parts.push(`\n\n## Skill: ${skill.name}\n\n${skill.content}`);
+  }
+  return parts.join("");
 }

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -16,5 +16,6 @@ export type {
   AgentOptions,
   AgentRegisteredOptions,
   AgentResult,
+  AgentToolCallSummary,
   AgentUserPromptSource,
 } from "./types.ts";

--- a/packages/ai/src/agent/index.ts
+++ b/packages/ai/src/agent/index.ts
@@ -5,6 +5,7 @@ export {
   type AgentByNameOverrides,
 } from "./destination.ts";
 export type { AgentDelta, AgentDeltaListener } from "./events.ts";
+export { agents, type AgentMarkdownOverride } from "./loader.ts";
 export { agentPlugin, type AgentPluginOptions } from "./plugin.ts";
 export {
   ADAPTER_AGENT_DEFAULT_OPTIONS,

--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -1,0 +1,221 @@
+import { rcError } from "@routecraft/routecraft";
+import {
+  optionalPositiveInt,
+  optionalStringArray,
+  readMarkdownDir,
+  readMarkdownFile,
+  requireString,
+} from "../skill/markdown.ts";
+import { tools } from "./tools/index.ts";
+import type { LlmModelId } from "../llm/types.ts";
+import type { AgentRegisteredOptions } from "./types.ts";
+
+/**
+ * Frontmatter fields supported today. Claude's subagent schema covers
+ * many more (`disallowedTools`, `permissionMode`, `mcpServers`,
+ * `hooks`, `memory`, `background`, `effort`, `isolation`, `color`,
+ * `initialPrompt`, ...) which we will add incrementally as the
+ * underlying features land. Any other key in the frontmatter throws
+ * `RC5003` "not yet supported" at load so a misspelt key never silently
+ * disappears.
+ */
+const SUPPORTED_AGENT_KEYS = new Set([
+  "name",
+  "description",
+  "model",
+  "maxTurns",
+  "tools",
+  "skills",
+]);
+
+/**
+ * Per-agent override layered on top of the markdown frontmatter. Only
+ * the fields that make sense to override at config time are exposed
+ * here. Lifecycle fields like `validate` and `onDelta` belong in code
+ * (markdown frontmatter cannot express closures) so set those on the
+ * agent at the call site or via `agentPlugin({ defaultOptions })`.
+ *
+ * @experimental
+ */
+export interface AgentMarkdownOverride extends Partial<
+  Pick<
+    AgentRegisteredOptions,
+    "description" | "model" | "maxTurns" | "tools" | "skills"
+  >
+> {
+  /**
+   * Replace the system prompt loaded from the markdown body. Useful
+   * when a deployment wants to swap a tone or constraint without
+   * editing the source file.
+   */
+  system?: string;
+}
+
+/**
+ * Convert a parsed markdown file into an `AgentRegisteredOptions`.
+ * Validates that frontmatter `name` matches the filename so the
+ * registry id is unambiguous; throws on unsupported frontmatter
+ * fields and on empty body so an agent never lands with a hollow
+ * system prompt.
+ *
+ * @internal
+ */
+function toAgent(
+  filename: string,
+  frontmatter: Record<string, unknown>,
+  body: string,
+  source: string,
+): { name: string; agent: AgentRegisteredOptions } {
+  for (const key of Object.keys(frontmatter)) {
+    if (!SUPPORTED_AGENT_KEYS.has(key)) {
+      throw rcError("RC5003", undefined, {
+        message: `Markdown file "${source}": frontmatter field "${key}" is not yet supported. Currently supported fields: ${[...SUPPORTED_AGENT_KEYS].sort().join(", ")}.`,
+      });
+    }
+  }
+  const name = requireString(frontmatter["name"], "name", source);
+  if (name !== filename) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter "name" ("${name}") must match the filename ("${filename}"). Rename one or the other.`,
+    });
+  }
+  const description = requireString(
+    frontmatter["description"],
+    "description",
+    source,
+  );
+  if (body.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": agent body is empty. The body becomes the agent's system prompt; an empty system prompt is rejected at dispatch.`,
+    });
+  }
+  const modelRaw = frontmatter["model"];
+  if (modelRaw !== undefined && typeof modelRaw !== "string") {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter "model" must be a string of the form "provider:model" (e.g. "anthropic:claude-sonnet-4-6").`,
+    });
+  }
+  if (typeof modelRaw === "string" && !modelRaw.includes(":")) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter "model" ("${modelRaw}") must use the full "provider:model" form. Bare model aliases like "sonnet" / "opus" / "haiku" are not yet supported by the markdown loader.`,
+    });
+  }
+  const maxTurns = optionalPositiveInt(
+    frontmatter["maxTurns"],
+    "maxTurns",
+    source,
+  );
+  const toolNames = optionalStringArray(frontmatter["tools"], "tools", source);
+  const skillNames = optionalStringArray(
+    frontmatter["skills"],
+    "skills",
+    source,
+  );
+  const agent: AgentRegisteredOptions = {
+    description,
+    system: body,
+  };
+  if (modelRaw) agent.model = modelRaw as LlmModelId;
+  if (maxTurns !== undefined) agent.maxTurns = maxTurns;
+  if (toolNames !== undefined) agent.tools = tools(toolNames);
+  if (skillNames !== undefined) agent.skills = skillNames;
+  return { name, agent };
+}
+
+/**
+ * Apply caller-supplied overrides on top of the agent loaded from
+ * markdown. Replaces, never extends: an explicit `tools` override
+ * replaces the markdown's tool list entirely (matches the
+ * agent-level tool inheritance contract).
+ *
+ * @internal
+ */
+function applyOverride(
+  agent: AgentRegisteredOptions,
+  override: AgentMarkdownOverride | undefined,
+): AgentRegisteredOptions {
+  if (!override) return agent;
+  const out: AgentRegisteredOptions = { ...agent };
+  if (override.description !== undefined)
+    out.description = override.description;
+  if (override.model !== undefined) out.model = override.model;
+  if (override.maxTurns !== undefined) out.maxTurns = override.maxTurns;
+  if (override.tools !== undefined) out.tools = override.tools;
+  if (override.skills !== undefined) out.skills = override.skills;
+  if (override.system !== undefined) out.system = override.system;
+  return out;
+}
+
+/**
+ * Load agents from a markdown file or directory.
+ *
+ * - If `path` points to a directory, every `.md` file directly under
+ *   it becomes one agent. The filename (without `.md`) is the agent
+ *   name and must match the frontmatter `name`.
+ * - If `path` points to a single `.md` file, the file becomes one
+ *   agent keyed by its filename.
+ *
+ * Frontmatter mirrors a deliberately narrow subset of Claude's
+ * subagent schema:
+ *
+ * | Field         | Required | Maps to                                |
+ * | ------------- | -------- | -------------------------------------- |
+ * | `name`        | yes      | record key + agent id                  |
+ * | `description` | yes      | `AgentRegisteredOptions.description`   |
+ * | `model`       | no       | `AgentRegisteredOptions.model` (full   |
+ * |               |          | `provider:model` form only)            |
+ * | `maxTurns`    | no       | `AgentRegisteredOptions.maxTurns`      |
+ * | `tools`       | no       | `tools(stringArray)`                   |
+ * | `skills`      | no       | `AgentRegisteredOptions.skills`        |
+ *
+ * Body of the file becomes `system`. Other Claude subagent fields
+ * (`disallowedTools`, `permissionMode`, `mcpServers`, `hooks`,
+ * `memory`, `background`, `effort`, `isolation`, `color`,
+ * `initialPrompt`, ...) throw `RC5003` "not yet supported" at load
+ * and will land in follow-up stories as the runtime gains the
+ * underlying features.
+ *
+ * Pass `overrides` keyed by agent name to replace any of
+ * `description` / `model` / `maxTurns` / `tools` / `skills` /
+ * `system` per agent without editing the markdown source.
+ *
+ * Returns a `Record<name, AgentRegisteredOptions>` ready to spread
+ * into `agentPlugin({ agents: agents("./agents") })`.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * agentPlugin({
+ *   agents: agents("./agents", {
+ *     researcher: { maxTurns: 30 },
+ *   }),
+ * });
+ * ```
+ */
+export function agents(
+  path: string,
+  overrides: Record<string, AgentMarkdownOverride> = {},
+): Record<string, AgentRegisteredOptions> {
+  const out: Record<string, AgentRegisteredOptions> = {};
+  const docs = path.endsWith(".md")
+    ? [readMarkdownFile(path)]
+    : readMarkdownDir(path);
+  for (const doc of docs) {
+    const { name, agent } = toAgent(
+      doc.filename,
+      doc.frontmatter,
+      doc.body,
+      doc.path,
+    );
+    out[name] = applyOverride(agent, overrides[name]);
+  }
+  for (const name of Object.keys(overrides)) {
+    if (!(name in out)) {
+      throw rcError("RC5003", undefined, {
+        message: `agents("${path}"): override for "${name}" but no agent with that name was loaded from disk.`,
+      });
+    }
+  }
+  return out;
+}

--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -193,14 +193,14 @@ function applyOverride(
  * });
  * ```
  */
-export function agents(
+export async function agents(
   path: string,
   overrides: Record<string, AgentMarkdownOverride> = {},
-): Record<string, AgentRegisteredOptions> {
+): Promise<Record<string, AgentRegisteredOptions>> {
   const out: Record<string, AgentRegisteredOptions> = {};
   const docs = path.endsWith(".md")
-    ? [readMarkdownFile(path)]
-    : readMarkdownDir(path);
+    ? [await readMarkdownFile(path)]
+    : await readMarkdownDir(path);
   for (const doc of docs) {
     const { name, agent } = toAgent(
       doc.filename,

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -11,6 +11,7 @@ import {
 import { validateFnOptions } from "../fn/fn.ts";
 import { ADAPTER_FN_REGISTRY } from "../fn/store.ts";
 import { parseProviderModel } from "../llm/shared.ts";
+import { ADAPTER_SKILL_REGISTRY, type Skill } from "../skill/types.ts";
 import type { AgentDefaultOptions, AgentRegisteredOptions } from "./types.ts";
 import { isDeferredFn, type FnEntry } from "./tools/types.ts";
 import { isToolSelection } from "./tools/selection.ts";
@@ -40,6 +41,21 @@ export interface AgentPluginOptions {
    * `@routecraft/testing` rather than dispatching through the plugin.
    */
   functions?: Record<string, FnEntry>;
+
+  /**
+   * Skills available to agents via `AgentOptions.skills: ["name", ...]`.
+   * Keyed by skill name; each entry's `content` is concatenated into
+   * the system prompt of any agent that lists the name.
+   *
+   * Spread the `Record<string, Skill>` returned by `skills(path)` to
+   * load skills from markdown files.
+   *
+   * Duplicate skill names across multiple `agentPlugin` installs throw
+   * at context init.
+   *
+   * @experimental
+   */
+  skills?: Record<string, Skill>;
 
   /**
    * Context-level defaults applied to any agent that doesn't override
@@ -111,6 +127,7 @@ function validateRegisteredAgent(
 export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
   const agents = options.agents ?? {};
   const functions = options.functions ?? {};
+  const skillsMap = options.skills ?? {};
   const defaultOptions = validatePluginDefaults(options.defaultOptions);
   return {
     apply(ctx: CraftContext) {
@@ -181,6 +198,53 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
         ctx.setStore(
           ADAPTER_FN_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
           fnMap,
+        );
+      }
+
+      const existingSkills = ctx.getStore(
+        ADAPTER_SKILL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
+      ) as Map<string, Skill> | undefined;
+      const skillMap = existingSkills ?? new Map<string, Skill>();
+      for (const [name, skill] of Object.entries(skillsMap)) {
+        if (typeof name !== "string" || name.trim() === "") {
+          throw rcError("RC5003", undefined, {
+            message: `agentPlugin: skill name must be a non-empty string.`,
+          });
+        }
+        if (skill === null || typeof skill !== "object") {
+          throw rcError("RC5003", undefined, {
+            message: `agentPlugin: skill "${name}" entry must be an object with name, description, and content.`,
+          });
+        }
+        if (skill.name !== name) {
+          throw rcError("RC5003", undefined, {
+            message: `agentPlugin: skill key "${name}" does not match its "name" field "${String(skill.name)}". Keys and names must match so the registry has one canonical id per skill.`,
+          });
+        }
+        if (
+          typeof skill.description !== "string" ||
+          skill.description.trim() === ""
+        ) {
+          throw rcError("RC5003", undefined, {
+            message: `agentPlugin: skill "${name}" is missing a non-empty "description".`,
+          });
+        }
+        if (typeof skill.content !== "string" || skill.content.trim() === "") {
+          throw rcError("RC5003", undefined, {
+            message: `agentPlugin: skill "${name}" is missing non-empty "content". Skills inject their content into the agent's system prompt; an empty content would not change behaviour.`,
+          });
+        }
+        if (skillMap.has(name)) {
+          throw rcError("RC5003", undefined, {
+            message: `agentPlugin: duplicate skill name "${name}". Each skill name must be unique within a context.`,
+          });
+        }
+        skillMap.set(name, skill);
+      }
+      if (!existingSkills && skillMap.size > 0) {
+        ctx.setStore(
+          ADAPTER_SKILL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
+          skillMap,
         );
       }
 

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -306,6 +306,12 @@ function toAgentResult(result: LlmResult): AgentResult {
   if (result.output !== undefined) out.output = result.output;
   if (result.reasoning !== undefined) out.reasoning = result.reasoning;
   if (result.usage) out.usage = result.usage;
+  // Pass through the per-call summary unchanged. Shapes are
+  // structurally identical between LlmToolCallSummary and
+  // AgentToolCallSummary so no remapping is needed.
+  if (result.toolCalls && result.toolCalls.length > 0) {
+    out.toolCalls = result.toolCalls;
+  }
   return out;
 }
 

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -1,12 +1,17 @@
 import {
   HeadersKeys,
+  rcError,
   type CraftContext,
   type EventName,
   type Exchange,
 } from "@routecraft/routecraft";
 import { callLlm, streamLlm } from "../llm/providers/index.ts";
 import { resolvePrompt, resolveUserPromptDefault } from "../llm/shared.ts";
-import type { LlmModelConfig, LlmResult } from "../llm/types.ts";
+import type {
+  LlmModelConfig,
+  LlmResult,
+  LlmToolCallSummary,
+} from "../llm/types.ts";
 import { toAiOutputSpec } from "../llm/structured-output.ts";
 import type { AgentDeltaListener } from "./events.ts";
 import { buildVercelTools } from "./tool-bridge.ts";
@@ -56,7 +61,7 @@ export function dispatchIdentityFrom(
 /** Default sampling settings; aligned with the LLM destination defaults. */
 const DEFAULT_TEMPERATURE = 0;
 const DEFAULT_MAX_TOKENS = 1024;
-const DEFAULT_MAX_TURNS = 8;
+const DEFAULT_MAX_TURNS = 20;
 
 /**
  * Resolved agent inputs ready for dispatch. Computed once by the
@@ -81,6 +86,13 @@ export interface AgentSessionInput {
   readonly system: string;
   /** Optional context reference passed to tool handlers. */
   readonly context: CraftContext | undefined;
+  /**
+   * Source exchange that triggered this dispatch. Forwarded to the
+   * `validate` hook (`ctx.exchange`) so validators can correlate the
+   * model's output with request-scoped state (headers, principal,
+   * correlation id) when deciding whether to accept or retry.
+   */
+  readonly exchange: Exchange<unknown>;
   /**
    * Dispatch identity used to emit `route:<routeId>:agent:*` events
    * on the context bus. Undefined for synthetic exchanges with no
@@ -118,34 +130,20 @@ export class AgentSession {
    * Run the synchronous tool-calling loop until the model emits a
    * final text response (or `stopWhen` fires). Returns the
    * consolidated `AgentResult`.
+   *
+   * When `validate` is set, runs the validation retry loop: every
+   * call's result is fed to the validator, and a string return
+   * triggers another model call with the validator message injected
+   * as a corrective user turn. Retries share the `maxTurns` budget;
+   * exhausting it with `validate` still rejecting fails the dispatch
+   * with `RC5003`.
    */
   async runUntilDone(abortSignal: AbortSignal): Promise<AgentResult> {
-    const { modelConfig, modelName, system, user, output, toolExtras } =
-      await this.prepare(abortSignal);
-    try {
-      const result = await callLlm({
-        config: modelConfig,
-        modelId: modelName,
-        options: {
-          temperature: DEFAULT_TEMPERATURE,
-          maxTokens: DEFAULT_MAX_TOKENS,
-        },
-        system,
-        user,
-        abortSignal,
-        ...(output !== undefined ? { output } : {}),
-        ...toolExtras,
-      });
-      this.emitFinished(result);
-      return toAgentResult(result);
-    } catch (err) {
-      this.emitError(err);
-      throw err;
-    }
+    return this.runWithValidation(abortSignal, undefined);
   }
 
   /**
-   * Run the streaming tool-calling loop. Same setup as
+   * Run the streaming tool-calling loop. Same shape as
    * {@link AgentSession.runUntilDone}, but the dispatch goes through
    * `streamText`: each normalised token-level delta is forwarded to
    * `onDelta` while the loop runs, and the consolidated
@@ -153,6 +151,10 @@ export class AgentSession {
    * decision events (tool-call, tool-result, finished,
    * error) flow on the context bus regardless of whether `onDelta`
    * is set; see `route:<id>:agent:*` events.
+   *
+   * `validate` retries follow the same loop as the sync path: each
+   * retry restarts the stream with the prior history + the validator
+   * message, and `onDelta` continues to fire across retries.
    *
    * Listener errors are caught and logged inside the LLM-provider
    * layer; they never abort the dispatch. Stream-level errors
@@ -164,25 +166,84 @@ export class AgentSession {
     abortSignal: AbortSignal,
     onDelta: AgentDeltaListener,
   ): Promise<AgentResult> {
-    const { modelConfig, modelName, system, user, output, toolExtras } =
-      await this.prepare(abortSignal);
+    return this.runWithValidation(abortSignal, onDelta);
+  }
+
+  /**
+   * Shared dispatch path used by both `runUntilDone` and `runStream`.
+   * Calls the model once, runs `validate` (when set), and either
+   * returns the accepted result or loops with a corrective user
+   * message until the validator accepts or `maxTurns` is exhausted.
+   *
+   * The cumulative `toolCalls` from every retry land on the final
+   * `AgentResult.toolCalls`, so post-dispatch assertions like
+   * "must have called send_email" see the agent's full tool history
+   * (not just the last call's).
+   *
+   * @internal
+   */
+  private async runWithValidation(
+    abortSignal: AbortSignal,
+    onDelta: AgentDeltaListener | undefined,
+  ): Promise<AgentResult> {
+    const { options, exchange } = this.input;
+    const validate = options.validate;
+    const maxTurns = options.maxTurns ?? DEFAULT_MAX_TURNS;
+    const prepared = await this.prepare(abortSignal);
+
+    let turnsUsed = 0;
+    let currentUser: string | unknown[] = this.input.user;
+    let lastValidatorMsg: string | undefined;
+    const accumulatedToolCalls: LlmToolCallSummary[] = [];
+
     try {
-      const result = await streamLlm({
-        config: modelConfig,
-        modelId: modelName,
-        options: {
-          temperature: DEFAULT_TEMPERATURE,
-          maxTokens: DEFAULT_MAX_TOKENS,
-        },
-        system,
-        user,
-        abortSignal,
-        onDelta,
-        ...(output !== undefined ? { output } : {}),
-        ...toolExtras,
-      });
-      this.emitFinished(result);
-      return toAgentResult(result);
+      while (true) {
+        const remaining = maxTurns - turnsUsed;
+        if (remaining <= 0) {
+          throw rcError("RC5003", undefined, {
+            message: lastValidatorMsg
+              ? `agent: maxTurns (${maxTurns}) reached while "validate" was still rejecting; last validator message: "${lastValidatorMsg}"`
+              : `agent: maxTurns (${maxTurns}) reached.`,
+          });
+        }
+        const result = await callOnce(
+          prepared,
+          currentUser,
+          remaining,
+          abortSignal,
+          onDelta,
+        );
+        turnsUsed += result.stepsCount ?? 1;
+        if (result.toolCalls && result.toolCalls.length > 0) {
+          accumulatedToolCalls.push(...result.toolCalls);
+        }
+        if (!validate) {
+          this.emitFinished(result);
+          return toAgentResult(result, accumulatedToolCalls);
+        }
+        const verdict = await Promise.resolve(
+          validate(toAgentResult(result, accumulatedToolCalls), {
+            exchange,
+            turnsUsed,
+          }),
+        );
+        if (verdict === undefined || verdict === null) {
+          this.emitFinished(result);
+          return toAgentResult(result, accumulatedToolCalls);
+        }
+        if (typeof verdict !== "string" || verdict.trim() === "") {
+          throw rcError("RC5003", undefined, {
+            message: `agent: "validate" returned a non-string, non-void value (${typeof verdict}). Return void to accept, a non-empty string to retry.`,
+          });
+        }
+        lastValidatorMsg = verdict;
+        currentUser = buildRetryPrompt(
+          this.input.user,
+          currentUser,
+          result,
+          verdict,
+        );
+      }
     } catch (err) {
       this.emitError(err);
       throw err;
@@ -247,10 +308,11 @@ export class AgentSession {
   }
 
   /**
-   * Shared setup for both dispatch paths: build the Vercel tool map,
-   * resolve the structured-output spec, and compute the
-   * tools/stopWhen extras. Pulled out so `runUntilDone` and
-   * `runStream` differ only in which underlying SDK call they make.
+   * Shared setup invoked once per dispatch (not per validate retry):
+   * builds the Vercel tool map and resolves the structured-output
+   * spec. `stopWhen` is built per call inside the validation loop
+   * so each call gets the *remaining* turn budget rather than the
+   * full `maxTurns`.
    *
    * @internal
    */
@@ -258,18 +320,14 @@ export class AgentSession {
     modelConfig: LlmModelConfig;
     modelName: string;
     system: string;
-    user: string;
     output?: unknown;
-    toolExtras:
-      | { tools: Record<string, unknown>; stopWhen: unknown }
-      | Record<string, never>;
+    vercelTools: Record<string, unknown>;
   }> {
     const {
       options,
       modelConfig,
       modelName,
       tools,
-      user,
       system,
       context,
       dispatchIdentity,
@@ -280,20 +338,57 @@ export class AgentSession {
       abortSignal,
       dispatchIdentity,
     );
-    const toolExtras =
-      Object.keys(vercelTools).length > 0
-        ? {
-            tools: vercelTools,
-            stopWhen: await buildStopWhen(
-              options.maxTurns ?? DEFAULT_MAX_TURNS,
-            ),
-          }
-        : {};
-    const base = { modelConfig, modelName, system, user, toolExtras };
+    const base = { modelConfig, modelName, system, vercelTools };
     return options.output !== undefined
       ? { ...base, output: toAiOutputSpec(options.output) }
       : base;
   }
+}
+
+interface PreparedSession {
+  modelConfig: LlmModelConfig;
+  modelName: string;
+  system: string;
+  output?: unknown;
+  vercelTools: Record<string, unknown>;
+}
+
+/**
+ * One model call. Builds `stopWhen: stepCountIs(remainingTurns)` so a
+ * later validate-retry consumes turns from the same shared budget,
+ * then dispatches via `callLlm` (sync) or `streamLlm` (when an
+ * `onDelta` listener is attached).
+ *
+ * @internal
+ */
+async function callOnce(
+  prepared: PreparedSession,
+  user: string | unknown[],
+  remainingTurns: number,
+  abortSignal: AbortSignal,
+  onDelta: AgentDeltaListener | undefined,
+): Promise<LlmResult> {
+  const toolExtras =
+    Object.keys(prepared.vercelTools).length > 0
+      ? {
+          tools: prepared.vercelTools,
+          stopWhen: await buildStopWhen(remainingTurns),
+        }
+      : {};
+  const base = {
+    config: prepared.modelConfig,
+    modelId: prepared.modelName,
+    options: {
+      temperature: DEFAULT_TEMPERATURE,
+      maxTokens: DEFAULT_MAX_TOKENS,
+    },
+    system: prepared.system,
+    user,
+    abortSignal,
+    ...(prepared.output !== undefined ? { output: prepared.output } : {}),
+    ...toolExtras,
+  };
+  return onDelta ? streamLlm({ ...base, onDelta }) : callLlm(base);
 }
 
 async function buildStopWhen(maxTurns: number): Promise<unknown> {
@@ -301,16 +396,48 @@ async function buildStopWhen(maxTurns: number): Promise<unknown> {
   return stepCountIs(maxTurns);
 }
 
-function toAgentResult(result: LlmResult): AgentResult {
+/**
+ * Build the prompt array for a `validate`-triggered retry.
+ *
+ * Concatenates: prior user-side messages (the initial user prompt
+ * promoted to a `{ role: "user" }` message on the first retry, or
+ * the array carried over from a prior retry), the SDK's response
+ * messages from the just-finished call (assistant text + any tool
+ * messages), and a fresh user-role corrective `"Validator: <msg>"`.
+ *
+ * @internal
+ */
+function buildRetryPrompt(
+  initialUser: string,
+  currentUser: string | unknown[],
+  lastResult: LlmResult,
+  validatorMsg: string,
+): unknown[] {
+  const userMsgs: unknown[] =
+    typeof currentUser === "string"
+      ? [{ role: "user", content: initialUser }]
+      : currentUser;
+  const responseMessages = lastResult.responseMessages ?? [];
+  return [
+    ...userMsgs,
+    ...responseMessages,
+    { role: "user", content: `Validator: ${validatorMsg}` },
+  ];
+}
+
+function toAgentResult(
+  result: LlmResult,
+  accumulatedToolCalls: LlmToolCallSummary[],
+): AgentResult {
   const out: AgentResult = { text: result.text };
   if (result.output !== undefined) out.output = result.output;
   if (result.reasoning !== undefined) out.reasoning = result.reasoning;
   if (result.usage) out.usage = result.usage;
-  // Pass through the per-call summary unchanged. Shapes are
-  // structurally identical between LlmToolCallSummary and
-  // AgentToolCallSummary so no remapping is needed.
-  if (result.toolCalls && result.toolCalls.length > 0) {
-    out.toolCalls = result.toolCalls;
+  // Cumulative across all validate retries so post-dispatch assertions
+  // like "must have called X" see the agent's full tool history rather
+  // than only the last call's.
+  if (accumulatedToolCalls.length > 0) {
+    out.toolCalls = accumulatedToolCalls;
   }
   return out;
 }

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -330,6 +330,7 @@ export class AgentSession {
       tools,
       system,
       context,
+      exchange,
       dispatchIdentity,
     } = this.input;
     const vercelTools = await buildVercelTools(
@@ -337,6 +338,7 @@ export class AgentSession {
       context,
       abortSignal,
       dispatchIdentity,
+      exchange.principal,
     );
     const base = { modelConfig, modelName, system, vercelTools };
     return options.output !== undefined

--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -51,11 +51,7 @@ export async function buildVercelTools(
   for (const r of resolved) {
     const guard = r.guard;
     const handler = r.handler;
-    const baseCtx: FnHandlerContext = makeFnHandlerContext(
-      r.name,
-      ctx,
-      abortSignal,
-    );
+    const baseCtx: FnHandlerContext = makeFnHandlerContext(r.name, abortSignal);
     out[r.name] = tool({
       description: r.description,
       inputSchema: toAiInputSchema(r.input) as Parameters<
@@ -141,18 +137,21 @@ export async function buildVercelTools(
 /**
  * Construct the synthetic `FnHandlerContext` handed to a tool's guard
  * and handler during agent dispatch. Mirrors the shape `testFn`
- * provides: `logger`, `abortSignal`, optional `context`,
- * optional `correlationId` (not yet populated by the runtime), and
- * optional `checkpointId` (durable-agents epic).
+ * provides: `logger`, `abortSignal`, optional `correlationId` (not yet
+ * populated by the runtime), and optional `checkpointId` (durable-agents
+ * epic).
+ *
+ * Intentionally does not expose the framework `CraftContext` to tool
+ * handlers; built-in tool builders that need to forward to a route
+ * (e.g. `directTool`) capture the context at resolve time and thread
+ * it through their own closure.
  */
 function makeFnHandlerContext(
   toolName: string,
-  ctx: CraftContext | undefined,
   abortSignal: AbortSignal,
 ): FnHandlerContext {
   return {
     logger: frameworkLogger.child({ tool: toolName }),
     abortSignal,
-    ...(ctx ? { context: ctx } : {}),
   };
 }

--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -174,13 +174,15 @@ function makeFnHandlerContext(
  * Clones first because `exchange.principal` is mutable by design
  * (the routecraft pipeline lets a `.process()` step attach a custom
  * principal), so freezing the live object in place would break
- * downstream steps. The clone is shallow-by-field but freezes the
- * `audience` / `scopes` / `roles` arrays and the `claims` map after
- * shallow-cloning each, so a tool handler also cannot mutate any
- * nested collection. `claims` value-objects are passed by reference
- * (deep-cloning arbitrary claim payloads on every dispatch is too
- * expensive); a tool that needs to defend against deeply nested
- * claim mutation should treat its own reads as a hot copy.
+ * downstream steps.
+ *
+ * `claims` is deep-cloned via `structuredClone` so that nested
+ * claim objects (e.g. `claims.perms.write`) are not shared with the
+ * original principal: shallow-cloning the top-level keys would let
+ * a tool handler mutate a nested value and have it leak back into
+ * the dispatching exchange's principal. After cloning, the entire
+ * snapshot is recursively frozen so any runtime mutation attempt
+ * (top-level field, array entry, nested claim object) throws.
  *
  * Runs once per dispatch in `buildVercelTools` and the same frozen
  * reference is reused for every tool invocation in that dispatch.
@@ -189,17 +191,28 @@ function makeFnHandlerContext(
  */
 function freezePrincipal(principal: Principal): Principal {
   const snapshot: Principal = { ...principal };
-  if (snapshot.audience) {
-    snapshot.audience = Object.freeze([...snapshot.audience]) as string[];
+  if (snapshot.audience) snapshot.audience = [...snapshot.audience];
+  if (snapshot.scopes) snapshot.scopes = [...snapshot.scopes];
+  if (snapshot.roles) snapshot.roles = [...snapshot.roles];
+  if (snapshot.claims) snapshot.claims = structuredClone(snapshot.claims);
+  return deepFreeze(snapshot);
+}
+
+/**
+ * Recursively `Object.freeze` an object, walking arrays and plain
+ * object values. Cycles are guarded via a visited set so a
+ * self-referential principal won't blow the stack. Functions and
+ * primitive values are left as-is.
+ *
+ * @internal
+ */
+function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value as object)) return value;
+  seen.add(value as object);
+  for (const key of Object.keys(value as object)) {
+    const v = (value as Record<string, unknown>)[key];
+    if (v !== null && typeof v === "object") deepFreeze(v, seen);
   }
-  if (snapshot.scopes) {
-    snapshot.scopes = Object.freeze([...snapshot.scopes]) as string[];
-  }
-  if (snapshot.roles) {
-    snapshot.roles = Object.freeze([...snapshot.roles]) as string[];
-  }
-  if (snapshot.claims) {
-    snapshot.claims = Object.freeze({ ...snapshot.claims });
-  }
-  return Object.freeze(snapshot);
+  return Object.freeze(value);
 }

--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -162,6 +162,44 @@ function makeFnHandlerContext(
   return {
     logger: frameworkLogger.child({ tool: toolName }),
     abortSignal,
-    ...(principal ? { principal } : {}),
+    ...(principal ? { principal: freezePrincipal(principal) } : {}),
   };
+}
+
+/**
+ * Build a deep-frozen snapshot of the dispatching exchange's
+ * principal so a tool handler that bypasses the `ReadonlyPrincipal`
+ * type cannot mutate it at runtime.
+ *
+ * Clones first because `exchange.principal` is mutable by design
+ * (the routecraft pipeline lets a `.process()` step attach a custom
+ * principal), so freezing the live object in place would break
+ * downstream steps. The clone is shallow-by-field but freezes the
+ * `audience` / `scopes` / `roles` arrays and the `claims` map after
+ * shallow-cloning each, so a tool handler also cannot mutate any
+ * nested collection. `claims` value-objects are passed by reference
+ * (deep-cloning arbitrary claim payloads on every dispatch is too
+ * expensive); a tool that needs to defend against deeply nested
+ * claim mutation should treat its own reads as a hot copy.
+ *
+ * Runs once per dispatch in `buildVercelTools` and the same frozen
+ * reference is reused for every tool invocation in that dispatch.
+ *
+ * @internal
+ */
+function freezePrincipal(principal: Principal): Principal {
+  const snapshot: Principal = { ...principal };
+  if (snapshot.audience) {
+    snapshot.audience = Object.freeze([...snapshot.audience]) as string[];
+  }
+  if (snapshot.scopes) {
+    snapshot.scopes = Object.freeze([...snapshot.scopes]) as string[];
+  }
+  if (snapshot.roles) {
+    snapshot.roles = Object.freeze([...snapshot.roles]) as string[];
+  }
+  if (snapshot.claims) {
+    snapshot.claims = Object.freeze({ ...snapshot.claims });
+  }
+  return Object.freeze(snapshot);
 }

--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -3,6 +3,7 @@ import {
   logger as frameworkLogger,
   type CraftContext,
   type EventName,
+  type Principal,
 } from "@routecraft/routecraft";
 import { toAiInputSchema } from "../llm/structured-output.ts";
 import type { FnHandlerContext } from "../fn/types.ts";
@@ -38,6 +39,7 @@ export async function buildVercelTools(
   ctx: CraftContext | undefined,
   abortSignal: AbortSignal,
   dispatchIdentity?: AgentDispatchIdentity,
+  principal?: Principal,
 ): Promise<Record<string, unknown>> {
   if (resolved.length === 0)
     return Object.create(null) as Record<string, unknown>;
@@ -51,7 +53,11 @@ export async function buildVercelTools(
   for (const r of resolved) {
     const guard = r.guard;
     const handler = r.handler;
-    const baseCtx: FnHandlerContext = makeFnHandlerContext(r.name, abortSignal);
+    const baseCtx: FnHandlerContext = makeFnHandlerContext(
+      r.name,
+      abortSignal,
+      principal,
+    );
     out[r.name] = tool({
       description: r.description,
       inputSchema: toAiInputSchema(r.input) as Parameters<
@@ -137,9 +143,11 @@ export async function buildVercelTools(
 /**
  * Construct the synthetic `FnHandlerContext` handed to a tool's guard
  * and handler during agent dispatch. Mirrors the shape `testFn`
- * provides: `logger`, `abortSignal`, optional `correlationId` (not yet
- * populated by the runtime), and optional `checkpointId` (durable-agents
- * epic).
+ * provides: `logger`, `abortSignal`, optional `principal` (carried
+ * over from the dispatching exchange so guards can authorise without
+ * re-reading the source request), optional `correlationId` (not yet
+ * populated by the runtime), and optional `checkpointId`
+ * (durable-agents epic).
  *
  * Intentionally does not expose the framework `CraftContext` to tool
  * handlers; built-in tool builders that need to forward to a route
@@ -149,9 +157,11 @@ export async function buildVercelTools(
 function makeFnHandlerContext(
   toolName: string,
   abortSignal: AbortSignal,
+  principal: Principal | undefined,
 ): FnHandlerContext {
   return {
     logger: frameworkLogger.child({ tool: toolName }),
     abortSignal,
+    ...(principal ? { principal } : {}),
   };
 }

--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -204,11 +204,22 @@ function freezePrincipal(principal: Principal): Principal {
  * self-referential principal won't blow the stack. Functions and
  * primitive values are left as-is.
  *
+ * Skips `ArrayBuffer.isView` values (TypedArray, DataView, Buffer):
+ * `Object.freeze` on a typed array with elements throws because the
+ * indexed properties on the backing buffer cannot be made
+ * non-configurable. A JWT claim that smuggles binary data (CBOR, an
+ * encrypted key, raw bytes) would otherwise crash the dispatch.
+ * `structuredClone` (used in `freezePrincipal` for `claims`) already
+ * gives us an independent copy of any TypedArray, so the caller's
+ * bytes are not shared with the snapshot; tool code that wants
+ * write-protection on a binary claim should treat its read as opaque.
+ *
  * @internal
  */
 function deepFreeze<T>(value: T, seen: WeakSet<object> = new WeakSet()): T {
   if (value === null || typeof value !== "object") return value;
   if (seen.has(value as object)) return value;
+  if (ArrayBuffer.isView(value)) return value;
   seen.add(value as object);
   for (const key of Object.keys(value as object)) {
     const v = (value as Record<string, unknown>)[key];

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -154,7 +154,7 @@ export function directTool<TIn = unknown>(
       }
       const tags = overrideTags ?? route.tags;
       const handler = ((input, hctx) =>
-        dispatchDirect(hctx, routeId, input)) as FnOptions["handler"];
+        dispatchDirect(ctx, hctx, routeId, input)) as FnOptions["handler"];
       return {
         description,
         input,
@@ -221,24 +221,20 @@ function readDirectRoute(
 }
 
 async function dispatchDirect<TIn>(
+  ctx: CraftContext,
   hctx: FnHandlerContext,
   routeId: string,
   input: TIn,
 ): Promise<unknown> {
-  if (!hctx.context) {
-    throw rcError("RC5003", undefined, {
-      message: `directTool: no CraftContext available on the handler context (cannot dispatch to direct route "${routeId}").`,
-    });
-  }
   const endpoint = sanitizeEndpoint(routeId);
   const headers = hctx.correlationId
     ? { [HeadersKeys.CORRELATION_ID]: hctx.correlationId }
     : undefined;
-  const exchange = new DefaultExchange<TIn>(hctx.context, {
+  const exchange = new DefaultExchange<TIn>(ctx, {
     body: input,
     ...(headers ? { headers } : {}),
   });
-  const channel = getDirectChannel<TIn>(hctx.context, endpoint, {});
+  const channel = getDirectChannel<TIn>(ctx, endpoint, {});
   const result = (await channel.send(endpoint, exchange)) as Exchange<unknown>;
   return result.body;
 }

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -24,17 +24,24 @@ import { DEFERRED_FN_BRAND, type DeferredFn } from "./types.ts";
 /**
  * Re-hydrate a frozen `ReadonlyPrincipal` (as exposed on
  * `FnHandlerContext`) into a fresh mutable `Principal` so it can be
- * attached to a downstream `DefaultExchange`. Shallow-clones the
- * arrays and the `claims` map so the downstream pipeline is free to
- * mutate them without reaching back into the agent's frozen
- * snapshot.
+ * attached to a downstream `DefaultExchange`.
+ *
+ * Arrays are spread-cloned. `claims` is deep-cloned via
+ * `structuredClone` so that nested claim objects in the downstream
+ * exchange's principal do not share references with the agent's
+ * frozen snapshot: a `.process()` step downstream that mutates a
+ * nested claim must not be able to reach back into the snapshot
+ * (and conversely, the snapshot's frozen state would otherwise
+ * propagate into a downstream pipeline that expects a writable
+ * principal).
  */
 function cloneFrozenPrincipal(rp: ReadonlyPrincipal): Principal {
   const out: Principal = { ...rp } as Principal;
   if (rp.audience) out.audience = [...rp.audience];
   if (rp.scopes) out.scopes = [...rp.scopes];
   if (rp.roles) out.roles = [...rp.roles];
-  if (rp.claims) out.claims = { ...rp.claims };
+  if (rp.claims)
+    out.claims = structuredClone(rp.claims) as Record<string, unknown>;
   return out;
 }
 

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -9,12 +9,34 @@ import {
   type DirectRouteMetadata,
   type Exchange,
   type KnownTag,
+  type Principal,
   type Tag,
 } from "@routecraft/routecraft";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { randomUUID } from "node:crypto";
-import type { FnHandlerContext, FnOptions } from "../../fn/types.ts";
+import type {
+  FnHandlerContext,
+  FnOptions,
+  ReadonlyPrincipal,
+} from "../../fn/types.ts";
 import { DEFERRED_FN_BRAND, type DeferredFn } from "./types.ts";
+
+/**
+ * Re-hydrate a frozen `ReadonlyPrincipal` (as exposed on
+ * `FnHandlerContext`) into a fresh mutable `Principal` so it can be
+ * attached to a downstream `DefaultExchange`. Shallow-clones the
+ * arrays and the `claims` map so the downstream pipeline is free to
+ * mutate them without reaching back into the agent's frozen
+ * snapshot.
+ */
+function cloneFrozenPrincipal(rp: ReadonlyPrincipal): Principal {
+  const out: Principal = { ...rp } as Principal;
+  if (rp.audience) out.audience = [...rp.audience];
+  if (rp.scopes) out.scopes = [...rp.scopes];
+  if (rp.roles) out.roles = [...rp.roles];
+  if (rp.claims) out.claims = { ...rp.claims };
+  return out;
+}
 
 /**
  * JSON Schema describing an empty object. Closed for additional
@@ -233,12 +255,18 @@ async function dispatchDirect<TIn>(
   // Forward the calling principal so the downstream direct route sees
   // the same authenticated identity as the agent that invoked the
   // tool. The agent layer never lets a tool override or escalate this:
-  // `principal` is read-only on FnHandlerContext, populated from the
-  // dispatching exchange at tool-bridge time.
+  // `principal` is deeply-readonly on FnHandlerContext (frozen at the
+  // tool-bridge boundary). Hand the downstream exchange a fresh
+  // mutable copy so it follows the existing Exchange.principal
+  // contract (a `.process()` step downstream may legitimately attach
+  // a different principal); the tool handler's own snapshot stays
+  // frozen and unaffected.
   const exchange = new DefaultExchange<TIn>(ctx, {
     body: input,
     ...(headers ? { headers } : {}),
-    ...(hctx.principal ? { principal: hctx.principal } : {}),
+    ...(hctx.principal
+      ? { principal: cloneFrozenPrincipal(hctx.principal) }
+      : {}),
   });
   const channel = getDirectChannel<TIn>(ctx, endpoint, {});
   const result = (await channel.send(endpoint, exchange)) as Exchange<unknown>;

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -230,9 +230,15 @@ async function dispatchDirect<TIn>(
   const headers = hctx.correlationId
     ? { [HeadersKeys.CORRELATION_ID]: hctx.correlationId }
     : undefined;
+  // Forward the calling principal so the downstream direct route sees
+  // the same authenticated identity as the agent that invoked the
+  // tool. The agent layer never lets a tool override or escalate this:
+  // `principal` is read-only on FnHandlerContext, populated from the
+  // dispatching exchange at tool-bridge time.
   const exchange = new DefaultExchange<TIn>(ctx, {
     body: input,
     ...(headers ? { headers } : {}),
+    ...(hctx.principal ? { principal: hctx.principal } : {}),
   });
   const channel = getDirectChannel<TIn>(ctx, endpoint, {});
   const result = (await channel.send(endpoint, exchange)) as Exchange<unknown>;

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -166,26 +166,92 @@ export interface AgentRegisteredOptions extends AgentOptions {
 }
 
 /**
+ * Summary of one tool invocation made during an agent dispatch.
+ * Captured for post-dispatch programmatic assertions: a downstream
+ * `.process()` step can inspect `AgentResult.toolCalls` to verify
+ * the agent called what it was supposed to (e.g. "must have called
+ * `replyEmail` before finishing"), and fail or escalate when it
+ * didn't.
+ *
+ * For real-time observability use the context-bus events
+ * (`route:<id>:agent:tool:invoked` / `result` / `error`) instead;
+ * this summary is for synchronous post-hoc checks.
+ *
+ * @experimental
+ */
+export interface AgentToolCallSummary {
+  /** Stable id assigned by the SDK to correlate invoked → result. */
+  toolCallId: string;
+  /** Name of the tool the model called. */
+  toolName: string;
+  /** Validated input passed to the handler. */
+  input: unknown;
+  /** Handler return value. Undefined when the call errored. */
+  output?: unknown;
+  /** Thrown value (or `RoutecraftError`). Undefined when the call succeeded. */
+  error?: unknown;
+}
+
+/**
  * Result produced by an agent destination. Body of the exchange is replaced
  * with this shape after the agent runs.
  *
  * @experimental
  */
 export interface AgentResult {
-  /** Generated text from the model. */
+  /**
+   * Raw text the model emitted as its final response. Always
+   * populated. When an `output` schema is set, this is the JSON
+   * string the model produced (which `output` exposes as the parsed,
+   * typed value); without an output schema, this is the conversational
+   * answer.
+   */
   text: string;
   /**
-   * Parsed structured output when an `output` schema was supplied on
-   * `AgentOptions` and the model produced a value matching the schema.
-   * Undefined otherwise.
+   * Parsed structured output. Populated **only** when an `output`
+   * schema was supplied on `AgentOptions` and the model produced a
+   * value matching that schema. With an output schema set, this is
+   * the canonical typed result; `text` carries the same data as a
+   * raw JSON string. Without an output schema, this field is
+   * undefined.
    */
   output?: unknown;
   /**
-   * Raw reasoning text from the provider when supplied (Anthropic
-   * extended thinking, OpenAI o1, etc.). Useful for debugging and
-   * audit; most consumers ignore it.
+   * Concatenated reasoning text from the provider (Anthropic extended
+   * thinking, OpenAI o1, etc.) when one was emitted. Useful for
+   * debugging and audit; most consumers ignore it.
    */
   reasoning?: string;
-  /** Token usage when reported by the provider. */
+  /**
+   * Token usage when reported by the provider. Most providers fill
+   * `inputTokens` + `outputTokens`; some also fill `totalTokens`.
+   */
   usage?: LlmUsage;
+  /**
+   * Flat summary of every tool the agent called during the dispatch,
+   * in invocation order. Empty (or absent) when the agent ran without
+   * invoking any tools.
+   *
+   * Consume in a post-dispatch `.process()` step to assert on agent
+   * behaviour and fail / escalate the route when the agent didn't do
+   * what was expected:
+   *
+   * ```ts
+   * .to(agent({ tools: tools(["replyEmail"]) }))
+   * .error((err, ex, forward) => forward("escalate", ex.body))
+   * .process((ex) => {
+   *   const r = ex.body as AgentResult;
+   *   const replied = r.toolCalls?.some(
+   *     c => c.toolName === "replyEmail" && !c.error,
+   *   );
+   *   if (!replied) throw new Error("Agent did not reply via tool");
+   *   return r;
+   * })
+   * ```
+   *
+   * For real-time observability subscribe to the context-bus events
+   * `route:<id>:agent:tool:invoked` / `:result` / `:error`. This
+   * summary is the synchronous post-hoc view of the same calls.
+   */
+  toolCalls?: AgentToolCallSummary[];
 }

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -119,6 +119,19 @@ export interface AgentOptions {
   output?: StandardSchemaV1;
 
   /**
+   * Names of skills (registered via `agentPlugin({ skills })` or the
+   * `skills(path)` markdown loader) whose content is concatenated into
+   * this agent's system prompt at dispatch. The full skill content is
+   * injected verbatim (mirrors Claude's subagent skills semantic),
+   * not exposed as a tool the agent can choose to invoke.
+   *
+   * Unknown skill names throw `RC5003` at dispatch.
+   *
+   * @experimental
+   */
+  skills?: string[];
+
+  /**
    * Cap on tool-calling turns for the Vercel AI SDK loop. Each turn
    * is one model call (which may emit any number of tool calls) plus
    * the resulting tool results. Resolves to `stopWhen: stepCountIs(n)`

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -1,3 +1,4 @@
+import type { Exchange } from "@routecraft/routecraft";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { LlmModelId, LlmPromptSource, LlmUsage } from "../llm/types.ts";
 import type { AgentDeltaListener } from "./events.ts";
@@ -121,10 +122,51 @@ export interface AgentOptions {
    * Cap on tool-calling turns for the Vercel AI SDK loop. Each turn
    * is one model call (which may emit any number of tool calls) plus
    * the resulting tool results. Resolves to `stopWhen: stepCountIs(n)`
-   * at dispatch. Defaults to 8 when neither the agent nor
+   * at dispatch. Defaults to 20 when neither the agent nor
    * `defaultOptions.maxTurns` supplies a value.
+   *
+   * `validate` retries share this same budget: a corrective turn
+   * triggered by `validate` consumes one turn just like any other
+   * model step.
    */
   maxTurns?: number;
+
+  /**
+   * Pre-finish validator. Invoked after the model emits a final text
+   * response (and after any `output` schema parsing). Returning
+   * `void` accepts the result and the dispatch resolves with it.
+   * Returning a string sends the agent back for another turn with
+   * the string injected as a corrective user message
+   * (`"Validator: <msg>"`); the model sees the prior assistant
+   * messages and tool history, so it can self-correct.
+   *
+   * Throwing inside `validate` fails the dispatch with the thrown
+   * error; use this when the violation is unrecoverable.
+   *
+   * Validate retries share the `maxTurns` budget. When the budget is
+   * exhausted while `validate` is still rejecting, the dispatch
+   * fails with `RC5003` carrying the last validator message.
+   *
+   * Per-agent only; not part of `defaultOptions` because what
+   * "valid" means is intrinsic to a specific agent's job.
+   *
+   * @example
+   * ```ts
+   * agent({
+   *   model: "anthropic:claude-sonnet-4-6",
+   *   system: "...",
+   *   validate: (result) => {
+   *     if (!result.toolCalls?.some(t => t.toolName === "send_email")) {
+   *       return "You must send an email before finishing.";
+   *     }
+   *   },
+   * });
+   * ```
+   */
+  validate?: (
+    result: AgentResult,
+    ctx: { exchange: Exchange<unknown>; turnsUsed: number },
+  ) => void | string | Promise<void | string>;
 
   /**
    * Listener invoked for each token-level delta emitted while the

--- a/packages/ai/src/fn/index.ts
+++ b/packages/ai/src/fn/index.ts
@@ -3,5 +3,6 @@ export type {
   FnHandlerContext,
   FnOptions,
   FnRegistry,
+  ReadonlyPrincipal,
   RegisteredFnId,
 } from "./types.ts";

--- a/packages/ai/src/fn/types.ts
+++ b/packages/ai/src/fn/types.ts
@@ -1,5 +1,4 @@
 import type {
-  CraftContext,
   ResolveKey,
   Tag,
   logger as frameworkLogger,
@@ -10,10 +9,12 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
  * Minimal context handed to a fn handler. Additional fields may land in
  * follow-up stories without breaking this signature.
  *
- * `context` is optional because tests may exercise a fn handler in
- * isolation via `testFn` from `@routecraft/testing`, which does not
- * construct a CraftContext. Production dispatch through the agent tool
- * loop always provides one; handlers that need it should null-check.
+ * Intentionally does not expose the framework `CraftContext`. Tool
+ * handlers must not be able to read context stores (they can hold
+ * provider credentials such as LLM API keys), nor reach the dispatch
+ * channel directly. Built-in tool builders that need to forward to a
+ * route (e.g. `directTool`) capture the context at resolve time and
+ * thread it through their own closure rather than via this interface.
  *
  * @experimental
  */
@@ -22,12 +23,6 @@ export interface FnHandlerContext {
   readonly logger: ReturnType<typeof frameworkLogger.child>;
   /** Context-level abort signal. Honour in long-running work. */
   readonly abortSignal: AbortSignal;
-  /**
-   * CraftContext reference for nested work (direct route calls, events,
-   * etc.). Undefined when the fn is invoked outside a running context
-   * (e.g. via `testFn` in unit tests).
-   */
-  readonly context?: CraftContext;
   /**
    * Correlation id of the calling exchange, when the fn was invoked
    * from inside a running route or agent dispatch. Propagated to any

--- a/packages/ai/src/fn/types.ts
+++ b/packages/ai/src/fn/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Principal,
   ResolveKey,
   Tag,
   logger as frameworkLogger,
@@ -23,6 +24,17 @@ export interface FnHandlerContext {
   readonly logger: ReturnType<typeof frameworkLogger.child>;
   /** Context-level abort signal. Honour in long-running work. */
   readonly abortSignal: AbortSignal;
+  /**
+   * Authenticated principal carried over from the exchange that
+   * triggered the agent dispatch. Read-only snapshot: tool handlers
+   * cannot escalate or impersonate, but can authorise their own work
+   * against the caller's identity (e.g.
+   * `if (!ctx.principal?.scopes?.includes("write")) throw ...`).
+   *
+   * Undefined when the originating exchange had no principal (e.g.
+   * an unauthenticated source, or `testFn` outside a context).
+   */
+  readonly principal?: Principal;
   /**
    * Correlation id of the calling exchange, when the fn was invoked
    * from inside a running route or agent dispatch. Propagated to any

--- a/packages/ai/src/fn/types.ts
+++ b/packages/ai/src/fn/types.ts
@@ -7,6 +7,29 @@ import type {
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 /**
+ * Deep-readonly view of a `Principal`. Prevents tool code from
+ * mutating the caller's identity at compile time: top-level fields
+ * are `readonly` and the array members (`audience`, `scopes`,
+ * `roles`) are `readonly string[]` so `.push` / index-assignment
+ * fail to typecheck. The `claims` map is wrapped in `Readonly<...>`
+ * so its keys cannot be replaced.
+ *
+ * Runtime protection lives alongside this in tool-bridge, where the
+ * principal is `Object.freeze`'d (recursively across the arrays and
+ * the claims map) before being stored on the handler context.
+ *
+ * @experimental
+ */
+export type ReadonlyPrincipal = Readonly<
+  Omit<Principal, "audience" | "scopes" | "roles" | "claims">
+> & {
+  readonly audience?: readonly string[];
+  readonly scopes?: readonly string[];
+  readonly roles?: readonly string[];
+  readonly claims?: Readonly<Record<string, unknown>>;
+};
+
+/**
  * Minimal context handed to a fn handler. Additional fields may land in
  * follow-up stories without breaking this signature.
  *
@@ -31,10 +54,16 @@ export interface FnHandlerContext {
    * against the caller's identity (e.g.
    * `if (!ctx.principal?.scopes?.includes("write")) throw ...`).
    *
+   * Typed as {@link ReadonlyPrincipal} so the field, its arrays
+   * (`scopes`, `roles`, `audience`), and the `claims` map are all
+   * read-only at compile time. The runtime backs this with a
+   * recursive `Object.freeze` so a tool that bypasses the type
+   * system still cannot tamper.
+   *
    * Undefined when the originating exchange had no principal (e.g.
    * an unauthenticated source, or `testFn` outside a context).
    */
-  readonly principal?: Principal;
+  readonly principal?: ReadonlyPrincipal;
   /**
    * Correlation id of the calling exchange, when the fn was invoked
    * from inside a running route or agent dispatch. Propagated to any

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -43,6 +43,7 @@ export type {
   LlmPromptSource,
   LlmProviderType,
   LlmResult,
+  LlmToolCallSummary,
   LlmUsage,
 } from "./llm/index.ts";
 
@@ -136,6 +137,7 @@ export type {
   AgentPluginOptions,
   AgentRegisteredOptions,
   AgentResult,
+  AgentToolCallSummary,
   AgentUserPromptSource,
 } from "./agent/index.ts";
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -122,6 +122,7 @@ export {
   agent,
   AgentDestinationAdapter,
   agentPlugin,
+  agents,
   ADAPTER_AGENT_DEFAULT_OPTIONS,
   ADAPTER_AGENT_REGISTRY,
   SuspendError,
@@ -132,6 +133,7 @@ export type {
   AgentDefaultOptions,
   AgentByNameOverrides,
   AgentDelta,
+  AgentMarkdownOverride,
   AgentDeltaListener,
   AgentOptions,
   AgentPluginOptions,
@@ -173,6 +175,16 @@ export {
   type ToolSelection,
   type ToolsItem,
 } from "./agent/tools/index.ts";
+
+// Skills (portable instruction-set primitive) and skills() markdown loader
+export {
+  ADAPTER_SKILL_REGISTRY,
+  skills,
+  type RegisteredSkillName,
+  type Skill,
+  type SkillOverride,
+  type SkillRegistry,
+} from "./skill/index.ts";
 
 // Embedding adapter and plugin
 export {

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -152,6 +152,7 @@ export type {
   FnHandlerContext,
   FnOptions,
   FnRegistry,
+  ReadonlyPrincipal,
   RegisteredFnId,
 } from "./fn/index.ts";
 

--- a/packages/ai/src/llm/index.ts
+++ b/packages/ai/src/llm/index.ts
@@ -22,5 +22,6 @@ export type {
   LlmPromptSource,
   LlmProviderType,
   LlmResult,
+  LlmToolCallSummary,
   LlmUsage,
 } from "./types.ts";

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -5,6 +5,7 @@ import type {
   LlmModelConfig,
   LlmOptionsMerged,
   LlmResult,
+  LlmToolCallSummary,
   LlmUsage,
 } from "../types.ts";
 
@@ -399,6 +400,8 @@ async function runGenerate(
   // generateText resolves finishReason synchronously on the result.
   const finishReason = (result as { finishReason?: unknown }).finishReason;
   if (typeof finishReason === "string") out.finishReason = finishReason;
+  const toolCalls = collectToolCalls(result);
+  if (toolCalls.length > 0) out.toolCalls = toolCalls;
   return out;
 }
 
@@ -471,6 +474,66 @@ async function runStreamGenerate(
     (result as { finishReason?: PromiseLike<string | undefined> }).finishReason,
   );
   if (typeof finishReason === "string") out.finishReason = finishReason;
+  // streamText exposes `steps` as a Promise that resolves with the
+  // full step history once the loop terminates. Await + flatten into
+  // the same `LlmToolCallSummary[]` shape `runGenerate` produces, so
+  // callers see one normalised tool-call list across both paths.
+  const steps = await safeAwait<unknown>(
+    (result as { steps?: PromiseLike<unknown> }).steps,
+  );
+  const toolCalls = collectToolCalls({ steps });
+  if (toolCalls.length > 0) out.toolCalls = toolCalls;
+  return out;
+}
+
+/**
+ * Walk an SDK result's `steps` array (sync or post-await) and
+ * produce a flat list of `LlmToolCallSummary` entries pairing each
+ * tool call with its result or error. Tolerates missing fields and
+ * legacy SDK shapes.
+ *
+ * @internal
+ */
+function collectToolCalls(result: unknown): LlmToolCallSummary[] {
+  if (result === null || typeof result !== "object") return [];
+  const steps = (result as { steps?: unknown }).steps;
+  if (!Array.isArray(steps)) return [];
+  const out: LlmToolCallSummary[] = [];
+  for (const step of steps) {
+    if (step === null || typeof step !== "object") continue;
+    const calls = (step as { toolCalls?: unknown }).toolCalls;
+    const results = (step as { toolResults?: unknown }).toolResults;
+    if (!Array.isArray(calls)) continue;
+    for (const call of calls) {
+      if (call === null || typeof call !== "object") continue;
+      const c = call as Record<string, unknown>;
+      const toolCallId =
+        typeof c["toolCallId"] === "string" ? c["toolCallId"] : "";
+      const toolName = typeof c["toolName"] === "string" ? c["toolName"] : "";
+      const input = c["input"] ?? c["args"];
+      const summary: LlmToolCallSummary = {
+        toolCallId,
+        toolName,
+        input,
+      };
+      // Pair the matching result by toolCallId (preferred) or by
+      // identical position in the same step (legacy fallback).
+      if (Array.isArray(results)) {
+        const match = (results as Record<string, unknown>[]).find(
+          (r) => r["toolCallId"] === toolCallId,
+        );
+        if (match) {
+          if ("output" in match || "result" in match) {
+            summary.output = match["output"] ?? match["result"];
+          }
+          if ("error" in match && match["error"] !== undefined) {
+            summary.error = match["error"];
+          }
+        }
+      }
+      out.push(summary);
+    }
+  }
   return out;
 }
 

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -104,7 +104,17 @@ export interface CallLlmParams {
     | "presencePenalty"
   >;
   system: string;
-  user: string;
+  /**
+   * User-side conversation. When a string, it is sent as a single
+   * user prompt. When an array, it is forwarded directly to the SDK
+   * as the `prompt` argument (Vercel AI SDK accepts
+   * `string | Array<ModelMessage>` for `prompt`). The agent session
+   * uses the array form to feed back the prior assistant + tool
+   * messages plus a validator-corrective user message on a `validate`
+   * retry, so the model sees the full history rather than a fresh
+   * conversation.
+   */
+  user: string | unknown[];
   /** Optional structured output spec (from toAiOutputSpec). Enables provider-level JSON schema. */
   output?: unknown;
   /**
@@ -350,7 +360,7 @@ function buildSdkParams(
   model: unknown,
   options: CallLlmParams["options"],
   system: string,
-  user: string,
+  user: string | unknown[],
   extras: ProviderExtras,
 ): Record<string, unknown> {
   const params: Record<string, unknown> = {
@@ -383,7 +393,7 @@ async function runGenerate(
   model: unknown,
   options: CallLlmParams["options"],
   system: string,
-  user: string,
+  user: string | unknown[],
   extras: ProviderExtras,
 ): Promise<LlmResult> {
   const { generateText } = await import("ai");
@@ -402,6 +412,11 @@ async function runGenerate(
   if (typeof finishReason === "string") out.finishReason = finishReason;
   const toolCalls = collectToolCalls(result);
   if (toolCalls.length > 0) out.toolCalls = toolCalls;
+  const steps = (result as { steps?: unknown }).steps;
+  if (Array.isArray(steps)) out.stepsCount = steps.length;
+  const responseMessages = (result as { response?: { messages?: unknown } })
+    .response?.messages;
+  if (Array.isArray(responseMessages)) out.responseMessages = responseMessages;
   return out;
 }
 
@@ -423,7 +438,7 @@ async function runStreamGenerate(
   model: unknown,
   options: CallLlmParams["options"],
   system: string,
-  user: string,
+  user: string | unknown[],
   extras: ProviderExtras,
   onDelta: AgentDeltaListener,
 ): Promise<LlmResult> {
@@ -483,6 +498,17 @@ async function runStreamGenerate(
   );
   const toolCalls = collectToolCalls({ steps });
   if (toolCalls.length > 0) out.toolCalls = toolCalls;
+  if (Array.isArray(steps)) out.stepsCount = steps.length;
+  // streamText exposes the consolidated response (messages, body, ...)
+  // as a Promise that resolves once the stream drains. Await it so the
+  // session can append response.messages to a validate-retry prompt
+  // without re-walking the stream.
+  const response = await safeAwait<{ messages?: unknown }>(
+    (result as { response?: PromiseLike<{ messages?: unknown }> }).response,
+  );
+  if (response && Array.isArray(response.messages)) {
+    out.responseMessages = response.messages;
+  }
   return out;
 }
 

--- a/packages/ai/src/llm/types.ts
+++ b/packages/ai/src/llm/types.ts
@@ -170,8 +170,32 @@ export interface LlmResult {
    * see a normalised string value.
    */
   finishReason?: string;
+  /**
+   * Flat list of tool calls made during the loop, in invocation
+   * order. Each entry pairs the model's call args with the handler's
+   * return (or thrown error). Populated by both sync and streaming
+   * paths; the agent layer surfaces these on `AgentResult.toolCalls`
+   * for post-dispatch assertions.
+   */
+  toolCalls?: LlmToolCallSummary[];
   /** Full generateText() result for advanced use (debugging, response metadata). */
   raw?: unknown;
+}
+
+/**
+ * One tool invocation captured during an LLM dispatch. Mirrors the
+ * shape of `AgentToolCallSummary` so the agent layer can re-export
+ * it without re-mapping. Keep `unknown` types loose here; the agent
+ * layer is the place to re-narrow if needed.
+ *
+ * @experimental
+ */
+export interface LlmToolCallSummary {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  output?: unknown;
+  error?: unknown;
 }
 
 /**

--- a/packages/ai/src/llm/types.ts
+++ b/packages/ai/src/llm/types.ts
@@ -178,6 +178,23 @@ export interface LlmResult {
    * for post-dispatch assertions.
    */
   toolCalls?: LlmToolCallSummary[];
+  /**
+   * Number of model steps the SDK consumed in this call. Mirrors
+   * `result.steps.length` and is populated by both the sync and
+   * streaming paths. The agent session uses this to track the shared
+   * turn budget across `validate` retries: every retry's step count
+   * is added to the running total and compared against `maxTurns`.
+   */
+  stepsCount?: number;
+  /**
+   * Conversation messages emitted during this call (assistant + tool
+   * messages, in order; mirrors the SDK's `result.response.messages`).
+   * The agent session uses this to assemble the messages array for a
+   * `validate`-triggered retry: original user prompt + these response
+   * messages + the corrective user message become the next call's
+   * `prompt`.
+   */
+  responseMessages?: unknown[];
   /** Full generateText() result for advanced use (debugging, response metadata). */
   raw?: unknown;
 }

--- a/packages/ai/src/skill/index.ts
+++ b/packages/ai/src/skill/index.ts
@@ -1,0 +1,7 @@
+export { skills, type SkillOverride } from "./loader.ts";
+export {
+  ADAPTER_SKILL_REGISTRY,
+  type Skill,
+  type SkillRegistry,
+  type RegisteredSkillName,
+} from "./types.ts";

--- a/packages/ai/src/skill/loader.ts
+++ b/packages/ai/src/skill/loader.ts
@@ -1,0 +1,120 @@
+import { rcError } from "@routecraft/routecraft";
+import {
+  readMarkdownDir,
+  readMarkdownFile,
+  requireString,
+} from "./markdown.ts";
+import type { Skill } from "./types.ts";
+
+/**
+ * Reject unknown frontmatter fields up front so a misspelt key never
+ * silently disappears. The frontmatter shape mirrors a deliberately
+ * narrow subset of Claude's subagent skills schema (`name`,
+ * `description`); future fields will land incrementally.
+ */
+const SUPPORTED_SKILL_KEYS = new Set(["name", "description"]);
+
+/**
+ * Per-skill override applied on top of the markdown frontmatter.
+ *
+ * @experimental
+ */
+export interface SkillOverride {
+  description?: string;
+  content?: string;
+}
+
+/**
+ * Convert a parsed markdown file into a `Skill`. Validates that
+ * frontmatter `name` matches the filename so the registry id is
+ * unambiguous, and that body is non-empty so the agent never injects
+ * a hollow skill into its system prompt.
+ *
+ * @internal
+ */
+function toSkill(
+  filename: string,
+  frontmatter: Record<string, unknown>,
+  body: string,
+  source: string,
+): Skill {
+  for (const key of Object.keys(frontmatter)) {
+    if (!SUPPORTED_SKILL_KEYS.has(key)) {
+      throw rcError("RC5003", undefined, {
+        message: `Markdown file "${source}": unsupported frontmatter field "${key}". Skills currently support only "name" and "description"; further fields land in follow-up stories.`,
+      });
+    }
+  }
+  const name = requireString(frontmatter["name"], "name", source);
+  if (name !== filename) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter "name" ("${name}") must match the filename ("${filename}"). Rename one or the other.`,
+    });
+  }
+  const description = requireString(
+    frontmatter["description"],
+    "description",
+    source,
+  );
+  if (body.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": skill body is empty. The body becomes the injected skill content; an empty body would not change the agent's behaviour.`,
+    });
+  }
+  return { name, description, content: body };
+}
+
+/**
+ * Load skills from a markdown file or directory.
+ *
+ * - If `path` points to a directory, every `.md` file directly under it
+ *   becomes one skill. The filename (without `.md`) is the skill name
+ *   and must match the frontmatter `name`.
+ * - If `path` points to a single `.md` file, the file becomes one
+ *   skill keyed by its filename.
+ *
+ * Frontmatter currently supports only `name` (required) and
+ * `description` (required). Body of the file becomes
+ * `Skill.content` and is concatenated into the system prompt of any
+ * agent that lists the skill name in its `skills` array.
+ *
+ * Pass `overrides` keyed by skill name to replace `description` or
+ * `content` per skill without editing the markdown source.
+ *
+ * Returns a `Record<name, Skill>` ready to spread into
+ * `agentPlugin({ skills: skills("./skills") })`.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * agentPlugin({
+ *   skills: skills("./skills"),
+ *   agents: agents("./agents"),
+ * });
+ * ```
+ */
+export function skills(
+  path: string,
+  overrides: Record<string, SkillOverride> = {},
+): Record<string, Skill> {
+  const out: Record<string, Skill> = {};
+  const docs = path.endsWith(".md")
+    ? [readMarkdownFile(path)]
+    : readMarkdownDir(path);
+  for (const doc of docs) {
+    const skill = toSkill(doc.filename, doc.frontmatter, doc.body, doc.path);
+    const override = overrides[skill.name];
+    out[skill.name] = override ? { ...skill, ...override } : skill;
+  }
+  // Surface override entries that didn't match any loaded skill so a
+  // typo in the override key doesn't silently no-op.
+  for (const name of Object.keys(overrides)) {
+    if (!(name in out)) {
+      throw rcError("RC5003", undefined, {
+        message: `skills("${path}"): override for "${name}" but no skill with that name was loaded from disk.`,
+      });
+    }
+  }
+  return out;
+}

--- a/packages/ai/src/skill/loader.ts
+++ b/packages/ai/src/skill/loader.ts
@@ -94,14 +94,14 @@ function toSkill(
  * });
  * ```
  */
-export function skills(
+export async function skills(
   path: string,
   overrides: Record<string, SkillOverride> = {},
-): Record<string, Skill> {
+): Promise<Record<string, Skill>> {
   const out: Record<string, Skill> = {};
   const docs = path.endsWith(".md")
-    ? [readMarkdownFile(path)]
-    : readMarkdownDir(path);
+    ? [await readMarkdownFile(path)]
+    : await readMarkdownDir(path);
   for (const doc of docs) {
     const skill = toSkill(doc.filename, doc.frontmatter, doc.body, doc.path);
     const override = overrides[skill.name];

--- a/packages/ai/src/skill/markdown.ts
+++ b/packages/ai/src/skill/markdown.ts
@@ -1,7 +1,6 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, basename, extname } from "node:path";
 import { rcError } from "@routecraft/routecraft";
-import { parse as parseYaml } from "yaml";
 
 /**
  * Parsed markdown document: front matter as a plain object plus the
@@ -21,6 +20,40 @@ export interface ParsedMarkdown {
 }
 
 /**
+ * YAML parser shape we depend on. Lazy-loaded the first time a
+ * markdown loader runs so the `yaml` package can be an optional peer
+ * dependency: callers that never invoke `agents()` / `skills()` do
+ * not need to install it, and it stays out of `@routecraft/ai`'s
+ * static import graph (size-limit is enforced on the entry bundle).
+ *
+ * @internal
+ */
+type YamlParse = (text: string) => unknown;
+let cachedParseYaml: YamlParse | undefined;
+
+async function loadYamlParse(): Promise<YamlParse> {
+  if (cachedParseYaml) return cachedParseYaml;
+  try {
+    const mod = (await import("yaml")) as { parse: YamlParse };
+    cachedParseYaml = mod.parse;
+    return cachedParseYaml;
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.message.includes("ERR_MODULE_NOT_FOUND") ||
+        err.message.includes("Cannot find module") ||
+        err.message.includes("Cannot find package")) &&
+      err.message.includes("yaml")
+    ) {
+      throw new Error(
+        `The markdown loaders (agents()/skills()) require the "yaml" package. Install it with: pnpm add yaml`,
+      );
+    }
+    throw err;
+  }
+}
+
+/**
  * Strip a `--- ... ---` YAML front-matter block from the start of the
  * file and return the parsed object plus the body. Files without a
  * leading `---` are treated as having no front matter (frontmatter is
@@ -28,7 +61,10 @@ export interface ParsedMarkdown {
  *
  * @internal
  */
-function splitFrontmatter(raw: string, path: string): ParsedMarkdown {
+async function splitFrontmatter(
+  raw: string,
+  path: string,
+): Promise<ParsedMarkdown> {
   const filename = basename(path, extname(path));
   if (!raw.startsWith("---")) {
     return {
@@ -48,7 +84,12 @@ function splitFrontmatter(raw: string, path: string): ParsedMarkdown {
   const body = raw.slice(end + 4).trim();
   let parsed: unknown;
   try {
-    parsed = yamlText ? parseYaml(yamlText) : {};
+    if (yamlText) {
+      const parseYaml = await loadYamlParse();
+      parsed = parseYaml(yamlText);
+    } else {
+      parsed = {};
+    }
   } catch (err) {
     throw rcError("RC5003", undefined, {
       message: `Markdown file "${path}": YAML front matter failed to parse. ${(err as Error).message}`,
@@ -74,7 +115,7 @@ function splitFrontmatter(raw: string, path: string): ParsedMarkdown {
  *
  * @internal
  */
-export function readMarkdownFile(path: string): ParsedMarkdown {
+export async function readMarkdownFile(path: string): Promise<ParsedMarkdown> {
   const abs = resolve(process.cwd(), path);
   let raw: string;
   try {
@@ -95,7 +136,7 @@ export function readMarkdownFile(path: string): ParsedMarkdown {
  *
  * @internal
  */
-export function readMarkdownDir(dir: string): ParsedMarkdown[] {
+export async function readMarkdownDir(dir: string): Promise<ParsedMarkdown[]> {
   const abs = resolve(process.cwd(), dir);
   let stats;
   try {
@@ -115,7 +156,7 @@ export function readMarkdownDir(dir: string): ParsedMarkdown[] {
     if (!entry.isFile()) continue;
     if (extname(entry.name).toLowerCase() !== ".md") continue;
     out.push(
-      splitFrontmatter(
+      await splitFrontmatter(
         readFileSync(join(abs, entry.name), "utf-8"),
         join(abs, entry.name),
       ),

--- a/packages/ai/src/skill/markdown.ts
+++ b/packages/ai/src/skill/markdown.ts
@@ -1,0 +1,199 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve, basename, extname } from "node:path";
+import { rcError } from "@routecraft/routecraft";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * Parsed markdown document: front matter as a plain object plus the
+ * remaining body. Returned by {@link readMarkdownFile}.
+ *
+ * @internal
+ */
+export interface ParsedMarkdown {
+  /** Path the document was read from. */
+  path: string;
+  /** Filename without extension. Matches the agent / skill `name` after validation. */
+  filename: string;
+  /** Parsed YAML front matter. Empty object when no front matter is present. */
+  frontmatter: Record<string, unknown>;
+  /** Trimmed body (everything after the front-matter block). */
+  body: string;
+}
+
+/**
+ * Strip a `--- ... ---` YAML front-matter block from the start of the
+ * file and return the parsed object plus the body. Files without a
+ * leading `---` are treated as having no front matter (frontmatter is
+ * `{}` and body is the full content).
+ *
+ * @internal
+ */
+function splitFrontmatter(raw: string, path: string): ParsedMarkdown {
+  const filename = basename(path, extname(path));
+  if (!raw.startsWith("---")) {
+    return {
+      path,
+      filename,
+      frontmatter: {},
+      body: raw.trim(),
+    };
+  }
+  const end = raw.indexOf("\n---", 3);
+  if (end === -1) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${path}": opened a YAML front-matter block with "---" but never closed it. Add a closing "---" line before the body.`,
+    });
+  }
+  const yamlText = raw.slice(3, end).trim();
+  const body = raw.slice(end + 4).trim();
+  let parsed: unknown;
+  try {
+    parsed = yamlText ? parseYaml(yamlText) : {};
+  } catch (err) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${path}": YAML front matter failed to parse. ${(err as Error).message}`,
+    });
+  }
+  if (parsed !== null && typeof parsed !== "object") {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${path}": YAML front matter must parse to an object (got ${typeof parsed}).`,
+    });
+  }
+  return {
+    path,
+    filename,
+    frontmatter: (parsed as Record<string, unknown> | null) ?? {},
+    body,
+  };
+}
+
+/**
+ * Read a single markdown file from disk and split into front matter +
+ * body. Resolves the path against `process.cwd()` so callers can pass
+ * relative locations (`"./agents/researcher.md"`).
+ *
+ * @internal
+ */
+export function readMarkdownFile(path: string): ParsedMarkdown {
+  const abs = resolve(process.cwd(), path);
+  let raw: string;
+  try {
+    raw = readFileSync(abs, "utf-8");
+  } catch (err) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${path}" could not be read: ${(err as Error).message}`,
+    });
+  }
+  return splitFrontmatter(raw, abs);
+}
+
+/**
+ * Read every `.md` file directly under `dir` and return one
+ * `ParsedMarkdown` entry per file. Subdirectories are not recursed
+ * (Claude's subagent layout is flat; supporting nesting would
+ * complicate id derivation).
+ *
+ * @internal
+ */
+export function readMarkdownDir(dir: string): ParsedMarkdown[] {
+  const abs = resolve(process.cwd(), dir);
+  let stats;
+  try {
+    stats = statSync(abs);
+  } catch (err) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown directory "${dir}" could not be opened: ${(err as Error).message}`,
+    });
+  }
+  if (!stats.isDirectory()) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown directory "${dir}" is not a directory. Pass a path to a directory containing .md files.`,
+    });
+  }
+  const out: ParsedMarkdown[] = [];
+  for (const entry of readdirSync(abs, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    if (extname(entry.name).toLowerCase() !== ".md") continue;
+    out.push(
+      splitFrontmatter(
+        readFileSync(join(abs, entry.name), "utf-8"),
+        join(abs, entry.name),
+      ),
+    );
+  }
+  // Sort so file order is deterministic regardless of filesystem
+  // listing order. Useful for stable tests and reproducible builds.
+  out.sort((a, b) => a.filename.localeCompare(b.filename));
+  return out;
+}
+
+/**
+ * Validate that `value` is a non-empty string and return it; otherwise
+ * throw RC5003 quoting the field name and source path.
+ *
+ * @internal
+ */
+export function requireString(
+  value: unknown,
+  field: string,
+  source: string,
+): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter field "${field}" must be a non-empty string.`,
+    });
+  }
+  return value;
+}
+
+/**
+ * Validate that `value` is an array of non-empty strings (or
+ * undefined) and return it; otherwise throw RC5003.
+ *
+ * @internal
+ */
+export function optionalStringArray(
+  value: unknown,
+  field: string,
+  source: string,
+): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter field "${field}" must be an array of strings.`,
+    });
+  }
+  for (const v of value) {
+    if (typeof v !== "string" || v.trim() === "") {
+      throw rcError("RC5003", undefined, {
+        message: `Markdown file "${source}": frontmatter field "${field}" must contain only non-empty strings.`,
+      });
+    }
+  }
+  return value as string[];
+}
+
+/**
+ * Validate that `value` is a finite positive integer (or undefined)
+ * and return it; otherwise throw RC5003.
+ *
+ * @internal
+ */
+export function optionalPositiveInt(
+  value: unknown,
+  field: string,
+  source: string,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 1
+  ) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter field "${field}" must be a positive integer.`,
+    });
+  }
+  return value;
+}

--- a/packages/ai/src/skill/types.ts
+++ b/packages/ai/src/skill/types.ts
@@ -1,0 +1,75 @@
+import type { ResolveKey } from "@routecraft/routecraft";
+
+/**
+ * Store key for the registry of skills installed by
+ * `agentPlugin({ skills })`. Resolved at agent dispatch time so an
+ * agent that lists `skills: ["X"]` gets the corresponding skill
+ * content concatenated into its system prompt.
+ *
+ * @experimental
+ */
+export const ADAPTER_SKILL_REGISTRY = Symbol.for(
+  "routecraft.adapter.skill.registry",
+);
+
+/**
+ * A reusable, portable instruction set that an agent loads into its
+ * system prompt at dispatch time. The full content is injected
+ * verbatim, not exposed as a tool the agent can choose to invoke; this
+ * matches the Claude subagent skills semantic ("inject the skill
+ * content, do not make it tool-callable").
+ *
+ * Skills are framework-portable: any provider can consume one because
+ * a skill is just text. Provider-specific hosted skills (e.g. the
+ * Anthropic hosted-skills feature surfaced through `@ai-sdk/anthropic`)
+ * are out of scope for this primitive and will land separately.
+ *
+ * @experimental
+ */
+export interface Skill {
+  /** Unique skill name. Matches the registry key and the filename when loaded via `skills(path)`. */
+  name: string;
+  /** Human-readable description. Surfaces in observability and in error messages when a skill lookup fails. */
+  description: string;
+  /** Full skill content. Concatenated into the system prompt of every agent that references the skill by name. */
+  content: string;
+}
+
+declare module "@routecraft/routecraft" {
+  interface StoreRegistry {
+    [ADAPTER_SKILL_REGISTRY]: Map<string, Skill>;
+  }
+}
+
+/**
+ * Registry for configured skills.
+ *
+ * Keys are skill names (matching the record keys in
+ * `agentPlugin({ skills })`). Populate via declaration merging to
+ * narrow `AgentOptions.skills` and `AgentRegisteredOptions.skills`
+ * entries to the set of registered skill names.
+ *
+ * @experimental
+ *
+ * @example
+ * ```typescript
+ * declare module "@routecraft/ai" {
+ *   interface SkillRegistry {
+ *     "web-search": true;
+ *     "cite-sources": true;
+ *   }
+ * }
+ * ```
+ */
+// biome-ignore lint/suspicious/noEmptyInterface: marker interface populated via declaration merging
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Marker interface, populated via declaration merging
+export interface SkillRegistry {}
+
+/**
+ * Resolved skill name type. When `SkillRegistry` is populated,
+ * constrains to the union of declared names. Falls back to `string`
+ * when the registry is empty.
+ *
+ * @experimental
+ */
+export type RegisteredSkillName = ResolveKey<SkillRegistry>;

--- a/packages/ai/test/agent-loader.test.ts
+++ b/packages/ai/test/agent-loader.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { agents, isToolSelection, tools } from "../src/index.ts";
+
+function tmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "rc-agents-"));
+}
+
+describe("agents() markdown loader", () => {
+  let dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs = [];
+  });
+
+  function makeDir(files: Record<string, string>): string {
+    const dir = tmpDir();
+    dirs.push(dir);
+    for (const [name, content] of Object.entries(files)) {
+      writeFileSync(join(dir, name), content, "utf-8");
+    }
+    return dir;
+  }
+
+  /**
+   * @case Loads a directory of agent markdown files into a Record keyed by name
+   * @preconditions Two agents with description, model, and body
+   * @expectedResult Both agents loaded; body becomes system; provider:model passed through
+   */
+  test("loads agents with name/description/model/system", () => {
+    const dir = makeDir({
+      "researcher.md":
+        "---\nname: researcher\ndescription: Researches things\nmodel: anthropic:claude-sonnet-4-6\n---\nYou are a researcher.",
+      "writer.md":
+        "---\nname: writer\ndescription: Writes prose\nmodel: openai:gpt-5\n---\nYou are a writer.",
+    });
+    const result = agents(dir);
+    expect(Object.keys(result).sort()).toEqual(["researcher", "writer"]);
+    expect(result["researcher"]).toMatchObject({
+      description: "Researches things",
+      model: "anthropic:claude-sonnet-4-6",
+      system: "You are a researcher.",
+    });
+  });
+
+  /**
+   * @case maxTurns and skills frontmatter pass through
+   * @preconditions Agent with maxTurns: 30 and skills: [a, b]
+   * @expectedResult AgentRegisteredOptions has both fields
+   */
+  test("maxTurns and skills frontmatter pass through", () => {
+    const dir = makeDir({
+      "x.md":
+        "---\nname: x\ndescription: d\nmaxTurns: 30\nskills:\n  - one\n  - two\n---\nsystem prompt",
+    });
+    const result = agents(dir);
+    expect(result["x"]?.maxTurns).toBe(30);
+    expect(result["x"]?.skills).toEqual(["one", "two"]);
+  });
+
+  /**
+   * @case tools string array becomes a tools([...]) selection
+   * @preconditions Agent with tools: [fetchOrder, "tagged:read-only"]
+   * @expectedResult agent.tools is a ToolSelection (brand check via isToolSelection)
+   */
+  test("tools frontmatter becomes a tools([...]) selection", () => {
+    const dir = makeDir({
+      "x.md":
+        '---\nname: x\ndescription: d\ntools:\n  - fetchOrder\n  - "tagged:read-only"\n---\nsystem',
+    });
+    const result = agents(dir);
+    expect(isToolSelection(result["x"]?.tools)).toBe(true);
+  });
+
+  /**
+   * @case Unsupported Claude frontmatter field throws not-yet-supported
+   * @preconditions Agent with permissionMode set
+   * @expectedResult Throws RC5003 mentioning the field and the supported list
+   */
+  test("rejects unsupported Claude subagent frontmatter fields", () => {
+    const dir = makeDir({
+      "x.md":
+        "---\nname: x\ndescription: d\npermissionMode: default\n---\nsystem",
+    });
+    expect(() => agents(dir)).toThrow(
+      /frontmatter field "permissionMode" is not yet supported/,
+    );
+  });
+
+  /**
+   * @case Bare model alias rejected with a clear hint
+   * @preconditions model: sonnet (no provider:)
+   * @expectedResult Throws RC5003 telling the user to use full provider:model form
+   */
+  test("rejects bare model aliases like 'sonnet'", () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\nmodel: sonnet\n---\nsystem",
+    });
+    expect(() => agents(dir)).toThrow(/full "provider:model" form/);
+  });
+
+  /**
+   * @case Per-agent override replaces fields from frontmatter
+   * @preconditions Override sets maxTurns and replaces tools
+   * @expectedResult Loaded agent reflects overrides; non-overridden fields preserved
+   */
+  test("applies per-agent overrides", () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: from-md\nmaxTurns: 5\n---\nsystem",
+    });
+    const result = agents(dir, {
+      x: { maxTurns: 30, tools: tools(["foo"]) },
+    });
+    expect(result["x"]?.maxTurns).toBe(30);
+    expect(isToolSelection(result["x"]?.tools)).toBe(true);
+    expect(result["x"]?.description).toBe("from-md");
+  });
+
+  /**
+   * @case Override referencing an unknown agent name fails loudly
+   * @preconditions Override key for an agent that wasn't loaded
+   * @expectedResult Throws RC5003 with the offending key
+   */
+  test("override for an unknown agent throws", () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\n---\nsystem",
+    });
+    expect(() => agents(dir, { y: { maxTurns: 1 } })).toThrow(
+      /override for "y" but no agent with that name/,
+    );
+  });
+});

--- a/packages/ai/test/agent-loader.test.ts
+++ b/packages/ai/test/agent-loader.test.ts
@@ -29,14 +29,14 @@ describe("agents() markdown loader", () => {
    * @preconditions Two agents with description, model, and body
    * @expectedResult Both agents loaded; body becomes system; provider:model passed through
    */
-  test("loads agents with name/description/model/system", () => {
+  test("loads agents with name/description/model/system", async () => {
     const dir = makeDir({
       "researcher.md":
         "---\nname: researcher\ndescription: Researches things\nmodel: anthropic:claude-sonnet-4-6\n---\nYou are a researcher.",
       "writer.md":
         "---\nname: writer\ndescription: Writes prose\nmodel: openai:gpt-5\n---\nYou are a writer.",
     });
-    const result = agents(dir);
+    const result = await agents(dir);
     expect(Object.keys(result).sort()).toEqual(["researcher", "writer"]);
     expect(result["researcher"]).toMatchObject({
       description: "Researches things",
@@ -50,12 +50,12 @@ describe("agents() markdown loader", () => {
    * @preconditions Agent with maxTurns: 30 and skills: [a, b]
    * @expectedResult AgentRegisteredOptions has both fields
    */
-  test("maxTurns and skills frontmatter pass through", () => {
+  test("maxTurns and skills frontmatter pass through", async () => {
     const dir = makeDir({
       "x.md":
         "---\nname: x\ndescription: d\nmaxTurns: 30\nskills:\n  - one\n  - two\n---\nsystem prompt",
     });
-    const result = agents(dir);
+    const result = await agents(dir);
     expect(result["x"]?.maxTurns).toBe(30);
     expect(result["x"]?.skills).toEqual(["one", "two"]);
   });
@@ -65,12 +65,12 @@ describe("agents() markdown loader", () => {
    * @preconditions Agent with tools: [fetchOrder, "tagged:read-only"]
    * @expectedResult agent.tools is a ToolSelection (brand check via isToolSelection)
    */
-  test("tools frontmatter becomes a tools([...]) selection", () => {
+  test("tools frontmatter becomes a tools([...]) selection", async () => {
     const dir = makeDir({
       "x.md":
         '---\nname: x\ndescription: d\ntools:\n  - fetchOrder\n  - "tagged:read-only"\n---\nsystem',
     });
-    const result = agents(dir);
+    const result = await agents(dir);
     expect(isToolSelection(result["x"]?.tools)).toBe(true);
   });
 
@@ -79,12 +79,12 @@ describe("agents() markdown loader", () => {
    * @preconditions Agent with permissionMode set
    * @expectedResult Throws RC5003 mentioning the field and the supported list
    */
-  test("rejects unsupported Claude subagent frontmatter fields", () => {
+  test("rejects unsupported Claude subagent frontmatter fields", async () => {
     const dir = makeDir({
       "x.md":
         "---\nname: x\ndescription: d\npermissionMode: default\n---\nsystem",
     });
-    expect(() => agents(dir)).toThrow(
+    await expect(agents(dir)).rejects.toThrow(
       /frontmatter field "permissionMode" is not yet supported/,
     );
   });
@@ -94,11 +94,11 @@ describe("agents() markdown loader", () => {
    * @preconditions model: sonnet (no provider:)
    * @expectedResult Throws RC5003 telling the user to use full provider:model form
    */
-  test("rejects bare model aliases like 'sonnet'", () => {
+  test("rejects bare model aliases like 'sonnet'", async () => {
     const dir = makeDir({
       "x.md": "---\nname: x\ndescription: d\nmodel: sonnet\n---\nsystem",
     });
-    expect(() => agents(dir)).toThrow(/full "provider:model" form/);
+    await expect(agents(dir)).rejects.toThrow(/full "provider:model" form/);
   });
 
   /**
@@ -106,11 +106,11 @@ describe("agents() markdown loader", () => {
    * @preconditions Override sets maxTurns and replaces tools
    * @expectedResult Loaded agent reflects overrides; non-overridden fields preserved
    */
-  test("applies per-agent overrides", () => {
+  test("applies per-agent overrides", async () => {
     const dir = makeDir({
       "x.md": "---\nname: x\ndescription: from-md\nmaxTurns: 5\n---\nsystem",
     });
-    const result = agents(dir, {
+    const result = await agents(dir, {
       x: { maxTurns: 30, tools: tools(["foo"]) },
     });
     expect(result["x"]?.maxTurns).toBe(30);
@@ -123,11 +123,11 @@ describe("agents() markdown loader", () => {
    * @preconditions Override key for an agent that wasn't loaded
    * @expectedResult Throws RC5003 with the offending key
    */
-  test("override for an unknown agent throws", () => {
+  test("override for an unknown agent throws", async () => {
     const dir = makeDir({
       "x.md": "---\nname: x\ndescription: d\n---\nsystem",
     });
-    expect(() => agents(dir, { y: { maxTurns: 1 } })).toThrow(
+    await expect(agents(dir, { y: { maxTurns: 1 } })).rejects.toThrow(
       /override for "y" but no agent with that name/,
     );
   });

--- a/packages/ai/test/agent-skills-dispatch.test.ts
+++ b/packages/ai/test/agent-skills-dispatch.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, afterEach, vi, beforeEach } from "vitest";
+import { craft, simple } from "@routecraft/routecraft";
+import { spy, testContext, type TestContext } from "@routecraft/testing";
+import { agent, agentPlugin, llmPlugin } from "../src/index.ts";
+import type { LlmResult } from "../src/llm/types.ts";
+
+// Capture the system prompt the LLM provider received so the test can
+// assert that referenced skill content was concatenated into it.
+let capturedSystem: string | undefined;
+
+vi.mock("../src/llm/providers/index.ts", () => ({
+  callLlm: vi.fn(async (params: { system: string }): Promise<LlmResult> => {
+    capturedSystem = params.system;
+    return { text: "ok", finishReason: "stop", stepsCount: 1 };
+  }),
+  streamLlm: vi.fn(async (): Promise<LlmResult> => {
+    throw new Error("unused in this test");
+  }),
+}));
+
+describe("agent skills: system-prompt concatenation at dispatch", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    capturedSystem = undefined;
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Agent with skills: [a, b] sees the skill content concatenated into its system prompt
+   * @preconditions Two skills registered; agent declares both
+   * @expectedResult Captured system prompt starts with the agent's own and ends with both skill blocks in order
+   */
+  test("skills are concatenated into the dispatched system prompt", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({
+            skills: {
+              "web-search": {
+                name: "web-search",
+                description: "Search the web",
+                content: "Always search before answering.",
+              },
+              "cite-sources": {
+                name: "cite-sources",
+                description: "Cite",
+                content: "Always cite your sources.",
+              },
+            },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("with-skills")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "You are an analyst.",
+              model: "anthropic:claude-opus-4-7",
+              skills: ["web-search", "cite-sources"],
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+    await t.test();
+    expect(capturedSystem).toBeDefined();
+    expect(capturedSystem!.startsWith("You are an analyst.")).toBe(true);
+    expect(capturedSystem).toContain("## Skill: web-search");
+    expect(capturedSystem).toContain("Always search before answering.");
+    expect(capturedSystem).toContain("## Skill: cite-sources");
+    expect(capturedSystem).toContain("Always cite your sources.");
+    // Order matters: web-search before cite-sources because the agent listed them in that order.
+    const wsIdx = capturedSystem!.indexOf("## Skill: web-search");
+    const csIdx = capturedSystem!.indexOf("## Skill: cite-sources");
+    expect(wsIdx).toBeLessThan(csIdx);
+  });
+
+  /**
+   * @case Unknown skill name fails the dispatch with RC5003 listing known names
+   * @preconditions Agent declares "missing" but only "x" is registered
+   * @expectedResult agent:error event fires; message lists known skills
+   */
+  test("unknown skill name fails dispatch with a clear error", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({
+            skills: {
+              x: { name: "x", description: "ok", content: "..." },
+            },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("missing-skill")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              skills: ["missing"],
+            }),
+          ),
+      )
+      .build();
+
+    const errors: unknown[] = [];
+    t.ctx.on(
+      "route:missing-skill:exchange:failed" as never,
+      ({ details }: { details: { error: unknown } }) => {
+        errors.push(details.error);
+      },
+    );
+    await t.test();
+    expect(errors.length).toBeGreaterThan(0);
+    const msg = (errors[0] as Error).message;
+    expect(msg).toMatch(/unknown skill "missing"/);
+    expect(msg).toMatch(/Known skill names: "x"/);
+  });
+});

--- a/packages/ai/test/agent-tool-calls.test.ts
+++ b/packages/ai/test/agent-tool-calls.test.ts
@@ -1,0 +1,241 @@
+import { describe, test, expect, afterEach, vi, beforeEach } from "vitest";
+import { craft, simple } from "@routecraft/routecraft";
+import { spy, testContext, type TestContext } from "@routecraft/testing";
+import {
+  agent,
+  llmPlugin,
+  type AgentResult,
+  type AgentToolCallSummary,
+} from "../src/index.ts";
+import type { LlmResult } from "../src/llm/types.ts";
+
+// Mock the LLM dispatcher so we control what tool calls flow into
+// the result. The tests assert on AgentResult.toolCalls produced by
+// the session, regardless of whether the streaming or sync path was
+// taken.
+vi.mock("../src/llm/providers/index.ts", () => ({
+  callLlm: vi.fn(
+    async (): Promise<LlmResult> => ({
+      text: "stubbed",
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      toolCalls: [
+        {
+          toolCallId: "call-1",
+          toolName: "fetchOrder",
+          input: { id: "abc" },
+          output: { status: "shipped" },
+        },
+        {
+          toolCallId: "call-2",
+          toolName: "sendSlack",
+          input: { channel: "#ops" },
+          error: new Error("slack-down"),
+        },
+      ],
+    }),
+  ),
+  streamLlm: vi.fn(
+    async (params: {
+      onDelta: (d: { type: string; text: string }) => void | Promise<void>;
+    }): Promise<LlmResult> => {
+      await params.onDelta({ type: "text-delta", text: "ok" });
+      return {
+        text: "ok",
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        toolCalls: [
+          {
+            toolCallId: "stream-call-1",
+            toolName: "search",
+            input: { q: "weather" },
+            output: { results: ["sunny"] },
+          },
+        ],
+      };
+    },
+  ),
+}));
+
+describe("AgentResult.toolCalls: post-dispatch tool-call summary", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case AgentResult.toolCalls populated for sync dispatch
+   * @preconditions Inline agent (no onDelta); mocked callLlm returns toolCalls
+   * @expectedResult Sink body has both tool calls in invocation order with input/output/error fields
+   */
+  test("sync dispatch populates AgentResult.toolCalls", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("sync-tool-calls")
+          .from(simple("hi"))
+          .to(agent({ system: "x", model: "anthropic:claude-opus-4-7" }))
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    const r = sink.received[0]!.body as AgentResult;
+    expect(r.toolCalls).toHaveLength(2);
+    const [first, second] = r.toolCalls!;
+    expect(first).toMatchObject({
+      toolCallId: "call-1",
+      toolName: "fetchOrder",
+      input: { id: "abc" },
+      output: { status: "shipped" },
+    });
+    expect(first.error).toBeUndefined();
+    expect(second).toMatchObject({
+      toolCallId: "call-2",
+      toolName: "sendSlack",
+    });
+    expect(second.output).toBeUndefined();
+    expect(second.error).toBeInstanceOf(Error);
+  });
+
+  /**
+   * @case AgentResult.toolCalls populated for streaming dispatch
+   * @preconditions Inline agent with onDelta; mocked streamLlm returns toolCalls
+   * @expectedResult Sink body has the streaming-path tool call summary
+   */
+  test("streaming dispatch populates AgentResult.toolCalls", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("stream-tool-calls")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              onDelta: () => {},
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    const r = sink.received[0]!.body as AgentResult;
+    expect(r.toolCalls).toHaveLength(1);
+    expect(r.toolCalls![0]).toMatchObject({
+      toolCallId: "stream-call-1",
+      toolName: "search",
+      input: { q: "weather" },
+      output: { results: ["sunny"] },
+    });
+  });
+
+  /**
+   * @case AgentResult.toolCalls absent when no tools were invoked
+   * @preconditions Mock returns no toolCalls field
+   * @expectedResult AgentResult.toolCalls is undefined (not an empty array)
+   */
+  test("toolCalls is undefined when no tools were invoked", async () => {
+    const sink = spy();
+    // Override the default mock for this test
+    const { callLlm } = await import("../src/llm/providers/index.ts");
+    (callLlm as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      text: "no tools",
+      finishReason: "stop",
+      // no toolCalls
+    });
+
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("no-tool-calls")
+          .from(simple("hi"))
+          .to(agent({ system: "x", model: "anthropic:claude-opus-4-7" }))
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    const r = sink.received[0]!.body as AgentResult;
+    expect(r.toolCalls).toBeUndefined();
+  });
+
+  /**
+   * @case Documented assertion pattern works end-to-end
+   * @preconditions Pipeline asserts the agent called `replyEmail`; mock returns no such call; step-scope .error() forwards
+   * @expectedResult The error path runs (assertion threw); the route does not reach the success sink
+   */
+  test("post-dispatch assertion + step-scope .error() escalation", async () => {
+    const successSink = spy();
+    const fallbackSink = spy();
+    const captured: AgentToolCallSummary[][] = [];
+
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("must-have-replied")
+          .from(simple("an inbound message"))
+          .to(agent({ system: "x", model: "anthropic:claude-opus-4-7" }))
+          .error(() => {
+            // step-scope wrapper around the next .process(); captures
+            // the assertion failure and routes to the fallback sink.
+            return { escalated: true };
+          })
+          .process((ex) => {
+            const r = ex.body as AgentResult;
+            captured.push(r.toolCalls ?? []);
+            const replied = r.toolCalls?.some(
+              (c) => c.toolName === "replyEmail" && !c.error,
+            );
+            if (!replied) throw new Error("Agent did not call replyEmail");
+            return ex;
+          })
+          .to(successSink)
+          .to(fallbackSink),
+      )
+      .build();
+
+    await t.test();
+    // Mock returned tool calls but none was `replyEmail`, so the
+    // assertion threw, the wrapper recovered with `{ escalated: true }`
+    // and the pipeline continued past the wrapped step.
+    expect(captured[0]?.map((c) => c.toolName)).toEqual([
+      "fetchOrder",
+      "sendSlack",
+    ]);
+    // The wrapper recovered and replaced the body; subsequent steps
+    // saw `{ escalated: true }` and ran (both sinks fire).
+    expect(successSink.received).toHaveLength(1);
+    expect(successSink.received[0]?.body).toEqual({ escalated: true });
+    expect(fallbackSink.received).toHaveLength(1);
+  });
+});

--- a/packages/ai/test/agent-validate.test.ts
+++ b/packages/ai/test/agent-validate.test.ts
@@ -1,0 +1,343 @@
+import { describe, test, expect, afterEach, vi, beforeEach } from "vitest";
+import { craft, simple } from "@routecraft/routecraft";
+import { spy, testContext, type TestContext } from "@routecraft/testing";
+import { agent, llmPlugin, type AgentResult } from "../src/index.ts";
+import type { LlmResult } from "../src/llm/types.ts";
+
+// Mock the LLM provider so the validator can drive deterministic
+// retry behaviour without hitting a real model. Each test installs
+// its own queue of responses via `queueResponses(...)` and
+// `callLlm` / `streamLlm` consume one entry per invocation.
+let responseQueue: LlmResult[] = [];
+
+function queueResponses(...rs: LlmResult[]): void {
+  responseQueue = [...rs];
+}
+
+function nextResponse(): LlmResult {
+  const r = responseQueue.shift();
+  if (!r) throw new Error("test bug: callLlm invoked beyond queued responses");
+  return r;
+}
+
+vi.mock("../src/llm/providers/index.ts", () => ({
+  callLlm: vi.fn(async (): Promise<LlmResult> => nextResponse()),
+  streamLlm: vi.fn(
+    async (params: {
+      onDelta: (d: { type: string; text: string }) => void | Promise<void>;
+    }): Promise<LlmResult> => {
+      await params.onDelta({ type: "text-delta", text: "tok" });
+      return nextResponse();
+    },
+  ),
+}));
+
+describe("agent.validate: pre-finish hook with corrective retry", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    responseQueue = [];
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case validate returns void, dispatch resolves on the first call
+   * @preconditions Single response; validate accepts unconditionally
+   * @expectedResult AgentResult.text is the first response; validate ran exactly once
+   */
+  test("validate returning void accepts the result on the first call", async () => {
+    queueResponses({
+      text: "first",
+      finishReason: "stop",
+      stepsCount: 1,
+    });
+    const validate = vi.fn(() => undefined);
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("v-accept")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              validate,
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+    await t.test();
+    const r = sink.received[0]!.body as AgentResult;
+    expect(r.text).toBe("first");
+    expect(validate).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * @case validate returns a string on the first call, accepts on the retry
+   * @preconditions Two queued responses; validate rejects the first, accepts the second
+   * @expectedResult Final AgentResult.text is the second response; validate ran twice; second call sees the corrective user message
+   */
+  test("validate returning a string triggers a retry with the corrective message", async () => {
+    queueResponses(
+      {
+        text: "missing tool call",
+        finishReason: "stop",
+        stepsCount: 1,
+        responseMessages: [{ role: "assistant", content: "missing tool call" }],
+      },
+      {
+        text: "now with the tool call",
+        finishReason: "stop",
+        stepsCount: 1,
+      },
+    );
+    const validateCalls: AgentResult[] = [];
+    const validate = vi.fn((result: AgentResult) => {
+      validateCalls.push(result);
+      return validateCalls.length === 1
+        ? "you must call send_email"
+        : undefined;
+    });
+
+    const { callLlm } =
+      (await import("../src/llm/providers/index.ts")) as unknown as {
+        callLlm: ReturnType<typeof vi.fn>;
+      };
+
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("v-retry")
+          .from(simple("original-user-prompt"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              validate,
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+    await t.test();
+
+    const r = sink.received[0]!.body as AgentResult;
+    expect(r.text).toBe("now with the tool call");
+    expect(validate).toHaveBeenCalledTimes(2);
+    // First call uses the raw string user prompt.
+    expect(callLlm.mock.calls[0]?.[0]).toMatchObject({
+      user: "original-user-prompt",
+    });
+    // Second call uses an array of messages: original user, prior assistant
+    // response, validator-corrective user message.
+    const secondUser = (
+      callLlm.mock.calls[1]?.[0] as {
+        user: unknown;
+      }
+    ).user;
+    expect(Array.isArray(secondUser)).toBe(true);
+    const arr = secondUser as { role: string; content: string }[];
+    expect(arr[0]).toEqual({ role: "user", content: "original-user-prompt" });
+    // Middle entry is the SDK response message we forwarded.
+    expect(arr[1]).toEqual({ role: "assistant", content: "missing tool call" });
+    expect(arr[arr.length - 1]).toEqual({
+      role: "user",
+      content: "Validator: you must call send_email",
+    });
+  });
+
+  /**
+   * @case validate exhausts maxTurns; dispatch fails with RC5003 carrying the last validator message
+   * @preconditions maxTurns=2 with 2 queued responses; validate always rejects
+   * @expectedResult Promise rejects with RC5003; message mentions maxTurns and the last validator message
+   */
+  test("validate that never accepts fails the dispatch when maxTurns is exhausted", async () => {
+    queueResponses(
+      {
+        text: "r1",
+        finishReason: "stop",
+        stepsCount: 1,
+        responseMessages: [{ role: "assistant", content: "r1" }],
+      },
+      {
+        text: "r2",
+        finishReason: "stop",
+        stepsCount: 1,
+        responseMessages: [{ role: "assistant", content: "r2" }],
+      },
+    );
+    const validate = vi.fn(() => "still not good enough");
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("v-exhaust")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              maxTurns: 2,
+              validate,
+            }),
+          ),
+      )
+      .build();
+
+    const errors: unknown[] = [];
+    t.ctx.on(
+      "route:v-exhaust:agent:error" as never,
+      ({ details }: { details: { error: unknown } }) => {
+        errors.push(details.error);
+      },
+    );
+
+    await t.test();
+    expect(errors).toHaveLength(1);
+    const err = errors[0] as Error;
+    expect(err.message).toMatch(/maxTurns \(2\)/);
+    expect(err.message).toMatch(/still not good enough/);
+  });
+
+  /**
+   * @case AgentResult.toolCalls is cumulative across validate retries
+   * @preconditions Two queued responses, each with a different tool call
+   * @expectedResult Final AgentResult.toolCalls contains tool calls from BOTH calls in order
+   */
+  test("toolCalls accumulate across validate retries", async () => {
+    queueResponses(
+      {
+        text: "first",
+        finishReason: "stop",
+        stepsCount: 1,
+        toolCalls: [
+          {
+            toolCallId: "c1",
+            toolName: "search",
+            input: { q: "x" },
+            output: { hits: 1 },
+          },
+        ],
+        responseMessages: [{ role: "assistant", content: "first" }],
+      },
+      {
+        text: "second",
+        finishReason: "stop",
+        stepsCount: 1,
+        toolCalls: [
+          {
+            toolCallId: "c2",
+            toolName: "send_email",
+            input: { to: "x@y" },
+            output: { ok: true },
+          },
+        ],
+      },
+    );
+    let calls = 0;
+    const validate = (result: AgentResult): string | void => {
+      calls += 1;
+      if (calls === 1) return "must call send_email";
+      // Accept once both tools have been invoked.
+      const names = (result.toolCalls ?? []).map((c) => c.toolName);
+      if (!names.includes("send_email")) return "still missing send_email";
+      return undefined;
+    };
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("v-accumulate")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              validate,
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+    await t.test();
+    const r = sink.received[0]!.body as AgentResult;
+    expect(r.toolCalls?.map((c) => c.toolName)).toEqual([
+      "search",
+      "send_email",
+    ]);
+  });
+
+  /**
+   * @case validate runs in the streaming path with the same retry semantics
+   * @preconditions Two queued responses; onDelta listener attached; validate rejects then accepts
+   * @expectedResult Final text is the second response; onDelta saw deltas from both calls
+   */
+  test("validate retries also work under the streaming path", async () => {
+    queueResponses(
+      {
+        text: "first",
+        finishReason: "stop",
+        stepsCount: 1,
+        responseMessages: [{ role: "assistant", content: "first" }],
+      },
+      { text: "final", finishReason: "stop", stepsCount: 1 },
+    );
+    let calls = 0;
+    const validate = () => (++calls === 1 ? "retry please" : undefined);
+    const onDelta = vi.fn();
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("v-stream")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              validate,
+              onDelta,
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+    await t.test();
+    const r = sink.received[0]!.body as AgentResult;
+    expect(r.text).toBe("final");
+    // onDelta fired once per stream call; validate retried once so we expect two delta events.
+    expect(onDelta).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ai/test/skill-loader.test.ts
+++ b/packages/ai/test/skill-loader.test.ts
@@ -29,14 +29,14 @@ describe("skills() markdown loader", () => {
    * @preconditions Two well-formed skill files
    * @expectedResult Returns both skills with content from the body
    */
-  test("loads a directory of skill markdown files", () => {
+  test("loads a directory of skill markdown files", async () => {
     const dir = makeDir({
       "web-search.md":
         "---\nname: web-search\ndescription: Search the web\n---\nUse a search engine first.",
       "cite-sources.md":
         "---\nname: cite-sources\ndescription: Cite your sources\n---\nAlways include citations.",
     });
-    const result = skills(dir);
+    const result = await skills(dir);
     expect(Object.keys(result).sort()).toEqual(["cite-sources", "web-search"]);
     expect(result["web-search"]).toEqual({
       name: "web-search",
@@ -50,12 +50,12 @@ describe("skills() markdown loader", () => {
    * @preconditions A single skill markdown file
    * @expectedResult Returns one entry keyed by filename
    */
-  test("loads a single .md file path", () => {
+  test("loads a single .md file path", async () => {
     const dir = makeDir({
       "rules.md":
         "---\nname: rules\ndescription: The rules\n---\nRule one. Rule two.",
     });
-    const result = skills(join(dir, "rules.md"));
+    const result = await skills(join(dir, "rules.md"));
     expect(result).toEqual({
       rules: {
         name: "rules",
@@ -70,11 +70,11 @@ describe("skills() markdown loader", () => {
    * @preconditions File "x.md" with frontmatter name "y"
    * @expectedResult Throws RC5003 mentioning the mismatch
    */
-  test("throws when frontmatter name does not match filename", () => {
+  test("throws when frontmatter name does not match filename", async () => {
     const dir = makeDir({
       "actual.md": "---\nname: claimed\ndescription: ok\n---\nbody",
     });
-    expect(() => skills(dir)).toThrow(/must match the filename/);
+    await expect(skills(dir)).rejects.toThrow(/must match the filename/);
   });
 
   /**
@@ -82,11 +82,11 @@ describe("skills() markdown loader", () => {
    * @preconditions File with `version: 1` in frontmatter
    * @expectedResult Throws RC5003 listing the unsupported field
    */
-  test("rejects unsupported frontmatter fields", () => {
+  test("rejects unsupported frontmatter fields", async () => {
     const dir = makeDir({
       "x.md": "---\nname: x\ndescription: ok\nversion: 1\n---\nbody",
     });
-    expect(() => skills(dir)).toThrow(
+    await expect(skills(dir)).rejects.toThrow(
       /unsupported frontmatter field "version"/,
     );
   });
@@ -96,11 +96,11 @@ describe("skills() markdown loader", () => {
    * @preconditions Skill markdown with frontmatter only
    * @expectedResult Throws RC5003 mentioning empty body
    */
-  test("rejects empty skill body", () => {
+  test("rejects empty skill body", async () => {
     const dir = makeDir({
       "x.md": "---\nname: x\ndescription: ok\n---\n",
     });
-    expect(() => skills(dir)).toThrow(/skill body is empty/);
+    await expect(skills(dir)).rejects.toThrow(/skill body is empty/);
   });
 
   /**
@@ -108,11 +108,11 @@ describe("skills() markdown loader", () => {
    * @preconditions Markdown loaded with override that replaces description
    * @expectedResult Result reflects override; original content preserved
    */
-  test("applies per-skill overrides", () => {
+  test("applies per-skill overrides", async () => {
     const dir = makeDir({
       "x.md": "---\nname: x\ndescription: from-md\n---\nbody from md",
     });
-    const result = skills(dir, { x: { description: "overridden" } });
+    const result = await skills(dir, { x: { description: "overridden" } });
     expect(result["x"]?.description).toBe("overridden");
     expect(result["x"]?.content).toBe("body from md");
   });
@@ -122,11 +122,11 @@ describe("skills() markdown loader", () => {
    * @preconditions Override key not present in loaded files
    * @expectedResult Throws RC5003 with the offending key
    */
-  test("override for an unknown skill throws", () => {
+  test("override for an unknown skill throws", async () => {
     const dir = makeDir({
       "x.md": "---\nname: x\ndescription: ok\n---\nbody",
     });
-    expect(() => skills(dir, { y: { description: "nope" } })).toThrow(
+    await expect(skills(dir, { y: { description: "nope" } })).rejects.toThrow(
       /override for "y" but no skill with that name/,
     );
   });

--- a/packages/ai/test/skill-loader.test.ts
+++ b/packages/ai/test/skill-loader.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { skills } from "../src/skill/index.ts";
+
+function tmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "rc-skills-"));
+}
+
+describe("skills() markdown loader", () => {
+  let dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs = [];
+  });
+
+  function makeDir(files: Record<string, string>): string {
+    const dir = tmpDir();
+    dirs.push(dir);
+    for (const [name, content] of Object.entries(files)) {
+      writeFileSync(join(dir, name), content, "utf-8");
+    }
+    return dir;
+  }
+
+  /**
+   * @case Loads multiple .md files in a directory into a Record keyed by name
+   * @preconditions Two well-formed skill files
+   * @expectedResult Returns both skills with content from the body
+   */
+  test("loads a directory of skill markdown files", () => {
+    const dir = makeDir({
+      "web-search.md":
+        "---\nname: web-search\ndescription: Search the web\n---\nUse a search engine first.",
+      "cite-sources.md":
+        "---\nname: cite-sources\ndescription: Cite your sources\n---\nAlways include citations.",
+    });
+    const result = skills(dir);
+    expect(Object.keys(result).sort()).toEqual(["cite-sources", "web-search"]);
+    expect(result["web-search"]).toEqual({
+      name: "web-search",
+      description: "Search the web",
+      content: "Use a search engine first.",
+    });
+  });
+
+  /**
+   * @case Single .md file path also works
+   * @preconditions A single skill markdown file
+   * @expectedResult Returns one entry keyed by filename
+   */
+  test("loads a single .md file path", () => {
+    const dir = makeDir({
+      "rules.md":
+        "---\nname: rules\ndescription: The rules\n---\nRule one. Rule two.",
+    });
+    const result = skills(join(dir, "rules.md"));
+    expect(result).toEqual({
+      rules: {
+        name: "rules",
+        description: "The rules",
+        content: "Rule one. Rule two.",
+      },
+    });
+  });
+
+  /**
+   * @case Frontmatter name must match filename
+   * @preconditions File "x.md" with frontmatter name "y"
+   * @expectedResult Throws RC5003 mentioning the mismatch
+   */
+  test("throws when frontmatter name does not match filename", () => {
+    const dir = makeDir({
+      "actual.md": "---\nname: claimed\ndescription: ok\n---\nbody",
+    });
+    expect(() => skills(dir)).toThrow(/must match the filename/);
+  });
+
+  /**
+   * @case Unsupported frontmatter field rejected with a clear message
+   * @preconditions File with `version: 1` in frontmatter
+   * @expectedResult Throws RC5003 listing the unsupported field
+   */
+  test("rejects unsupported frontmatter fields", () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: ok\nversion: 1\n---\nbody",
+    });
+    expect(() => skills(dir)).toThrow(
+      /unsupported frontmatter field "version"/,
+    );
+  });
+
+  /**
+   * @case Empty body rejected at load
+   * @preconditions Skill markdown with frontmatter only
+   * @expectedResult Throws RC5003 mentioning empty body
+   */
+  test("rejects empty skill body", () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: ok\n---\n",
+    });
+    expect(() => skills(dir)).toThrow(/skill body is empty/);
+  });
+
+  /**
+   * @case Per-skill description override
+   * @preconditions Markdown loaded with override that replaces description
+   * @expectedResult Result reflects override; original content preserved
+   */
+  test("applies per-skill overrides", () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: from-md\n---\nbody from md",
+    });
+    const result = skills(dir, { x: { description: "overridden" } });
+    expect(result["x"]?.description).toBe("overridden");
+    expect(result["x"]?.content).toBe("body from md");
+  });
+
+  /**
+   * @case Override referencing an unknown skill name fails loudly
+   * @preconditions Override key not present in loaded files
+   * @expectedResult Throws RC5003 with the offending key
+   */
+  test("override for an unknown skill throws", () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: ok\n---\nbody",
+    });
+    expect(() => skills(dir, { y: { description: "nope" } })).toThrow(
+      /override for "y" but no skill with that name/,
+    );
+  });
+});

--- a/packages/ai/test/tool-bridge.test.ts
+++ b/packages/ai/test/tool-bridge.test.ts
@@ -252,6 +252,45 @@ describe("buildVercelTools: execute path", () => {
   });
 
   /**
+   * @case TypedArray (Buffer / Uint8Array) inside claims does not crash dispatch
+   * @preconditions Principal with `claims.binary = Uint8Array(...)`
+   * @expectedResult buildVercelTools + execute succeed; the binary value reaches the handler intact
+   */
+  test("binary claim values do not crash deep-freeze", async () => {
+    let captured: { binary?: Uint8Array } | undefined;
+    const handler = vi.fn(async (_input: unknown, ctx: unknown) => {
+      const c = ctx as {
+        principal?: { claims?: { binary?: Uint8Array } };
+      };
+      captured = c.principal?.claims;
+    });
+    const resolved: ResolvedTool = {
+      name: "binary-claim",
+      description: "Binary claim.",
+      input: z.object({}),
+      handler: handler as unknown as ResolvedTool["handler"],
+    };
+    const principal = {
+      kind: "jwt" as const,
+      scheme: "bearer" as const,
+      subject: "user-42",
+      claims: { binary: new Uint8Array([1, 2, 3]) },
+    };
+    const map = await buildVercelTools(
+      [resolved],
+      undefined,
+      new AbortController().signal,
+      undefined,
+      principal,
+    );
+    const tool = map["binary-claim"] as {
+      execute: (input: unknown) => Promise<unknown>;
+    };
+    await expect(tool.execute({})).resolves.toBeUndefined();
+    expect(Array.from(captured!.binary!)).toEqual([1, 2, 3]);
+  });
+
+  /**
    * @case Guard that resolves passes through to the handler
    * @preconditions Guard returns void (no throw)
    * @expectedResult Handler runs and returns its value

--- a/packages/ai/test/tool-bridge.test.ts
+++ b/packages/ai/test/tool-bridge.test.ts
@@ -136,6 +136,63 @@ describe("buildVercelTools: execute path", () => {
   });
 
   /**
+   * @case Tool handler cannot mutate the principal snapshot at runtime
+   * @preconditions Principal supplied to buildVercelTools; handler attempts to push to scopes and replace claims
+   * @expectedResult Both attempts throw a TypeError (frozen object); the handler's ctx.principal !== the original (it's a snapshot clone) so freezing does not pollute the caller's reference
+   */
+  test("principal snapshot is deep-frozen and isolated from the caller", async () => {
+    let capturedCtx:
+      | { principal?: { scopes?: readonly string[]; claims?: object } }
+      | undefined;
+    const handler = vi.fn(async (_input: unknown, ctx: unknown) => {
+      capturedCtx = ctx as {
+        principal?: { scopes?: readonly string[]; claims?: object };
+      };
+    });
+    const resolved: ResolvedTool = {
+      name: "snapshot-check",
+      description: "Snapshot check.",
+      input: z.object({}),
+      handler: handler as unknown as ResolvedTool["handler"],
+    };
+    const principal = {
+      kind: "jwt" as const,
+      scheme: "bearer" as const,
+      subject: "user-42",
+      scopes: ["read"],
+      claims: { tenantId: "abc" },
+    };
+    const map = await buildVercelTools(
+      [resolved],
+      undefined,
+      new AbortController().signal,
+      undefined,
+      principal,
+    );
+    const tool = map["snapshot-check"] as {
+      execute: (input: unknown) => Promise<unknown>;
+    };
+    await tool.execute({});
+
+    const snapshot = capturedCtx!.principal!;
+    // The exposed snapshot is a clone, not the caller's original object.
+    expect(snapshot).not.toBe(principal);
+    // Mutating the original after the fact must not affect the snapshot.
+    principal.scopes.push("write");
+    expect(snapshot.scopes).toEqual(["read"]);
+    // Runtime: a tool that bypasses the readonly type still cannot mutate.
+    expect(() => {
+      (snapshot.scopes as string[]).push("admin");
+    }).toThrow(TypeError);
+    expect(() => {
+      (snapshot.claims as Record<string, unknown>)["tenantId"] = "evil";
+    }).toThrow(TypeError);
+    expect(() => {
+      (snapshot as { subject?: string }).subject = "impersonated";
+    }).toThrow(TypeError);
+  });
+
+  /**
    * @case Guard that resolves passes through to the handler
    * @preconditions Guard returns void (no throw)
    * @expectedResult Handler runs and returns its value

--- a/packages/ai/test/tool-bridge.test.ts
+++ b/packages/ai/test/tool-bridge.test.ts
@@ -193,6 +193,65 @@ describe("buildVercelTools: execute path", () => {
   });
 
   /**
+   * @case Nested claim objects are deep-cloned and deep-frozen
+   * @preconditions Principal with a nested object claim and a nested array claim
+   * @expectedResult Mutating the original nested objects does not affect the snapshot; runtime mutation of nested values throws TypeError
+   */
+  test("nested claim objects are deep-frozen and isolated", async () => {
+    let capturedCtx: { principal?: { claims?: Record<string, unknown> } } = {};
+    const handler = vi.fn(async (_input: unknown, ctx: unknown) => {
+      capturedCtx = ctx as {
+        principal?: { claims?: Record<string, unknown> };
+      };
+    });
+    const resolved: ResolvedTool = {
+      name: "nested-claims",
+      description: "Nested claims.",
+      input: z.object({}),
+      handler: handler as unknown as ResolvedTool["handler"],
+    };
+    const principal = {
+      kind: "jwt" as const,
+      scheme: "bearer" as const,
+      subject: "user-42",
+      claims: {
+        perms: { write: false, admin: false },
+        tags: ["alpha", "beta"],
+      },
+    };
+    const map = await buildVercelTools(
+      [resolved],
+      undefined,
+      new AbortController().signal,
+      undefined,
+      principal,
+    );
+    const tool = map["nested-claims"] as {
+      execute: (input: unknown) => Promise<unknown>;
+    };
+    await tool.execute({});
+
+    const claims = capturedCtx.principal!.claims as {
+      perms: { write: boolean; admin: boolean };
+      tags: string[];
+    };
+    // Snapshot is a deep clone: mutating the original nested perms / tags
+    // after dispatch must not leak into the snapshot.
+    principal.claims.perms.admin = true;
+    principal.claims.tags.push("gamma");
+    expect(claims.perms).toEqual({ write: false, admin: false });
+    expect(claims.tags).toEqual(["alpha", "beta"]);
+    // Runtime: a tool that bypasses the readonly type still cannot
+    // mutate any nested claim value or array.
+    expect(() => {
+      claims.perms.admin = true;
+    }).toThrow(TypeError);
+    expect(() => {
+      claims.tags.push("evil");
+    }).toThrow(TypeError);
+  });
+
+  /**
    * @case Guard that resolves passes through to the handler
    * @preconditions Guard returns void (no throw)
    * @expectedResult Handler runs and returns its value

--- a/packages/ai/test/tool-bridge.test.ts
+++ b/packages/ai/test/tool-bridge.test.ts
@@ -99,6 +99,43 @@ describe("buildVercelTools: execute path", () => {
   });
 
   /**
+   * @case Principal from the dispatching exchange surfaces on the tool ctx
+   * @preconditions buildVercelTools called with a Principal; handler captures its ctx
+   * @expectedResult Handler's ctx.principal matches the supplied Principal (not undefined)
+   */
+  test("principal flows through to the handler ctx", async () => {
+    const handler = vi.fn(async () => "done");
+    const resolved: ResolvedTool = {
+      name: "needs-auth",
+      description: "Needs auth.",
+      input: z.object({}),
+      handler: handler as ResolvedTool["handler"],
+    };
+    const principal = {
+      kind: "jwt" as const,
+      scheme: "bearer" as const,
+      subject: "user-42",
+      scopes: ["read", "write"],
+    };
+    const map = await buildVercelTools(
+      [resolved],
+      undefined,
+      new AbortController().signal,
+      undefined,
+      principal,
+    );
+    const tool = map["needs-auth"] as {
+      execute: (input: unknown) => Promise<unknown>;
+    };
+    await tool.execute({});
+    const callArgs = handler.mock.calls[0] as unknown as [
+      input: unknown,
+      ctx: { principal?: typeof principal },
+    ];
+    expect(callArgs[1].principal).toEqual(principal);
+  });
+
+  /**
    * @case Guard that resolves passes through to the handler
    * @preconditions Guard returns void (no throw)
    * @expectedResult Handler runs and returns its value

--- a/packages/ai/test/tools-builders.test.ts
+++ b/packages/ai/test/tools-builders.test.ts
@@ -287,7 +287,6 @@ describe("tool builders - directTool dispatch", () => {
           typeof fn.handler
         >[1]["logger"],
         abortSignal: new AbortController().signal,
-        context: t.ctx,
       },
     );
     expect(result).toMatchObject({ orderId: "abc", ok: true });

--- a/packages/ai/test/tools-builders.test.ts
+++ b/packages/ai/test/tools-builders.test.ts
@@ -291,6 +291,54 @@ describe("tool builders - directTool dispatch", () => {
     );
     expect(result).toMatchObject({ orderId: "abc", ok: true });
   });
+
+  /**
+   * @case directTool forwards FnHandlerContext.principal to the downstream direct route's exchange
+   * @preconditions Handler invoked with a principal in its ctx; downstream route captures `ex.principal`
+   * @expectedResult Captured principal on the inner route equals the one from the calling tool ctx
+   */
+  test("dispatchDirect forwards the calling principal to the downstream exchange", async () => {
+    const inputSchema = z.object({ orderId: z.string() });
+    let downstreamPrincipal: unknown;
+    t = await testContext()
+      .routes([
+        craft()
+          .id("orders/fetch-with-auth")
+          .description("Fetch with auth.")
+          .input(inputSchema)
+          .from(direct())
+          .process((ex) => {
+            downstreamPrincipal = ex.principal;
+            return {
+              ...ex,
+              body: { ok: true },
+            };
+          })
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const principal = {
+      kind: "jwt" as const,
+      scheme: "bearer" as const,
+      subject: "agent-caller",
+      scopes: ["orders.read"],
+    };
+    const desc = directTool("orders/fetch-with-auth");
+    const fn = desc.resolve(t.ctx, "ordersFetchWithAuth");
+    await fn.handler(
+      { orderId: "abc" },
+      {
+        logger: undefined as unknown as Parameters<
+          typeof fn.handler
+        >[1]["logger"],
+        abortSignal: new AbortController().signal,
+        principal,
+      },
+    );
+    expect(downstreamPrincipal).toEqual(principal);
+  });
 });
 
 describe("tool builders - agentTool stub", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,9 +218,6 @@ importers:
       ai:
         specifier: ^6.0.168
         version: 6.0.168(zod@4.3.6)
-      yaml:
-        specifier: ^2.8.0
-        version: 2.8.3
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
@@ -252,6 +249,9 @@ importers:
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.3
       zod:
         specifier: ^4.3.6
         version: 4.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       ai:
         specifier: ^6.0.168
         version: 6.0.168(zod@4.3.6)
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.3
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.71


### PR DESCRIPTION
## Summary

Five agent-system enhancements landing together for 0.5.0:

1. **`AgentResult.toolCalls` + `LlmResult.toolCalls`** with JSDoc clarity on `text` vs `output` vs `reasoning`. Flat per-call summary lifted from `result.steps[]` so post-dispatch assertions work without parsing raw SDK shapes.

2. **`agents(path, overrides?)` and `skills(path, overrides?)` markdown loaders.** Mirror a deliberately narrow subset of Claude's subagent frontmatter schema (`name`, `description`, `model`, `maxTurns`, `tools`, `skills` for agents; `name`, `description` for skills). Unsupported Claude fields (`disallowedTools`, `permissionMode`, `mcpServers`, `hooks`, `memory`, `background`, `effort`, `isolation`, `color`, `initialPrompt`) throw RC5003 "not yet supported" so a misspelt or unsupported key never silently disappears, and each becomes a clean follow-up as the underlying runtime feature lands. New `Skill` primitive concatenated into the agent's system prompt at dispatch under a `## Skill: <name>` heading. Adds `yaml` as a dep.

3. **`agent.validate` pre-finish hook with corrective retry.** `(result, ctx) => void | string` invoked after each model call. `void` accepts; a string sends the agent back for another turn with `"Validator: <msg>"` injected as a user message. Retries share the `maxTurns` budget; exhausting it while validate is still rejecting fails the dispatch via RC5003 carrying the last validator message. `AgentResult.toolCalls` becomes cumulative across retries so "must have called X" assertions see the full tool history. Default `maxTurns` bumped 8 → 20 to accommodate validate-driven loops.

4. **Header-tampering investigation (research only, no code change).** Confirmed the agent layer cannot tamper with routecraft headers: tools never see the exchange, and the existing `appendSkillsToSystem` / `dispatchDirect` paths route tool dispatches through fresh `DefaultExchange` constructions, not header-mutation on the live exchange. The agent inherits whatever principal the route already established. Auth-snapshot work is deferred to land alongside the in-flight `exchange.principal` PR.

5. **`FnHandlerContext` narrowing (breaking).** Drop `context: CraftContext` from `FnHandlerContext`. Tool handlers no longer have a path to read framework context stores (which carry provider credentials such as LLM API keys, MCP server configs, etc.). The only built-in consumer that needed it (`directTool`'s `dispatchDirect`) captures the context at resolve time and threads it through its own closure.

## Breaking changes

- `FnHandlerContext` no longer has `context`. User-authored fns / guards / direct tools that read `hctx.context` will fail to typecheck. Move ctx-dependent work either out of the tool handler entirely or into a custom DeferredFn that captures ctx at resolve time (see how `directTool` does it in `packages/ai/src/agent/tools/builders.ts`).
- `AgentOptions.maxTurns` default is now 20 (was 8). Most agents will not notice; agents that relied on the lower cap as an implicit cost guard should set `maxTurns` explicitly.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format` clean
- [x] `pnpm test` 95 files, 1034 passed / 1 skipped
- [x] `pnpm build` clean (all packages + examples)
- [x] New tests cover: validate accept/retry/exhaust paths (sync + streaming), cumulative toolCalls across retries, skills dispatch concatenation, unknown-skill error, `agents()` and `skills()` loader happy / unsupported-field / mismatched-name / override paths

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

---
_Generated by [Claude Code](https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent validation with corrective retries, markdown loaders for agents and skills, flat tool-call summaries, and a deep‑frozen `principal` on tool contexts. Removes framework context from `FnHandlerContext`, raises the default `maxTurns`, and fixes a crash with TypedArray claims.

- **New Features**
  - `AgentResult.toolCalls` and `LlmResult.toolCalls`: flat, ordered summaries of each tool call with `input`, `output`, and `error`. Populated for sync and streaming paths; cumulative across `validate` retries.
  - `agent.validate`: return a string to trigger a corrective retry with "Validator: <msg>"; shares the turn budget and on exhaustion throws `RC5003` with the last validator message. Validator receives `{ exchange, turnsUsed }`. Provider now accepts array `user` prompts and exposes `stepsCount` and `responseMessages` for retries.
  - `skills(path, overrides?)` and `agents(path, overrides?)`: load from markdown. Only supported frontmatter keys are accepted; unknown keys throw `RC5003`. Agent `skills` are concatenated into the system prompt under `## Skill: <name>`; unknown skill names throw `RC5003`. `agents()` requires `provider:model` and allows per-agent overrides. `agentPlugin({ skills })` registers skills and rejects duplicates. Loaders lazy-load `yaml` (optional peer dep) and are async.
  - `FnHandlerContext.principal`: deep-readonly, deep-frozen snapshot (`ReadonlyPrincipal`) of the dispatching exchange principal is available to tool handlers and guards. Nested `claims` are deep-cloned and frozen; TypedArray claims are supported. `directTool` re-clones and forwards the same principal to downstream routes.

- **Migration**
  - `FnHandlerContext` no longer includes `context`. Update fns/guards/tools to capture `CraftContext` at resolve time (as `directTool` now does), not from the handler context.
  - If you relied on the old `AgentOptions.maxTurns` default (8), set it explicitly; the new default is 20.

<sup>Written for commit d0bfb63cd007a1a3bee4885f64c845d67239f4a5. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/278?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

