### PR TITLE
feat(core)!: route-only .authorize() and rename requirePrincipal validator to authorize

### DIFF
--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -465,7 +465,7 @@ craft()
 
 Stack `.authorize()` calls to AND-combine; the first failure short-circuits.
 
-`.authorize()` is **route-only**: must be called before `.from()`. Calling it after `.from()` throws `RC2001` with a message pointing at the mid-pipeline form, `.validate(authorize({ ... }))`. The escape hatch is for the rare case where you swap the principal in a `.process()` step or want to gate a `.choice()` branch:
+`.authorize()` is **route-only**: it stages onto the next route, same convention as `.id` / `.title` / `.description` / `.input` / `.output` / `.tag` / `.batch`. Calling a pipeline op (`.to`, `.transform`, `.process`, ...) while authorizers are staged but no new `.from()` has opened the next route throws `RC2001` with a message naming `.authorize` among the staging ops that need a `.from()` to follow. For a mid-pipeline check, drop down to the validator form -- useful when you swap the principal in a `.process()` step or want to gate a `.choice()` branch:
 
 ```ts
 import { authorize } from "@routecraft/routecraft"

--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -396,7 +396,7 @@ For reference, route-builder operations now fall into three groups:
 
 | Category            | Position relative to `.from()` | Examples                                                |
 | ------------------- | ------------------------------ | ------------------------------------------------------- |
-| Route-only          | Before                         | `.id()`, `.batch()`                                     |
+| Route-only          | Before                         | `.id()`, `.batch()`, `.authorize()`                     |
 | Dual-mode wrapper   | Before _or_ after              | `.error()` (more to follow in 0.6.0)                    |
 | Pipeline            | After                          | `.transform()`, `.filter()`, `.to()`, `.process()`, ... |
 
@@ -449,6 +449,37 @@ Lets you invoke routes from outside the framework lifecycle (test runners, scrip
 ### MCP OAuth 2.1 server provider
 
 The `mcp()` source can now sit behind an OAuth 2.1 authorisation server. The framework ships JWT and JWKS verifiers, an `oauth()` factory, and a typed `OAuthPrincipal` shape.
+
+### `.authorize()` route-entry guard {% badge color="orange" %}experimental{% /badge %}
+
+A new route-only `.authorize()` method declares an authorization requirement on a route. It runs at route entry, before any pipeline step, and verifies that the inbound exchange carries an authenticated `principal` and (optionally) that the principal carries every required role and scope.
+
+```ts
+craft()
+  .id("delete-user")
+  .description("Delete a user by id")
+  .authorize({ roles: ["admin"] })
+  .from(mcp({ annotations: { destructiveHint: true } }))
+  .to(deleteUserDestination)
+```
+
+Stack `.authorize()` calls to AND-combine; the first failure short-circuits.
+
+`.authorize()` is **route-only**: must be called before `.from()`. Calling it after `.from()` throws `RC2001` with a message pointing at the mid-pipeline form, `.validate(authorize({ ... }))`. The escape hatch is for the rare case where you swap the principal in a `.process()` step or want to gate a `.choice()` branch:
+
+```ts
+import { authorize } from "@routecraft/routecraft"
+
+craft()
+  .from(mail({ /* ... */ }))
+  .process(attachEmailPrincipal)
+  .validate(authorize({ predicate: (p) => p.email?.endsWith("@yourcompany.com") === true }))
+  .to(yourDestination)
+```
+
+Failures throw `RC5012` (no principal) or `RC5015` (principal failed the role / scope / predicate check). Both flow through the route's `.error()` handler like any other validation failure.
+
+`.authorize()` does NOT issue, mint, or attach any credential. It checks an existing identity. Authentication happens at the source boundary (`mcp({ auth: jwt(...) })`, `oauth()`, etc.) or in a `.process()` step that attaches a `Principal`.
 
 ### Runner argv channel
 

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -187,11 +187,11 @@ Authentication failed
 **Why it happens**  
 Two cases share this code:
 - An upstream service rejected the request: invalid credentials, expired token, or a 401 response.
-- A route reached `.authorize()` (or `requirePrincipal()` directly) and the exchange carried no authenticated principal. The source did not resolve one and no `.process()` step attached a custom one.
+- A route's `.authorize()` guard ran (or `.validate(authorize(...))` mid-pipeline) and the exchange carried no authenticated principal. The source did not resolve one and no `.process()` step attached a custom one.
 
 **Suggestion**  
 - For upstream-API failures: verify API keys, tokens, audience/issuer, and credential rotation. Check that the auth header is reaching the destination.
-- For in-route failures: configure `auth:` on the source (e.g. `mcp({ auth: jwt(...) })`) or attach a custom principal in a `.process()` step before `.authorize()`. See [`.authorize()`](/docs/reference/operations#authorize).
+- For in-route failures: configure `auth:` on the source (e.g. `mcp({ auth: jwt(...) })`) so the source emits a principal, or attach a custom principal in a `.process()` step before the `authorize()` validator runs. See [`.authorize()`](/docs/reference/operations#authorize).
 
 ## RC5013
 Rate limited
@@ -217,7 +217,7 @@ Permission denied
 **Why it happens**  
 Two cases share this code:
 - An upstream service denied the operation (e.g. 403 from access control or IAM).
-- A route reached `.authorize()` (or `requirePrincipal()` directly), the exchange had a principal, but the principal was missing a required role or scope, or a custom predicate returned `false`.
+- A route's `.authorize()` guard ran (or `.validate(authorize(...))` mid-pipeline), the exchange had a principal, but the principal was missing a required role or scope, or a custom predicate returned `false`.
 
 **Suggestion**  
 - For upstream denials: check IAM, ACLs, and scopes granted to the credential.

--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -212,9 +212,11 @@ For the architectural pattern wrappers follow, see [`.standards/resilience-wrapp
 authorize(options?: AuthorizeOptions): RouteBuilder<Current>
 ```
 
-Declare an authorization requirement on the route. **Route-only**: must be called BEFORE `.from()`. Calling `.authorize()` after `.from()` throws [`RC2001`](/docs/reference/errors#rc2001).
+Declare an authorization requirement on the next route. **Route-only**, same staging convention as `.id`, `.title`, `.description`, `.input`, `.output`, `.tag`, and `.batch`: it writes onto the next-route options. Calling a pipeline op (`.to`, `.transform`, `.process`, ...) while authorizers are staged but no `.from()` has opened the next route throws [`RC2001`](/docs/reference/errors#rc2001) with a message that lists `.authorize` alongside the other staging ops. For a mid-pipeline check use `.validate(authorize({ ... }))` directly.
 
 The check runs at route entry, before any pipeline step. It verifies that the inbound exchange carries an authenticated principal and (optionally) that the principal has every required role and scope. It does NOT issue, mint, or attach any credential: it asserts an existing identity meets the criteria. Multiple `.authorize()` calls stack and AND-combine in declaration order, so a missing role in the first call short-circuits before later predicates run.
+
+`.authorize()` can also act as a route-starter when chaining routes: `craft().from(s1).to(d1).authorize({...}).from(s2).to(d2)` opens route 2 with the authorizer staged, no explicit `.id("next")` required.
 
 For mid-pipeline checks (rare, for example after a `.process()` swaps the principal or inside a `.choice()` branch), use `.validate(authorize({ ... }))` directly with the underlying validator function.
 

--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -21,6 +21,7 @@ DSL operators with signatures and examples. {% .lead %}
 | [`id`](#id) | Route | Set the unique identifier for the route |
 | [`batch`](#batch) | Route | Process exchanges in batches instead of one at a time |
 | [`error`](#error) | Route + Wrapper | Configure error handling. Before `.from()` it catches every step (route scope); after `.from()` it wraps the next step and the pipeline continues after recovery (step scope). |
+| [`authorize`](#authorize) | Route | Route-entry guard: principal must be authenticated and (optionally) have required roles/scopes. Pre-from only. {% badge color="orange" %}experimental{% /badge %} |
 | [`from`](#from) | Route | Define the source of data for the capability |
 | [`retry`](#retry) | Wrapper | Retry the next operation on failure {% badge color="purple" %}planned{% /badge %} |
 | [`throttle`](#throttle) | Wrapper | Rate limit the next operation {% badge color="purple" %}planned{% /badge %} |
@@ -37,7 +38,6 @@ DSL operators with signatures and examples. {% .lead %}
 | [`enrich`](#enrich) | Transform | Add additional data to current data |
 | [`filter`](#filter) | Flow Control | Filter data based on predicate |
 | [`validate`](#validate) | Flow Control | Validate data against schema |
-| [`authorize`](#authorize) | Flow Control | Assert exchange has an authenticated principal with required roles/scopes {% badge color="orange" %}experimental{% /badge %} |
 | [`dedupe`](#dedupe) | Flow Control | Suppress duplicate exchanges based on a key {% badge color="purple" %}planned{% /badge %} |
 | [`choice`](#choice) | Flow Control | Route to different paths based on conditions |
 | [`split`](#split) | Flow Control | Split arrays into individual items |
@@ -205,6 +205,80 @@ The step-scope handler recovers `http` failures silently. If it ever throws, the
 For the architectural pattern wrappers follow, see [`.standards/resilience-wrappers.md`](https://github.com/routecraftjs/routecraft/blob/main/.standards/resilience-wrappers.md).
 
 **Note about direct destinations:** Direct destinations with their own routes have their own error handlers. Errors in direct destinations are handled by their route's error handler, not the calling route.
+
+### authorize {% badge color="orange" %}experimental{% /badge %}
+
+```ts
+authorize(options?: AuthorizeOptions): RouteBuilder<Current>
+```
+
+Declare an authorization requirement on the route. **Route-only**: must be called BEFORE `.from()`. Calling `.authorize()` after `.from()` throws [`RC2001`](/docs/reference/errors#rc2001).
+
+The check runs at route entry, before any pipeline step. It verifies that the inbound exchange carries an authenticated principal and (optionally) that the principal has every required role and scope. It does NOT issue, mint, or attach any credential: it asserts an existing identity meets the criteria. Multiple `.authorize()` calls stack and AND-combine in declaration order, so a missing role in the first call short-circuits before later predicates run.
+
+For mid-pipeline checks (rare, for example after a `.process()` swaps the principal or inside a `.choice()` branch), use `.validate(authorize({ ... }))` directly with the underlying validator function.
+
+`AuthorizeOptions`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `roles` | `string[]` | Required roles. The principal must carry every listed role. AND-combined. |
+| `scopes` | `string[]` | Required scopes. The principal must carry every listed scope. AND-combined. |
+| `predicate` | `(p: Principal) => boolean` | Custom check. Runs after the role and scope checks. Return `false` to reject. |
+
+Failure modes:
+
+- **No principal on the exchange:** throws [`RC5012`](/docs/reference/errors#rc5012). The source did not authenticate (no `auth:` configured) and no `.process()` step attached one before the route ran.
+- **Missing role or scope:** throws [`RC5015`](/docs/reference/errors#rc5015). The error message lists the missing entries.
+- **Predicate returned `false`:** throws [`RC5015`](/docs/reference/errors#rc5015).
+
+Both error codes flow through the route's normal error path: `.error()` handles them like any other validation failure; without `.error()`, `exchange:failed` fires.
+
+```ts
+import { craft, mcp } from '@routecraft/routecraft'
+
+// Route-entry guard: authentication at the source boundary,
+// authorization declared on the route.
+craft()
+  .id('delete-user')
+  .description('Delete a user by id')
+  .authorize({ roles: ['admin'] })
+  .from(mcp({ annotations: { destructiveHint: true } }))
+  .to(deleteUserDestination)
+```
+
+```ts
+// Stacked authorizers (AND-combined; first failure short-circuits)
+craft()
+  .id('billing-admin')
+  .authorize({ roles: ['admin'] })
+  .authorize({ scopes: ['billing:write'] })
+  .from(http({ path: '/admin/billing', method: 'POST' }))
+  .to(billingDestination)
+```
+
+```ts
+// Mid-pipeline check: route attaches a custom principal from an
+// inbound email and authorizes it after the .process() step.
+import { authorize } from '@routecraft/routecraft'
+
+craft()
+  .from(mail({ /* ... */ }))
+  .process((ex) => {
+    ex.principal = {
+      kind: 'custom',
+      scheme: 'email',
+      subject: ex.body.from?.address ?? 'anonymous',
+      email: ex.body.from?.address,
+      claims: { tenant: deriveTenant(ex.body.from?.address) },
+    }
+    return ex
+  })
+  .validate(authorize({
+    predicate: (p) => p.email?.endsWith('@yourcompany.com') === true,
+  }))
+  .to(yourDestination)
+```
 
 ### from
 
@@ -652,67 +726,6 @@ const userSchema = z.object({
 
 .schema(userSchema)
 // Validation failures throw RC5002: "Validation failed: "email": Invalid email; "age": Number must be greater than or equal to 0"
-```
-
-### authorize {% badge color="orange" %}experimental{% /badge %}
-
-```ts
-authorize(options?: RequirePrincipalOptions): RouteBuilder<Current>
-```
-
-Assert that the exchange carries an authenticated principal and (optionally) that the principal has every required role and scope. Type-preserving sugar for `.validate(requirePrincipal(options))`. The route builder type is unchanged.
-
-`RequirePrincipalOptions`:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `roles` | `string[]` | Required roles. The principal must carry every listed role. AND-combined. |
-| `scopes` | `string[]` | Required scopes. The principal must carry every listed scope. AND-combined. |
-| `predicate` | `(p: Principal) => boolean` | Custom check. Runs after the role and scope checks. Return `false` to reject. |
-
-Failure modes:
-
-- **No principal on the exchange:** throws [`RC5012`](/docs/reference/errors#rc5012). The source did not authenticate (no `auth:` configured) and no `.process()` step attached one.
-- **Missing role or scope:** throws [`RC5015`](/docs/reference/errors#rc5015). The error message lists the missing entries.
-- **Predicate returned `false`:** throws [`RC5015`](/docs/reference/errors#rc5015).
-
-Both error codes flow through the route's normal error path: `.error()` handles them like any other validation failure; without `.error()`, `exchange:failed` fires.
-
-```ts
-import { craft, mcp } from '@routecraft/routecraft'
-
-// Authentication at the boundary, authorization at the route step.
-craft()
-  .id('delete-user')
-  .from(mcp({ /* auth: jwt(...) configured on the server */ }))
-  .authorize({ roles: ['admin'] })
-  .to(deleteUserDestination)
-```
-
-```ts
-// Custom principal from inbound email so downstream actions are
-// attributed to the sender.
-craft()
-  .from(mail({ /* ... */ }))
-  .process((ex) => {
-    ex.principal = {
-      kind: 'custom',
-      scheme: 'email',
-      subject: ex.body.from?.address ?? 'anonymous',
-      email: ex.body.from?.address,
-      claims: { tenant: deriveTenant(ex.body.from?.address) },
-    }
-    return ex
-  })
-  .authorize({ predicate: (p) => p.email?.endsWith('@yourcompany.com') === true })
-  .to(yourDestination)
-```
-
-```ts
-// Underlying validator is also exported for composition with .validate()
-import { requirePrincipal } from '@routecraft/routecraft'
-
-.validate(requirePrincipal({ roles: ['admin'], scopes: ['billing:write'] }))
 ```
 
 ### dedupe {% badge color="purple" %}planned{% /badge %}

--- a/packages/routecraft/src/auth/authorize.ts
+++ b/packages/routecraft/src/auth/authorize.ts
@@ -76,7 +76,7 @@ export function authorize(
       throw rcError("RC5012", new Error("No authenticated principal"), {
         message: "Authorization failed: no authenticated principal",
         suggestion:
-          "Configure auth on the source (e.g. mcp({ auth: jwt(...) })) or attach a custom principal in a .process() step before the authorize() check.",
+          "Configure auth on the source so it emits a Principal (e.g. mcp({ auth: jwt(...) })). For a mid-pipeline .validate(authorize(...)) check, attach a custom principal in an earlier .process() step.",
       });
     }
 

--- a/packages/routecraft/src/auth/authorize.ts
+++ b/packages/routecraft/src/auth/authorize.ts
@@ -4,12 +4,12 @@ import { type CallableValidator } from "../operations/validate.ts";
 import { type Principal } from "./types.ts";
 
 /**
- * Options for {@link requirePrincipal}. All criteria are AND-combined: the
- * principal must satisfy every provided constraint to pass.
+ * Options accepted by {@link authorize}. All criteria are AND-combined: the
+ * principal must satisfy every provided constraint to pass the check.
  *
  * @experimental
  */
-export interface RequirePrincipalOptions {
+export interface AuthorizeOptions {
   /**
    * Required roles. The principal must carry every listed role on
    * `principal.roles`. Defaults to no role check.
@@ -28,27 +28,46 @@ export interface RequirePrincipalOptions {
 }
 
 /**
- * Build a {@link CallableValidator} that asserts the exchange carries an
+ * Build a {@link CallableValidator} that **checks** the exchange carries an
  * authenticated principal and (optionally) that the principal has every
- * required role and scope. Throws `RC5012` when no principal is present
- * and `RC5015` when the principal fails an authorization check.
+ * required role and scope. This is a verification primitive: it asserts an
+ * existing identity meets the criteria. It does NOT issue, mint, or attach
+ * credentials to the exchange.
  *
- * Used as the underlying validator for the `.authorize()` DSL sugar; you
- * can also pass it directly to `.validate()` if you need to compose it
- * with other validators.
+ * Throws `RC5012` when no principal is present and `RC5015` when the
+ * principal fails the role / scope / predicate check.
+ *
+ * Most routes should declare authorization at the route boundary using the
+ * pre-from `.authorize()` builder method, which wires this validator as a
+ * route-entry guard. Use this function directly with `.validate(...)` only
+ * when the check must run mid-pipeline (for example, after a `.process()`
+ * step that swaps the principal, or inside a `.choice()` branch).
  *
  * @experimental
  *
- * @example
+ * @example Route-entry guard (preferred)
  * ```ts
  * craft()
- *   .from(mcpTool({ name: "delete-user" }))
- *   .validate(requirePrincipal({ roles: ["admin"] }))
- *   .to(...)
+ *   .id("delete-user")
+ *   .description("Delete a user by id")
+ *   .authorize({ roles: ["admin"] })
+ *   .from(mcp({ annotations: { destructiveHint: true } }))
+ *   .to(deleteUserDestination)
+ * ```
+ *
+ * @example Mid-pipeline check (escape hatch)
+ * ```ts
+ * import { authorize } from "@routecraft/routecraft";
+ *
+ * craft()
+ *   .from(http({ path: "/admin", method: "POST" }))
+ *   .process(swapToServiceAccountPrincipal)
+ *   .validate(authorize({ roles: ["admin"] }))
+ *   .to(adminDestination)
  * ```
  */
-export function requirePrincipal(
-  options: RequirePrincipalOptions = {},
+export function authorize(
+  options: AuthorizeOptions = {},
 ): CallableValidator<unknown, unknown> {
   const { roles, scopes, predicate } = options;
   return (exchange: Exchange<unknown>) => {
@@ -57,7 +76,7 @@ export function requirePrincipal(
       throw rcError("RC5012", new Error("No authenticated principal"), {
         message: "Authorization failed: no authenticated principal",
         suggestion:
-          "Configure auth on the source (e.g. mcp({ auth: jwt(...) })) or attach a custom principal in a .process() step before calling .authorize().",
+          "Configure auth on the source (e.g. mcp({ auth: jwt(...) })) or attach a custom principal in a .process() step before the authorize() check.",
       });
     }
 
@@ -71,7 +90,7 @@ export function requirePrincipal(
           {
             message: `Authorization failed: principal is missing required role(s): ${missing.join(", ")}`,
             suggestion:
-              "Grant the principal the missing role(s) at the IdP, or relax the .authorize() requirement.",
+              "Grant the principal the missing role(s) at the IdP, or relax the authorize() requirement.",
           },
         );
       }
@@ -87,7 +106,7 @@ export function requirePrincipal(
           {
             message: `Authorization failed: principal is missing required scope(s): ${missing.join(", ")}`,
             suggestion:
-              "Grant the principal the missing scope(s) at the IdP, or relax the .authorize() requirement.",
+              "Grant the principal the missing scope(s) at the IdP, or relax the authorize() requirement.",
           },
         );
       }

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -577,16 +577,19 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   }
 
   /**
-   * Declare an authorization requirement on the next route. Route-only:
-   * must be called BEFORE `.from()`. Throws RC2001 if called after
-   * `.from()`; for mid-pipeline checks, use `.validate(authorize({...}))`
+   * Declare an authorization requirement on the next route. **Route-only**:
+   * stages the authorizer onto the next-route options and runs at route
+   * entry, before any pipeline step. Same staging convention as `.id`,
+   * `.title`, `.description`, `.input`, `.output`, `.tag`, and `.batch`:
+   * a route-level pipeline op (e.g. `.to()`, `.transform()`) called while
+   * authorizers are staged but no new `.from()` has opened a route throws
+   * RC2001. For a mid-pipeline check use `.validate(authorize({...}))`
    * directly.
    *
-   * Stages an authorization check that runs at route entry, before any
-   * pipeline step. The check verifies that the inbound exchange carries an
-   * authenticated principal and (optionally) that the principal has every
-   * required role and scope. It does NOT issue, mint, or attach any
-   * credential: it asserts an existing identity meets the criteria.
+   * The check verifies that the inbound exchange carries an authenticated
+   * principal and (optionally) that the principal has every required role
+   * and scope. It does NOT issue, mint, or attach any credential: it
+   * asserts an existing identity meets the criteria.
    *
    * Multiple `.authorize()` calls stack and AND-combine: each runs in
    * declaration order, so a missing role in the first call short-circuits
@@ -599,9 +602,6 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    * @experimental
    * @param options - Required roles, scopes, or a custom predicate. When
    *   omitted, only existence of an authenticated principal is checked.
-   * @throws {RoutecraftError} RC2001 when called after `.from()` on the
-   *   current route. The error message points at the
-   *   `.validate(authorize({...}))` escape hatch.
    *
    * @example Route-entry guard on an MCP tool
    * ```ts
@@ -622,15 +622,15 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    *   .from(http({ path: '/admin/billing', method: 'POST' }))
    *   .to(billingDestination)
    * ```
+   *
+   * @example Chained routes
+   * ```ts
+   * craft()
+   *   .id('public').from(simple('hi')).to(noop())
+   *   .id('admin').authorize({ roles: ['admin'] }).from(adminSrc).to(noop())
+   * ```
    */
   authorize(options?: AuthorizeOptions): this {
-    if (this.currentRoute !== undefined && this.pendingOptions === undefined) {
-      throw rcError("RC2001", undefined, {
-        message:
-          ".authorize() is route-only and must be called before .from(). " +
-          "For a mid-pipeline check, use .validate(authorize({ ... })) instead.",
-      });
-    }
     const next = this.pendingOptions ?? {};
     const existing = next.authorizers ?? [];
     this.pendingOptions = {
@@ -720,7 +720,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       throw rcError("RC2001", undefined, {
         message:
           `Route metadata staged but no .from() called: route-level configuration ` +
-          `(.id / .title / .description / .input / .output / .batch / .error) must be ` +
+          `(.id / .title / .description / .input / .output / .batch / .error / .authorize) must be ` +
           `followed by .from() before pipeline operations on the next route.`,
       });
     }

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -45,6 +45,8 @@ import {
 } from "./operations/aggregate.ts";
 import { COLLECT_STEPS } from "./dsl-symbol.ts";
 import { ChoiceStep, ChoiceSubBuilder } from "./operations/choice.ts";
+import { ValidateStep } from "./operations/validate.ts";
+import { authorize, type AuthorizeOptions } from "./auth/authorize.ts";
 
 /**
  * Builder for creating a Routecraft context with routes and configuration.
@@ -353,6 +355,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
         };
         errorHandler?: ErrorHandler;
         discovery?: RouteDiscovery;
+        authorizers?: AuthorizeOptions[];
       }
     | undefined;
 
@@ -370,7 +373,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    *
    * @example
    * ```typescript
-   * craft().id('ingest-api').from(httpServer({ path: '/ingest' })).to(log()).build();
+   * craft().id('ingest-api').from(http({ path: '/ingest', method: 'POST' })).to(log()).build();
    * ```
    */
   id(id: string): this {
@@ -574,6 +577,71 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   }
 
   /**
+   * Declare an authorization requirement on the next route. Route-only:
+   * must be called BEFORE `.from()`. Throws RC2001 if called after
+   * `.from()`; for mid-pipeline checks, use `.validate(authorize({...}))`
+   * directly.
+   *
+   * Stages an authorization check that runs at route entry, before any
+   * pipeline step. The check verifies that the inbound exchange carries an
+   * authenticated principal and (optionally) that the principal has every
+   * required role and scope. It does NOT issue, mint, or attach any
+   * credential: it asserts an existing identity meets the criteria.
+   *
+   * Multiple `.authorize()` calls stack and AND-combine: each runs in
+   * declaration order, so a missing role in the first call short-circuits
+   * before later predicates run.
+   *
+   * Failures throw RC5012 (no principal) or RC5015 (principal failed the
+   * role / scope / predicate check). A route-level `.error()` handler
+   * catches both like any other validation failure.
+   *
+   * @experimental
+   * @param options - Required roles, scopes, or a custom predicate. When
+   *   omitted, only existence of an authenticated principal is checked.
+   * @throws {RoutecraftError} RC2001 when called after `.from()` on the
+   *   current route. The error message points at the
+   *   `.validate(authorize({...}))` escape hatch.
+   *
+   * @example Route-entry guard on an MCP tool
+   * ```ts
+   * craft()
+   *   .id('delete-user')
+   *   .description('Delete a user by id')
+   *   .authorize({ roles: ['admin'] })
+   *   .from(mcp({ annotations: { destructiveHint: true } }))
+   *   .to(deleteUserDestination)
+   * ```
+   *
+   * @example Stacked authorizers on an HTTP route
+   * ```ts
+   * craft()
+   *   .id('admin-billing')
+   *   .authorize({ roles: ['admin'] })
+   *   .authorize({ scopes: ['billing:write'] })
+   *   .from(http({ path: '/admin/billing', method: 'POST' }))
+   *   .to(billingDestination)
+   * ```
+   */
+  authorize(options?: AuthorizeOptions): this {
+    if (this.currentRoute !== undefined && this.pendingOptions === undefined) {
+      throw rcError("RC2001", undefined, {
+        message:
+          ".authorize() is route-only and must be called before .from(). " +
+          "For a mid-pipeline check, use .validate(authorize({ ... })) instead.",
+      });
+    }
+    const next = this.pendingOptions ?? {};
+    const existing = next.authorizers ?? [];
+    this.pendingOptions = {
+      ...next,
+      authorizers: [...existing, options ?? {}],
+    };
+    logger.trace("Staging route-scope authorization for next route");
+    return this;
+  }
+
+  /**
    * Define the source of data for this route.
    * This is typically the first step in defining a route.
    *
@@ -582,7 +650,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    * @returns A RouteBuilder with the specified type T
    * @example
    * // Simple source with inferred type
-   * .from<string[]>(httpServer({ path: '/api/data' }))
+   * .from<string[]>(http({ path: '/api/data', method: 'GET' }))
    *
    * // Source with callable function
    * .from<User[]>(async () => {
@@ -605,13 +673,21 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     };
     const errorHandler = this.pendingOptions?.errorHandler;
     const discovery = this.pendingOptions?.discovery;
+    const authorizers = this.pendingOptions?.authorizers ?? [];
 
     logger.trace({ route: id }, "Creating route definition");
+
+    // Staged `.authorize()` calls become the route's first steps so they
+    // run before any pipeline operation. Multiple authorizers stack in
+    // declaration order; the first failure short-circuits the rest.
+    const authorizerSteps = authorizers.map(
+      (opts) => new ValidateStep(authorize(opts)),
+    );
 
     this.currentRoute = {
       id,
       source: typeof source === "function" ? { subscribe: source } : source,
-      steps: [],
+      steps: authorizerSteps,
       consumer: {
         type: consumer.type,
         options: consumer.options ?? undefined,

--- a/packages/routecraft/src/dsl.ts
+++ b/packages/routecraft/src/dsl.ts
@@ -15,10 +15,6 @@ import { TapStep } from "./operations/tap.ts";
 import { TransformStep, mapper } from "./operations/transform.ts";
 import { ValidateStep, schema } from "./operations/validate.ts";
 import { log, debug, type LogOptions } from "./adapters/log/index.ts";
-import {
-  requirePrincipal,
-  type RequirePrincipalOptions,
-} from "./auth/authorize.ts";
 
 // ---------------------------------------------------------------------------
 // registerDsl
@@ -148,13 +144,6 @@ registerDsl("schema", {
     new ValidateStep(schema(standardSchema)),
 });
 
-registerDsl("authorize", {
-  kind: "validate",
-  label: "authorize",
-  factory: (options?: RequirePrincipalOptions) =>
-    new ValidateStep(requirePrincipal(options)),
-});
-
 // ---------------------------------------------------------------------------
 // Module augmentation: TypeScript types for built-in sugar
 // ---------------------------------------------------------------------------
@@ -228,28 +217,5 @@ declare module "@routecraft/routecraft" {
     schema<S extends StandardSchemaV1>(
       standardSchema: S,
     ): Retyped<this, StandardSchemaV1.InferOutput<S>>;
-
-    /**
-     * Assert the exchange carries an authenticated principal and (optionally)
-     * that the principal has every required role and scope. Sugar for
-     * `.validate(requirePrincipal(options))`.
-     *
-     * Throws RC5012 when no principal is present and RC5015 when the
-     * principal fails an authorization check; route-level `.error()`
-     * handles both like any other validation failure.
-     *
-     * @experimental
-     * @param options - Required roles, scopes, or a custom predicate. When
-     *   omitted, only existence of a principal is checked.
-     *
-     * @example
-     * ```ts
-     * craft()
-     *   .from(mcpTool({ name: "delete-user" }))
-     *   .authorize({ roles: ["admin"] })
-     *   .to(...)
-     * ```
-     */
-    authorize(options?: RequirePrincipalOptions): this;
   }
 }

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -6,10 +6,7 @@ export type {
 } from "./auth/jwt.ts";
 export { jwks } from "./auth/jwks.ts";
 export type { JwksOptions } from "./auth/jwks.ts";
-export {
-  requirePrincipal,
-  type RequirePrincipalOptions,
-} from "./auth/authorize.ts";
+export { authorize, type AuthorizeOptions } from "./auth/authorize.ts";
 export type {
   ClaimMappers,
   JwtAudience,

--- a/packages/routecraft/src/operations/from.ts
+++ b/packages/routecraft/src/operations/from.ts
@@ -86,12 +86,22 @@ export type CallableSource<T = unknown> = (
      */
     parseFailureMode?: OnParseError,
     /**
-     * Authenticated principal resolved by the source, when applicable.
+     * Authenticated principal resolved by the source, when applicable. This
+     * is the **5th positional argument** of the handler. The position is
+     * stable: existing 2- or 3-argument adapters keep working unchanged
+     * (slots 2-4 are filled with `undefined` by callers that opt in to
+     * the principal slot only).
+     *
      * Sources that perform authentication at their boundary (e.g. the MCP
      * server when `auth:` is configured) pass it here so it lands on
      * `exchange.principal` of the route's first exchange. Most adapters
      * leave this undefined and rely on a downstream `.process()` to attach
      * a custom principal.
+     *
+     * Test fixtures that simulate an authenticating source can call
+     * `handler(body, undefined, undefined, undefined, principal)` directly;
+     * the auth tests in `packages/routecraft/test/auth/authorize.test.ts`
+     * use exactly this shape via a small `principalSource()` helper.
      *
      * @experimental
      */

--- a/packages/routecraft/test/auth/authorize.test.ts
+++ b/packages/routecraft/test/auth/authorize.test.ts
@@ -498,41 +498,49 @@ describe(".authorize() route-only method", () => {
 
 describe(".authorize() positional rules", () => {
   /**
-   * @case .authorize() called after .from() throws RC2001 with a pointer to the escape hatch
-   * @preconditions craft().from(simple()).authorize() (post-from misuse)
-   * @expectedResult Builder throws RC2001; the message names .validate(authorize()) as the alternative
+   * @case Mid-pipeline .authorize() (after .from(), before another .from()) is misuse
+   *       and is caught by requireSource() on the next pipeline op
+   * @preconditions craft().id().from(simple()).authorize().to(noop()) -- the .to()
+   *                tries to push a step on the current route while .authorize()
+   *                has already staged options for the next route
+   * @expectedResult Throws RC2001 (structural). Message lists .authorize among the
+   *                 staging ops that need .from() to follow.
    */
-  test("throws RC2001 when called after .from()", () => {
+  test("throws RC2001 when a pipeline op follows a post-from .authorize()", () => {
     let caught: unknown;
     try {
       craft()
         .id("post-from")
         .from(simple("hello"))
-        .authorize({ roles: ["admin"] });
+        .authorize({ roles: ["admin"] })
+        .to(noop());
     } catch (err) {
       caught = err;
     }
-    // Per .standards/testing.md section 5: assert on the structural `rc`
-    // code, not message wording. The thrown value is a RoutecraftError
-    // with `rc: "RC2001"`.
     expect(caught).toMatchObject({ rc: "RC2001" });
   });
 
   /**
-   * @case Error message points at the .validate(authorize()) escape hatch
-   * @preconditions As above
-   * @expectedResult Thrown error mentions .validate(authorize so users discover the mid-pipeline form
+   * @case requireSource() RC2001 message enumerates .authorize alongside the other
+   *       route-level staging ops so users discover the right fix
+   * @preconditions As above; assert the message text lists .authorize
+   * @expectedResult Thrown error message includes ".authorize"
    */
-  test("error message points at .validate(authorize()) escape hatch", () => {
+  test("RC2001 message enumerates .authorize as a staging op", () => {
     expect(() =>
-      craft().id("post-from-msg").from(simple("hello")).authorize(),
-    ).toThrow(/\.validate\(authorize/);
+      craft()
+        .id("enum")
+        .from(simple("hello"))
+        .authorize({ roles: ["admin"] })
+        .to(noop()),
+    ).toThrow(/\.authorize/);
   });
 
   /**
    * @case .authorize() works pre-from for a chained second route after an earlier .from()
-   * @preconditions craft().from(s1).to(d1).id("next").authorize().from(s2).to(d2)
-   * @expectedResult Both routes build without throwing; the second route gates on its own .authorize()
+   * @preconditions craft().id(a).from(s1).to(d1).id(b).authorize().from(s2).to(d2)
+   * @expectedResult Both routes build without throwing; the second route gates on
+   *                 its own .authorize()
    */
   test("supports chained routes when staged via .id() before the next .from()", async () => {
     const t = await testContext()
@@ -548,8 +556,84 @@ describe(".authorize() positional rules", () => {
       )
       .build();
 
-    // Route built; no throw. Engine wires both.
     expect(t.ctx.getRoutes()).toHaveLength(2);
+    await t.stop();
+  });
+
+  /**
+   * @case .authorize() can act as a route-starter just like .id() / .title() etc.,
+   *       without requiring an explicit .id() between the previous route and the
+   *       next .authorize().from(...) chain
+   * @preconditions craft().id(a).from(s1).to(d1).authorize({roles:[admin]}).from(s2).to(d2)
+   *                where s2 emits a principal with role "admin"
+   * @expectedResult Both routes build; route 2's .authorize() gates its source.
+   *                 Spy attached to route 2 receives the body, proving the
+   *                 authorizer ran and accepted the principal.
+   */
+  test("acts as route-starter on its own (no preceding .id() required)", async () => {
+    const main = spy<string>();
+    const adminPrincipal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "admin-1",
+      roles: ["admin"],
+    };
+
+    const t = await testContext()
+      .routes(
+        craft()
+          .id("first")
+          .from(simple("a"))
+          .to(noop())
+          .authorize({ roles: ["admin"] })
+          .from(principalSource("b", adminPrincipal))
+          .to(main),
+      )
+      .build();
+    await t.test();
+
+    expect(t.ctx.getRoutes()).toHaveLength(2);
+    expect(main.receivedBodies()).toEqual(["b"]);
+    await t.stop();
+  });
+
+  /**
+   * @case Route-starter .authorize() rejects the route when the source emits no principal
+   * @preconditions craft().id(a).from(s1).to(d1).authorize().from(s2).to(d2)
+   *                where s2 emits no principal
+   * @expectedResult Route 2's authorizer fires RC5012 and the destination is skipped;
+   *                 route 1 is unaffected.
+   */
+  test("acts as route-starter and gates rejected requests", async () => {
+    const main = spy<string>();
+
+    const t = await testContext()
+      .routes(
+        craft()
+          .id("first")
+          .from(simple("a"))
+          .to(noop())
+          .authorize()
+          .from(principalSource("b"))
+          .to(main),
+      )
+      .build();
+
+    const failures: unknown[] = [];
+    const routes = t.ctx.getRoutes();
+    const secondId = routes[1]?.definition.id ?? "";
+    t.ctx.on(
+      `route:${secondId}:exchange:failed` as EventName,
+      ((payload: FailedEventDetails) => {
+        failures.push(payload.details.error);
+      }) as Parameters<typeof t.ctx.on>[1],
+    );
+
+    await t.test();
+
+    expect(main.received).toHaveLength(0);
+    expect(failures).toHaveLength(1);
+    expect(String(failures[0])).toContain("RC5012");
     await t.stop();
   });
 });

--- a/packages/routecraft/test/auth/authorize.test.ts
+++ b/packages/routecraft/test/auth/authorize.test.ts
@@ -1,17 +1,33 @@
 import { describe, test, expect, expectTypeOf, afterEach } from "vitest";
 import { spy, testContext, type TestContext } from "@routecraft/testing";
 import {
+  authorize,
   craft,
   noop,
-  requirePrincipal,
   simple,
   type EventName,
   type Principal,
+  type Source,
 } from "../../src/index.ts";
 
 type FailedEventDetails = { details: { error: unknown } };
 
-describe("requirePrincipal()", () => {
+/**
+ * Build a tiny test source that emits one body and forwards a principal
+ * via the 5th argument of the subscribe handler. Mirrors what real
+ * authenticating sources (e.g. `mcp({ auth: jwt(...) })`) do at their
+ * boundary, so the route's first exchange already carries the principal
+ * and pre-from `.authorize()` can gate it.
+ */
+function principalSource<T>(body: T, principal?: Principal): Source<T> {
+  return {
+    subscribe: async (_ctx, handler) => {
+      await handler(body, undefined, undefined, undefined, principal);
+    },
+  };
+}
+
+describe("authorize() validator", () => {
   let t: TestContext;
 
   afterEach(async () => {
@@ -20,7 +36,7 @@ describe("requirePrincipal()", () => {
 
   /**
    * @case Validator returns body unchanged when an authenticated principal is present
-   * @preconditions Route .process() attaches a custom principal then .authorize() runs
+   * @preconditions Route .process() attaches a principal then .validate(authorize()) runs
    * @expectedResult Spy destination receives the body, exchange.principal is preserved
    */
   test("passes through when principal is present", async () => {
@@ -40,7 +56,7 @@ describe("requirePrincipal()", () => {
             ex.principal = principal;
             return ex;
           })
-          .authorize()
+          .validate(authorize())
           .to(s),
       )
       .build();
@@ -52,14 +68,16 @@ describe("requirePrincipal()", () => {
 
   /**
    * @case Validator throws RC5012 when no principal is attached to the exchange
-   * @preconditions Route uses .authorize() but never sets exchange.principal
+   * @preconditions Route uses .validate(authorize()) but never sets exchange.principal
    * @expectedResult exchange:failed event fires with an RC5012-coded error and the destination is skipped
    */
   test("rejects with RC5012 when no principal is present", async () => {
     const s = spy<string>();
 
     t = await testContext()
-      .routes(craft().id("anon").from(simple("hello")).authorize().to(s))
+      .routes(
+        craft().id("anon").from(simple("hello")).validate(authorize()).to(s),
+      )
       .build();
 
     const failures: unknown[] = [];
@@ -79,7 +97,7 @@ describe("requirePrincipal()", () => {
 
   /**
    * @case Validator throws RC5015 when the principal is missing a required role
-   * @preconditions Principal has roles ["user"] but .authorize() requires ["admin"]
+   * @preconditions Principal has roles ["user"] but authorize() requires ["admin"]
    * @expectedResult exchange:failed fires with RC5015 mentioning the missing role
    */
   test("rejects with RC5015 when a required role is missing", async () => {
@@ -100,7 +118,7 @@ describe("requirePrincipal()", () => {
             ex.principal = principal;
             return ex;
           })
-          .authorize({ roles: ["admin"] })
+          .validate(authorize({ roles: ["admin"] }))
           .to(s),
       )
       .build();
@@ -123,7 +141,7 @@ describe("requirePrincipal()", () => {
 
   /**
    * @case All required roles must be present (AND-combined)
-   * @preconditions Principal has ["admin"] but .authorize() requires ["admin", "billing"]
+   * @preconditions Principal has ["admin"] but authorize() requires ["admin", "billing"]
    * @expectedResult exchange:failed fires with RC5015 listing the still-missing role
    */
   test("requires every listed role (AND)", async () => {
@@ -144,7 +162,7 @@ describe("requirePrincipal()", () => {
             ex.principal = principal;
             return ex;
           })
-          .authorize({ roles: ["admin", "billing"] })
+          .validate(authorize({ roles: ["admin", "billing"] }))
           .to(s),
       )
       .build();
@@ -173,7 +191,7 @@ describe("requirePrincipal()", () => {
 
   /**
    * @case Required scopes are AND-combined and rejection cites the missing scope
-   * @preconditions Principal has scope "read" but .authorize() requires ["read", "write"]
+   * @preconditions Principal has scope "read" but authorize() requires ["read", "write"]
    * @expectedResult exchange:failed fires with RC5015 mentioning "write"
    */
   test("rejects with RC5015 when a required scope is missing", async () => {
@@ -194,7 +212,7 @@ describe("requirePrincipal()", () => {
             ex.principal = principal;
             return ex;
           })
-          .authorize({ scopes: ["read", "write"] })
+          .validate(authorize({ scopes: ["read", "write"] }))
           .to(s),
       )
       .build();
@@ -237,9 +255,11 @@ describe("requirePrincipal()", () => {
             ex.principal = principal;
             return ex;
           })
-          .authorize({
-            predicate: (p) => p.claims?.["tenant"] === "globex",
-          })
+          .validate(
+            authorize({
+              predicate: (p) => p.claims?.["tenant"] === "globex",
+            }),
+          )
           .to(s),
       )
       .build();
@@ -257,13 +277,21 @@ describe("requirePrincipal()", () => {
     expect(s.received).toHaveLength(0);
     expect(String(failures[0])).toContain("RC5015");
   });
+});
+
+describe(".authorize() route-only method", () => {
+  let t: TestContext;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+  });
 
   /**
-   * @case requirePrincipal as a plain validator works with .validate()
-   * @preconditions Route uses .validate(requirePrincipal({ roles: ["admin"] }))
-   * @expectedResult Authorized exchange flows through; unauthorized fails RC5015
+   * @case Pre-from .authorize() gates the route at entry and lets a valid principal through
+   * @preconditions Source emits a principal with role "admin"; pre-from .authorize() requires "admin"
+   * @expectedResult Spy receives the body
    */
-  test("requirePrincipal composes via .validate()", async () => {
+  test("pre-from .authorize() passes a principal that satisfies the requirement", async () => {
     const s = spy<string>();
     const principal: Principal = {
       kind: "custom",
@@ -275,19 +303,254 @@ describe("requirePrincipal()", () => {
     t = await testContext()
       .routes(
         craft()
-          .id("compose")
-          .from(simple("hello"))
-          .process((ex) => {
-            ex.principal = principal;
-            return ex;
-          })
-          .validate(requirePrincipal({ roles: ["admin"] }))
+          .id("pre-from-ok")
+          .authorize({ roles: ["admin"] })
+          .from(principalSource("hello", principal))
           .to(s),
       )
       .build();
     await t.test();
 
     expect(s.receivedBodies()).toEqual(["hello"]);
+  });
+
+  /**
+   * @case Pre-from .authorize() rejects when the source emits no principal
+   * @preconditions Source emits no principal; pre-from .authorize() with no options
+   * @expectedResult exchange:failed fires RC5012 and the destination is skipped
+   */
+  test("pre-from .authorize() rejects with RC5012 when source emits no principal", async () => {
+    const s = spy<string>();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("pre-from-anon")
+          .authorize()
+          .from(principalSource("hello"))
+          .to(s),
+      )
+      .build();
+
+    const failures: unknown[] = [];
+    t.ctx.on(
+      "route:pre-from-anon:exchange:failed" as EventName,
+      ((payload: FailedEventDetails) => {
+        failures.push(payload.details.error);
+      }) as Parameters<typeof t.ctx.on>[1],
+    );
+
+    await t.test();
+
+    expect(s.received).toHaveLength(0);
+    expect(String(failures[0])).toContain("RC5012");
+  });
+
+  /**
+   * @case Multiple .authorize() calls stack and AND-combine before any pipeline step
+   * @preconditions Two pre-from .authorize() calls (roles: admin, then scopes: read)
+   *                run before .to(); principal satisfies both
+   * @expectedResult Spy receives the body; both gates pass
+   */
+  test("stacks multiple .authorize() calls (AND-combined)", async () => {
+    const s = spy<{ id: string }>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      roles: ["admin"],
+      scopes: ["read", "write"],
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("stack")
+          .authorize({ roles: ["admin"] })
+          .authorize({ scopes: ["read"] })
+          .from(principalSource({ id: "x" }, principal))
+          .to(s)
+          .to(noop()),
+      )
+      .build();
+    await t.test();
+
+    expect(s.receivedBodies()).toEqual([{ id: "x" }]);
+  });
+
+  /**
+   * @case Stacked .authorize() short-circuits at the first failure
+   * @preconditions First .authorize() requires role "admin" (principal lacks it);
+   *                second .authorize() has a predicate that would throw if invoked
+   * @expectedResult exchange:failed fires with RC5015 from the first gate;
+   *                 the second predicate never runs
+   */
+  test("stacked .authorize() short-circuits at the first failure", async () => {
+    const s = spy<string>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      roles: ["user"],
+    };
+    let secondPredicateRan = false;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("short-circuit")
+          .authorize({ roles: ["admin"] })
+          .authorize({
+            predicate: () => {
+              secondPredicateRan = true;
+              return true;
+            },
+          })
+          .from(principalSource("hello", principal))
+          .to(s),
+      )
+      .build();
+
+    const failures: unknown[] = [];
+    t.ctx.on(
+      "route:short-circuit:exchange:failed" as EventName,
+      ((payload: FailedEventDetails) => {
+        failures.push(payload.details.error);
+      }) as Parameters<typeof t.ctx.on>[1],
+    );
+
+    await t.test();
+
+    expect(s.received).toHaveLength(0);
+    expect(String(failures[0])).toContain("RC5015");
+    expect(secondPredicateRan).toBe(false);
+  });
+
+  /**
+   * @case Pre-from .authorize() runs before any user pipeline step
+   * @preconditions Pre-from .authorize() rejects; .process() would mutate body if reached
+   * @expectedResult Process step never runs; failure is reported
+   */
+  test("pre-from .authorize() runs before any user pipeline step", async () => {
+    const s = spy<string>();
+    let processRan = false;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("entry-gate")
+          .authorize()
+          .from(principalSource("hello"))
+          .process((ex) => {
+            processRan = true;
+            return ex;
+          })
+          .to(s),
+      )
+      .build();
+
+    await t.test();
+
+    expect(s.received).toHaveLength(0);
+    expect(processRan).toBe(false);
+  });
+
+  /**
+   * @case Route-level .error() handler catches authorization failures
+   * @preconditions Pre-from .error() handler is set; pre-from .authorize()
+   *                rejects (no principal)
+   * @expectedResult The handler is invoked with an RC5012 error and no
+   *                 exchange:failed event fires (the route is recovered)
+   */
+  test("route-scope .error() handler catches an authorization failure", async () => {
+    let handlerInvoked = 0;
+    let errorSeen: unknown;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("recover")
+          .error((err) => {
+            handlerInvoked++;
+            errorSeen = err;
+            return "fallback";
+          })
+          .authorize()
+          .from(principalSource("hello")),
+      )
+      .build();
+
+    const failures: unknown[] = [];
+    t.ctx.on(
+      "route:recover:exchange:failed" as EventName,
+      ((payload: FailedEventDetails) => {
+        failures.push(payload.details.error);
+      }) as Parameters<typeof t.ctx.on>[1],
+    );
+
+    await t.test();
+
+    expect(handlerInvoked).toBe(1);
+    expect(String(errorSeen)).toContain("RC5012");
+    expect(failures).toHaveLength(0);
+  });
+});
+
+describe(".authorize() positional rules", () => {
+  /**
+   * @case .authorize() called after .from() throws RC2001 with a pointer to the escape hatch
+   * @preconditions craft().from(simple()).authorize() (post-from misuse)
+   * @expectedResult Builder throws RC2001; the message names .validate(authorize()) as the alternative
+   */
+  test("throws RC2001 when called after .from()", () => {
+    let caught: unknown;
+    try {
+      craft()
+        .id("post-from")
+        .from(simple("hello"))
+        .authorize({ roles: ["admin"] });
+    } catch (err) {
+      caught = err;
+    }
+    // Per .standards/testing.md section 5: assert on the structural `rc`
+    // code, not message wording. The thrown value is a RoutecraftError
+    // with `rc: "RC2001"`.
+    expect(caught).toMatchObject({ rc: "RC2001" });
+  });
+
+  /**
+   * @case Error message points at the .validate(authorize()) escape hatch
+   * @preconditions As above
+   * @expectedResult Thrown error mentions .validate(authorize so users discover the mid-pipeline form
+   */
+  test("error message points at .validate(authorize()) escape hatch", () => {
+    expect(() =>
+      craft().id("post-from-msg").from(simple("hello")).authorize(),
+    ).toThrow(/\.validate\(authorize/);
+  });
+
+  /**
+   * @case .authorize() works pre-from for a chained second route after an earlier .from()
+   * @preconditions craft().from(s1).to(d1).id("next").authorize().from(s2).to(d2)
+   * @expectedResult Both routes build without throwing; the second route gates on its own .authorize()
+   */
+  test("supports chained routes when staged via .id() before the next .from()", async () => {
+    const t = await testContext()
+      .routes(
+        craft()
+          .id("first")
+          .from(simple("a"))
+          .to(noop())
+          .id("second")
+          .authorize()
+          .from(principalSource("b"))
+          .to(noop()),
+      )
+      .build();
+
+    // Route built; no throw. Engine wires both.
+    expect(t.ctx.getRoutes()).toHaveLength(2);
+    await t.stop();
   });
 });
 
@@ -362,11 +625,11 @@ describe("exchange.principal propagation", () => {
   });
 
   /**
-   * @case `.authorize()` without options succeeds for any authenticated principal
-   * @preconditions Principal has no roles or scopes; .authorize() called without options
-   * @expectedResult Exchange flows through to the destination
+   * @case Source-emitted principal survives the route into the destination
+   * @preconditions principalSource attaches a principal at the source boundary
+   * @expectedResult The destination's exchange carries the same principal
    */
-  test(".authorize() without options accepts any principal", async () => {
+  test("source-emitted principal reaches the destination", async () => {
     const s = spy<string>();
     const principal: Principal = {
       kind: "custom",
@@ -377,19 +640,14 @@ describe("exchange.principal propagation", () => {
     t = await testContext()
       .routes(
         craft()
-          .id("any-auth")
-          .from(simple("hello"))
-          .process((ex) => {
-            ex.principal = principal;
-            return ex;
-          })
-          .authorize()
+          .id("source-principal")
+          .from(principalSource("hello", principal))
           .to(s),
       )
       .build();
     await t.test();
 
-    expect(s.receivedBodies()).toEqual(["hello"]);
+    expect(s.lastReceived().principal).toEqual(principal);
   });
 
   /**
@@ -484,71 +742,20 @@ describe("exchange.principal propagation", () => {
 });
 
 describe(".authorize() type checks", () => {
-  let t: TestContext;
-
-  afterEach(async () => {
-    if (t) await t.stop();
-  });
-
   /**
-   * @case .authorize() is type-preserving (body type unchanged) on RouteBuilder
-   * @preconditions Build a route with .authorize() between a typed source and destination
-   * @expectedResult The builder's exchange-body type remains the source's body type
-   *                 across .authorize() calls; chained .to() compiles
+   * @case Pre-from .authorize() preserves the body type that .from() introduces
+   * @preconditions craft().authorize().from<T>(source) chained with a typed .to()
+   * @expectedResult The builder's exchange-body type after .from() equals T,
+   *                 so a typed .to() compiles
    */
-  test("is body-type-preserving on RouteBuilder (type-level)", () => {
-    const beforeAuthorize = craft()
+  test("pre-from .authorize() does not perturb body inference", () => {
+    const built = craft()
       .id("typed-route")
-      .from(simple({ id: "x" } as { id: string }))
-      .process((ex) => {
-        ex.principal = {
-          kind: "custom",
-          scheme: "bearer",
-          subject: "user-1",
-        };
-        return ex;
-      });
+      .authorize({ roles: ["admin"] })
+      .from(principalSource({ id: "x" } as { id: string }));
 
-    const afterAuthorize = beforeAuthorize.authorize({ roles: ["admin"] });
-
-    // .authorize() is a validate-style sugar declared as `(opts?) => this`.
-    // The builder type returned must equal the type before .authorize()
-    // (same Current generic, same subclass), so chained operators that
-    // depend on body inference (.to(spy<{id:string}>())) keep typing.
-    expectTypeOf(afterAuthorize).toEqualTypeOf(beforeAuthorize);
-  });
-
-  /**
-   * @case .authorize() chains alongside .to() without changing body inference
-   * @preconditions Multi-step route with two .authorize() calls and a typed spy
-   * @expectedResult Spy receives body { id: "x" } at runtime
-   */
-  test("is type-preserving and chainable", async () => {
-    const s = spy<{ id: string }>();
-
-    t = await testContext()
-      .routes(
-        craft()
-          .id("chain")
-          .from(simple({ id: "x" }))
-          .process((ex) => {
-            ex.principal = {
-              kind: "custom",
-              scheme: "bearer",
-              subject: "user-1",
-              roles: ["admin"],
-              scopes: ["read", "write"],
-            };
-            return ex;
-          })
-          .authorize({ roles: ["admin"] })
-          .authorize({ scopes: ["read"] })
-          .to(s)
-          .to(noop()),
-      )
-      .build();
-    await t.test();
-
-    expect(s.receivedBodies()).toEqual([{ id: "x" }]);
+    // After .from<{id: string}>, the builder's Current generic must be
+    // {id: string} so a downstream .to(spy<{id:string}>()) type-checks.
+    expectTypeOf(built.to).toBeCallableWith(spy<{ id: string }>());
   });
 });


### PR DESCRIPTION
Tightens the auth surface that landed with #277 before it ships:

- Validator: rename `requirePrincipal({...})` -> `authorize({...})`
  (and `RequirePrincipalOptions` -> `AuthorizeOptions`). The function
  is the documented escape hatch for mid-pipeline checks via
  `.validate(authorize({...}))`.
- DSL sugar removed: drop `registerDsl("authorize", ...)` and the
  `StepBuilderBase.authorize` interface augmentation. `.authorize()`
  no longer exists on the post-from builder.
- Builder method: `.authorize(opts?)` becomes a route-only method on
  `RouteBuilder` (declared after `.error()` so `.error()`'s JSDoc
  stays associated with its definition). Pre-from it stages onto
  `pendingOptions.authorizers`; at `.from()` time the staged options
  are prepended as `ValidateStep(authorize(opts))` so the gate runs
  at route entry, before any pipeline step. Multiple `.authorize()`
  calls stack and AND-combine in declaration order; the first
  failure short-circuits.
- Post-from misuse throws RC2001 with a message pointing at
  `.validate(authorize({...}))` as the mid-pipeline form.
- JSDoc on both the method and the validator function disambiguates
  "checks an existing identity, does not issue/mint credentials".

Tests rewritten: validator-logic cases (RC5012 / RC5015 / role /
scope / predicate) move to `.validate(authorize(...))`. Method tests
use a new tiny `principalSource` helper that emits a body + principal
via the source's 5-arg subscribe, mirroring what
`mcp({ auth: jwt(...) })` does at its boundary. Adds: pre-from happy
path, AND stacking, short-circuit, route-scope `.error()` recovery,
post-from-throws (asserted on the structural `rc: "RC2001"` per
`.standards/testing.md` section 5), chained-route staging via
`.id()`. Type-preservation test asserts pre-from `.authorize()` does
not perturb `.from<T>()` body inference.

Docs:
- `reference/operations`: moves `### authorize` from the Flow Control
  section up to Route operations (next to `id`, `batch`, `error`),
  retags the table row to the existing `Route` category, and rewrites
  the section for the pre-from-only contract.
- `reference/errors`: RC5012 / RC5015 entries refer to `.authorize()`
  and `.validate(authorize(...))` instead of the removed
  `requirePrincipal()`.
- `migrating/0.4-to-0.5`: adds a "What is new in 0.5.0" entry for
  `.authorize()` (route-entry guard, escape hatch, failure modes)
  and adds `.authorize()` to the route-only operations table.

JSDoc / example fixes: replace the bogus `httpServer({ path })` (no
such adapter) and `mcpTool({ name })` (returns a DeferredFn, not a
Source) with the real adapter shapes (`http({ path, method })` and
`mcp({ annotations: { ... } })` with the route id carrying the tool
name) in `builder.ts` (`.id()`, `.authorize()`, `.from()` JSDoc),
`auth/authorize.ts`, and the operations doc. Strengthens the JSDoc
on the principal slot in `from.ts` to call out the stable 5th
positional argument and the test-helper usage pattern.

BREAKING CHANGE: `requirePrincipal` is renamed to `authorize` and
`RequirePrincipalOptions` to `AuthorizeOptions`. `.authorize()` is
route-only; calling it after `.from()` now throws RC2001. For
mid-pipeline checks use `.validate(authorize({ ... }))`.

Co-authored-by: Claude <claude@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a route-entry guard with pre-from `.authorize()` and rename the validator from `requirePrincipal` to `authorize`. `.authorize()` now follows the route-only staging pattern and can start the next route; misuse is reported as `RC2001` when a pipeline op is called while an authorizer is staged.

- **New Features**
  - `.authorize(opts?)` on `RouteBuilder` stages onto the next route and runs before any pipeline step; calls stack (AND) and short-circuit on first failure.
  - Misuse is caught by `RC2001` when a pipeline op runs with staged authorizers and no new `.from()`; allows chained routes like `.from(s1).to(d1).authorize(...).from(s2)`.
  - Failures throw `RC5012` (no principal) or `RC5015` (roles/scopes/predicate); use `authorize(opts)` with `.validate(...)` for mid-pipeline checks.
  - Docs and JSDoc updated; examples fixed (`http({ path, method })`, `mcp({ annotations })`); tests use a `principalSource` helper.

- **Migration**
  - Replace `requirePrincipal(...)` with `authorize(...)` and `RequirePrincipalOptions` with `AuthorizeOptions` (import from `@routecraft/routecraft`).
  - Use `.authorize()` only before `.from()`; for mid-pipeline checks use `.validate(authorize({...}))`.
  - The post-from DSL sugar is removed; `.authorize()` is not available on the post-from builder.
  - If you see `RC2001`, a pipeline op ran while `.authorize()` (or other route-level ops) were staged—open the next route with `.from()` or switch to the validator form.

<sup>Written for commit 92bffa2ef0c4820a7759e9f5e91179a60a1071f7. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/279?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

