### PR TITLE
fix(mail): reconnect on transient fetch failures in poll mode

### DIFF
--- a/packages/routecraft/src/adapters/mail/source.ts
+++ b/packages/routecraft/src/adapters/mail/source.ts
@@ -186,8 +186,11 @@ export class MailSourceAdapter implements Source<MailMessage> {
       if (resolved.pollIntervalMs) {
         await this.pollLoop(
           clientRef,
+          manager,
+          account,
           resolved,
           folder,
+          usePool,
           markSeenEnabled,
           handlerWithHeaders,
           abortController,
@@ -251,10 +254,18 @@ export class MailSourceAdapter implements Source<MailMessage> {
     }
   }
 
+  /**
+   * Reconnect on a dropped connection using the same backoff as IDLE. Without
+   * this, a transient socket failure during a fetch would tear the
+   * subscription down for good and the only recovery is a process restart.
+   */
   private async pollLoop(
     clientRef: { current: ImapClient | null },
+    manager: MailClientManager | null,
+    account: string | undefined,
     options: MailServerOptions,
     folder: string,
+    usePool: boolean,
     markSeenEnabled: boolean,
     handler: (message: MailMessage) => Promise<Exchange>,
     abortController: AbortController,
@@ -265,7 +276,35 @@ export class MailSourceAdapter implements Source<MailMessage> {
       const client = clientRef.current;
       if (!client) return;
 
-      const messages = await fetchMessages(client, options, folder, logger);
+      let messages: MailMessage[];
+      try {
+        messages = await fetchMessages(client, options, folder, logger);
+      } catch (error) {
+        if (abortController.signal.aborted) return;
+        if (isMailAuthError(error)) {
+          // Auth failures will not recover on reconnect; surface clearly and stop.
+          throwMailConnectionError(error, "IMAP");
+        }
+        logger?.warn(
+          {
+            err: error instanceof Error ? error : new Error(String(error)),
+            folder,
+          },
+          "mail adapter poll fetch failed; attempting reconnect",
+        );
+        await this.reconnectWithBackoff(
+          clientRef,
+          manager,
+          account,
+          options,
+          folder,
+          usePool,
+          abortController,
+          logger,
+        );
+        if (abortController.signal.aborted) return;
+        continue;
+      }
 
       for (const message of messages) {
         if (abortController.signal.aborted) break;

--- a/packages/routecraft/src/adapters/mail/source.ts
+++ b/packages/routecraft/src/adapters/mail/source.ts
@@ -21,11 +21,11 @@ import {
 type ImapClient = InstanceType<typeof import("imapflow").ImapFlow>;
 
 /** Cap reconnect attempts so an unrecoverable server fault does not loop forever. */
-const IDLE_RECONNECT_MAX_ATTEMPTS = 30;
-/** Initial backoff between IDLE reconnect attempts. */
-const IDLE_RECONNECT_BASE_MS = 1_000;
+const MAIL_RECONNECT_MAX_ATTEMPTS = 30;
+/** Initial backoff between mail reconnect attempts. */
+const MAIL_RECONNECT_BASE_MS = 1_000;
 /** Cap for exponential backoff. */
-const IDLE_RECONNECT_MAX_MS = 60_000;
+const MAIL_RECONNECT_MAX_MS = 60_000;
 
 /**
  * Source adapter that receives email messages from IMAP using IDLE or polling.
@@ -299,6 +299,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
           options,
           folder,
           usePool,
+          "poll",
           abortController,
           logger,
         );
@@ -394,6 +395,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
           options,
           folder,
           usePool,
+          "idle",
           abortController,
           logger,
         );
@@ -458,9 +460,11 @@ export class MailSourceAdapter implements Source<MailMessage> {
   }
 
   /**
-   * Replace a dead IMAP client after an IDLE failure. Exponential backoff
-   * with jitter, capped total attempts. Releases the current client on the
-   * first attempt so the pool slot is freed for the new connection.
+   * Replace a dead IMAP client after a fetch or IDLE failure. Exponential
+   * backoff with jitter, capped total attempts. Releases the current client
+   * on the first attempt so the pool slot is freed for the new connection.
+   * `mode` is interpolated into log lines and the give-up error so operators
+   * can tell which loop the reconnect was driven from.
    */
   private async reconnectWithBackoff(
     clientRef: { current: ImapClient | null },
@@ -469,6 +473,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
     options: MailServerOptions,
     folder: string,
     usePool: boolean,
+    mode: "idle" | "poll",
     abortController: AbortController,
     logger?: MailFetchLogger,
   ): Promise<void> {
@@ -486,12 +491,12 @@ export class MailSourceAdapter implements Source<MailMessage> {
       }
     }
 
-    for (let attempt = 1; attempt <= IDLE_RECONNECT_MAX_ATTEMPTS; attempt++) {
+    for (let attempt = 1; attempt <= MAIL_RECONNECT_MAX_ATTEMPTS; attempt++) {
       if (abortController.signal.aborted) return;
 
       const base = Math.min(
-        IDLE_RECONNECT_BASE_MS * 2 ** (attempt - 1),
-        IDLE_RECONNECT_MAX_MS,
+        MAIL_RECONNECT_BASE_MS * 2 ** (attempt - 1),
+        MAIL_RECONNECT_MAX_MS,
       );
       // Full jitter: pick uniformly in [0, base] so retries don't thunder.
       const delay = Math.floor(Math.random() * base);
@@ -508,8 +513,8 @@ export class MailSourceAdapter implements Source<MailMessage> {
         );
         clientRef.current = fresh;
         logger?.debug(
-          { folder, attempt },
-          "mail adapter IDLE reconnect succeeded",
+          { folder, attempt, mode },
+          `mail adapter ${mode} reconnect succeeded`,
         );
         return;
       } catch (error) {
@@ -521,14 +526,15 @@ export class MailSourceAdapter implements Source<MailMessage> {
             err: error instanceof Error ? error : new Error(String(error)),
             folder,
             attempt,
+            mode,
           },
-          "mail adapter IDLE reconnect attempt failed",
+          `mail adapter ${mode} reconnect attempt failed`,
         );
       }
     }
 
     throw rcError("RC5010", undefined, {
-      message: `Mail adapter IDLE reconnect gave up after ${IDLE_RECONNECT_MAX_ATTEMPTS} attempts on folder "${folder}".`,
+      message: `Mail adapter ${mode} reconnect gave up after ${MAIL_RECONNECT_MAX_ATTEMPTS} attempts on folder "${folder}".`,
     });
   }
 }

--- a/packages/routecraft/test/mail.test.ts
+++ b/packages/routecraft/test/mail.test.ts
@@ -1442,6 +1442,10 @@ describe("Mail Adapter", () => {
       await t.ctx.stop();
       await startPromise.catch(() => {});
 
+      // Auth errors flow through context:error -> t.errors, not start() rejection
+      // (the route runtime uses Promise.allSettled internally).
+      expect(t.errors).toHaveLength(1);
+      expect(t.errors[0]).toMatchObject({ rc: "RC5012" });
       expect(idleCalls).toBe(1);
       // No reconnect: mailboxOpen called once at initial subscribe
       expect(mockMailboxOpen.mock.calls.length).toBe(1);
@@ -1536,6 +1540,10 @@ describe("Mail Adapter", () => {
       await t.ctx.stop();
       await startPromise.catch(() => {});
 
+      // Auth errors flow through context:error -> t.errors, not start() rejection
+      // (the route runtime uses Promise.allSettled internally).
+      expect(t.errors).toHaveLength(1);
+      expect(t.errors[0]).toMatchObject({ rc: "RC5012" });
       expect(fetchCalls).toBe(1);
       // No reconnect: mailboxOpen called once at initial subscribe
       expect(mockMailboxOpen.mock.calls.length).toBe(1);

--- a/packages/routecraft/test/mail.test.ts
+++ b/packages/routecraft/test/mail.test.ts
@@ -1448,6 +1448,100 @@ describe("Mail Adapter", () => {
     });
 
     /**
+     * @case Poll mode reconnects after a non-auth fetch failure
+     * @preconditions First fetch() throws "Connection not available", subsequent fetches succeed
+     * @expectedResult mailboxOpen is called more than once (initial + reconnect) and the route stays alive
+     */
+    test("poll reconnects after a transient fetch failure", async () => {
+      // Zero jitter so the reconnect backoff collapses to 0ms in the test.
+      vi.spyOn(Math, "random").mockReturnValue(0);
+
+      let fetchCalls = 0;
+      mockFetch.mockImplementation(() => {
+        fetchCalls++;
+        if (fetchCalls === 1) {
+          throw new Error("Connection not available");
+        }
+        return {
+          async *[Symbol.asyncIterator]() {},
+        };
+      });
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("test-poll-reconnect")
+            .from(mail("INBOX", { pollIntervalMs: 5 }))
+            .to(spy()),
+        )
+        .build();
+
+      const startPromise = t.ctx.start();
+      await new Promise((r) => setTimeout(r, 50));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(fetchCalls).toBeGreaterThanOrEqual(2);
+      // Initial open + reconnect open
+      expect(mockMailboxOpen.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    /**
+     * @case Auth errors during poll do not trigger reconnect
+     * @preconditions fetch() rejects with an auth error on the first call
+     * @expectedResult Subscription fails with an auth error and no reconnect is attempted
+     */
+    test("poll auth failure stops the subscription without reconnect", async () => {
+      let fetchCalls = 0;
+      mockFetch.mockImplementation(() => {
+        fetchCalls++;
+        throw new Error("AUTHENTICATIONFAILED");
+      });
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "wrong" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("test-poll-auth-fail")
+            .from(mail("INBOX", { pollIntervalMs: 5 }))
+            .to(spy()),
+        )
+        .build();
+
+      const startPromise = t.ctx.start();
+      await new Promise((r) => setTimeout(r, 30));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(fetchCalls).toBe(1);
+      // No reconnect: mailboxOpen called once at initial subscribe
+      expect(mockMailboxOpen.mock.calls.length).toBe(1);
+    });
+
+    /**
      * @case Throws RC5003 at subscribe when markSeen is false without pollIntervalMs
      * @preconditions markSeen: false with no pollIntervalMs (IDLE flood footgun)
      * @expectedResult t.test() rejects with RC5003


### PR DESCRIPTION
## Summary

- Poll mode mail source had no reconnect logic, so a dropped IMAP socket (server idle timeout, network blip) threw RC5001, exited the loop, and killed the route fatally — only a process restart would recover. Hit in production: a Zoe mail route stopped processing at 09:00 and stayed dead.
- IDLE mode got `reconnectWithBackoff` in #241 but the poll path was missed.
- Mirrors the IDLE behavior: auth errors surface fatally, every other error reconnects with exponential backoff (capped at 30 attempts, 60s ceiling) and resumes polling.

## Why this stays in the adapter even after route-level resilience wrappers

A future `.retry()` resilience wrapper would tear the whole subscription down and rebuild it on failure. Adapter-level reconnect operates at a finer grain: it swaps the dead client for a fresh one from the pool while keeping the rest of the subscription intact. They compose — `.retry()` is the safety net for when the adapter gives up; the adapter handles in-subscription liveness so `.retry()` is rarely needed.

A separate issue should track the framework-level supervisor (`.retry()` / `.circuitBreaker()` resilience wrappers) — that is a design discussion, not a bug fix.

## Test plan

- [x] `pnpm vitest run packages/routecraft/test/mail.test.ts` — all 65 mail tests pass, including two new tests covering poll reconnect on transient failure and poll auth-failure stop-without-reconnect.
- [x] `pnpm typecheck` clean.
- [ ] Validate against the production Zoe mail route after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes poll-mode IMAP to auto-reconnect on transient fetch failures so routes don’t die after a dropped socket. Auth errors still fail fast; other errors back off and resume polling.

- **Bug Fixes**
  - Added reconnectWithBackoff in the poll loop using the same backoff as IDLE (`MAIL_RECONNECT_*`) and the pool when enabled.
  - Logs and errors now include the loop mode ("poll" | "idle"); RC5010 message reflects the source.
  - Tests cover poll reconnect and no-retry on auth; tightened auth-failure assertions (including IDLE) to expect RC5012 via context errors.

<sup>Written for commit bcf3f7db7eea3d9951eaf6cd956f7f1f734497e1. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/281?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

