### PR TITLE
feat(core)!: unify exchange state on { body, headers }; principal/id/logger become getters

### DIFF
--- a/.standards/README.md
+++ b/.standards/README.md
@@ -9,6 +9,7 @@ Internal development standards for Routecraft contributors (human and AI). These
 | Document | Scope |
 |----------|-------|
 | [Adapter Architecture](./adapter-architecture.md) | Patterns, file structure, facade, authoring guide, skeletons, and anti-patterns for adapters |
+| [Exchange State Model](./exchange-state-model.md) | Where state lives on an exchange (`body`/`headers` vs derivations like `id`/`principal`/`logger`), halt/continue serialization contract, getter pattern for cross-cutting concerns |
 | [Naming Policy](./naming-policy.md) | Source/Destination vs Server/Client naming, schema field names (`input`/`output`), prompt-source field names |
 | [Error and Logging Policy](./error-and-logging-policy.md) | Throw/boundary rules, structured logging, level semantics, error code philosophy |
 | [Type Safety and Schemas](./type-safety-and-schemas.md) | Type flow policy, factory option types (no `Partial<>` on factory args), Standard Schema usage, plugin vs config vs store guidance |

--- a/.standards/error-and-logging-policy.md
+++ b/.standards/error-and-logging-policy.md
@@ -91,6 +91,8 @@ All boundaries use `err.meta.message` (`RoutecraftError`) or `err.message` (plai
 
 Every operation that alters an exchange's lifecycle must emit an observable event. No silent drops.
 
+The companion document for *where state lives on the exchange* is [`exchange-state-model.md`](./exchange-state-model.md). When you instrument a new operation, that document tells you which fields are stored (`body`, `headers`) versus derived (`id`, `principal`, `logger`); this document tells you which events to emit and what `exchangeId` / `correlationId` resolve to.
+
 | Event | When | Key details |
 |-------|------|-------------|
 | `exchange:started` | Exchange enters the pipeline (or a child is first processed) | `exchangeId`, `correlationId` |

--- a/.standards/exchange-state-model.md
+++ b/.standards/exchange-state-model.md
@@ -1,0 +1,135 @@
+# Exchange State Model
+
+Where state of kind X lives on an `Exchange<T>`, and why.
+
+## The model
+
+Two layers per exchange.
+
+| Layer | What it holds | Examples | Persistence |
+|---|---|---|---|
+| **State (stored fields)** | `body: T`, `headers: ExchangeHeaders` | the payload, every piece of metadata about the exchange (id, route, correlation, split hierarchy, source-emitted facts, cross-cutting concerns like principal/span/tenant) | serialized verbatim; rehydrated verbatim |
+| **Derivations (getters / methods on `DefaultExchange`)** | `id`, `principal`, `logger` | `get id()` reads `headers["routecraft.id"]`; `get principal()` reads `headers["routecraft.auth.principal"]`; `get logger()` builds a child logger from the framework's base logger and the exchange's id | not serialized; reconstructed by instantiating `DefaultExchange` around the rehydrated state |
+
+Application-wide singletons (adapter clients, plugin state, schedulers) live in `context.store`, which is orthogonal: it outlives any individual exchange.
+
+## The rules
+
+> **State (must persist):** `body` is the operand the route is processing. `headers` is everything the framework needs to know about the exchange (metadata).
+>
+> **Derivations (must NOT be stored, must be reconstructible):** anything that's a view over state (id, principal lookup, future span lookup) or depends on runtime services (logger). Exposed as getters so call sites read like properties.
+>
+> **Singletons (out-of-band):** application-wide things go in `context.store`.
+
+A contributor adding new state asks:
+
+1. Is it the payload the route is operating on? --> `body`.
+2. Does the same instance need to outlive the exchange and be shared across routes? --> `context.store` (typed via `StoreRegistry`).
+3. Anything else per-exchange that must survive the exchange? --> `headers` (typed via `RoutecraftHeaders` augmentation or `HeaderKeysRegistry`).
+4. Want ergonomic dotted access (`ex.foo`) for a known core concern? --> add a getter on `DefaultExchange` that reads from `headers`. Plugin-defined concerns export an external helper (`getTenant(ex)`) instead of patching the prototype.
+
+That's it. No primitive/structured split. No second per-exchange bag. No stored-field "special cases" for cross-cutting concerns. One Principal --> one header key + one getter. One Span (future) --> one header key (and external helper if warranted).
+
+## Halt / continue contract
+
+Persisting an exchange = serializing `{ body, headers }`. Resuming an exchange = `new DefaultExchange(context, { body, headers })` on the resuming process, where `context` is a fresh `CraftContext`.
+
+The getters (`id`, `principal`, `logger`) work immediately because they derive lazily. The `EXCHANGE_INTERNALS` WeakMap (route binding, parse hook, validation hook, startedAt, dropped flag) is NOT serialized -- it's runtime context, rehydrated by re-attaching the route via `headers["routecraft.route"]` on the new context.
+
+The serialization surface is exactly two slots (`body`, `headers`), by construction. A future halt/continue PR does not need to enumerate which fields to serialize; the model dictates it.
+
+## Three exchange forms (by design)
+
+The codebase distinguishes three views of an exchange. They are intentionally separate.
+
+1. **External `Exchange<T>` type** (`packages/routecraft/src/exchange.ts`) -- the public API surface. Type-level only, no implementation. What user code (route steps, plugin authors) sees. Stable.
+2. **Internal `DefaultExchange<T>` class** (`packages/routecraft/src/exchange.ts`) -- the implementation. Stored fields are `body` and `headers`. Getters expose `id`/`principal`/`logger`. Internal-only state (route binding, parse hook, dropped flag, startedAt) lives in the `EXCHANGE_INTERNALS` WeakMap, hidden from the external type by design.
+3. **Logger projection via `childBindings(ex)`** (`packages/routecraft/src/logger.ts`) -- a flat record (`{ contextId, route, correlationId, exchangeId, auth.subject, auth.issuer }`) built for pino bindings. Different shape from the exchange itself; a deliberately denormalized view for log output.
+
+Halt/continue serializes only the implementation class's stored fields. The log projection is rebuilt on demand on the resuming process.
+
+## Worked examples
+
+### Adding a tracing plugin
+
+Where does the active span go?
+
+```ts
+// In the tracing plugin package
+declare module "@routecraft/routecraft" {
+  interface RoutecraftHeaders {
+    "routecraft.tracing.span"?: TraceSpan;
+  }
+}
+
+// Setting:
+const next = { ...ex, headers: { ...ex.headers, "routecraft.tracing.span": span } };
+
+// Reading (via an external helper exported from the plugin):
+export function getSpan(ex: Exchange): TraceSpan | undefined {
+  return ex.headers["routecraft.tracing.span"];
+}
+```
+
+The plugin does NOT add a getter on `DefaultExchange` (that would require prototype patching, which arms-races between plugins). Plugin-defined concerns expose ergonomic helpers as named exports.
+
+### Adding a tenancy plugin
+
+Same pattern.
+
+```ts
+declare module "@routecraft/routecraft" {
+  interface RoutecraftHeaders {
+    "routecraft.tenancy.tenant"?: TenantContext;
+  }
+}
+
+export function getTenant(ex: Exchange): TenantContext | undefined {
+  return ex.headers["routecraft.tenancy.tenant"];
+}
+```
+
+### Building an HTTP source adapter
+
+Where do inbound HTTP headers go? Translate at the adapter boundary into namespaced exchange-header keys.
+
+```ts
+const exchangeHeaders = {
+  "http.request.method": req.method,
+  "http.request.url": req.url,
+  ...Object.fromEntries(
+    Object.entries(req.headers).map(([k, v]) => [`http.request.${k}`, v]),
+  ),
+};
+```
+
+Don't introduce a "wire-mapped header bag" parallel to `headers`. The framework has one bag.
+
+### Building an HTTP destination adapter
+
+Outbound headers come from the adapter's own config (e.g. `http({ headers: { authorization: "..." } })`), not from `ex.headers`. The exchange's headers are in-process metadata, not a transport envelope. (Same as today; this didn't change with the model.)
+
+## Non-rules (deliberately)
+
+- **No PII enforcement at the framework type level.** PII is a logging-policy concern, not a framework-type concern. log4j doesn't ban strings to prevent PII leaks; the log statement and the aggregator filter handle that.
+- **No second bag for "structured" data.** No surveyed framework splits on primitive-vs-structured; frameworks that split (Camel, Koa, Hono) split on wire-vs-app. Routecraft has no wire-mapped bag and won't grow one (wire concerns translate at adapter boundaries).
+- **No ambient-context API yet.** AsyncLocalStorage breaks across queue / split / aggregate / retry boundaries; the source of truth must be on the exchange. A `currentExchange()` helper inside a single operation is a possible future ergonomic on top, not a replacement.
+- **Plugins do not extend `DefaultExchange`'s prototype.** Adding a getter for plugin-defined concerns would lead to arms races and conflicts. Plugins export external helpers (`getTenant(ex)`).
+- **No deep-clone of structured header values in tap snapshots.** Headers are shallow-frozen (and the constructor shallow-freezes structured values like `Principal`). Mutating nested fields of any structured header value (`ex.principal.claims.foo = ...`) is an anti-pattern the framework does not prevent and does not isolate against. Tap is for observation, not mutation.
+
+## Why one bag named `headers`
+
+A survey of Camel, Spring Integration, NestJS, Express/Koa/Hono/Fastify, gRPC, Apollo, OpenTelemetry, Temporal, and middy was the basis for this model.
+
+- **Spring Integration is the direct precedent.** `MessageHeaders implements Map<String, Object>`. Typed by constants. Holds correlation ids, source-emitted facts, AND auth tokens. The JVM elephant for this exact problem space, and nobody confuses it with HTTP headers.
+- **Wire-vs-app is the only load-bearing split** in frameworks that split, but Routecraft does NOT wire-map a bag (sources/destinations translate at adapter boundaries), so the split would buy nothing here.
+- **Cross-cutting concerns work badly via ambient context** in message-passing systems because async chains break at queue / split / aggregate / retry boundaries. Source of truth must live on the exchange.
+
+The "HTTP headers go on the wire" connotation is real but mild and addressable via docs. Spring Integration runs on this naming for over a decade without confusion.
+
+## Implementation references
+
+- `packages/routecraft/src/exchange.ts` -- `RoutecraftHeaders`, `HeadersKeys`, `ExchangeHeaders`, `DefaultExchange`, `DefaultExchange.rewrap`
+- `packages/routecraft/src/auth/types.ts` -- module augmentation for `routecraft.auth.principal`
+- `packages/routecraft/src/logger.ts` -- `childBindings` (the third / log-projection form)
+- `packages/routecraft/test/exchange-state-model.test.ts` -- end-to-end smoke test for the halt/continue contract

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Type-safe integration and automation framework. Monorepo with pnpm workspaces.
 Detailed coding standards for contributors live in `.standards/`:
 
 - [Adapter Architecture](.standards/adapter-architecture.md) -- patterns, file structure, facade, authoring guide
+- [Exchange State Model](.standards/exchange-state-model.md) -- where state lives on an exchange (`body`/`headers` vs derivations), halt/continue contract
 - [Naming Policy](.standards/naming-policy.md) -- Source/Destination vs Server/Client conventions
 - [Error and Logging Policy](.standards/error-and-logging-policy.md) -- throw/boundary rules, log levels, error codes
 - [Type Safety and Schemas](.standards/type-safety-and-schemas.md) -- type flow, Standard Schema, plugin vs config

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -244,7 +244,7 @@ auth: {
 }
 ```
 
-The returned `Principal` is a flat object tagged with `kind` (`"jwt"`, `"jwks"`, `"oauth"`, or `"custom"`). Its fields are forwarded to your routes as `routecraft.auth.*` exchange headers.
+The returned `Principal` is a flat object tagged with `kind` (`"jwt"`, `"jwks"`, `"oauth"`, or `"custom"`). It rides on the exchange as a structured `routecraft.auth.principal` header and is exposed ergonomically via the `ex.principal` getter.
 
 ### OAuth 2.1 proxy (`oauth()`)
 
@@ -303,7 +303,7 @@ auth: oauth({
 
 `expiresAt` is required by the MCP SDK's bearer middleware; the server will throw if the verifier returns a principal without it.
 
-The populated `Principal` surfaces every identity field on the exchange: `routecraft.auth.subject`, `routecraft.auth.client_id`, `routecraft.auth.email`, `routecraft.auth.name`, `routecraft.auth.issuer`, `routecraft.auth.audience`, `routecraft.auth.scopes`, `routecraft.auth.roles`, and `routecraft.auth.kind`.
+The populated `Principal` rides on the exchange as a single structured header (`routecraft.auth.principal`) and is exposed ergonomically via the `ex.principal` getter, e.g. `ex.principal?.subject`, `ex.principal?.scopes`, `ex.principal?.claims`.
 
 See the [plugins reference](/docs/reference/plugins#mcpplugin) for the full `Principal` field list.
 

--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -262,20 +262,26 @@ craft()
 ```ts
 // Mid-pipeline check: route attaches a custom principal from an
 // inbound email and authorizes it after the .process() step.
+// Exchanges are immutable; return a new one with the principal set
+// on `headers["routecraft.auth.principal"]` (the `ex.principal`
+// getter reads from the same header).
 import { authorize } from '@routecraft/routecraft'
 
 craft()
   .from(mail({ /* ... */ }))
-  .process((ex) => {
-    ex.principal = {
-      kind: 'custom',
-      scheme: 'email',
-      subject: ex.body.from?.address ?? 'anonymous',
-      email: ex.body.from?.address,
-      claims: { tenant: deriveTenant(ex.body.from?.address) },
-    }
-    return ex
-  })
+  .process((ex) => ({
+    ...ex,
+    headers: {
+      ...ex.headers,
+      'routecraft.auth.principal': {
+        kind: 'custom',
+        scheme: 'email',
+        subject: ex.body.from?.address ?? 'anonymous',
+        email: ex.body.from?.address,
+        claims: { tenant: deriveTenant(ex.body.from?.address) },
+      },
+    },
+  }))
   .validate(authorize({
     predicate: (p) => p.email?.endsWith('@yourcompany.com') === true,
   }))

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -303,7 +303,7 @@ auth: oauth({
 })
 ```
 
-`issuer` and `audience` are required, so the server cannot silently accept tokens from a different IdP or minted for a different resource. The factory maps standard JWT claims (`sub`, `client_id`, `email`, `name`, `iss`, `aud`, `scope`, `roles`, `exp`) to `OAuthPrincipal` fields automatically; all of them surface as `routecraft.auth.*` exchange headers.
+`issuer` and `audience` are required, so the server cannot silently accept tokens from a different IdP or minted for a different resource. The factory maps standard JWT claims (`sub`, `client_id`, `email`, `name`, `iss`, `aud`, `scope`, `roles`, `exp`) to `OAuthPrincipal` fields automatically; the resolved principal surfaces on the structured `routecraft.auth.principal` exchange header and is exposed ergonomically via the `ex.principal` getter.
 
 `client` accepts either a static `OAuthClientInfo` (matched on `client_id`; unknown IDs are rejected) or a supplier `(clientId) => Promise<OAuthClientInfo | undefined>` for dynamic lookup against a database or registry.
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -229,7 +229,7 @@ Subtypes:
 | `'basic'` | `name?` |
 | `'custom'` | `name?`, `email?`, `roles?`, `scopes?`, `expiresAt?`, `claims?` |
 
-The populated principal surfaces on the exchange via `routecraft.auth.*` headers (see `McpHeadersKeys`): `auth.subject`, `auth.scheme`, `auth.name`, `auth.email`, `auth.roles`, `auth.scopes`, `auth.issuer`, `auth.audience`, and `auth.client_id` (OAuth only).
+The populated principal rides on the exchange as a single structured header (`routecraft.auth.principal`) and is exposed ergonomically via the `ex.principal` getter; read fields with `ex.principal?.subject`, `ex.principal?.scopes`, `ex.principal?.claims`, etc.
 
 ### Built-in `jwt()` helper
 

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -256,24 +256,24 @@ async function dispatchDirect<TIn>(
   input: TIn,
 ): Promise<unknown> {
   const endpoint = sanitizeEndpoint(routeId);
-  const headers = hctx.correlationId
-    ? { [HeadersKeys.CORRELATION_ID]: hctx.correlationId }
-    : undefined;
   // Forward the calling principal so the downstream direct route sees
   // the same authenticated identity as the agent that invoked the
   // tool. The agent layer never lets a tool override or escalate this:
   // `principal` is deeply-readonly on FnHandlerContext (frozen at the
   // tool-bridge boundary). Hand the downstream exchange a fresh
-  // mutable copy so it follows the existing Exchange.principal
-  // contract (a `.process()` step downstream may legitimately attach
-  // a different principal); the tool handler's own snapshot stays
-  // frozen and unaffected.
+  // mutable copy so a `.process()` step downstream may legitimately
+  // attach a different principal; the tool handler's own snapshot
+  // stays frozen and unaffected.
+  const headers: Record<string, unknown> = {};
+  if (hctx.correlationId) {
+    headers[HeadersKeys.CORRELATION_ID] = hctx.correlationId;
+  }
+  if (hctx.principal) {
+    headers[HeadersKeys.AUTH_PRINCIPAL] = cloneFrozenPrincipal(hctx.principal);
+  }
   const exchange = new DefaultExchange<TIn>(ctx, {
     body: input,
-    ...(headers ? { headers } : {}),
-    ...(hctx.principal
-      ? { principal: cloneFrozenPrincipal(hctx.principal) }
-      : {}),
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
   });
   const channel = getDirectChannel<TIn>(ctx, endpoint, {});
   const result = (await channel.send(endpoint, exchange)) as Exchange<unknown>;

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -1,5 +1,9 @@
 import type { CraftContext } from "@routecraft/routecraft";
-import { DefaultExchange, isRoutecraftError } from "@routecraft/routecraft";
+import {
+  DefaultExchange,
+  HeadersKeys,
+  isRoutecraftError,
+} from "@routecraft/routecraft";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createServer } from "node:http";
 import type { IncomingMessage } from "node:http";
@@ -1000,35 +1004,21 @@ export class McpServer {
         "MCP tool call exchange body",
       );
 
-      // Build exchange headers, including auth principal if present.
+      // Build exchange headers. The authenticated principal (when present)
+      // rides as a single structured header rather than ten flat keys; the
+      // `ex.principal` getter on the exchange surfaces it ergonomically.
       const principal = principalStore.getStore();
-      const headers: Record<string, string | string[] | undefined> = {
+      const headers: Record<string, unknown> = {
         [McpHeadersKeys.TOOL]: toolName,
         [McpHeadersKeys.SESSION]: `mcp-${Date.now()}`,
       };
       if (principal) {
-        headers[McpHeadersKeys.AUTH_SUBJECT] = principal.subject;
-        headers[McpHeadersKeys.AUTH_SCHEME] = principal.scheme;
-        headers[McpHeadersKeys.AUTH_KIND] = principal.kind;
-        if (principal.name) headers[McpHeadersKeys.AUTH_NAME] = principal.name;
-        if (principal.email)
-          headers[McpHeadersKeys.AUTH_EMAIL] = principal.email;
-        if (principal.roles)
-          headers[McpHeadersKeys.AUTH_ROLES] = principal.roles;
-        if (principal.scopes)
-          headers[McpHeadersKeys.AUTH_SCOPES] = principal.scopes;
-        if (principal.issuer)
-          headers[McpHeadersKeys.AUTH_ISSUER] = principal.issuer;
-        if (principal.audience)
-          headers[McpHeadersKeys.AUTH_AUDIENCE] = principal.audience;
-        if (principal.clientId)
-          headers[McpHeadersKeys.AUTH_CLIENT_ID] = principal.clientId;
+        headers[HeadersKeys.AUTH_PRINCIPAL] = principal;
       }
 
       const exchange = new DefaultExchange(this.context, {
         body,
         headers,
-        principal,
       });
 
       this.context.emit(`plugin:mcp:tool:called`, {

--- a/packages/ai/src/mcp/types.ts
+++ b/packages/ai/src/mcp/types.ts
@@ -154,46 +154,26 @@ export type McpClientServerConfig = McpClientHttpConfig | McpClientStdioConfig;
 
 /**
  * Header keys set on exchanges created by the MCP server.
- * Use these with `exchange.headers[McpHeadersKeys.AUTH_SUBJECT]` for type-safe access.
+ *
+ * Authenticated identity is exposed via `ex.principal` (a getter over
+ * `ex.headers["routecraft.auth.principal"]`); read principal fields off the
+ * structured object instead of looking them up under flat header keys.
  *
  * @example
  * ```ts
  * import { McpHeadersKeys } from '@routecraft/ai'
  *
  * .process((ex) => {
- *   const user = ex.headers[McpHeadersKeys.AUTH_SUBJECT]
+ *   const subject = ex.principal?.subject
  *   const tool = ex.headers[McpHeadersKeys.TOOL]
  * })
  * ```
  */
-// The `routecraft.auth.*` key strings below mirror the RoutecraftHeaders
-// augmentation in `@routecraft/routecraft/src/auth/types.ts`. Any rename or
-// addition must be kept in sync in both places.
 export enum McpHeadersKeys {
   /** The MCP tool name that triggered this exchange. */
   TOOL = "routecraft.mcp.tool",
   /** The MCP session identifier. */
   SESSION = "routecraft.mcp.session",
-  /** Authenticated subject (from Principal). */
-  AUTH_SUBJECT = "routecraft.auth.subject",
-  /** Authentication scheme used. */
-  AUTH_SCHEME = "routecraft.auth.scheme",
-  /** Authentication kind (jwt | jwks | oauth | custom). */
-  AUTH_KIND = "routecraft.auth.kind",
-  /** Roles assigned to the authenticated principal. */
-  AUTH_ROLES = "routecraft.auth.roles",
-  /** Scopes granted to the authenticated principal. */
-  AUTH_SCOPES = "routecraft.auth.scopes",
-  /** Email of the authenticated principal. */
-  AUTH_EMAIL = "routecraft.auth.email",
-  /** Display name of the authenticated principal. */
-  AUTH_NAME = "routecraft.auth.name",
-  /** Token issuer (JWT `iss`). */
-  AUTH_ISSUER = "routecraft.auth.issuer",
-  /** Intended audience (JWT `aud`). */
-  AUTH_AUDIENCE = "routecraft.auth.audience",
-  /** OAuth client ID (distinct from subject). */
-  AUTH_CLIENT_ID = "routecraft.auth.client_id",
 }
 
 /**
@@ -257,8 +237,9 @@ export interface OAuthAuthOptions {
    * Called on every authenticated request to `/mcp`.
    *
    * The returned principal flows through to route exchanges as
-   * `routecraft.auth.*` headers. `expiresAt` is part of the type contract
-   * because the MCP SDK's bearer middleware requires it.
+   * `headers["routecraft.auth.principal"]` (surfaced via the `ex.principal`
+   * getter). `expiresAt` is part of the type contract because the MCP
+   * SDK's bearer middleware requires it.
    */
   verifyAccessToken: (token: string) => Promise<OAuthPrincipal>;
   /**

--- a/packages/ai/test/mcp-server.test.ts
+++ b/packages/ai/test/mcp-server.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "vitest";
 import { McpServer } from "../src/mcp/server.ts";
 import { testContext, type TestContext } from "@routecraft/testing";
-import { craft, direct, noop } from "@routecraft/routecraft";
+import { craft, direct, noop, type Principal } from "@routecraft/routecraft";
 import { mcp, MCP_PLUGIN_REGISTERED } from "../src/index.ts";
 import { buildAuthHeaders } from "../src/mcp/build-auth-headers.ts";
 import { z } from "zod";
@@ -676,14 +676,14 @@ describe("McpServer", () => {
 
     describe("oauth auth", () => {
       /**
-       * @case oauth() verify returning a fully populated Principal surfaces every identity field as a routecraft.auth.* header
+       * @case oauth() verify returning a fully populated Principal rides as one structured header
        * @preconditions McpServer with oauth() auth; verify returns subject, clientId, email, name, issuer, audience, roles, scopes, expiresAt, claims
-       * @expectedResult Route's tap receives exchange headers with auth.subject = JWT sub (not clientId), auth.client_id, auth.email, auth.name, auth.issuer, auth.audience, auth.roles, auth.scopes, auth.scheme
+       * @expectedResult Route receives a single structured principal at headers["routecraft.auth.principal"] (also exposed via the ex.principal getter); legacy flat routecraft.auth.* keys are no longer set
        */
-      test("surfaces full principal claims as exchange headers", async () => {
+      test("surfaces full principal as a single structured header", async () => {
         const { oauth } = await import("../src/mcp/oauth.ts");
-        let captured: Record<string, string | string[] | undefined> | undefined;
         let capturedPrincipal: unknown | undefined;
+        let capturedHeaders: Record<string, unknown> | undefined;
 
         const authConfig = oauth({
           resourceIssuerUrl: "http://localhost:9999",
@@ -722,10 +722,7 @@ describe("McpServer", () => {
               .input({ body: z.object({}) })
               .from(mcp())
               .tap((ex) => {
-                captured = ex.headers as Record<
-                  string,
-                  string | string[] | undefined
-                >;
+                capturedHeaders = ex.headers as Record<string, unknown>;
                 capturedPrincipal = ex.principal;
               })
               .to(noop()),
@@ -748,37 +745,39 @@ describe("McpServer", () => {
         );
         expect(callRes.statusCode).toBe(200);
 
-        expect(captured).toBeDefined();
-        const h = captured as Record<string, string | string[] | undefined>;
-        expect(h["routecraft.auth.subject"]).toBe("user-42");
-        expect(h["routecraft.auth.client_id"]).toBe("client-abc");
-        expect(h["routecraft.auth.scheme"]).toBe("bearer");
-        expect(h["routecraft.auth.name"]).toBe("Ada Lovelace");
-        expect(h["routecraft.auth.email"]).toBe("ada@example.com");
-        expect(h["routecraft.auth.issuer"]).toBe("https://idp.example.com");
-        expect(h["routecraft.auth.audience"]).toEqual(["mcp.example.com"]);
-        expect(h["routecraft.auth.roles"]).toEqual(["admin"]);
-        expect(h["routecraft.auth.scopes"]).toEqual(["email", "profile"]);
-
-        // Full structured principal also rides on the exchange so route
-        // handlers can read claims, expiresAt, etc. (fields that don't
-        // flatten cleanly into the per-key auth headers).
         expect(capturedPrincipal).toMatchObject({
           kind: "oauth",
+          scheme: "bearer",
           subject: "user-42",
           clientId: "client-abc",
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+          issuer: "https://idp.example.com",
+          audience: ["mcp.example.com"],
+          roles: ["admin"],
+          scopes: ["email", "profile"],
           claims: { sub: "user-42", custom: "value" },
         });
+
+        // The principal rides on the structured header key; the ex.principal
+        // getter is sugar over it. Legacy flat routecraft.auth.* keys are
+        // no longer set.
+        expect(capturedHeaders?.["routecraft.auth.principal"]).toBe(
+          capturedPrincipal,
+        );
+        expect(capturedHeaders?.["routecraft.auth.subject"]).toBeUndefined();
+        expect(capturedHeaders?.["routecraft.auth.client_id"]).toBeUndefined();
+        expect(capturedHeaders?.["routecraft.auth.email"]).toBeUndefined();
       });
 
       /**
-       * @case Minimal Principal (no identity enrichment) populates only subject, client_id, scheme, scopes
+       * @case Minimal Principal carries only the fields verify returned; absent fields stay undefined on the principal
        * @preconditions McpServer with oauth(); verify returns only required fields (kind, scheme, subject, clientId, scopes)
-       * @expectedResult Exchange headers include subject, client_id, scheme, scopes; optional identity headers are absent
+       * @expectedResult ex.principal has subject, clientId, scheme, scopes set; email/name/issuer/audience are undefined on the structured object
        */
-      test("minimal principal omits optional identity headers", async () => {
+      test("minimal principal omits optional identity fields", async () => {
         const { oauth } = await import("../src/mcp/oauth.ts");
-        let captured: Record<string, string | string[] | undefined> | undefined;
+        let capturedPrincipal: Principal | undefined;
 
         const authConfig = oauth({
           resourceIssuerUrl: "http://localhost:9999",
@@ -809,10 +808,7 @@ describe("McpServer", () => {
               .input({ body: z.object({}) })
               .from(mcp())
               .tap((ex) => {
-                captured = ex.headers as Record<
-                  string,
-                  string | string[] | undefined
-                >;
+                capturedPrincipal = ex.principal;
               })
               .to(noop()),
           ],
@@ -834,16 +830,15 @@ describe("McpServer", () => {
         );
         expect(callRes.statusCode).toBe(200);
 
-        expect(captured).toBeDefined();
-        const h = captured as Record<string, string | string[] | undefined>;
-        expect(h["routecraft.auth.subject"]).toBe("client-only");
-        expect(h["routecraft.auth.client_id"]).toBe("client-only");
-        expect(h["routecraft.auth.scheme"]).toBe("bearer");
-        expect(h["routecraft.auth.scopes"]).toEqual(["read"]);
-        expect(h["routecraft.auth.email"]).toBeUndefined();
-        expect(h["routecraft.auth.name"]).toBeUndefined();
-        expect(h["routecraft.auth.issuer"]).toBeUndefined();
-        expect(h["routecraft.auth.audience"]).toBeUndefined();
+        expect(capturedPrincipal).toBeDefined();
+        expect(capturedPrincipal?.subject).toBe("client-only");
+        expect(capturedPrincipal?.clientId).toBe("client-only");
+        expect(capturedPrincipal?.scheme).toBe("bearer");
+        expect(capturedPrincipal?.scopes).toEqual(["read"]);
+        expect(capturedPrincipal?.email).toBeUndefined();
+        expect(capturedPrincipal?.name).toBeUndefined();
+        expect(capturedPrincipal?.issuer).toBeUndefined();
+        expect(capturedPrincipal?.audience).toBeUndefined();
       });
 
       /**
@@ -948,8 +943,8 @@ describe("McpServer", () => {
        * @preconditions McpServer with validator returning kind: "jwt" with claims, issuer, audience, roles
        * @expectedResult Exchange headers include auth.issuer, auth.audience, auth.roles, auth.email, auth.name
        */
-      test("jwt principal populates jwt-specific headers", async () => {
-        let captured: Record<string, string | string[] | undefined> | undefined;
+      test("jwt principal carries jwt-specific fields", async () => {
+        let capturedPrincipal: Principal | undefined;
 
         const { post, initSession } = await startHttpServer(
           [
@@ -959,10 +954,7 @@ describe("McpServer", () => {
               .input({ body: z.object({}) })
               .from(mcp())
               .tap((ex) => {
-                captured = ex.headers as Record<
-                  string,
-                  string | string[] | undefined
-                >;
+                capturedPrincipal = ex.principal;
               })
               .to(noop()),
           ],
@@ -1000,25 +992,26 @@ describe("McpServer", () => {
         );
         expect(callRes.statusCode).toBe(200);
 
-        const h = captured as Record<string, string | string[] | undefined>;
-        expect(h["routecraft.auth.subject"]).toBe("jwt-user");
-        expect(h["routecraft.auth.name"]).toBe("JWT User");
-        expect(h["routecraft.auth.email"]).toBe("jwt@example.com");
-        expect(h["routecraft.auth.issuer"]).toBe("https://idp.example.com");
-        expect(h["routecraft.auth.audience"]).toEqual(["aud-a", "aud-b"]);
-        expect(h["routecraft.auth.roles"]).toEqual(["member"]);
-        expect(h["routecraft.auth.scopes"]).toEqual(["read", "write"]);
-        // JWT principals have no clientId; header must be absent.
-        expect(h["routecraft.auth.client_id"]).toBeUndefined();
+        expect(capturedPrincipal).toBeDefined();
+        expect(capturedPrincipal?.kind).toBe("jwt");
+        expect(capturedPrincipal?.subject).toBe("jwt-user");
+        expect(capturedPrincipal?.name).toBe("JWT User");
+        expect(capturedPrincipal?.email).toBe("jwt@example.com");
+        expect(capturedPrincipal?.issuer).toBe("https://idp.example.com");
+        expect(capturedPrincipal?.audience).toEqual(["aud-a", "aud-b"]);
+        expect(capturedPrincipal?.roles).toEqual(["member"]);
+        expect(capturedPrincipal?.scopes).toEqual(["read", "write"]);
+        // JWT principals have no clientId.
+        expect(capturedPrincipal?.clientId).toBeUndefined();
       });
 
       /**
-       * @case Validator returning a custom Principal surfaces subject and name but no JWT-specific headers
+       * @case Validator returning a custom Principal carries subject and name but no JWT-specific fields
        * @preconditions McpServer with validator returning kind: "custom" with a name
-       * @expectedResult Exchange headers include auth.subject, auth.scheme, auth.name; JWT-only headers are absent
+       * @expectedResult ex.principal has subject, scheme, name; email/issuer/audience/scopes/clientId are undefined
        */
-      test("custom principal omits jwt-only headers", async () => {
-        let captured: Record<string, string | string[] | undefined> | undefined;
+      test("custom principal omits jwt-only fields", async () => {
+        let capturedPrincipal: Principal | undefined;
 
         const { post, initSession } = await startHttpServer(
           [
@@ -1028,10 +1021,7 @@ describe("McpServer", () => {
               .input({ body: z.object({}) })
               .from(mcp())
               .tap((ex) => {
-                captured = ex.headers as Record<
-                  string,
-                  string | string[] | undefined
-                >;
+                capturedPrincipal = ex.principal;
               })
               .to(noop()),
           ],
@@ -1062,15 +1052,16 @@ describe("McpServer", () => {
         );
         expect(callRes.statusCode).toBe(200);
 
-        const h = captured as Record<string, string | string[] | undefined>;
-        expect(h["routecraft.auth.subject"]).toBe("key-123");
-        expect(h["routecraft.auth.scheme"]).toBe("bearer");
-        expect(h["routecraft.auth.name"]).toBe("Deploy key");
-        expect(h["routecraft.auth.email"]).toBeUndefined();
-        expect(h["routecraft.auth.issuer"]).toBeUndefined();
-        expect(h["routecraft.auth.audience"]).toBeUndefined();
-        expect(h["routecraft.auth.scopes"]).toBeUndefined();
-        expect(h["routecraft.auth.client_id"]).toBeUndefined();
+        expect(capturedPrincipal).toBeDefined();
+        expect(capturedPrincipal?.kind).toBe("custom");
+        expect(capturedPrincipal?.subject).toBe("key-123");
+        expect(capturedPrincipal?.scheme).toBe("bearer");
+        expect(capturedPrincipal?.name).toBe("Deploy key");
+        expect(capturedPrincipal?.email).toBeUndefined();
+        expect(capturedPrincipal?.issuer).toBeUndefined();
+        expect(capturedPrincipal?.audience).toBeUndefined();
+        expect(capturedPrincipal?.scopes).toBeUndefined();
+        expect(capturedPrincipal?.clientId).toBeUndefined();
       });
     });
   });

--- a/packages/ai/test/mcp.test.ts
+++ b/packages/ai/test/mcp.test.ts
@@ -26,7 +26,7 @@ async function invokeTool(
   t: TestContext,
   endpoint: string,
   body: unknown,
-  headers: Record<string, string | string[] | undefined> = {},
+  headers: Record<string, unknown> = {},
 ): Promise<void> {
   const registry = t.ctx.getStore(MCP_LOCAL_KEY) as
     | Map<string, McpLocalToolEntry>
@@ -229,6 +229,11 @@ describe("mcp() DSL function", () => {
       .build();
 
     await t.startAndWaitReady();
+    const principal = {
+      kind: "custom" as const,
+      scheme: "bearer" as const,
+      subject: "user-42",
+    };
     await invokeTool(
       t,
       "merge-tool",
@@ -236,16 +241,21 @@ describe("mcp() DSL function", () => {
       {
         [McpHeadersKeys.TOOL]: "merge-tool",
         [McpHeadersKeys.SESSION]: "sess-1",
-        [McpHeadersKeys.AUTH_SUBJECT]: "user-42",
+        "routecraft.auth.principal": principal,
         "x-tenant": "acme",
       },
     );
 
     expect(consumer).toHaveBeenCalledTimes(1);
-    const headers = consumer.mock.calls[0][0].headers as Record<string, string>;
+    const headers = consumer.mock.calls[0][0].headers as Record<
+      string,
+      unknown
+    >;
     expect(headers[McpHeadersKeys.TOOL]).toBe("merge-tool");
     expect(headers[McpHeadersKeys.SESSION]).toBe("sess-1");
-    expect(headers[McpHeadersKeys.AUTH_SUBJECT]).toBe("user-42");
+    expect(headers["routecraft.auth.principal"]).toMatchObject({
+      subject: "user-42",
+    });
     expect(headers["x-tenant"]).toBe("acme");
   });
 

--- a/packages/routecraft/src/adapters/direct/source.ts
+++ b/packages/routecraft/src/adapters/direct/source.ts
@@ -4,7 +4,6 @@ import type { CraftContext } from "../../context";
 import { rcError } from "../../error";
 import type { DirectServerOptions } from "./types";
 import { getDirectChannel, registerRoute, sanitizeEndpoint } from "./shared";
-import type { Principal } from "../../auth/types";
 
 /**
  * DirectSourceAdapter implements the Source interface for the direct adapter.
@@ -34,7 +33,6 @@ export class DirectSourceAdapter<T = unknown> implements Source<T> {
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
       parseFailureMode?: import("../shared/parse").OnParseError,
-      principal?: Principal | undefined,
     ) => Promise<Exchange>,
     abortController: AbortController,
     onReady?: () => void,
@@ -69,19 +67,15 @@ export class DirectSourceAdapter<T = unknown> implements Source<T> {
     }
 
     // Unwrap the channel's Exchange payload and hand body / headers to the
-    // framework-provided handler. The caller's principal rides through as
-    // the 5th arg so route-to-route invocations preserve identity (the
-    // called route's `.authorize()` sees the same principal as the caller).
+    // framework-provided handler. The caller's principal rides through on
+    // `headers["routecraft.auth.principal"]` (the source of truth after
+    // the state-model unification), so route-to-route invocations
+    // preserve identity automatically: the called route's `.authorize()`
+    // sees the same principal as the caller without a separate parameter.
     // Framework-level input validation runs inside the handler, so the
     // adapter has nothing more to do here.
     const wrappedHandler = async (exchange: Exchange<T>) => {
-      const result = await handler(
-        exchange.body as T,
-        exchange.headers,
-        undefined,
-        undefined,
-        exchange.principal,
-      );
+      const result = await handler(exchange.body as T, exchange.headers);
       return result as Exchange<T>;
     };
 

--- a/packages/routecraft/src/auth/types.ts
+++ b/packages/routecraft/src/auth/types.ts
@@ -148,25 +148,15 @@ export interface OAuthValidatorAuthOptions {
 // targets the package specifier and not a relative path.
 declare module "@routecraft/routecraft" {
   interface RoutecraftHeaders {
-    /** Authenticated subject (from Principal). */
-    "routecraft.auth.subject"?: string;
-    /** Authentication scheme used (e.g. "bearer"). */
-    "routecraft.auth.scheme"?: string;
-    /** Authentication kind (jwt | jwks | oauth | custom). */
-    "routecraft.auth.kind"?: string;
-    /** Roles assigned to the authenticated principal. */
-    "routecraft.auth.roles"?: string[];
-    /** Scopes granted to the authenticated principal. */
-    "routecraft.auth.scopes"?: string[];
-    /** Email of the authenticated principal. */
-    "routecraft.auth.email"?: string;
-    /** Display name of the authenticated principal. */
-    "routecraft.auth.name"?: string;
-    /** Token issuer (JWT `iss`). */
-    "routecraft.auth.issuer"?: string;
-    /** Intended audience (JWT `aud`). */
-    "routecraft.auth.audience"?: string[];
-    /** OAuth client ID (distinct from subject). */
-    "routecraft.auth.client_id"?: string;
+    /**
+     * Authenticated principal resolved from the request, when available.
+     *
+     * One header carries the entire structured `Principal` rather than ten
+     * flat string keys (subject, issuer, audience, ...). The `ex.principal`
+     * getter is sugar over reading this header. See
+     * `.standards/exchange-state-model.md` for the rationale (cross-cutting
+     * concerns get one header key, never a special field).
+     */
+    "routecraft.auth.principal"?: Principal;
   }
 }

--- a/packages/routecraft/src/consumers/batch.ts
+++ b/packages/routecraft/src/consumers/batch.ts
@@ -14,7 +14,6 @@ import {
   type HeaderValue,
 } from "../exchange.ts";
 import { type OnParseError } from "../adapters/shared/parse.ts";
-import { type Principal } from "../auth/types.ts";
 
 export type BatchOptions = {
   /**
@@ -66,17 +65,18 @@ export class BatchConsumer implements Consumer<BatchOptions> {
   /**
    * Register the route handler for batched delivery.
    *
-   * **Principal handling.** The merged-batch path does NOT forward a
-   * principal to the route's exchange: a batch may aggregate items from
-   * different identities (or none), and there is no defined merge policy
-   * for combining principals. Routes that need per-message identity
-   * attribution should use the simple consumer or attach a principal in a
-   * `.process()` step after the batch is unpacked.
+   * **Principal handling.** The merged-batch path inherits whatever the
+   * configured `merge` produces for headers; the default merge keeps the
+   * last-write-wins value for `routecraft.auth.principal` if multiple
+   * items in the batch carry one, which is rarely meaningful. Routes that
+   * need per-message identity attribution should use the simple consumer
+   * or attach a principal in a `.process()` step after the batch is
+   * unpacked.
    *
    * The per-item parse-failure escape hatch (where a bad item is routed as
-   * its own exchange instead of joining the batch) DOES forward
-   * `message.principal`, so authorization checks in `.error()` see the
-   * same identity the source resolved.
+   * its own exchange instead of joining the batch) forwards the source's
+   * headers verbatim, so any `routecraft.auth.principal` set by the source
+   * survives into `.error()` for authorization checks.
    */
   async register(
     handler: (
@@ -84,7 +84,6 @@ export class BatchConsumer implements Consumer<BatchOptions> {
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
       parseFailureMode?: OnParseError,
-      principal?: Principal | undefined,
     ) => Promise<Exchange>,
   ): Promise<void> {
     let batch: Message[] = [];
@@ -175,7 +174,6 @@ export class BatchConsumer implements Consumer<BatchOptions> {
               throw parseErr;
             },
             itemMode,
-            message.principal,
           );
         }
         delete message.parse;

--- a/packages/routecraft/src/consumers/simple.ts
+++ b/packages/routecraft/src/consumers/simple.ts
@@ -3,7 +3,6 @@ import { type RouteDefinition } from "../route.ts";
 import { type ProcessingQueue, type Message, type Consumer } from "../types.ts";
 import { type Exchange, type ExchangeHeaders } from "../exchange.ts";
 import { type OnParseError } from "../adapters/shared/parse.ts";
-import { type Principal } from "../auth/types.ts";
 
 export class SimpleConsumer implements Consumer<never> {
   constructor(
@@ -19,7 +18,6 @@ export class SimpleConsumer implements Consumer<never> {
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
       parseFailureMode?: OnParseError,
-      principal?: Principal | undefined,
     ) => Promise<Exchange>,
   ): Promise<void> {
     this.channel.setHandler(async (message) => {
@@ -28,7 +26,6 @@ export class SimpleConsumer implements Consumer<never> {
         message.headers,
         message.parse,
         message.parseFailureMode,
-        message.principal,
       );
     });
   }

--- a/packages/routecraft/src/exchange.ts
+++ b/packages/routecraft/src/exchange.ts
@@ -78,6 +78,8 @@ export interface HeaderKeysRegistry {}
  * {@link HeaderKeysRegistry} interface.
  */
 export const HeadersKeys = {
+  /** Unique identifier for this exchange. Stored in headers so it survives halt/continue alongside body. */
+  ID: "routecraft.id",
   /** The operation type (from, process, to) */
   OPERATION: "routecraft.operation",
   /** The route id */
@@ -124,6 +126,13 @@ export const HeadersKeys = {
   JSONL_LINE: "routecraft.jsonl.line",
   /** The file path when reading a JSONL file in chunked mode */
   JSONL_PATH: "routecraft.jsonl.path",
+
+  /**
+   * Authenticated principal resolved from the request, when available.
+   * Carries the structured `Principal` object; the `ex.principal` getter
+   * is sugar over `ex.headers[HeadersKeys.AUTH_PRINCIPAL]`.
+   */
+  AUTH_PRINCIPAL: "routecraft.auth.principal",
 } as const satisfies Record<string, string>;
 
 /**
@@ -134,6 +143,15 @@ export const HeadersKeys = {
  * {@link HeaderKeysRegistry} to add typed headers.
  */
 export interface RoutecraftHeaders {
+  /**
+   * Unique identifier for this exchange.
+   *
+   * Stored in headers (not as a separate field) so it travels with the
+   * exchange's serializable state. This is the single source of truth for
+   * exchange identity; the `ex.id` getter reads from this key.
+   */
+  "routecraft.id": string;
+
   /** The current operation being performed (OperationType or DSL label) */
   "routecraft.operation": OperationType | string;
 
@@ -175,22 +193,45 @@ export interface RoutecraftHeaders {
 }
 
 /**
- * Allowed types for a single header value. Custom headers can use any of these; standard headers use specific types (see RoutecraftHeaders).
+ * Allowed types for a single header value at the **bag** level.
  *
- * Array values are typed `readonly string[]` so they cannot be mutated
- * via `push` / `splice` / index assignment through the (already
- * `Readonly<>`) `ExchangeHeaders` map. The contract is type-level;
- * the constructor does not deep-clone or freeze array values, since
- * the only path that produces them is the framework itself
- * (`split` builds the `routecraft.split_hierarchy` array, then
- * `rewrap`s share frozen header references downstream).
+ * `unknown` lets cross-cutting concerns (auth principal, future tracing
+ * spans, tenancy contexts) live in `headers` as a single typed slot rather
+ * than being spread across many flat keys. Per-key types are narrowed by
+ * {@link RoutecraftHeaders} and by the {@link HeaderKeysRegistry}
+ * declaration-merging mechanism; this bag-level type is just the catch-all
+ * for unregistered keys.
+ *
+ * For API surfaces that accept a static header value (e.g. `.header("k",
+ * v)`), prefer {@link HeaderLiteral} which excludes function types so user
+ * lambdas get correct inference in the value-or-function overload.
+ *
+ * Array values declared on registered keys are typed `readonly string[]` so
+ * they cannot be mutated via `push` / `splice` / index assignment through
+ * the (already `Readonly<>`) `ExchangeHeaders` map. The contract is
+ * type-level; the constructor freezes array values defensively so a caller
+ * who casts away the readonly cannot mutate a shared reference.
  */
-export type HeaderValue =
+export type HeaderValue = unknown;
+
+/**
+ * Allowed types for a header value when supplied as a literal at an API
+ * boundary that also accepts a callback (e.g. `.header("k", v)` /
+ * `.header("k", ex => ...)`). Excludes function types so the callback arm
+ * of the union infers parameters correctly.
+ *
+ * Includes the original primitive types for source-compat plus
+ * `Readonly<Record<string, unknown>>` so structured values (Principal,
+ * future Span, etc.) can be assigned directly when they aren't mediated by
+ * a callback.
+ */
+export type HeaderLiteral =
   | string
   | number
   | boolean
   | undefined
-  | readonly string[];
+  | readonly string[]
+  | Readonly<Record<string, unknown>>;
 
 /**
  * Mapped type that surfaces keys declared via {@link HeaderKeysRegistry}
@@ -218,29 +259,42 @@ export type ExchangeHeaders = Readonly<
 /**
  * Represents a message being processed through a route.
  *
- * An exchange encapsulates:
- * - The data being processed (body)
- * - Metadata about the processing (headers)
- * - A unique identifier
- * - Logging capabilities
- * - The authenticated principal, if any (set at the source boundary by
- *   adapters that perform authentication, or in a route step via
- *   `.process()` when callers want to attach a custom identity)
+ * An exchange has two kinds of state:
  *
- * Exchanges are immutable. Operations that change body, headers, or
- * principal must produce a new exchange (typically via spread) and return
- * it; the framework re-wraps the result via {@link DefaultExchange.rewrap}
- * so it preserves internal bindings (context, route). Body is not deep-
- * frozen so adapter authors can attach arbitrary user payloads, but the
- * framework will not mutate it and authors should treat it the same way.
+ * 1. **Stored fields** (`body`, `headers`) carry the data and metadata that
+ *    must survive halt/continue. Persistence serializes exactly these two
+ *    slots; rehydration constructs a new instance around them.
+ * 2. **Derived accessors** (`id`, `principal`, `logger`) read from
+ *    `headers` (or runtime services) and look like properties at the call
+ *    site. They are not stored separately. `id` reads
+ *    `headers["routecraft.id"]`; `principal` reads
+ *    `headers["routecraft.auth.principal"]`; `logger` builds a child logger
+ *    lazily from the framework's logger and the exchange's id.
+ *
+ * Cross-cutting concerns (auth, tracing, tenancy) all live as keys in
+ * `headers` rather than as top-level fields. This keeps the serialization
+ * surface small and avoids a "special field" precedent for every new
+ * concern.
+ *
+ * Exchanges are immutable. Operations that change body or headers must
+ * produce a new exchange (typically via spread) and return it; the
+ * framework re-wraps the result via {@link DefaultExchange.rewrap} so it
+ * preserves internal bindings (context, route). Body is not deep-frozen so
+ * adapter authors can attach arbitrary user payloads, but the framework
+ * will not mutate it and authors should treat it the same way.
  *
  * @template T The type of data in the body
  */
 export type Exchange<T = unknown> = {
-  /** Unique identifier for this exchange */
+  /**
+   * Unique identifier for this exchange.
+   *
+   * Reads from `headers["routecraft.id"]`. Stable across `rewrap`s so
+   * pipeline steps see the same id throughout a route.
+   */
   readonly id: string;
 
-  /** Headers containing metadata */
+  /** Headers containing metadata, including cross-cutting concerns like the authenticated principal. */
   readonly headers: ExchangeHeaders;
 
   /** The data being processed */
@@ -249,25 +303,27 @@ export type Exchange<T = unknown> = {
   /**
    * Authenticated principal for this exchange, when one has been resolved.
    *
-   * Set automatically by source adapters that perform authentication (e.g.
-   * the MCP server when `auth:` is configured). Routes may also assign a
-   * custom principal in `.process()` to attribute downstream actions to a
-   * specific identity (for example, mapping the sender of an inbound email
-   * onto a `kind: "custom"` principal).
+   * Sugar over `headers["routecraft.auth.principal"]`. Set automatically by
+   * source adapters that perform authentication (e.g. the MCP server when
+   * `auth:` is configured) by writing the principal into headers. Routes
+   * may also assign a custom principal in `.process()` by spreading new
+   * headers with this key.
    *
-   * Operations that re-stitch exchanges (`process`, `split`, `aggregate`,
-   * `enrich`, `tap`) propagate the principal with `?? current` semantics:
-   * a returned exchange that omits a principal inherits the parent's,
-   * rather than clearing it. The `| undefined` in the type lets callers
-   * pass `undefined` through `Partial<Exchange>` constructor options
-   * under `exactOptionalPropertyTypes`; it does NOT mean an assignment of
-   * `undefined` clears the field downstream.
+   * Propagates naturally because it lives in `headers`: any operation that
+   * spreads `prev.headers` keeps the principal sticky-set automatically,
+   * with no special-case plumbing.
    *
    * @experimental
    */
   readonly principal?: Principal | undefined;
 
-  /** Logger for this exchange (pino child logger) */
+  /**
+   * Logger for this exchange (pino child logger).
+   *
+   * Built lazily from the framework's base logger and the exchange's id /
+   * route / correlation. Not stored as serializable state; rehydrated
+   * exchanges build a fresh child logger on first access.
+   */
   readonly logger: ReturnType<typeof logger.child>;
 };
 
@@ -452,13 +508,16 @@ export function getStartedAt(exchange: Exchange): number | undefined {
  * `Readonly<...>` headers object (e.g. from another exchange) or a plain
  * literal.
  *
+ * `id` and `principal` are NOT options here: they live inside `headers`
+ * (`headers["routecraft.id"]` and `headers["routecraft.auth.principal"]`).
+ * Callers that want to control them set the corresponding header keys when
+ * building `headers`.
+ *
  * @internal
  */
 type DefaultExchangeOptions<T> = {
-  id?: string;
   body?: T;
   headers?: ExchangeHeaders;
-  principal?: Principal | undefined;
 };
 
 /**
@@ -471,7 +530,8 @@ type DefaultExchangeOptions<T> = {
  *   rewrap of the same logical exchange.
  * - `logger` is reused because its child bindings (contextId, route,
  *   correlationId, exchangeId) are unchanged across `rewrap` (rewrap
- *   preserves `id`).
+ *   preserves `id`). Pre-populating the lazy `#logger` slot avoids
+ *   rebuilding the same child on every rewrap of a long pipeline.
  *
  * @internal
  */
@@ -483,9 +543,15 @@ type RewrapState = {
 /**
  * Default implementation of the Exchange interface.
  *
- * Provides standard exchange functionality with automatic
- * ID generation and header initialization. Instances are immutable: the
- * constructor freezes the wrapper, headers, and principal. Body is left
+ * The implementation stores exactly two fields, `body` and `headers`.
+ * Everything else surfaced on the public `Exchange<T>` API (`id`,
+ * `principal`, `logger`) is exposed through getters that derive from
+ * `headers` plus runtime services. This keeps the serialization surface
+ * for halt/continue narrow (just `{ body, headers }`) and removes the
+ * "special field" precedent for cross-cutting concerns.
+ *
+ * Instances are immutable: the constructor freezes the wrapper and headers
+ * (and any non-primitive header values, defensively). Body is left
  * unfrozen so user payloads of any shape can flow through; the framework
  * does not mutate it.
  *
@@ -499,62 +565,55 @@ type RewrapState = {
  * });
  *
  * // Access exchange properties
- * console.log(exchange.id);        // Unique UUID
+ * console.log(exchange.id);        // Unique UUID (read from headers["routecraft.id"])
  * console.log(exchange.body);      // "Hello, World!"
  * console.log(exchange.headers);   // Headers object with standard fields
  * ```
  */
 export class DefaultExchange<T = unknown> implements Exchange<T> {
-  /** Unique identifier for this exchange */
-  readonly id: string;
-
-  /** Headers containing metadata */
+  /** Headers containing metadata, including the exchange id and (when set) the authenticated principal. */
   readonly headers: ExchangeHeaders;
 
   /** The data being processed */
   readonly body: T;
 
-  /** Authenticated principal, when one has been resolved. */
-  readonly principal?: Principal | undefined;
-
-  /** Logger for this exchange (pino child logger) */
-  public readonly logger: ReturnType<typeof logger.child>;
+  /**
+   * Lazily-built pino child logger. Filled on first access by the `logger`
+   * getter, or pre-populated by `rewrap` so a long pipeline reuses the
+   * parent exchange's child instead of rebuilding it on every step.
+   *
+   * Private fields are stored in a hidden internal slot, not as own
+   * properties, so writes to `#logger` are unaffected by `Object.freeze(this)`.
+   */
+  #logger: ReturnType<typeof logger.child> | undefined;
 
   /**
    * Create a new exchange.
    *
    * @param context The CraftContext this exchange belongs to
-   * @param options Optional configuration for the exchange
+   * @param options Optional configuration for the exchange. Set the exchange
+   *   id by including `headers["routecraft.id"]`; set the principal by
+   *   including `headers["routecraft.auth.principal"]`. Both default to
+   *   sensible runtime values when omitted (id: `randomUUID()`).
    * @param rewrapState Internal: when {@link DefaultExchange.rewrap} is
    *   building a derived instance, it threads the previous exchange's
    *   internals and logger through this parameter so they are genuinely
-   *   shared (not just copied) and the constructor skips default
-   *   `randomUUID()` / `logger.child(...)` work that the rewrap path
-   *   would immediately overwrite. Not for direct adapter use.
+   *   shared (not just copied) and the constructor skips
+   *   `logger.child(...)` work that the rewrap path would otherwise repeat.
+   *   Not for direct adapter use.
    */
   constructor(
     context: CraftContext,
     options?: DefaultExchangeOptions<T>,
     rewrapState?: RewrapState,
   ) {
-    this.id = options?.id || randomUUID();
-    // Skip the default `randomUUID()` calls for ROUTE_ID / CORRELATION_ID
-    // when the caller already supplies headers that include the standard
-    // keys. The rewrap path always does (it spreads `prev.headers`), and
-    // so do `buildExchange` / `split` (they set `routecraft.route`
-    // explicitly). The legacy code path generated two UUIDs per
-    // construction unconditionally and let the spread overwrite them,
-    // which on a 5-step pipeline meant ~10 wasted crypto calls per
-    // exchange.
-    // Skip the default `randomUUID()` work per-key when the caller
-    // already supplies a value. The rewrap path always supplies all
-    // three (it spreads `prev.headers`), and so do `buildExchange` /
-    // `split`. The legacy code path generated two UUIDs per
-    // construction unconditionally and let the spread overwrite them,
-    // which on a 5-step pipeline meant ~10 wasted crypto calls per
-    // exchange. Per-key gating preserves required defaults (`OPERATION`,
-    // `CORRELATION_ID`) when a caller supplies only `ROUTE_ID`, instead
-    // of an all-or-nothing fast path that would silently drop them.
+    // Per-key gating preserves required defaults (`ID`, `OPERATION`,
+    // `ROUTE_ID`, `CORRELATION_ID`) when a caller supplies only some of
+    // them, instead of an all-or-nothing fast path that would silently
+    // drop the others. The rewrap path supplies all four via the spread
+    // of `prev.headers`, so the `??` branches are no-ops in the hot path
+    // and the per-construction `randomUUID()` cost is paid only at the
+    // route boundary.
     //
     // The supplied headers are spread FIRST so that the explicit
     // required-key slots that follow override an `undefined` value the
@@ -564,27 +623,45 @@ export class DefaultExchange<T = unknown> implements Exchange<T> {
     const supplied = options?.headers;
     const merged: Record<string, HeaderValue> = {
       ...(supplied || {}),
+      [HeadersKeys.ID]: supplied?.[HeadersKeys.ID] ?? randomUUID(),
       [HeadersKeys.ROUTE_ID]: supplied?.[HeadersKeys.ROUTE_ID] ?? randomUUID(),
       [HeadersKeys.OPERATION]:
         supplied?.[HeadersKeys.OPERATION] ?? OperationType.FROM,
       [HeadersKeys.CORRELATION_ID]:
         supplied?.[HeadersKeys.CORRELATION_ID] ?? randomUUID(),
     };
-    // Type-level `readonly` on `HeaderValue` array variants prevents
-    // mutation through `exchange.headers` in TypeScript code, but a
-    // caller who casts away the readonly could still `arr.push(...)`
-    // into a shared array reference. Clone-and-freeze each array
-    // value so the runtime guarantee matches the type contract; this
-    // is the same defence-in-depth applied to the headers wrapper
-    // itself. The clone leaves the caller's input array untouched
-    // (we don't want `Object.freeze(supplied[key])` to surprise them),
-    // and skipping arrays already frozen avoids an extra allocation
-    // when the value came from another exchange's headers via spread.
+    // Defensive freeze on values that callers might mutate by reference:
+    //
+    // - Arrays: type-level `readonly` on `HeaderValue` array variants
+    //   prevents mutation through `exchange.headers` in TypeScript code,
+    //   but a caller who casts away the readonly could still
+    //   `arr.push(...)` into a shared array reference. Clone-and-freeze
+    //   each unfrozen array so the runtime guarantee matches the type
+    //   contract.
+    // - Principal: a structured header value. Shallow-freezing the wrapper
+    //   makes claim mutation by adapters caught at runtime
+    //   (`exchange.principal.subject = ...` throws). Nested claims are
+    //   not deep-frozen.
+    //
+    // We don't deep-clone or freeze arbitrary objects; those are caller
+    // payloads and the framework treats them as opaque, the same way
+    // `body` is left unfrozen.
     for (const key of Object.keys(merged)) {
       const value = merged[key];
       if (Array.isArray(value) && !Object.isFrozen(value)) {
         merged[key] = Object.freeze([...value]);
       }
+    }
+    const principal = merged[HeadersKeys.AUTH_PRINCIPAL];
+    if (
+      principal !== undefined &&
+      typeof principal === "object" &&
+      principal !== null &&
+      !Object.isFrozen(principal)
+    ) {
+      merged[HeadersKeys.AUTH_PRINCIPAL] = Object.freeze({
+        ...(principal as Principal),
+      });
     }
     this.headers = Object.freeze(merged);
     // Honour an explicit `body: undefined` from the caller (e.g. a
@@ -592,13 +669,6 @@ export class DefaultExchange<T = unknown> implements Exchange<T> {
     // path). Only fall back to `{}` when the caller did not pass a body
     // key at all.
     this.body = options && "body" in options ? (options.body as T) : ({} as T);
-    if (options?.principal !== undefined) {
-      // Object.freeze on a primitive is a no-op; on a Principal object it
-      // makes claim mutation by adapters caught at runtime. We do not deep-
-      // freeze the principal's internals (e.g. nested claims); shallow is
-      // enough to stop direct rewrites like `exchange.principal.subject = ...`.
-      this.principal = Object.freeze(options.principal);
-    }
 
     // Store internals: symbol key (cross-instance) and WeakMap (same-instance compat).
     // Internals live BEFORE the wrapper is frozen because freeze prevents
@@ -613,16 +683,51 @@ export class DefaultExchange<T = unknown> implements Exchange<T> {
     setInternals(this, INTERNALS_KEY, internals);
     EXCHANGE_INTERNALS.set(this, internals);
     setBrand(this, BRAND.Exchange);
-    // Reuse `prev`'s logger when rewrapping; the child bindings
-    // (contextId, route, correlationId, exchangeId) are unchanged because
-    // rewrap preserves id, so the logger stays correctly scoped.
-    this.logger = rewrapState?.logger ?? logger.child(childBindings(this));
+    // Pre-populate the lazy logger slot when rewrapping. The child
+    // bindings (contextId, route, correlationId, exchangeId) are
+    // unchanged because rewrap preserves id, so the parent's logger
+    // stays correctly scoped. Fresh exchanges leave `#logger` undefined
+    // so the first read of `.logger` builds the child on demand.
+    if (rewrapState?.logger) {
+      this.#logger = rewrapState.logger;
+    }
 
-    // Freeze the wrapper itself last so all properties (including the
+    // Freeze the wrapper itself last so own properties (including the
     // symbol-keyed internals slot and the brand) are sealed against
     // reassignment. Mutating user code via `as any` casts now produces a
-    // TypeError in strict mode, which the package runs in.
+    // TypeError in strict mode, which the package runs in. Private fields
+    // (`#logger`) live in a hidden internal slot and are unaffected by
+    // freeze, so the lazy-build path keeps working post-freeze.
     Object.freeze(this);
+  }
+
+  /**
+   * Unique identifier for this exchange. Reads from
+   * `headers["routecraft.id"]` so the id travels with the serializable
+   * state and survives halt/continue.
+   */
+  get id(): string {
+    return this.headers[HeadersKeys.ID] as string;
+  }
+
+  /**
+   * Authenticated principal, when one has been resolved. Sugar over
+   * `headers["routecraft.auth.principal"]`.
+   */
+  get principal(): Principal | undefined {
+    return this.headers[HeadersKeys.AUTH_PRINCIPAL] as Principal | undefined;
+  }
+
+  /**
+   * Pino child logger scoped to this exchange. Built lazily from the
+   * framework's base logger; rebuilt on a rehydrated exchange because the
+   * logger is not part of the serializable state.
+   */
+  get logger(): ReturnType<typeof logger.child> {
+    if (this.#logger === undefined) {
+      this.#logger = logger.child(childBindings(this));
+    }
+    return this.#logger;
   }
 
   /**
@@ -633,22 +738,24 @@ export class DefaultExchange<T = unknown> implements Exchange<T> {
    * spread) back into proper instances without losing the framework's
    * back-channel state.
    *
-   * - `id` defaults to `prev.id` (preserves identity through pipeline steps).
-   * - `headers` defaults to `prev.headers` (frozen reference is safe to share).
+   * - `headers` defaults to `prev.headers`. Identity (`routecraft.id`) is
+   *   forced to `prev.id` so it survives a caller-supplied headers object
+   *   that came from a different exchange. Cross-cutting concerns
+   *   (`routecraft.auth.principal`, future tracing/tenancy keys) flow
+   *   through naturally because they live in the same headers bag.
    * - `body` defaults to `prev.body`.
-   * - `principal` follows `?? prev.principal` semantics so a returned
-   *   exchange that omits the principal inherits the parent's. Pass an
-   *   explicit `Principal` to set; passing `undefined` does NOT clear.
+   *
+   * Identity-changing operations (split, aggregate restoring a parent)
+   * construct a new `DefaultExchange` directly with fresh headers rather
+   * than calling `rewrap`.
    *
    * @internal
    */
   static rewrap<T>(
     prev: Exchange,
     partial: {
-      readonly id?: string;
       readonly body?: T;
       readonly headers?: ExchangeHeaders;
-      readonly principal?: Principal;
     } = {},
   ): DefaultExchange<T> {
     const prevInternals =
@@ -665,24 +772,33 @@ export class DefaultExchange<T = unknown> implements Exchange<T> {
       );
     }
 
+    // Force prev's id into the new headers so a caller-supplied `headers`
+    // object that came from a foreign exchange (e.g. user code returning
+    // `{ ...someOtherExchange, body: x }` from `.process()`) does not
+    // silently change the exchange identity mid-route. Identity is owned
+    // by the framework and is preserved across rewraps. Identity-changing
+    // operations (split, aggregate-restore-parent) construct a new
+    // `DefaultExchange` directly rather than going through `rewrap`.
+    //
     // For body, use `'body' in partial` so an explicit `body: undefined`
     // (e.g. `transform(() => undefined)` or `json({ path: missingKey })`)
-    // sets the new body to undefined rather than inheriting prev's. Headers
-    // are never undefined in the type system, and principal uses `??` to
-    // preserve `?? prev.principal` inheritance semantics.
+    // sets the new body to undefined rather than inheriting prev's.
     //
     // Internals are shared by reference (not copied) via `rewrapState` so a
     // post-construction write on either prev or next is visible on the
     // other. The logger is reused for the same reason: bindings derive
     // from id/contextId/route/correlationId, all of which `rewrap`
     // preserves.
+    const baseHeaders = partial.headers ?? prev.headers;
+    const newHeaders =
+      baseHeaders[HeadersKeys.ID] === prev.id
+        ? baseHeaders
+        : { ...baseHeaders, [HeadersKeys.ID]: prev.id };
     return new DefaultExchange<T>(
       context,
       {
-        id: partial.id ?? prev.id,
-        headers: partial.headers ?? prev.headers,
+        headers: newHeaders,
         body: ("body" in partial ? partial.body : prev.body) as T,
-        principal: partial.principal ?? prev.principal,
       },
       { internals: prevInternals, logger: prev.logger },
     );

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -27,6 +27,7 @@ export {
   type HeaderKeysRegistry,
   HeadersKeys,
   type HeaderValue,
+  type HeaderLiteral,
   OperationType,
   type RoutecraftHeaders,
 } from "./exchange.ts";

--- a/packages/routecraft/src/logger.ts
+++ b/packages/routecraft/src/logger.ts
@@ -193,14 +193,12 @@ export function childBindings(
 
       // Include non-PII auth identifiers from the principal when present.
       // Only subject and issuer are safe for logs; fields like email,
-      // name, and roles are omitted to avoid leaking PII. Falls back to
-      // the legacy flat headers so adapters that only set headers (and
-      // not the principal) still get auth bindings in logs.
+      // name, and roles are omitted to avoid leaking PII.
       const principal = ex.principal;
-      const sub = principal?.subject ?? ex.headers["routecraft.auth.subject"];
-      if (sub !== undefined) bindings["auth.subject"] = sub;
-      const iss = principal?.issuer ?? ex.headers["routecraft.auth.issuer"];
-      if (iss !== undefined) bindings["auth.issuer"] = iss;
+      if (principal?.subject !== undefined)
+        bindings["auth.subject"] = principal.subject;
+      if (principal?.issuer !== undefined)
+        bindings["auth.issuer"] = principal.issuer;
 
       return bindings;
     }

--- a/packages/routecraft/src/operations/aggregate.ts
+++ b/packages/routecraft/src/operations/aggregate.ts
@@ -64,6 +64,13 @@ export const defaultAggregate = <T>(
   // Check if any body is an array
   const hasArrayBody = exchanges.some((x) => Array.isArray(x.body));
 
+  // Spread-of-exchange (`{ ...exchanges[0], body }`) used to copy stored
+  // fields like `principal` forward; with the unified state model only
+  // `body` and `headers` are own-properties, so we hand the consuming
+  // `AggregateStep` the explicit shape it needs (body + headers from the
+  // first exchange). Identity, principal, and logger are derived from
+  // headers via getters and reattach automatically when the engine wraps
+  // the aggregate result back into a `DefaultExchange`.
   if (hasArrayBody) {
     // Flatten arrays and combine with scalar values
     const flattened: ExtractArrayElement<T>[] = [];
@@ -75,16 +82,16 @@ export const defaultAggregate = <T>(
       }
     }
     return {
-      ...exchanges[0],
+      headers: exchanges[0].headers,
       body: flattened as FlattenedAggregateResult<T>,
-    };
+    } as Exchange<FlattenedAggregateResult<T>>;
   }
 
   // No arrays found, return array of bodies (original behavior)
   return {
-    ...exchanges[0],
+    headers: exchanges[0].headers,
     body: exchanges.map((x) => x.body) as FlattenedAggregateResult<T>,
-  };
+  } as Exchange<FlattenedAggregateResult<T>>;
 };
 
 /**

--- a/packages/routecraft/src/operations/aggregate.ts
+++ b/packages/routecraft/src/operations/aggregate.ts
@@ -160,9 +160,6 @@ export class AggregateStep<T = unknown, R = unknown> implements Step<
       const next = DefaultExchange.rewrap<R>(exchange, {
         body: aggregatedExchange.body,
         headers: aggregatedExchange.headers,
-        ...(aggregatedExchange.principal !== undefined && {
-          principal: aggregatedExchange.principal,
-        }),
       });
 
       if (context) {
@@ -245,9 +242,6 @@ export class AggregateStep<T = unknown, R = unknown> implements Step<
     const next = DefaultExchange.rewrap<R>(baseExchange, {
       body: aggregatedExchange.body,
       headers: finalHeaders,
-      ...(aggregatedExchange.principal !== undefined && {
-        principal: aggregatedExchange.principal,
-      }),
     });
 
     if (context) {

--- a/packages/routecraft/src/operations/enrich.ts
+++ b/packages/routecraft/src/operations/enrich.ts
@@ -258,9 +258,6 @@ export class EnrichStep<T = unknown, R = unknown> implements Step<
         : DefaultExchange.rewrap<T>(exchange, {
             body: result.body,
             headers: result.headers,
-            ...(result.principal !== undefined && {
-              principal: result.principal,
-            }),
           });
 
     // Push the exchange to the queue

--- a/packages/routecraft/src/operations/from.ts
+++ b/packages/routecraft/src/operations/from.ts
@@ -3,7 +3,6 @@ import { type Exchange, type ExchangeHeaders } from "../exchange.ts";
 import { type RouteDiscovery } from "../route.ts";
 import { type Adapter } from "../types.ts";
 import { type OnParseError } from "../adapters/shared/parse.ts";
-import { type Principal } from "../auth/types.ts";
 
 /**
  * Metadata the engine passes to a source adapter at subscribe time.
@@ -40,12 +39,11 @@ export interface SourceMeta {
  * tied to `Exchange<T>` should NOT assume the body is `T` when the failure
  * came from the parse step itself; they may be looking at raw bytes.
  *
- * The optional fifth argument, `principal`, lets sources forward an
- * authenticated identity onto the route's first exchange. Existing
- * sources need no change: structurally, they continue to pass two or
- * three arguments and the framework treats the rest as undefined.
  * Sources that authenticate at their boundary (e.g. the MCP server with
- * `auth:` configured) opt in by passing the principal as the fifth arg.
+ * `auth:` configured) forward the resolved identity by writing the
+ * structured `Principal` into `headers["routecraft.auth.principal"]`
+ * before calling the handler. The framework no longer accepts a separate
+ * positional principal argument: state lives on `headers`, full stop.
  *
  * @template T - Body type of messages produced by this source (after parse)
  */
@@ -85,27 +83,6 @@ export type CallableSource<T = unknown> = (
      * @experimental
      */
     parseFailureMode?: OnParseError,
-    /**
-     * Authenticated principal resolved by the source, when applicable. This
-     * is the **5th positional argument** of the handler. The position is
-     * stable: existing 2- or 3-argument adapters keep working unchanged
-     * (slots 2-4 are filled with `undefined` by callers that opt in to
-     * the principal slot only).
-     *
-     * Sources that perform authentication at their boundary (e.g. the MCP
-     * server when `auth:` is configured) pass it here so it lands on
-     * `exchange.principal` of the route's first exchange. Most adapters
-     * leave this undefined and rely on a downstream `.process()` to attach
-     * a custom principal.
-     *
-     * Test fixtures that simulate an authenticating source can call
-     * `handler(body, undefined, undefined, undefined, principal)` directly;
-     * the auth tests in `packages/routecraft/test/auth/authorize.test.ts`
-     * use exactly this shape via a small `principalSource()` helper.
-     *
-     * @experimental
-     */
-    principal?: Principal | undefined,
   ) => Promise<Exchange>,
   abortController: AbortController,
   onReady?: () => void,

--- a/packages/routecraft/src/operations/header.ts
+++ b/packages/routecraft/src/operations/header.ts
@@ -5,7 +5,9 @@ import {
   type HeaderValue,
   type HeaderLiteral,
   DefaultExchange,
+  HeadersKeys,
 } from "../exchange.ts";
+import { rcError } from "../error.ts";
 
 /**
  * Function that returns the value for a header. Can be async. Use with `.header(key, valueOrFn)`.
@@ -40,6 +42,20 @@ export class HeaderStep<T = unknown> implements Step<HeaderSetter<T>> {
     key: string,
     setterOrValue: CallableHeaderSetter<T> | HeaderLiteral,
   ) {
+    // Exchange identity is framework-owned: `DefaultExchange.rewrap`
+    // unconditionally restores `prev.id` into the new headers so identity
+    // is preserved across every pipeline step. A `.header()` write of
+    // `routecraft.id` would land in the merged record but be overwritten
+    // by the next rewrap, silently no-op-ing. Reject up front with a
+    // clear message rather than letting the user chase a phantom bug.
+    if (key === HeadersKeys.ID) {
+      throw rcError("RC5003", undefined, {
+        message: `.header() cannot set "${HeadersKeys.ID}": exchange identity is framework-owned and preserved across every rewrap.`,
+        suggestion:
+          "Identity is set once when the exchange is constructed and propagates automatically. If you need to correlate with an upstream id, use routecraft.correlation_id (settable via .header() or by source adapters).",
+      });
+    }
+
     const set: CallableHeaderSetter<T> =
       typeof setterOrValue === "function"
         ? (setterOrValue as CallableHeaderSetter<T>)

--- a/packages/routecraft/src/operations/header.ts
+++ b/packages/routecraft/src/operations/header.ts
@@ -3,6 +3,7 @@ import {
   type Exchange,
   OperationType,
   type HeaderValue,
+  type HeaderLiteral,
   DefaultExchange,
 } from "../exchange.ts";
 
@@ -37,7 +38,7 @@ export class HeaderStep<T = unknown> implements Step<HeaderSetter<T>> {
 
   constructor(
     key: string,
-    setterOrValue: CallableHeaderSetter<T> | HeaderValue,
+    setterOrValue: CallableHeaderSetter<T> | HeaderLiteral,
   ) {
     const set: CallableHeaderSetter<T> =
       typeof setterOrValue === "function"

--- a/packages/routecraft/src/operations/process.ts
+++ b/packages/routecraft/src/operations/process.ts
@@ -81,6 +81,13 @@ export class ProcessStep<T = unknown, R = T> implements Step<Processor<T, R>> {
     // event correlation, split bookkeeping, and child telemetry break.
     // Identity-changing operations (split, aggregate) have dedicated
     // paths.
+    // Fast-path: a processor that returns the same instance it was handed
+    // (typical for `tap`-like uses or transform-in-place patterns) skips
+    // a `rewrap` allocation. The double cast is required because
+    // `exchange: Exchange<T>` and `returned: Exchange<R>` have different
+    // generic parameters even when they are the same runtime reference;
+    // `===` operates on the runtime reference, the cast just satisfies
+    // the type checker that the reference is shape-compatible with R.
     const next =
       returned === (exchange as unknown as Exchange<R>)
         ? (exchange as unknown as Exchange<R>)

--- a/packages/routecraft/src/operations/process.ts
+++ b/packages/routecraft/src/operations/process.ts
@@ -65,9 +65,14 @@ export class ProcessStep<T = unknown, R = T> implements Step<Processor<T, R>> {
     // foreign context -- always rewrap onto THIS exchange's internals.
     // An `instanceof DefaultExchange` fast-path would let a user return
     // `new DefaultExchange(otherContext, ...)` and break route binding
-    // for downstream telemetry / split / tap; rewrap restores it. This
-    // also keeps the principal sticky-set rule (`?? prev.principal`)
-    // consistent regardless of return shape.
+    // for downstream telemetry / split / tap; rewrap restores it.
+    //
+    // Cross-cutting concerns like the authenticated principal flow through
+    // `returned.headers` automatically: rewrap forces `prev.id` for
+    // identity but otherwise threads the user's headers verbatim, so a
+    // returned exchange that preserves `headers` (the common case via
+    // spread) keeps its principal, span, tenant, etc. without any
+    // operation-specific plumbing.
     //
     // We do NOT forward `returned.id` into rewrap. `.process()` is a body
     // transform; identity is owned by the framework. A user who returns
@@ -82,9 +87,6 @@ export class ProcessStep<T = unknown, R = T> implements Step<Processor<T, R>> {
         : DefaultExchange.rewrap<R>(exchange, {
             body: returned.body,
             headers: returned.headers,
-            ...(returned.principal !== undefined && {
-              principal: returned.principal,
-            }),
           });
     queue.push({ exchange: next, steps: remainingSteps });
   }

--- a/packages/routecraft/src/operations/split.ts
+++ b/packages/routecraft/src/operations/split.ts
@@ -125,21 +125,26 @@ export class SplitStep<T = unknown, R = unknown> implements Step<
     const splitHierarchy = [...existingHierarchy, groupId];
 
     for (const resultExchange of splitExchanges) {
+      // Spread parent headers first so cross-cutting concerns
+      // (`routecraft.auth.principal`, future tracing/tenancy keys) flow
+      // through to children when the user-supplied splitter result omits
+      // them. The user's headers override on collision; the framework
+      // assigns a fresh id and the split-hierarchy slot last.
       const postProcessedExchange = new DefaultExchange<R>(context, {
-        id: randomUUID(),
         body: resultExchange.body,
         headers: {
+          ...exchange.headers,
           ...resultExchange.headers,
+          [HeadersKeys.ID]: randomUUID(),
           [HeadersKeys.SPLIT_HIERARCHY]: splitHierarchy,
         },
-        principal: resultExchange.principal ?? exchange.principal,
       });
 
       // Set route in internals if it exists (symbol-key for cross-instance)
       if (route) {
         const internals =
           (
-            postProcessedExchange as Exchange & {
+            postProcessedExchange as unknown as Exchange & {
               [key: symbol]: { context: unknown; route?: Route };
             }
           )[INTERNALS_KEY] ?? EXCHANGE_INTERNALS.get(postProcessedExchange);

--- a/packages/routecraft/src/operations/tap.ts
+++ b/packages/routecraft/src/operations/tap.ts
@@ -3,6 +3,7 @@ import { type Adapter, type Step } from "../types.ts";
 import {
   type Exchange,
   OperationType,
+  HeadersKeys,
   DefaultExchange,
   getExchangeContext,
   getExchangeRoute,
@@ -16,14 +17,19 @@ import {
 } from "../testing-hooks.ts";
 
 /**
- * Creates a snapshot of an exchange for async tap execution. Body and
- * principal are deep-cloned so tap-side mutations (which the framework
- * cannot prevent for arbitrary user payloads or nested principal claims)
- * do not race with the main pipeline. Headers are framework-immutable
- * (shallow-frozen) and therefore safe to share between snapshot and main
- * pipeline by reference; we only freeze the wrapper of the principal,
- * not its nested claims, so a downstream `.process()` that mutates
- * `principal.claims.someKey` would otherwise leak into the tap snapshot.
+ * Creates a snapshot of an exchange for async tap execution. Body is
+ * deep-cloned so tap-side mutations (which the framework cannot prevent
+ * for arbitrary user payloads) do not race with the main pipeline.
+ * Headers are framework-immutable (shallow-frozen) and safe to share
+ * between snapshot and main pipeline by reference; structured header
+ * values like `Principal` are shallow-frozen by the constructor so direct
+ * field rewrites are caught at runtime. Taps that mutate nested fields
+ * (e.g. `principal.claims.foo`) are an anti-pattern; tap is for
+ * observation, not mutation.
+ *
+ * The snapshot gets a fresh id (overriding the parent's
+ * `routecraft.id`) so log lines and any downstream identity-aware
+ * tooling can distinguish tap from main pipeline.
  *
  * @internal
  */
@@ -32,12 +38,11 @@ function snapshotExchange<T>(
   context: CraftContext,
 ): Exchange<T> {
   return new DefaultExchange<T>(context, {
-    id: randomUUID(),
     body: structuredClone(exchange.body),
-    headers: exchange.headers,
-    ...(exchange.principal !== undefined && {
-      principal: structuredClone(exchange.principal),
-    }),
+    headers: {
+      ...exchange.headers,
+      [HeadersKeys.ID]: randomUUID(),
+    },
   });
 }
 

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -28,7 +28,6 @@ import {
   type OnParseError,
   PARSE_DROPPED_REASON,
 } from "./adapters/shared/parse.ts";
-import { type Principal } from "./auth/types.ts";
 import {
   type Adapter,
   type Step,
@@ -444,17 +443,18 @@ export class DefaultRoute implements Route {
   /**
    * Create a new exchange object from a message and optional headers.
    *
+   * Sources that authenticate at their boundary set the structured
+   * `Principal` on `headers["routecraft.auth.principal"]` before calling
+   * the consumer handler; that value flows through this method as a
+   * normal header and surfaces on the exchange via the `ex.principal`
+   * getter.
+   *
    * @param message The message data
    * @param headers Optional headers to include
-   * @param principal Optional authenticated principal forwarded by the source
    * @returns A new Exchange object
    * @private
    */
-  private buildExchange(
-    message: unknown,
-    headers?: ExchangeHeaders,
-    principal?: Principal | undefined,
-  ): Exchange {
+  private buildExchange(message: unknown, headers?: ExchangeHeaders): Exchange {
     // Preserve the caller's correlation id when the source forwarded one
     // (route-to-route via direct(), MCP tool calls, HTTP requests carrying
     // a trace header). Falls back to a fresh UUID for sources that emit
@@ -470,9 +470,6 @@ export class DefaultRoute implements Route {
       [HeadersKeys.ROUTE_ID]: this.definition.id,
       [HeadersKeys.OPERATION]: OperationType.FROM,
     };
-    if (principal !== undefined) {
-      builtHeaders[HeadersKeys.AUTH_PRINCIPAL] = principal;
-    }
     const exchange = new DefaultExchange(this.context, {
       body: message,
       headers: builtHeaders,
@@ -795,8 +792,8 @@ export class DefaultRoute implements Route {
     // `exchange:dropped` for telemetry and re-throws so the source's own
     // caller (e.g. a direct channel's `send`) sees the validation error.
     this.consumer.register(
-      async (message, headers, parse, parseFailureMode, principal) => {
-        const initialExchange = this.buildExchange(message, headers, principal);
+      async (message, headers, parse, parseFailureMode) => {
+        const initialExchange = this.buildExchange(message, headers);
         const inputSchemas = this.definition.discovery?.input;
         const hasInputSchema = !!inputSchemas?.body || !!inputSchemas?.headers;
 
@@ -866,7 +863,7 @@ export class DefaultRoute implements Route {
     };
     return activeSource.subscribe(
       this.context,
-      (message, headers, parse, parseFailureMode, principal) => {
+      (message, headers, parse, parseFailureMode) => {
         onReady(); // fallback: fire before first message if adapter never called it
         return this.messageChannel.enqueue({
           message,
@@ -877,7 +874,6 @@ export class DefaultRoute implements Route {
                 parseFailureMode: parseFailureMode ?? "fail",
               }
             : {}),
-          ...(principal !== undefined && { principal }),
         });
       },
       this.abortController,

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -464,21 +464,24 @@ export class DefaultRoute implements Route {
     const incomingCorrelationId = headers?.[HeadersKeys.CORRELATION_ID] as
       | string
       | undefined;
+    const builtHeaders: Record<string, unknown> = {
+      ...headers,
+      [HeadersKeys.CORRELATION_ID]: incomingCorrelationId ?? randomUUID(),
+      [HeadersKeys.ROUTE_ID]: this.definition.id,
+      [HeadersKeys.OPERATION]: OperationType.FROM,
+    };
+    if (principal !== undefined) {
+      builtHeaders[HeadersKeys.AUTH_PRINCIPAL] = principal;
+    }
     const exchange = new DefaultExchange(this.context, {
       body: message,
-      headers: {
-        ...headers,
-        [HeadersKeys.CORRELATION_ID]: incomingCorrelationId ?? randomUUID(),
-        [HeadersKeys.ROUTE_ID]: this.definition.id,
-        [HeadersKeys.OPERATION]: OperationType.FROM,
-      },
-      ...(principal !== undefined && { principal }),
+      headers: builtHeaders,
     });
 
     // Add route to internals so steps like tap can access it (symbol-key for cross-instance)
     const internals =
       (
-        exchange as Exchange & {
+        exchange as unknown as Exchange & {
           [key: symbol]: { context: CraftContext; route?: Route };
         }
       )[INTERNALS_KEY] ?? EXCHANGE_INTERNALS.get(exchange);

--- a/packages/routecraft/src/step-builder-base.ts
+++ b/packages/routecraft/src/step-builder-base.ts
@@ -1,6 +1,10 @@
 import { ENRICH_MERGE_TYPE } from "./brand.ts";
 import { type Adapter, type Step } from "./types.ts";
-import { type Exchange, type HeaderValue } from "./exchange.ts";
+import {
+  type Exchange,
+  type HeaderValue,
+  type HeaderLiteral,
+} from "./exchange.ts";
 import {
   type Destination,
   type CallableDestination,
@@ -293,7 +297,7 @@ export abstract class StepBuilderBase<Current = unknown> {
   header(
     key: string,
     valueOrFn:
-      | HeaderValue
+      | HeaderLiteral
       | ((exchange: Exchange<Current>) => HeaderValue | Promise<HeaderValue>),
   ): this {
     this.pushStep(new HeaderStep<Current>(key, valueOrFn));

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -4,7 +4,6 @@ import { type CraftContext } from "./context.ts";
 import { type RouteDefinition } from "./route.ts";
 import { type Route } from "./route.ts";
 import { type OnParseError } from "./adapters/shared/parse.ts";
-import { type Principal } from "./auth/types.ts";
 
 /**
  * Base interface for all adapters (sources, destinations, transformers, filters, etc.).
@@ -112,14 +111,6 @@ export type Message = {
   headers?: ExchangeHeaders;
   parse?: (raw: unknown) => unknown | Promise<unknown>;
   parseFailureMode?: OnParseError;
-  /**
-   * Authenticated principal resolved by the source, if any. Forwarded by
-   * the consumer to the route's exchange so downstream steps (and the
-   * `.authorize()` validator) see the same identity the source resolved.
-   *
-   * @experimental
-   */
-  principal?: Principal | undefined;
 };
 
 export interface Consumer<O = unknown> {
@@ -145,7 +136,6 @@ export interface Consumer<O = unknown> {
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
       parseFailureMode?: OnParseError,
-      principal?: Principal | undefined,
     ) => Promise<Exchange>,
   ): void;
 }

--- a/packages/routecraft/test/auth/authorize.test.ts
+++ b/packages/routecraft/test/auth/authorize.test.ts
@@ -52,7 +52,13 @@ describe("authorize() validator", () => {
         craft()
           .id("ok")
           .from(simple("hello"))
-          .process((ex) => ({ ...ex, principal }))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
           .validate(authorize())
           .to(s),
       )
@@ -111,7 +117,13 @@ describe("authorize() validator", () => {
         craft()
           .id("rbac")
           .from(simple("hello"))
-          .process((ex) => ({ ...ex, principal }))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
           .validate(authorize({ roles: ["admin"] }))
           .to(s),
       )
@@ -152,7 +164,13 @@ describe("authorize() validator", () => {
         craft()
           .id("multi-role")
           .from(simple("hello"))
-          .process((ex) => ({ ...ex, principal }))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
           .validate(authorize({ roles: ["admin", "billing"] }))
           .to(s),
       )
@@ -199,7 +217,13 @@ describe("authorize() validator", () => {
         craft()
           .id("scope")
           .from(simple("hello"))
-          .process((ex) => ({ ...ex, principal }))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
           .validate(authorize({ scopes: ["read", "write"] }))
           .to(s),
       )
@@ -239,7 +263,13 @@ describe("authorize() validator", () => {
         craft()
           .id("predicate")
           .from(simple("hello"))
-          .process((ex) => ({ ...ex, principal }))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
           .validate(
             authorize({
               predicate: (p) => p.claims?.["tenant"] === "globex",
@@ -649,7 +679,13 @@ describe("exchange.principal propagation", () => {
         craft()
           .id("email-attribution")
           .from(simple("hello"))
-          .process((ex) => ({ ...ex, principal }))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
           .to(s),
       )
       .build();
@@ -676,7 +712,13 @@ describe("exchange.principal propagation", () => {
         craft()
           .id("transform-keeps-principal")
           .from(simple("hello"))
-          .process((ex) => ({ ...ex, principal }))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
           .transform((body) => `${body}!`)
           .to(s),
       )
@@ -732,7 +774,13 @@ describe("exchange.principal propagation", () => {
         craft()
           .id("tap-principal")
           .from(simple("hello"))
-          .process((ex) => ({ ...ex, principal }))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
           .tap(tapped)
           .to(main),
       )
@@ -743,59 +791,18 @@ describe("exchange.principal propagation", () => {
     expect(tapped.lastReceived().principal).toEqual(principal);
   });
 
-  /**
-   * @case Tap snapshot principal is deep-cloned, not shared by reference,
-   *       so concurrent mutation of one side does not leak to the other
-   * @preconditions Route attaches a principal whose `claims` is a mutable
-   *                object, taps to a spy, mutates the main exchange's
-   *                principal in a downstream `.process()`
-   * @expectedResult The tap spy's captured principal still carries the
-   *                 original `claims` value (unaffected by the mutation)
-   */
-  test("tap snapshot principal is isolated from main flow mutations", async () => {
-    const main = spy<string>();
-    const tapped = spy<string>();
-    const principal: Principal = {
-      kind: "custom",
-      scheme: "bearer",
-      subject: "user-1",
-      claims: { tenant: "acme", flags: ["original"] },
-    };
-
-    t = await testContext()
-      .routes(
-        craft()
-          .id("tap-principal-isolation")
-          .from(simple("hello"))
-          .process((ex) => ({ ...ex, principal }))
-          .tap(tapped)
-          .process((ex) => {
-            // Mutate the live principal AFTER tap has snapshotted it.
-            // If the snapshot shares the principal by reference, the tap
-            // spy will observe these mutations.
-            (ex.principal!.claims as Record<string, unknown>)["tenant"] =
-              "globex";
-            (ex.principal!.claims as { flags: string[] }).flags.push("mutated");
-            return ex;
-          })
-          .to(main),
-      )
-      .build();
-    await t.test();
-
-    // Tap snapshot must reflect the principal AT SNAPSHOT TIME, not the
-    // post-mutation state of the main flow.
-    expect(tapped.lastReceived().principal?.claims).toEqual({
-      tenant: "acme",
-      flags: ["original"],
-    });
-    // Main flow saw the mutation (sanity check that the test actually
-    // mutated something).
-    expect(main.lastReceived().principal?.claims).toEqual({
-      tenant: "globex",
-      flags: ["original", "mutated"],
-    });
-  });
+  // Note: the previous "tap snapshot principal is isolated from main flow
+  // mutations" test asserted a deep-clone of the principal in tap
+  // snapshots. With the unified state model (`{ body, headers }` is the
+  // serialization surface; cross-cutting concerns live in `headers` like
+  // anything else), the framework no longer special-cases principal in
+  // tap. The headers wrapper is shallow-frozen and the principal wrapper
+  // is shallow-frozen; nested mutations of any structured header value
+  // (e.g. `principal.claims.foo`) are an anti-pattern the framework does
+  // not prevent and therefore do not provide isolation guarantees against.
+  // Tap is for observation, not mutation; routes that need to attach a
+  // different identity should set a new principal in `headers` rather
+  // than mutating the existing one. See `.standards/exchange-state-model.md`.
 });
 
 describe(".authorize() type checks", () => {

--- a/packages/routecraft/test/auth/authorize.test.ts
+++ b/packages/routecraft/test/auth/authorize.test.ts
@@ -14,15 +14,19 @@ type FailedEventDetails = { details: { error: unknown } };
 
 /**
  * Build a tiny test source that emits one body and forwards a principal
- * via the 5th argument of the subscribe handler. Mirrors what real
- * authenticating sources (e.g. `mcp({ auth: jwt(...) })`) do at their
- * boundary, so the route's first exchange already carries the principal
- * and pre-from `.authorize()` can gate it.
+ * by writing it onto `headers["routecraft.auth.principal"]` before
+ * invoking the handler. Mirrors what real authenticating sources
+ * (e.g. `mcp({ auth: jwt(...) })`) do at their boundary, so the route's
+ * first exchange already carries the principal and pre-from
+ * `.authorize()` can gate it.
  */
 function principalSource<T>(body: T, principal?: Principal): Source<T> {
   return {
     subscribe: async (_ctx, handler) => {
-      await handler(body, undefined, undefined, undefined, principal);
+      const headers = principal
+        ? { "routecraft.auth.principal": principal }
+        : undefined;
+      await handler(body, headers);
     },
   };
 }
@@ -791,18 +795,68 @@ describe("exchange.principal propagation", () => {
     expect(tapped.lastReceived().principal).toEqual(principal);
   });
 
-  // Note: the previous "tap snapshot principal is isolated from main flow
-  // mutations" test asserted a deep-clone of the principal in tap
-  // snapshots. With the unified state model (`{ body, headers }` is the
-  // serialization surface; cross-cutting concerns live in `headers` like
-  // anything else), the framework no longer special-cases principal in
-  // tap. The headers wrapper is shallow-frozen and the principal wrapper
-  // is shallow-frozen; nested mutations of any structured header value
-  // (e.g. `principal.claims.foo`) are an anti-pattern the framework does
-  // not prevent and therefore do not provide isolation guarantees against.
-  // Tap is for observation, not mutation; routes that need to attach a
-  // different identity should set a new principal in `headers` rather
-  // than mutating the existing one. See `.standards/exchange-state-model.md`.
+  /**
+   * @case Tap snapshots share structured-header values (like `principal.claims`)
+   *       by reference with the main flow. With the unified state model
+   *       (`{ body, headers }` is the serialization surface; cross-cutting
+   *       concerns live in `headers` like anything else), the framework no
+   *       longer deep-clones principal into tap snapshots. Nested mutation
+   *       of structured header values is an anti-pattern the framework
+   *       does not prevent or isolate against; routes that need a fresh
+   *       identity should set a new principal on `headers` rather than
+   *       mutating the existing one. This test pins that contract so a
+   *       future PR cannot silently re-introduce the deep-clone.
+   *       See `.standards/exchange-state-model.md`.
+   * @preconditions Route attaches a principal with mutable `claims`, taps,
+   *                then mutates `principal.claims.tenant` in a downstream
+   *                `.process()` step
+   * @expectedResult Both the tap snapshot and the main-flow exchange see
+   *                 the post-mutation `claims.tenant` value (shared by
+   *                 reference; no isolation)
+   */
+  test("tap snapshot shares principal claims by reference (no deep-clone)", async () => {
+    const main = spy<string>();
+    const tapped = spy<string>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      claims: { tenant: "before" },
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("tap-principal-shared-ref")
+          .from(simple("hello"))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
+          .tap(tapped)
+          .process((ex) => {
+            // Anti-pattern (and the test's whole point): the framework
+            // does not isolate nested mutations of structured header
+            // values. The mutation leaks into the tap snapshot because
+            // they share the same `principal` object reference.
+            (ex.principal!.claims as { tenant: string }).tenant = "after";
+            return ex;
+          })
+          .to(main),
+      )
+      .build();
+    await t.test();
+
+    expect(
+      (main.lastReceived().principal!.claims as { tenant: string }).tenant,
+    ).toBe("after");
+    expect(
+      (tapped.lastReceived().principal!.claims as { tenant: string }).tenant,
+    ).toBe("after");
+  });
 });
 
 describe(".authorize() type checks", () => {

--- a/packages/routecraft/test/batch.test.ts
+++ b/packages/routecraft/test/batch.test.ts
@@ -162,12 +162,14 @@ describe("BatchConsumer", () => {
   });
 
   /**
-   * @case Per-item parse-failure path forwards `message.principal` so authz
-   *       checks in `.error()` see the same identity the source resolved
-   * @preconditions Bad item with a `principal` set on the queued Message
-   * @expectedResult Handler is invoked with the principal as its 5th arg
+   * @case Per-item parse-failure path forwards the source-supplied headers
+   *       (including `routecraft.auth.principal`) so authz checks in
+   *       `.error()` see the same identity the source resolved
+   * @preconditions Bad item with `routecraft.auth.principal` set on the
+   *                queued Message's headers
+   * @expectedResult Handler is invoked with the same headers, principal intact
    */
-  test("forwards principal through the per-item parse-failure path", async () => {
+  test("forwards principal header through the per-item parse-failure path", async () => {
     const ctx = new CraftContext();
     const queue = new InMemoryProcessingQueue<Message>();
     const consumer = new BatchConsumer(
@@ -179,17 +181,15 @@ describe("BatchConsumer", () => {
 
     const calls: { principal: unknown }[] = [];
 
-    await consumer.register(
-      async (_message, _headers, _parse, _mode, principal) => {
-        calls.push({ principal });
-        return {
-          id: "exchange-id",
-          body: _message,
-          headers: {},
-          logger: ctx.logger,
-        } as Exchange;
-      },
-    );
+    await consumer.register(async (_message, headers) => {
+      calls.push({ principal: headers?.["routecraft.auth.principal"] });
+      return {
+        id: "exchange-id",
+        body: _message,
+        headers: {},
+        logger: ctx.logger,
+      } as Exchange;
+    });
 
     const principal = {
       kind: "custom" as const,
@@ -199,10 +199,9 @@ describe("BatchConsumer", () => {
 
     const badPromise = queue.enqueue({
       message: "not-json",
-      headers: {},
+      headers: { "routecraft.auth.principal": principal },
       parse: (raw) => JSON.parse(raw as string),
       parseFailureMode: "fail",
-      principal,
     });
 
     await badPromise;
@@ -211,13 +210,15 @@ describe("BatchConsumer", () => {
   });
 
   /**
-   * @case Merged-batch path drops principals by design (multi-principal merge
-   *       has no defined policy); contract is documented on `register()`
-   * @preconditions Two queued items, each with a principal set
-   * @expectedResult Handler is invoked once with `principal === undefined`
-   *                 because the merged exchange does not carry per-item identity
+   * @case Merged-batch path uses last-write-wins semantics for headers,
+   *       including `routecraft.auth.principal`; multi-identity batches
+   *       resolve to the last item's principal. Documented on `register()`;
+   *       routes needing per-item identity should use the simple consumer
+   *       or supply a custom `merge`.
+   * @preconditions Two queued items, each with a different principal in headers
+   * @expectedResult Handler is invoked once with the second item's principal
    */
-  test("does not forward principal through the merged batch path", async () => {
+  test("merges principal header with last-write-wins semantics", async () => {
     const ctx = new CraftContext();
     const queue = new InMemoryProcessingQueue<Message>();
     const consumer = new BatchConsumer(
@@ -229,17 +230,15 @@ describe("BatchConsumer", () => {
 
     const calls: { principal: unknown }[] = [];
 
-    await consumer.register(
-      async (_message, _headers, _parse, _mode, principal) => {
-        calls.push({ principal });
-        return {
-          id: "exchange-id",
-          body: _message,
-          headers: {},
-          logger: ctx.logger,
-        } as Exchange;
-      },
-    );
+    await consumer.register(async (_message, headers) => {
+      calls.push({ principal: headers?.["routecraft.auth.principal"] });
+      return {
+        id: "exchange-id",
+        body: _message,
+        headers: {},
+        logger: ctx.logger,
+      } as Exchange;
+    });
 
     const principalA = {
       kind: "custom" as const,
@@ -254,20 +253,18 @@ describe("BatchConsumer", () => {
 
     const promiseA = queue.enqueue({
       message: 1,
-      headers: {},
-      principal: principalA,
+      headers: { "routecraft.auth.principal": principalA },
     });
     const promiseB = queue.enqueue({
       message: 2,
-      headers: {},
-      principal: principalB,
+      headers: { "routecraft.auth.principal": principalB },
     });
 
     await vi.advanceTimersByTimeAsync(50);
     await Promise.all([promiseA, promiseB]);
 
-    // One merged invocation; principal arg is intentionally undefined.
+    // One merged invocation; last-wins on the principal header.
     expect(calls).toHaveLength(1);
-    expect(calls[0].principal).toBeUndefined();
+    expect(calls[0].principal).toEqual(principalB);
   });
 });

--- a/packages/routecraft/test/direct-simple.test.ts
+++ b/packages/routecraft/test/direct-simple.test.ts
@@ -319,9 +319,8 @@ describe("Direct adapter", () => {
 
   /**
    * @case Principal flows from caller to callee across direct()
-   * @preconditions Producer route attaches a custom principal and forwards via direct()
-   * @expectedResult The callee's exchange carries the same principal so
-   *                 .authorize() / route handlers see the caller's identity
+   * @preconditions Producer route attaches a custom principal under headers["routecraft.auth.principal"] and forwards via direct()
+   * @expectedResult The callee's exchange carries the same principal so .authorize() / route handlers see the caller's identity
    */
   test("propagates principal across direct() boundaries", async () => {
     const principal = {
@@ -337,7 +336,10 @@ describe("Direct adapter", () => {
         craft()
           .id("caller-with-principal")
           .from(simple("ping"))
-          .process((ex) => ({ ...ex, principal }))
+          .process((ex) => ({
+            ...ex,
+            headers: { ...ex.headers, "routecraft.auth.principal": principal },
+          }))
           .to(direct("callee-reads-principal")),
         craft()
           .id("callee-reads-principal")

--- a/packages/routecraft/test/exchange-state-model.test.ts
+++ b/packages/routecraft/test/exchange-state-model.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach } from "vitest";
+import { describe, test, afterEach, expect, expectTypeOf } from "vitest";
 import { testContext, type TestContext } from "@routecraft/testing";
 import {
   craft,
@@ -146,6 +146,38 @@ describe("Exchange state model", () => {
     expect(ex.principal).toEqual(principal);
     expect(ex.headers["routecraft.id"]).toBe("fixed-id-123");
     expect(ex.headers["routecraft.auth.principal"]).toEqual(principal);
+  });
+
+  /**
+   * @case Type-level: registered headers preserve their narrow types when
+   *       indexed by literal key, while unregistered keys widen to
+   *       `unknown` (the bag-level `HeaderValue`). Locks the contract that
+   *       widening `HeaderValue` to `unknown` did not regress reads of
+   *       registered headers; future refactors of `ExchangeHeaders` must
+   *       not collapse this distinction.
+   * @preconditions A reference to `Exchange<unknown>` declared via type-only
+   * @expectedResult `routecraft.route` reads as `string | undefined`,
+   *                 `routecraft.timer.counter` as `number | undefined`,
+   *                 `routecraft.split_hierarchy` as `readonly string[] |
+   *                 undefined`, and an arbitrary key as `unknown`
+   */
+  test("registered header reads preserve narrow types; unknown keys widen to unknown", () => {
+    type H = Exchange["headers"];
+    expectTypeOf<H["routecraft.route"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<H[typeof HeadersKeys.CORRELATION_ID]>().toEqualTypeOf<
+      string | undefined
+    >();
+    expectTypeOf<H["routecraft.timer.counter"]>().toEqualTypeOf<
+      number | undefined
+    >();
+    expectTypeOf<H["routecraft.split_hierarchy"]>().toEqualTypeOf<
+      readonly string[] | undefined
+    >();
+    expectTypeOf<H["routecraft.auth.principal"]>().toEqualTypeOf<
+      Principal | undefined
+    >();
+    // Unregistered keys widen to `unknown` (the bag-level catch-all).
+    expectTypeOf<H["my.custom.unregistered"]>().toEqualTypeOf<unknown>();
   });
 
   /**

--- a/packages/routecraft/test/exchange-state-model.test.ts
+++ b/packages/routecraft/test/exchange-state-model.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { testContext, type TestContext } from "@routecraft/testing";
+import {
+  craft,
+  DefaultExchange,
+  HeadersKeys,
+  simple,
+  type Exchange,
+  type Principal,
+} from "@routecraft/routecraft";
+
+describe("Exchange state model", () => {
+  let t: TestContext;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+  });
+
+  /**
+   * @case Stored state is exactly { body, headers } (the halt/continue contract)
+   * @preconditions A DefaultExchange constructed inside a route, with id and principal both set via headers
+   * @expectedResult Only `body` and `headers` appear as own enumerable properties; `id`, `principal`, `logger` are getters on the prototype
+   */
+  test("only body and headers are own enumerable properties", async () => {
+    let captured: Exchange | undefined;
+    t = await testContext()
+      .routes(
+        craft()
+          .id("state-model-shape")
+          .from(simple("hello"))
+          .process((ex) => {
+            captured = ex;
+            return ex;
+          })
+          .to(() => undefined),
+      )
+      .build();
+
+    await t.test();
+
+    expect(captured).toBeDefined();
+    const ownKeys = Object.keys(captured!).sort();
+    // Symbol-keyed internals slot is not an enumerable property, so it
+    // does not appear in Object.keys.
+    expect(ownKeys).toEqual(["body", "headers"]);
+    // The derived accessors are still readable on the public type.
+    expect(typeof captured!.id).toBe("string");
+    expect(typeof captured!.logger).toBe("object");
+  });
+
+  /**
+   * @case Halt/continue contract: { body, headers } is sufficient to rehydrate an exchange
+   * @preconditions Take a constructed exchange's body+headers, JSON round-trip them, reconstruct via new DefaultExchange
+   * @expectedResult The rehydrated exchange exposes the original id and principal through its getters
+   */
+  test("rehydrates correctly from JSON-serialized { body, headers }", async () => {
+    let original: Exchange | undefined;
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      roles: ["admin"],
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("rehydrate-source")
+          .from(simple("payload"))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
+          .process((ex) => {
+            original = ex;
+            return ex;
+          })
+          .to(() => undefined),
+      )
+      .build();
+
+    await t.test();
+
+    expect(original).toBeDefined();
+    const originalId = original!.id;
+
+    // Serialize the persistable surface and rehydrate. This is exactly
+    // what halt/continue would do across a process boundary.
+    const wirePayload = JSON.parse(
+      JSON.stringify({
+        body: original!.body,
+        headers: original!.headers,
+      }),
+    );
+
+    const rehydrated = new DefaultExchange(t.ctx, {
+      body: wirePayload.body,
+      headers: wirePayload.headers,
+    });
+
+    expect(rehydrated.body).toBe("payload");
+    // id flows through headers, so it survives the round-trip.
+    expect(rehydrated.id).toBe(originalId);
+    expect(rehydrated.headers[HeadersKeys.ID]).toBe(originalId);
+    // Principal is reconstructed by the getter from the rehydrated header.
+    expect(rehydrated.principal).toEqual(principal);
+    // Logger is regenerated lazily; the rehydrated exchange must still
+    // produce a usable child logger without the original's runtime services.
+    expect(typeof rehydrated.logger).toBe("object");
+    expect(typeof rehydrated.logger.info).toBe("function");
+  });
+
+  /**
+   * @case Constructor accepts headers carrying both id and principal
+   * @preconditions Build a DefaultExchange directly with headers including id and principal
+   * @expectedResult The id getter returns the supplied id; the principal getter returns the supplied principal
+   */
+  test("id and principal are read from headers via getters", async () => {
+    t = await testContext()
+      .routes(
+        craft()
+          .id("getter-readback")
+          .from(simple("noop"))
+          .to(() => undefined),
+      )
+      .build();
+
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "alice",
+    };
+    const ex = new DefaultExchange(t.ctx, {
+      body: { hello: "world" },
+      headers: {
+        "routecraft.id": "fixed-id-123",
+        "routecraft.auth.principal": principal,
+        "routecraft.route": "getter-readback",
+      },
+    });
+
+    expect(ex.id).toBe("fixed-id-123");
+    expect(ex.principal).toEqual(principal);
+    expect(ex.headers["routecraft.id"]).toBe("fixed-id-123");
+    expect(ex.headers["routecraft.auth.principal"]).toEqual(principal);
+  });
+
+  /**
+   * @case A constructor without an id-in-headers generates a fresh UUID
+   * @preconditions DefaultExchange built without supplying routecraft.id in headers
+   * @expectedResult ex.id is a non-empty string and matches headers["routecraft.id"]
+   */
+  test("generates a fresh id when headers omit routecraft.id", async () => {
+    t = await testContext()
+      .routes(
+        craft()
+          .id("auto-id")
+          .from(simple("noop"))
+          .to(() => undefined),
+      )
+      .build();
+
+    const ex = new DefaultExchange(t.ctx, { body: 1 });
+
+    expect(typeof ex.id).toBe("string");
+    expect(ex.id).toBeTruthy();
+    expect(ex.id).toBe(ex.headers["routecraft.id"]);
+  });
+});

--- a/packages/routecraft/test/header.test.ts
+++ b/packages/routecraft/test/header.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, afterEach } from "vitest";
 import { testContext, spy, type TestContext } from "@routecraft/testing";
-import { craft, simple } from "@routecraft/routecraft";
+import { craft, HeadersKeys, simple } from "@routecraft/routecraft";
 
 describe("Header operation", () => {
   let t: TestContext;
@@ -57,5 +57,22 @@ describe("Header operation", () => {
 
     expect(s.received).toHaveLength(1);
     expect(s.received[0].headers["user-id"]).toBe("u1");
+  });
+
+  /**
+   * @case `.header()` rejects writes to the framework-owned identity key
+   *       up front, instead of silently no-op-ing once `rewrap` restores
+   *       `prev.id` over the user's value
+   * @preconditions Builder pipeline tries to set `routecraft.id`
+   * @expectedResult Constructor throws RC5003 with a clear message
+   */
+  test("rejects .header() writes to routecraft.id with RC5003", () => {
+    expect(() =>
+      craft()
+        .id("header-rejects-id")
+        .from(simple("test"))
+        .header(HeadersKeys.ID, "fixed-id")
+        .to(spy()),
+    ).toThrow(/routecraft\.id/);
   });
 });


### PR DESCRIPTION
Tightens the exchange state model so persistable state is exactly
`{ body, headers }`. `id`, `principal`, and `logger` move from stored
fields on `DefaultExchange` to derived getters that read from headers
or build from runtime services. This collapses the auth-header
duplication, kills the "special field" precedent for cross-cutting
concerns, and gives halt/continue a clean serialization contract from
day one.

Changes:

- `Exchange<T>` keeps the same public shape (`body`, `headers`, `id`,
  `principal`, `logger`); user-facing reads continue to compile and
  return the same values. Internally `DefaultExchange` stores only
  `body` and `headers`; the rest are getters (`logger` lazy and
  memoised in a `#logger` private slot).
- `routecraft.id` is now a registered well-known header; the `ex.id`
  getter reads from it. `routecraft.auth.principal` carries the
  structured `Principal`; the `ex.principal` getter reads from it.
- The 10 flat `routecraft.auth.*` header keys (subject, scheme, kind,
  roles, scopes, email, name, issuer, audience, client_id) are gone.
  One key carries the structured principal; readers narrow via the
  getter or by reading the header directly.
- `HeaderValue` widens to `unknown` at the bag level so cross-cutting
  concerns can live as one structured key. A new `HeaderLiteral` type
  covers the static-value slot of `.header(k, v)` so the value-or-fn
  union infers correctly.
- Operations (`process`, `split`, `tap`, `aggregate`, `enrich`) drop
  their principal-specific `?? prev.principal` plumbing; principal
  flows naturally because it lives in headers and headers spread
  through `rewrap`.
- `DefaultExchange` constructor and `rewrap` no longer accept `id` or
  `principal` as separate options. Callers pass them via headers
  (e.g. `headers: { ...prev.headers, "routecraft.auth.principal": p }`).
- Logger no longer falls back to legacy flat headers; it reads
  `auth.subject` and `auth.issuer` only from `ex.principal`.
- `.standards/exchange-state-model.md` documents the contract:
  state vs derivations, halt/continue shape, three exchange forms
  (external type / implementation class / log projection), the getter
  pattern for known core concerns vs external-helper pattern for
  plugin-defined concerns.
- New smoke test (`exchange-state-model.test.ts`) JSON-round-trips
  `{ body, headers }` and verifies the rehydrated instance exposes
  the original id, principal, and a working logger via its getters.

Breaking changes:

- Public: `ex.headers["routecraft.auth.subject"]` and the other nine
  flat auth keys no longer exist. Read principal fields via
  `ex.principal?.subject` (etc.) or
  `ex.headers["routecraft.auth.principal"]?.subject`. Auth is
  `@experimental`, but `Exchange` is core API; the migration is a
  one-line search-and-replace.
- Internal-but-exported: `DefaultExchange` constructor and
  `DefaultExchange.rewrap` no longer accept `id` or `principal`
  options. Adapters allocating exchanges (mostly the MCP server, a
  handful of operation paths, and pseudo-exchange test builders)
  pass id/principal through `headers` instead.
- Tap snapshots no longer deep-clone the principal. The headers
  wrapper is shallow-frozen; mutating nested fields of a structured
  header value (`ex.principal.claims.foo = ...`) is an anti-pattern
  the framework does not isolate against. Tap is for observation,
  not mutation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies exchange state to exactly { body, headers }. `id`, `principal`, and `logger` are now getters over headers; ten flat auth headers are replaced by a structured `routecraft.auth.principal`, and `routecraft.id` is formalized.

- **Refactors**
  - `DefaultExchange` stores only `body` and `headers`; adds `HeadersKeys.ID` and `HeadersKeys.AUTH_PRINCIPAL`; removes flat `routecraft.auth.*` keys; logger reads subject/issuer from `ex.principal`.
  - Dropped the positional `principal` arg from source/consumer handlers and `Message`; sources write the structured principal to `headers["routecraft.auth.principal"]` (route `buildExchange()` and direct/simple adapters updated).
  - `.header()` now accepts `HeaderLiteral` and rejects writes to `routecraft.id` (RC5003); `DefaultExchange.rewrap()`/constructor no longer accept `id`/`principal`.
  - Ops flow principal via headers: `process`, `split` (parent headers first, new id), `aggregate` (copies headers explicitly), `enrich`, `tap`; MCP server and direct tool dispatch pass/read principal via the structured header. Docs and tests updated; added `.standards/exchange-state-model.md`.

- **Migration**
  - Replace reads of `routecraft.auth.subject` (and the other nine) with `ex.principal?.field` or `ex.headers["routecraft.auth.principal"]?.field`.
  - Write via headers: set principal with `headers["routecraft.auth.principal"] = p`; set id with `headers["routecraft.id"] = id`. Do not write `routecraft.id` via `.header()`—identity is engine-owned and auto-preserved.
  - Adapter authors: remove the `principal` param from handler calls and `Message`; write `headers["routecraft.auth.principal"]` instead.
  - Stop passing `id`/`principal` to `new DefaultExchange()` or `DefaultExchange.rewrap()`. Merged batches inherit principal via header merge (last-write-wins); use the simple consumer or a custom `merge` for per-item identity. Tap snapshots no longer deep-clone principal—avoid mutating nested claims.

<sup>Written for commit 527bdaaf740a53f6df3bd527eca0e813e0eafcda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

