### PR TITLE
feat(docs): deploy canary docs at /next/ on GitHub Pages

### DIFF
--- a/.github/scripts/set-version.mjs
+++ b/.github/scripts/set-version.mjs
@@ -138,34 +138,4 @@ if (existsSync(cliIndexPath)) {
   }
 }
 
-// Update VersionSelector component
-const versionSelectorPath = join(
-  rootDir,
-  "apps",
-  "routecraft.dev",
-  "src",
-  "components",
-  "VersionSelector.tsx",
-);
-if (existsSync(versionSelectorPath)) {
-  try {
-    let selectorContent = readFileSync(versionSelectorPath, "utf8");
-    const versionRegex =
-      /const versions = \[\{ label: 'v[0-9.a-zA-Z\-+]+', value: 'v[0-9.a-zA-Z\-+]+' \}\]/;
-    const newVersionLine = `const versions = [{ label: 'v${version}', value: 'v${version}' }]`;
-
-    if (versionRegex.test(selectorContent)) {
-      selectorContent = selectorContent.replace(versionRegex, newVersionLine);
-      writeFileSync(versionSelectorPath, selectorContent);
-      console.log(`✓ Updated VersionSelector component → v${version}`);
-      updatedCount++;
-    } else {
-      console.warn("⚠ Could not find version line in VersionSelector.tsx");
-    }
-  } catch (error) {
-    console.error(`✗ Failed to update VersionSelector version:`, error.message);
-    process.exit(1);
-  }
-}
-
 console.log(`\nSuccessfully updated ${updatedCount} package(s)`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,7 +475,7 @@ jobs:
         with:
           path: canary
           fetch-depth: 0
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'push' && github.sha || 'refs/heads/main' }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,23 +195,6 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
 
-      - name: Setup Pages
-        id: configure-pages
-        if: github.event_name == 'release'
-        uses: actions/configure-pages@v6
-        with:
-          static_site_generator: next
-
-      - name: Export Pages base path env
-        if: github.event_name == 'release'
-        run: |
-          echo "NEXT_PUBLIC_BASE_PATH=${{ steps.configure-pages.outputs.base_path }}" >> $GITHUB_ENV
-          echo "NEXT_PUBLIC_ASSET_PREFIX=${{ steps.configure-pages.outputs.asset_base_url }}" >> $GITHUB_ENV
-
-      - name: Set release version
-        if: github.event_name == 'release'
-        run: pnpm run version:set "${GITHUB_REF#refs/tags/v}"
-
       - name: Build packages
         run: pnpm run build
         env:
@@ -226,14 +209,6 @@ jobs:
         with:
           path: "**/dist"
           key: build-${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Upload docs export artifact
-        if: github.event_name == 'release'
-        uses: actions/upload-artifact@v7
-        with:
-          name: docs-export
-          path: apps/routecraft.dev/out
-          if-no-files-found: error
 
   integration-test:
     needs: [changes, validate, test, build]
@@ -305,7 +280,7 @@ jobs:
             packages/ai/package.json packages/browser/package.json packages/cli/package.json \
             packages/create-routecraft/package.json packages/eslint-plugin-routecraft/package.json packages/os/package.json packages/routecraft/package.json packages/testing/package.json \
             packages/cli/src/index.ts \
-            apps/routecraft.dev/package.json apps/routecraft.dev/src/components/VersionSelector.tsx
+            apps/routecraft.dev/package.json
 
   publish-canary:
     needs: [changes, build, integration-test]
@@ -487,9 +462,138 @@ jobs:
             npm publish "./$pkg" --access public --provenance
           done
 
+  build-docs-site:
+    needs: [changes, validate, test, build]
+    if: |
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'release'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.docs == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (canary)
+        uses: actions/checkout@v6
+        with:
+          path: canary
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: canary/.nvmrc
+          cache: pnpm
+          cache-dependency-path: canary/pnpm-lock.yaml
+
+      - name: Install canary dependencies
+        working-directory: canary
+        run: pnpm install --frozen-lockfile
+
+      - name: Build canary docs (/next)
+        working-directory: canary
+        env:
+          NEXT_PUBLIC_BASE_PATH: /next
+          NEXT_PUBLIC_DOC_VERSION: next
+          NEXT_PUBLIC_DOC_COMMIT: ${{ github.sha }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+        run: pnpm --filter routecraft.dev build
+
+      - name: Find latest stable tag
+        id: latest
+        working-directory: canary
+        run: |
+          set -eo pipefail
+          if LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null); then
+            echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+            echo "version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
+            echo "Latest stable tag: $LATEST_TAG"
+          else
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "No stable tag found; deploying canary only"
+          fi
+
+      - name: Checkout stable tag
+        if: steps.latest.outputs.tag != ''
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.latest.outputs.tag }}
+          path: stable
+
+      - name: Install stable dependencies
+        if: steps.latest.outputs.tag != ''
+        working-directory: stable
+        run: pnpm install --frozen-lockfile
+
+      - name: Set stable version metadata
+        if: steps.latest.outputs.tag != ''
+        working-directory: stable
+        run: pnpm run version:set "${{ steps.latest.outputs.version }}"
+
+      - name: Build stable docs (/latest)
+        if: steps.latest.outputs.tag != ''
+        working-directory: stable
+        env:
+          NEXT_PUBLIC_BASE_PATH: /latest
+          NEXT_PUBLIC_DOC_VERSION: v${{ steps.latest.outputs.version }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+        run: pnpm --filter routecraft.dev build
+
+      - name: Assemble merged site
+        env:
+          STABLE_VERSION: ${{ steps.latest.outputs.version }}
+        run: |
+          set -eo pipefail
+          mkdir -p site
+          mv canary/apps/routecraft.dev/out site/next
+
+          if [ -d stable/apps/routecraft.dev/out ]; then
+            mv stable/apps/routecraft.dev/out site/latest
+            ROOT_TARGET="/latest/"
+            cat > site/versions.json <<JSON
+          [
+            { "label": "next", "basePath": "/next" },
+            { "label": "v${STABLE_VERSION}", "basePath": "/latest", "default": true }
+          ]
+          JSON
+          else
+            ROOT_TARGET="/next/"
+            cat > site/versions.json <<'JSON'
+          [
+            { "label": "next", "basePath": "/next", "default": true }
+          ]
+          JSON
+          fi
+
+          cat > site/index.html <<HTML
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <title>Routecraft Docs</title>
+              <meta http-equiv="refresh" content="0; url=${ROOT_TARGET}">
+              <link rel="canonical" href="${ROOT_TARGET}">
+            </head>
+            <body>
+              <p>Redirecting to <a href="${ROOT_TARGET}">${ROOT_TARGET}</a>...</p>
+            </body>
+          </html>
+          HTML
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
   deploy-pages:
-    needs: [build]
-    if: github.event_name == 'release'
+    needs: [changes, build-docs-site]
+    if: |
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'release'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.docs == 'true')
     runs-on: ubuntu-latest
     concurrency:
       group: pages
@@ -499,20 +603,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     permissions:
       id-token: write
-      contents: read
       pages: write
     steps:
-      - name: Download docs export artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: docs-export
-          path: docs-export
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs-export
-
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'push' && github.sha || 'refs/heads/main' }}
 
+      - name: Record canary commit
+        id: canary_commit
+        working-directory: canary
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Install pnpm
         uses: pnpm/action-setup@v5
 
@@ -496,7 +501,7 @@ jobs:
         env:
           NEXT_PUBLIC_BASE_PATH: /next
           NEXT_PUBLIC_DOC_VERSION: next
-          NEXT_PUBLIC_DOC_COMMIT: ${{ github.sha }}
+          NEXT_PUBLIC_DOC_COMMIT: ${{ steps.canary_commit.outputs.sha }}
           NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
           NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
         run: pnpm --filter routecraft.dev build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,11 +537,11 @@ jobs:
         working-directory: stable
         run: pnpm run version:set "${{ steps.latest.outputs.version }}"
 
-      - name: Build stable docs (/latest)
+      - name: Build stable docs (root)
         if: steps.latest.outputs.tag != ''
         working-directory: stable
         env:
-          NEXT_PUBLIC_BASE_PATH: /latest
+          NEXT_PUBLIC_BASE_PATH: ""
           NEXT_PUBLIC_DOC_VERSION: v${{ steps.latest.outputs.version }}
           NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
           NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
@@ -552,41 +552,26 @@ jobs:
           STABLE_VERSION: ${{ steps.latest.outputs.version }}
         run: |
           set -eo pipefail
-          mkdir -p site
-          mv canary/apps/routecraft.dev/out site/next
 
           if [ -d stable/apps/routecraft.dev/out ]; then
-            mv stable/apps/routecraft.dev/out site/latest
-            ROOT_TARGET="/latest/"
+            # Stable serves at root; canary serves at /next/
+            mv stable/apps/routecraft.dev/out site
+            mv canary/apps/routecraft.dev/out site/next
             cat > site/versions.json <<JSON
           [
             { "label": "next", "basePath": "/next" },
-            { "label": "v${STABLE_VERSION}", "basePath": "/latest", "default": true }
+            { "label": "v${STABLE_VERSION}", "basePath": "", "default": true }
           ]
           JSON
           else
-            ROOT_TARGET="/next/"
+            # No stable tag yet: canary serves at root, no /next/
+            mv canary/apps/routecraft.dev/out site
             cat > site/versions.json <<'JSON'
           [
-            { "label": "next", "basePath": "/next", "default": true }
+            { "label": "next", "basePath": "", "default": true }
           ]
           JSON
           fi
-
-          cat > site/index.html <<HTML
-          <!doctype html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8">
-              <title>Routecraft Docs</title>
-              <meta http-equiv="refresh" content="0; url=${ROOT_TARGET}">
-              <link rel="canonical" href="${ROOT_TARGET}">
-            </head>
-            <body>
-              <p>Redirecting to <a href="${ROOT_TARGET}">${ROOT_TARGET}</a>...</p>
-            </body>
-          </html>
-          HTML
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/apps/routecraft.dev/src/components/VersionSelector.tsx
+++ b/apps/routecraft.dev/src/components/VersionSelector.tsx
@@ -61,7 +61,8 @@ export function VersionSelector(props: { className?: string }) {
   const handleChange = (target: Version) => {
     if (target.basePath === currentBasePath) return
     const suffix = pathname.endsWith('/') ? pathname : `${pathname}/`
-    window.location.href = `${target.basePath}${suffix}`
+    const { search, hash } = window.location
+    window.location.href = `${target.basePath}${suffix}${search}${hash}`
   }
 
   return (

--- a/apps/routecraft.dev/src/components/VersionSelector.tsx
+++ b/apps/routecraft.dev/src/components/VersionSelector.tsx
@@ -1,14 +1,26 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import {
   Listbox,
   ListboxButton,
   ListboxOption,
   ListboxOptions,
 } from '@headlessui/react'
+import { usePathname } from 'next/navigation'
 import clsx from 'clsx'
 
-const versions = [{ label: 'v0.4.0', value: 'v0.4.0' }]
+type Version = {
+  label: string
+  basePath: string
+  default?: boolean
+}
+
+const currentLabel = process.env.NEXT_PUBLIC_DOC_VERSION ?? 'dev'
+const currentBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
+const fallbackVersions: Version[] = [
+  { label: currentLabel, basePath: currentBasePath },
+]
 
 function ChevronDownIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   return (
@@ -25,17 +37,40 @@ function ChevronDownIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   )
 }
 
-export function VersionSelector(
-  props: React.ComponentPropsWithoutRef<typeof Listbox<'div'>>,
-) {
+export function VersionSelector(props: { className?: string }) {
+  const [versions, setVersions] = useState<Version[]>(fallbackVersions)
+  const pathname = usePathname()
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetch('/versions.json', { signal: controller.signal })
+      .then((res) => (res.ok ? (res.json() as Promise<Version[]>) : null))
+      .then((data) => {
+        if (Array.isArray(data) && data.length > 0) {
+          setVersions(data)
+        }
+      })
+      .catch(() => {
+        // Manifest is optional; fall back to the build-time label.
+      })
+    return () => controller.abort()
+  }, [])
+
+  const current = versions.find((v) => v.label === currentLabel) ?? versions[0]
+
+  const handleChange = (target: Version) => {
+    if (target.basePath === currentBasePath) return
+    const suffix = pathname.endsWith('/') ? pathname : `${pathname}/`
+    window.location.href = `${target.basePath}${suffix}`
+  }
+
   return (
-    <Listbox
+    <Listbox<'div', Version>
       as="div"
-      value={versions[0].value}
-      onChange={() => {
-        // TODO: implement version switching logic
-      }}
-      {...props}
+      value={current}
+      onChange={handleChange}
+      by="label"
+      className={props.className}
     >
       <div className="relative">
         <ListboxButton
@@ -48,14 +83,14 @@ export function VersionSelector(
           )}
           aria-label="Documentation version"
         >
-          <span>{versions[0].value}</span>
+          <span>{current.label}</span>
           <ChevronDownIcon className="h-4 w-4 text-slate-400 dark:text-slate-300" />
         </ListboxButton>
         <ListboxOptions className="absolute top-[calc(100%+0.5rem)] right-0 z-50 w-36 space-y-1 rounded-xl bg-white p-2 text-sm font-medium text-slate-700 shadow-sm dark:bg-slate-900 dark:text-slate-100">
           {versions.map((version) => (
             <ListboxOption
-              key={version.value}
-              value={version.value}
+              key={version.label}
+              value={version}
               className={({ active, selected }) =>
                 clsx(
                   'flex cursor-pointer items-center rounded-lg px-3 py-2 transition-colors select-none',


### PR DESCRIPTION
## Summary

Deploys canary docs to `routecraft.dev/next/` while keeping the latest stable release at the root of `routecraft.dev/`. Both versions are served from a single GitHub Pages artifact, no Dokploy needed.

A `versions.json` manifest at the site root lists available versions; the `VersionSelector` reads it at runtime and switches versions via a full-page navigation across basePath boundaries (preserving `?query` and `#fragment`).

## Why root-stable instead of `/latest/`?

An earlier iteration put stable at `/latest/` with a meta-refresh at root. That broke every existing `routecraft.dev/docs/*` URL, the canonical `routecraft.dev/sitemap.xml`, `routecraft.dev/robots.txt`, and `routecraft.dev/llms.txt`. Serving the stable build at the root preserves all of those URLs unchanged because the stable build IS the root build. The same pattern is used by `react.dev`, `nextjs.org`, and most mature project docs.

The only thing this gives up is an explicit "latest" namespace. If pinned-version URLs (`/v0.5/`, `/v0.4/`) are ever needed, they can be added later as additional slots without renaming anything.

## Changes

- **`apps/routecraft.dev/src/components/VersionSelector.tsx`** -- rewritten to read `NEXT_PUBLIC_DOC_VERSION` + `NEXT_PUBLIC_BASE_PATH` at build time, fetch `/versions.json` at runtime, and switch versions via `window.location` (preserving `search` and `hash`). Falls back gracefully to a single-entry list if the manifest is missing.
- **`.github/scripts/set-version.mjs`** -- dropped the `VersionSelector.tsx` source mutation block. The selector is no longer touched by the version setter, so the canary label stays as "next" and isn't overwritten on every release/canary publish.
- **`.github/workflows/ci.yml`**:
  - Removed the release-only Pages config + docs export upload from the `build` job. That job now only validates package builds.
  - New `build-docs-site` job: checks out `main` (or `refs/heads/main` on release/dispatch) and the latest stable tag in two working directories. Builds canary with `NEXT_PUBLIC_BASE_PATH=/next` and stable with empty basePath, generates `versions.json`, uploads the merged folder via `actions/upload-pages-artifact@v5`. Runs on `push: main` (when docs changed), `release`, or `workflow_dispatch`.
  - `NEXT_PUBLIC_DOC_COMMIT` is captured from the canary checkout's actual HEAD (via `git rev-parse`), not `github.sha`.
  - `deploy-pages` now consumes that artifact directly and runs on the same triggers.
  - Removed `apps/routecraft.dev/src/components/VersionSelector.tsx` from the `integration-test` "Restore repo" list (no longer mutated).

## Behaviour after merge

- Push to main with docs changes -> root rebuilt + redeployed alongside `/next/`.
- Cut a release tag -> root rebuilds from the new tag; `/next/` rebuilds from main HEAD.
- `routecraft.dev/` -> stable docs homepage (no redirect).
- `routecraft.dev/docs/*`, `/sitemap.xml`, `/llms.txt`, `/robots.txt`, `/raw/*.md` -- all unchanged.
- `routecraft.dev/next/docs/*`, `/next/raw/*.md`, etc. -- canary equivalents under the basePath.

## Edge cases handled

- No stable tag yet -> canary serves at root, no `/next/` slot.
- Switching versions preserves query string and fragment so anchored deep links survive.
- Hotfix release on an older line (e.g. `v0.4.1` while main is at `v0.5.0`) does NOT downgrade the root, because `git describe --tags --abbrev=0` from a `main` checkout always picks the highest stable reachable from main. (Discussed [in this thread](https://github.com/routecraftjs/routecraft/pull/286#discussion_r3184998549).)

## Test plan

- [ ] CI runs on push to this branch, with `build-docs-site` correctly skipped (it only runs on `push: main`, `release`, or `workflow_dispatch`).
- [ ] After merge, push to main triggers a docs redeploy producing the merged site.
- [ ] `routecraft.dev/` serves stable docs directly (no redirect flicker).
- [ ] `routecraft.dev/docs/...` continues to resolve as before.
- [ ] `routecraft.dev/sitemap.xml`, `/robots.txt`, `/llms.txt`, `/raw/docs.md` all continue to work.
- [ ] `routecraft.dev/next/` loads canary docs with selector showing "next".
- [ ] `routecraft.dev/next/raw/docs.md` returns canary's raw bundle.
- [ ] Selecting "next" from the dropdown navigates to `/next/<same path>` with `?query` and `#hash` preserved.

https://claude.ai/code/session_017pMuqYQ7NXMN4e1GV4QVJX