### PR TITLE
ci: switch integration-test matrix to runtime: [bun, node] with embedding smoke (prep for #211)

### DIFF
--- a/.github/scripts/smoke-test-embedding.mjs
+++ b/.github/scripts/smoke-test-embedding.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+/**
+ * Smoke test for the Node embedding path: pack @routecraft/routecraft, install
+ * it from the tarball into a clean temp dir under npm, write a small runner.ts
+ * that builds a context and dispatches a message via the client, and execute
+ * it under plain Node (no CLI). Asserts the expected log line appears in
+ * stdout and the process exits 0.
+ *
+ * Run from repo root after `pnpm run version:set` and `pnpm build`. Uses only
+ * npm and node so behaviour matches a real Node user embedding Routecraft in
+ * their own application.
+ *
+ * Usage: node .github/scripts/smoke-test-embedding.mjs [version]
+ *   version: optional; defaults to packages/routecraft/package.json version
+ */
+
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+import { tmpdir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(__dirname, "../..");
+
+const version =
+  process.argv[2] ||
+  JSON.parse(
+    readFileSync(join(rootDir, "packages/routecraft/package.json"), "utf8"),
+  ).version;
+
+if (!version) {
+  console.error("Usage: node smoke-test-embedding.mjs [version]");
+  process.exit(1);
+}
+
+const packDir = join(rootDir, "dist", "packs");
+const smokeDir = process.env.RUNNER_TEMP
+  ? join(process.env.RUNNER_TEMP, "smoke-embedding")
+  : join(tmpdir(), "routecraft-smoke-embedding");
+
+function run(cmd, opts = {}) {
+  const cwd = opts.cwd || rootDir;
+  console.log(`$ ${cmd}`);
+  return execSync(cmd, {
+    cwd,
+    stdio: opts.stdio ?? "inherit",
+    ...opts,
+  });
+}
+
+console.log(`Smoke testing Node embedding (version: ${version})\n`);
+
+// 1. Pack routecraft. Embedding does not need the CLI or testing tarballs:
+//    consumers depend on @routecraft/routecraft only.
+mkdirSync(packDir, { recursive: true });
+run(`npm pack --pack-destination "${packDir}"`, {
+  cwd: join(rootDir, "packages", "routecraft"),
+});
+
+const tarballs = readdirSync(packDir).filter(
+  (f) => f.startsWith("routecraft-routecraft-") && f.endsWith(".tgz"),
+);
+if (tarballs.length !== 1) {
+  console.error(
+    `Expected 1 routecraft tarball in ${packDir}, got: ${
+      tarballs.join(", ") || "none"
+    }`,
+  );
+  process.exit(1);
+}
+
+// 2. Temp dir: npm init + install routecraft from the tarball only.
+mkdirSync(smokeDir, { recursive: true });
+run("npm init -y", { cwd: smokeDir });
+const smokePkgPath = join(smokeDir, "package.json");
+const smokePkg = JSON.parse(readFileSync(smokePkgPath, "utf8"));
+smokePkg.type = "module";
+writeFileSync(smokePkgPath, JSON.stringify(smokePkg, null, 2) + "\n");
+
+const tarballPath = join(packDir, tarballs[0]);
+// croner and cheerio are declared optional peer deps, but the bundled
+// dist/index.js currently statically imports them; install alongside
+// routecraft so the embed loads. Once the optional-peer contract is
+// honoured (lazy dynamic imports), this can be reduced to the tarball
+// alone and the negative arm of this smoke test (cron() without croner)
+// becomes meaningful.
+run(`npm install "${tarballPath}" croner cheerio`, { cwd: smokeDir });
+
+// 3. Write a runner.ts that exercises the embedding API: ContextBuilder,
+//    a route with direct() source and log() destination, and a single
+//    client.send() to assert the dispatch path works end to end.
+const runnerSource = `import {
+  craft,
+  direct,
+  log,
+  ContextBuilder,
+} from "@routecraft/routecraft";
+
+const route = craft()
+  .id("greet")
+  .from(direct<{ name: string }>())
+  .transform((body) => \`Hello, \${body.name}!\`)
+  .to(log());
+
+const builder = new ContextBuilder();
+builder.routes(route);
+const { context, client } = await builder.build();
+context.start();
+
+try {
+  await client.send("greet", { name: "embedded-node" });
+  console.log("[smoke-embedding] dispatched OK");
+} finally {
+  await context.stop();
+}
+`;
+writeFileSync(join(smokeDir, "runner.ts"), runnerSource);
+
+// 4. Execute under plain Node. Node 24 strips TypeScript types by default;
+//    older versions need --experimental-strip-types. We pass the flag
+//    unconditionally; on 24+ it is a harmless no-op alias.
+//    CRAFT_LOG_LEVEL=info ensures log() output appears in the captured stream
+//    (default is warn).
+const output = run("node --experimental-strip-types runner.ts", {
+  cwd: smokeDir,
+  stdio: ["ignore", "pipe", "pipe"],
+  env: { ...process.env, CRAFT_LOG_LEVEL: "info" },
+}).toString();
+
+if (!output.includes("[smoke-embedding] dispatched OK")) {
+  console.error("Expected dispatch confirmation in output, got:\n" + output);
+  process.exit(1);
+}
+
+if (!output.includes("Hello, embedded-node!")) {
+  console.error(
+    'Expected log() to emit "Hello, embedded-node!" in output, got:\n' + output,
+  );
+  process.exit(1);
+}
+
+console.log(output);
+console.log("\nNode embedding smoke test passed.");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pm: [npm, bun]
-    name: integration-test (${{ matrix.pm }})
+        runtime: [bun, node]
+    name: integration-test (${{ matrix.runtime }})
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -235,7 +235,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install bun
-        if: matrix.pm == 'bun'
+        if: matrix.runtime == 'bun'
         uses: oven-sh/setup-bun@v2
 
       - name: Restore node_modules
@@ -258,10 +258,15 @@ jobs:
           VERSION=$(node -p "require('./packages/routecraft/package.json').version")
           pnpm run version:set "$VERSION"
 
-      - name: Run integration tests
+      - name: Run scaffolder integration tests (bun)
+        if: matrix.runtime == 'bun'
         env:
-          TEST_PACKAGE_MANAGER: ${{ matrix.pm }}
+          TEST_PACKAGE_MANAGER: bun
         run: pnpm test:integration
+
+      - name: Smoke test Node embedding (pack + npm install + node runner.ts)
+        if: matrix.runtime == 'node'
+        run: node .github/scripts/smoke-test-embedding.mjs
 
       - name: Restore repo (only paths set-version touched)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,17 +258,6 @@ jobs:
           VERSION=$(node -p "require('./packages/routecraft/package.json').version")
           pnpm run version:set "$VERSION"
 
-      - name: Install CLI globally
-        if: matrix.pm == 'npm'
-        working-directory: ./packages/cli
-        run: |
-          npm link
-          craft --version
-
-      - name: Smoke test publishable (pack + npm install + npx craft run)
-        if: matrix.pm == 'npm'
-        run: node .github/scripts/smoke-test-publishable.mjs
-
       - name: Run integration tests
         env:
           TEST_PACKAGE_MANAGER: ${{ matrix.pm }}


### PR DESCRIPTION
Prep PR for #288 (closes #211).

## What

Restructures the `integration-test` job in `.github/workflows/ci.yml` and introduces an embedded-mode smoke test:

- Matrix renamed `pm: [npm, bun]` → `runtime: [bun, node]`.
- **bun leg**: `pnpm test:integration` with `TEST_PACKAGE_MANAGER=bun` (unchanged scaffolded-project flow under Bun).
- **node leg**: new. Runs `node .github/scripts/smoke-test-embedding.mjs`. Packs `@routecraft/routecraft`, npm-installs into a clean temp dir alongside `croner` + `cheerio` (still statically imported by the bundle until #288 lands), writes a small `runner.ts` exercising `ContextBuilder + direct() + log() + client.send()`, and runs it under plain Node. Asserts the dispatched body reaches the log destination.
- Drops the npm-leg-only `Install CLI globally` (`npm link + craft --version`) and `Smoke test publishable` steps. They were CLI-focused; the embedding smoke covers the Node consumer contract more directly.

## Why

PR #288 / issue #211 makes the `craft` CLI Bun-only and fixes the optional-peer contract. The two dropped steps invoke the CLI directly under Node and would fail against #288's code. Because `pull_request_target` runs the workflow file from the **base** branch (main), #288's own workflow updates can't take effect until #288 merges — and its CI fails under main's old workflow. This prep PR breaks the chicken-and-egg.

The new node leg is the substantive addition: it locks in **embedded-mode coverage** on every PR going forward, complementing the bun CLI scaffolder flow. Without it, the Node consumer story has zero CI coverage today.

## Verified locally against current main code

- `node .github/scripts/smoke-test-embedding.mjs` → "Node embedding smoke test passed."
- `TEST_PACKAGE_MANAGER=bun pnpm test:integration` → 3 passed.

## Impact on main

- npm-leg integration step (`Install CLI globally + smoke-test-publishable + scaffolder npm`) drops; replaced by the node-leg embedding smoke. Net coverage shifts from "CLI under npx" to "library under Node embedding".
- The bun-leg scaffolder integration test is unchanged.

## Follow-up after this lands

1. PR #288's CI runs against this prep'd workflow. The node leg invokes #288's updated `smoke-test-embedding.mjs` (no `croner cheerio` install line because the lazy-load fix in #288 honours the optional-peer contract; plus a negative arm asserting RC5017 fires when an optional peer is missing).
2. PR #288 merges. The full Bun-runtime + optional-peer-contract change is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)