### PR TITLE
fix(ci): point pnpm setup at canary/package.json in build-docs-site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,6 +484,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
+        with:
+          package_json_file: canary/package.json
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

The new `build-docs-site` job introduced in #286 is failing on main with `Error: No pnpm version is specified`. Run that surfaced it: https://github.com/routecraftjs/routecraft/actions/runs/25365171651

## Root cause

`build-docs-site` checks out `main` into a `canary/` subfolder via `path: canary` (because we also need a separate checkout of the latest tag at `stable/`). Without a `package.json` at the runner's working directory root, `pnpm/action-setup@v5` cannot discover the pnpm version from the `packageManager` field and bails out.

## Fix

Tell `pnpm/action-setup@v5` explicitly where the `package.json` is via `package_json_file: canary/package.json`. One-line addition.

## Test plan

- [ ] CI on this PR runs to validate the workflow itself parses (note: `build-docs-site` is gated to push-to-main / release / workflow_dispatch, so it won't actually run on this PR build).
- [ ] After merge, the next push-to-main triggers `build-docs-site` and proceeds past the pnpm setup step into the canary build.
- [ ] `routecraft.dev/next/` becomes reachable.

https://claude.ai/code/session_017pMuqYQ7NXMN4e1GV4QVJX

---
_Generated by [Claude Code](https://claude.ai/code/session_017pMuqYQ7NXMN4e1GV4QVJX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `build-docs-site` CI job by pointing `pnpm/action-setup@v5` to `canary/package.json`, resolving the “No pnpm version is specified” error when the repo is checked out into `canary/`.

- **Bug Fixes**
  - Set `package_json_file: canary/package.json` in the pnpm setup step.

<sup>Written for commit 8bd6462ed97bb3666f1ee6c6349a7bcbe92ae32b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

