### PR TITLE
Document log and debug operators, clarify map and schema

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -32,12 +32,13 @@ DSL operators with signatures and examples. {% .lead %}
 | [`delay`](#delay) | Wrapper | Add delay before the next operation {% badge color="purple" %}planned{% /badge %} |
 | [`onError`](#onError) | Wrapper | Handle errors from the next operation {% badge color="purple" %}planned{% /badge %} |
 | [`transform`](#transform) | Transform | Transform data using a function (body only) |
-| [`map`](#map) | Transform | Map fields from source to target object |
+| [`map`](#map) | Transform | Sugar for `transform(mapper(...))`: map fields from source to target object |
 | [`process`](#process) | Transform | Process data with full exchange access |
 | [`header`](#header) | Transform | Set or override an exchange header |
 | [`enrich`](#enrich) | Transform | Add additional data to current data |
 | [`filter`](#filter) | Flow Control | Filter data based on predicate |
 | [`validate`](#validate) | Flow Control | Validate data against schema |
+| [`schema`](#schema) | Flow Control | Sugar for `validate(schema(...))`: validate against a Standard Schema |
 | [`dedupe`](#dedupe) | Flow Control | Suppress duplicate exchanges based on a key {% badge color="purple" %}planned{% /badge %} |
 | [`choice`](#choice) | Flow Control | Route to different paths based on conditions |
 | [`split`](#split) | Flow Control | Split arrays into individual items |
@@ -45,6 +46,8 @@ DSL operators with signatures and examples. {% .lead %}
 | [`multicast`](#multicast) | Flow Control | Send exchange to multiple destinations {% badge color="purple" %}planned{% /badge %} |
 | [`loop`](#loop) | Flow Control | Repeat operations while condition is true {% badge color="purple" %}planned{% /badge %} |
 | [`tap`](#tap) | Side Effect | Fire-and-forget side effect, does not block the pipeline |
+| [`log`](#log) | Side Effect | Sugar for `tap(log())`: log the current exchange at info level |
+| [`debug`](#debug) | Side Effect | Sugar for `tap(debug())`: log the current exchange at debug level |
 | [`to`](#to) | Side Effect | Send data to a destination adapter and end the pipeline |
 
 ## Route operations
@@ -549,7 +552,7 @@ Set or override a header on the exchange. The body remains unchanged.
 map<Return>(fieldMappings: Record<keyof Return, (src: Current) => Return[keyof Return]>): RouteBuilder<Return>
 ```
 
-Map fields from the current data to create a new object of a specified type. This is a specialized transformer that creates a new object by mapping fields from the source object.
+Map fields from the current data to create a new object of a specified type. Sugar for `.transform(mapper({...}))`: a specialized transformer that creates a new object by mapping fields from the source object.
 
 ```ts
 // Map from API response to database model
@@ -1045,6 +1048,49 @@ The tap receives a **deep copy** of the exchange with:
 - `context.stop()` automatically calls `context.drain()` to wait for all tap jobs
 - Ensures all async work finishes before shutdown completes
 
+
+### log
+
+```ts
+log(
+  formatter?: (exchange: Exchange<Current>) => unknown,
+  options?: { level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal' },
+): RouteBuilder<Current>
+```
+
+Sugar for `.tap(log(formatter, options))`. Logs the current exchange via the exchange logger and continues the pipeline unchanged. Defaults to `info` level. By default the logger prints `id`, `body`, and `headers`; pass a `formatter` to log a derived value instead.
+
+```ts
+// Log id, body, headers at info level
+.log()
+
+// Log a derived value
+.log((exchange) => ({ id: exchange.id, body: exchange.body }))
+
+// Log at a different level
+.log(undefined, { level: 'warn' })
+```
+
+Use `.log()` for ad-hoc visibility inside a route. For more control or a non-default destination, use `.tap(log(...))` directly.
+
+### debug
+
+```ts
+debug(
+  formatter?: (exchange: Exchange<Current>) => unknown,
+  options?: Record<string, never>,
+): RouteBuilder<Current>
+```
+
+Sugar for `.tap(debug(formatter))`. Same shape as `.log()`, but the level is fixed to `debug`. Useful for verbose pipeline tracing that can be silenced via the logger configuration without removing the call.
+
+```ts
+// Debug log id, body, headers
+.debug()
+
+// Debug log a derived value
+.debug((exchange) => ({ correlation: exchange.headers['x-correlation-id'], body: exchange.body }))
+```
 
 ### to
 


### PR DESCRIPTION
## Summary
This PR updates the operations reference documentation to include two new side effect operators (`log` and `debug`) and clarifies the relationship between several operators and their underlying functions.

## Key Changes
- **Added documentation for `log` operator**: A sugar operator for `.tap(log())` that logs the current exchange at info level (or custom level) with optional formatting
- **Added documentation for `debug` operator**: A sugar operator for `.tap(debug())` that logs at debug level, useful for verbose tracing that can be silenced via logger configuration
- **Clarified `map` operator**: Updated description to explicitly note it's sugar for `.transform(mapper(...))` 
- **Clarified `schema` operator**: Added to the operations table with description noting it's sugar for `.validate(schema(...))`
- **Updated operations table**: Added `log` and `debug` entries in the Side Effect category

## Implementation Details
- Both `log` and `debug` operators accept an optional formatter function to customize what gets logged
- `log` supports configurable log levels (trace, debug, info, warn, error, fatal) via options
- `debug` has a fixed debug level with no options parameter
- Documentation includes practical examples showing default usage and custom formatting
- Guidance provided to use `.tap(log(...))` directly for more control or non-default destinations

https://claude.ai/code/session_01Fh1436pnnDWczMe39LGSAZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the `log` and `debug` side-effect operators and clarified how `map` and `schema` map to their underlying functions. Updates complete the operations table and add concise logging examples.

- **New Features**
  - Added `log`: sugar for `.tap(log())`; defaults to info; supports formatter and custom level.
  - Added `debug`: sugar for `.tap(debug())`; fixed debug level; supports formatter.
  - Clarified sugar: `map` → `.transform(mapper(...))`; `schema` → `.validate(schema(...))` (added to table).
  - Included examples and a note to use `.tap(log(...))` for more control.

<sup>Written for commit 4fbf1ea004c4a65a1a114487ce295824e90bb9c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

