### PR TITLE
Add Claude Code skills for authoring Routecraft adapters and capabilities

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "routecraft",
+  "description": "Official Routecraft Claude Code plugins. Currently ships routecraft-skills for authoring adapters and capabilities.",
+  "owner": {
+    "name": "routecraftjs",
+    "email": "hello@routecraft.dev"
+  },
+  "plugins": [
+    {
+      "name": "routecraft-skills",
+      "source": "./",
+      "description": "Skills for authoring Routecraft adapters and capabilities. Each skill points Claude at the closest example and the matching public docs, then runs lint, typecheck, and tests until clean.",
+      "version": "0.5.0",
+      "author": {
+        "name": "routecraftjs"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "routecraft-skills",
+  "description": "Skills for authoring Routecraft adapters and capabilities. Each skill points Claude at the closest existing example and the relevant public docs, then runs lint, typecheck, and tests until they pass.",
+  "version": "0.5.0",
+  "author": {
+    "name": "routecraftjs",
+    "url": "https://routecraft.dev"
+  },
+  "homepage": "https://routecraft.dev",
+  "repository": "https://github.com/routecraftjs/routecraft",
+  "license": "Apache-2.0",
+  "keywords": ["routecraft", "ai-native", "scaffolding"]
+}

--- a/.github/scripts/set-version.mjs
+++ b/.github/scripts/set-version.mjs
@@ -75,6 +75,66 @@ function updatePackage(pkgPath) {
 }
 
 /**
+ * Update a Claude Code plugin manifest's version, if present.
+ * Plugin manifests live at <package>/.claude-plugin/plugin.json.
+ */
+function updatePluginManifest(pkgDir) {
+  const manifestPath = join(pkgDir, ".claude-plugin", "plugin.json");
+  if (!existsSync(manifestPath)) {
+    return false;
+  }
+
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    if (typeof manifest.version !== "string") return false;
+    const oldVersion = manifest.version;
+    manifest.version = version;
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+    console.log(
+      `✓ ${manifest.name ?? manifestPath}: ${oldVersion} → ${version} (plugin manifest)`,
+    );
+    return true;
+  } catch (error) {
+    console.error(`✗ Failed to update ${manifestPath}:`, error.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * Update the version of every plugin entry in a marketplace manifest.
+ * Marketplace manifests live at <root>/.claude-plugin/marketplace.json.
+ */
+function updateMarketplaceManifest(rootPath) {
+  const manifestPath = join(rootPath, ".claude-plugin", "marketplace.json");
+  if (!existsSync(manifestPath)) {
+    return 0;
+  }
+
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    if (!Array.isArray(manifest.plugins)) return 0;
+    let updated = 0;
+    for (const entry of manifest.plugins) {
+      if (entry && typeof entry.version === "string") {
+        const oldVersion = entry.version;
+        entry.version = version;
+        console.log(
+          `✓ marketplace plugin "${entry.name}": ${oldVersion} → ${version}`,
+        );
+        updated++;
+      }
+    }
+    if (updated > 0) {
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+    }
+    return updated;
+  } catch (error) {
+    console.error(`✗ Failed to update ${manifestPath}:`, error.message);
+    process.exit(1);
+  }
+}
+
+/**
  * Find and update all packages in a directory
  */
 function updatePackagesInDir(dirPath) {
@@ -89,8 +149,12 @@ function updatePackagesInDir(dirPath) {
   });
 
   for (const dir of dirs) {
-    const pkgPath = join(dirPath, dir, "package.json");
+    const pkgDir = join(dirPath, dir);
+    const pkgPath = join(pkgDir, "package.json");
     if (updatePackage(pkgPath)) {
+      count++;
+    }
+    if (updatePluginManifest(pkgDir)) {
       count++;
     }
   }
@@ -115,6 +179,15 @@ updatedCount += updatePackagesInDir(join(rootDir, "packages"));
 
 // Update all packages in apps/*
 updatedCount += updatePackagesInDir(join(rootDir, "apps"));
+
+// Update root-level Claude Code plugin manifest, if present (when the repo root
+// itself is a plugin, e.g. plugin.json next to a top-level skills/ directory)
+if (updatePluginManifest(rootDir)) {
+  updatedCount++;
+}
+
+// Update root-level marketplace manifest, if present
+updatedCount += updateMarketplaceManifest(rootDir);
 
 // Update CLI version in source code
 const cliIndexPath = join(rootDir, "packages", "cli", "src", "index.ts");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,8 @@ jobs:
           git checkout -- package.json examples/package.json \
             packages/ai/package.json packages/browser/package.json packages/cli/package.json \
             packages/create-routecraft/package.json packages/eslint-plugin-routecraft/package.json packages/os/package.json packages/routecraft/package.json packages/testing/package.json \
+            .claude-plugin/plugin.json \
+            .claude-plugin/marketplace.json \
             packages/cli/src/index.ts \
             apps/routecraft.dev/package.json
 

--- a/.standards/naming-policy.md
+++ b/.standards/naming-policy.md
@@ -20,6 +20,27 @@ For adapters that can both receive and send on a protocol (direct, mcp, http, we
 
 Examples: `DirectServerOptions` / `DirectClientOptions`, `McpServerOptions` / `McpClientOptions`, `HttpServerOptions` / `HttpClientOptions`.
 
+### Shared fields between roles
+
+When the two roles genuinely share fields (auth config, base URL, common headers, retry policy), factor them into **XxxBaseOptions** and have both `XxxServerOptions` and `XxxClientOptions` `extends XxxBaseOptions`. Export the union as **XxxOptions**:
+
+```ts
+export interface HttpBaseOptions { auth?: HttpAuth; baseUrl?: string; }
+export interface HttpServerOptions extends HttpBaseOptions { /* server-only */ }
+export interface HttpClientOptions extends HttpBaseOptions { /* client-only */ }
+export type HttpOptions = HttpServerOptions | HttpClientOptions;
+```
+
+When the two roles do not share fields (e.g. `mail`: IMAP polling on the server side and SMTP send on the client side), declare each independently and export the union directly:
+
+```ts
+export interface MailServerOptions { /* IMAP-only */ }
+export interface MailClientOptions { /* SMTP-only */ }
+export type MailOptions = MailServerOptions | MailClientOptions;
+```
+
+Do not invent an empty `XxxBaseOptions` to make the structure look uniform; the union is what matters and an empty parent only adds friction. The decision rule is "would I write the same field on both Server and Client?" -- if yes for two or more fields, factor; otherwise, declare independently.
+
 ## Single-role adapters
 
 Adapters that only act as source or only as destination (timer, simple, log, noop) use a single options type: **XxxOptions** (e.g., `TimerOptions`, `LogOptions`). Do not use Server/Client in their option names.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ See [DEFINITION_OF_DONE.md](DEFINITION_OF_DONE.md) for what must be satisfied be
 | `@routecraft/eslint-plugin-routecraft` | `packages/eslint-plugin-routecraft` | ESLint plugin |
 | `create-routecraft` | `packages/create-routecraft` | Project scaffolder |
 
+## Agent Skills
+
+Routecraft ships Agent Skills (open standard, any agent) at the repo root in `skills/` for authoring adapters and capabilities. Install with the Vercel `skills` CLI: `bunx skills add routecraftjs/routecraft`. See [skills/README.md](./skills/README.md). The repo root also doubles as a Claude Code plugin (`.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`); install via `/plugin install routecraft-skills@routecraft`.
+
 ## Documentation
 
 - Docs site source: `apps/routecraft.dev/src/app/docs/`

--- a/DEFINITION_OF_DONE.md
+++ b/DEFINITION_OF_DONE.md
@@ -2,6 +2,10 @@
 
 Every change -- feature, fix, refactor -- must satisfy the checklists below before it can be merged. CI enforces builds, linting, formatting, and type checking automatically. The checklists here cover what CI **cannot** catch.
 
+## Scope
+
+The checklists below apply to **packages that ship code**: anything under `packages/*` whose published artefact contains executable JavaScript or TypeScript declarations. Documentation-only packages (no `.js`, `.ts`, or `.d.ts` files in their `files` allowlist; for example `@routecraft/skills`, which ships only Markdown and JSON) are exempt from the General Checklist test rule and the per-surface checklists. They must still satisfy: Conventional Commits, the no-em-dashes rule, and any policy that applies to documentation prose.
+
 ## General Checklist (every change)
 
 - [ ] New or changed behavior has corresponding tests in `packages/*/test/**/*.test.ts`

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Claude discovers your tool and uses it automatically. ✨
 - `packages/eslint-plugin-routecraft` – ESLint rules for capability authoring
 - `packages/os` – System-native adapters (shell, etc.) – placeholder, in development
 - `packages/testing` – Test utilities (`testContext`, spy logger, `mockAdapter`, fixtures)
+- `skills/` – Agent Skills for authoring Routecraft (Claude Code, Cursor, Codex, Windsurf, Cline, Continue, Copilot, ...; `bunx skills add routecraftjs/routecraft`). See [skills/README.md](./skills/README.md)
 - `apps/routecraft.dev` – Documentation site (docs, examples, guides)
 - `examples/` – Runnable example capabilities
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,68 @@
+# Routecraft Agent Skills
+
+Agent Skills for authoring Routecraft code. Each skill is a navigator: it asks a few clarifying questions, points the agent at the closest existing example plus the matching page on [routecraft.dev](https://routecraft.dev), and then has the agent verify its work by running `bun run lint`, `bun run typecheck`, and `bun run test` until they pass.
+
+These skills follow the [Agent Skills](https://agentskills.io) open standard, so they work in any agent that reads `SKILL.md` files: Claude Code, Cursor, Codex, Windsurf, Cline, Continue, Copilot, and 50+ others. Routecraft's ambition is for agents to write good Routecraft code by default; these skills are one half of that contract (the linter is the other half).
+
+The skills live at the repo root in `/skills/` and are not published to npm. They are distributed in two ways: directly from this GitHub repo via Vercel's [`skills`](https://github.com/vercel-labs/skills) CLI (universal, any agent), or as a Claude Code plugin via the routecraft marketplace.
+
+## Skills
+
+- **`create-adapter`** -- author a new Routecraft adapter (source, destination, transformer, or multi-role)
+- **`create-capability`** -- author a new Routecraft capability (the user-facing pipeline produced by `craft()`: linear, split or aggregate, choice, batched)
+
+## Install
+
+### Universal (any agent: Claude Code, Cursor, Codex, Windsurf, Cline, Continue, Copilot, OpenHands, ...)
+
+Use Vercel's [`skills`](https://github.com/vercel-labs/skills) CLI; it supports 50+ agents and writes the skills to the right place for whichever one you use.
+
+```bash
+bunx skills add routecraftjs/routecraft
+# or with npx:
+npx skills add routecraftjs/routecraft
+```
+
+Useful flags:
+
+- `--skill create-adapter` -- install a single skill instead of all
+- `-a claude-code` -- target a specific agent (defaults to detect)
+- `-g` -- install globally (user directory) instead of project
+- `--list` -- list available skills without installing
+
+### Claude Code (plugin marketplace)
+
+```text
+/plugin marketplace add routecraftjs/routecraft
+/plugin install routecraft-skills@routecraft
+```
+
+The skills become available as `/routecraft-skills:create-adapter` and `/routecraft-skills:create-capability`.
+
+### Other agents (manual)
+
+The skills are just files. Clone the repo (or download the `/skills/` directory) and follow your agent's docs for `SKILL.md` discovery.
+
+## How a skill works
+
+Every skill follows the same shape:
+
+1. **Clarifying questions** -- 2 to 4 short questions to narrow the user's intent
+2. **Pick the closest example** -- a curated table mapping intent to a doc URL plus a matching example on GitHub
+3. **Read first, then write** -- the agent reads both before writing
+4. **Authoring checklist** -- short, agent-actionable rules
+5. **Verify** -- `bun run lint && bun run typecheck && bun run test`, iterate until clean
+
+The skill bodies link to AI-friendly docs at `https://routecraft.dev/raw/docs/<page>.md` and `https://routecraft.dev/llms.txt`. They never link into `.standards/*` (those target framework contributors, not agents writing user code).
+
+## Versioning
+
+The skills are versioned with the rest of the Routecraft monorepo. The Vercel `skills` CLI installs from a git ref (default `main`); pin to a tag or commit if you want a specific version.
+
+## Contributing
+
+Skills get better as the linked examples grow. To propose a new example mapping, edit the relevant `<skill>/reference/examples-index.md` and open a PR.
+
+## License
+
+Apache 2.0

--- a/skills/create-adapter/SKILL.md
+++ b/skills/create-adapter/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: create-adapter
+description: Author a new Routecraft adapter (source, destination, transformer, or multi-role). Use when the user asks to add a new integration, connector, endpoint type, or producer or consumer of exchanges.
+allowed-tools: Read Glob Grep WebFetch Bash(bun run lint:*) Bash(bun run typecheck:*) Bash(bun run test:*)
+---
+
+# Create a Routecraft adapter
+
+Adapters are how Routecraft talks to the outside world. A source produces exchanges, a destination consumes them, and a transformer changes the body in flight. Many adapters fill more than one role.
+
+You are writing this adapter for the user. Treat the linter (`bun run lint`) as authoritative once you have written the code: if it disagrees, the linter wins.
+
+## When to use this skill
+
+Use this skill when the user asks to:
+
+- Add a new integration (Stripe, Slack, S3, a database, a queue)
+- Wrap a third-party SDK so it can be used inside a capability
+- Replace bespoke `process()` calls with a reusable adapter
+- Add a transformer that turns one body shape into another
+
+If the user only needs a one-shot data transformation inside a single capability, use `.transform()` or `.process()` directly instead. If the work is reusable across capabilities, it belongs in an adapter.
+
+## Step 1: clarify
+
+Before writing, confirm answers to these questions. Ask the user only the ones that are not already obvious from context.
+
+1. **Which roles does the adapter play?** Source (`.from(...)`), Destination (`.to(...)`, `.enrich(...)`, `.tap(...)`), Transformer (`.transform(...)`), or several of these?
+2. **How is data produced or consumed?** Request/response (HTTP-style)? Polling on an interval? Long-running stream or subscription? Filesystem? Two-sided protocol (server + client like mail)?
+3. **Where do options come from?** Per-call options on the factory, or context-wide defaults configured via a plugin?
+4. **What is the exchange shape?** What does `body` look like for sources you produce, and what does `body` need to look like for destinations you consume?
+
+## Step 2: pick the closest example
+
+Read [`reference/examples-index.md`](reference/examples-index.md) and pick the row that best matches the answers above. The index maps intent to the relevant public doc page and the closest existing adapter on GitHub.
+
+Then, in this order:
+
+1. `WebFetch` the linked doc page (raw markdown variant on `routecraft.dev/raw/docs/...`)
+2. `WebFetch` the linked example adapter source on GitHub (use the `raw.githubusercontent.com` URL)
+3. If the user is in this monorepo, `Read` `packages/routecraft/src/adapters/<closest>/` end to end. Pay attention to file layout, the factory, the `tagAdapter` call, and the types module
+4. Only after that, write the new adapter
+
+Do not write the adapter from memory. The patterns are precise and the examples are short. Read first.
+
+## Step 3: write the adapter
+
+Create the adapter under `packages/routecraft/src/adapters/<concept>/` if you are inside this monorepo, or under your project's adapters folder otherwise. Mirror the file layout of the example you read. Typical files:
+
+- `index.ts` -- the public factory function. Calls `tagAdapter(instance, factory, factoryArgs(...))`. This is what users import
+- `source.ts` -- the source class (if applicable)
+- `destination.ts` -- the destination class (if applicable)
+- `transformer.ts` -- the transformer class (if applicable)
+- `shared.ts` -- option parsing or helpers shared between the role files
+- `types.ts` -- exported option and result types
+
+Authoring rules to keep in mind while writing:
+
+- **Naming**: classes are `{Concept}{Role}Adapter` (e.g. `HttpDestinationAdapter`, `CronSourceAdapter`). The factory function is the lowercase concept (`http`, `cron`)
+- **Single factory per concept**: one factory, one concept. Use overloads to discriminate roles by `arguments.length` and `typeof`, never by inspecting option values
+- **Tagging**: every factory return value goes through `tagAdapter(instance, factory, factoryArgs(...))`. The eslint plugin and tests rely on this
+- **Two-sided naming**: when an adapter is both server and client, name the option types `{Concept}ServerOptions` and `{Concept}ClientOptions`, and export the union as `{Concept}Options`. If the two roles share fields, factor them into `{Concept}BaseOptions` and have both `Server` and `Client` extend it; if they do not, declare each independently. Source/Destination is for *interface* names; Server/Client is for *option type* names
+- **Store keys**: use `Symbol.for("routecraft.adapter.<concept>.<key>")` so keys survive duplicate package copies in the same process
+- **No mutation**: transformers return new objects via spread (`{ ...exchange, body: newBody }`). Do not mutate the incoming exchange
+- **Errors**: throw at adapter boundaries with a stable `rc` error code from `@routecraft/routecraft`. Capabilities catch and surface these via the capability-level error handler
+
+## Step 4: write tests
+
+Tests live in the package's `test/` directory: `packages/<pkg>/test/<name>.test.ts`. Do not colocate tests next to source. Every test must have a JSDoc with `@case`, `@preconditions`, `@expectedResult`. Prefer the helpers from `@routecraft/testing`:
+
+- `testContext()` to build an isolated context
+- `spy()` for destinations whose payload you want to assert on
+- `pseudo("name", options)` for a stand-in source or destination
+- `mockAdapter(factory, {...})` to assert how a factory was called
+
+For the full pattern, fetch:
+
+```
+https://routecraft.dev/raw/docs/introduction/testing.md
+```
+
+## Step 5: verify
+
+Run, in this order, until each is clean:
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+```
+
+Use `bun run <script>` (not `bun <script>`) so Bun invokes the package.json script rather than its built-in test runner. If `bun run lint` complains, fix the code rather than silencing the rule. The linter encodes Routecraft's authoring rules; it is allowed to be stricter than this skill. If the linter does not catch something the user expected it to catch, that is a follow-up for the lint package, not a workaround here.
+
+## Useful URLs
+
+- Adapters reference: https://routecraft.dev/raw/docs/reference/adapters.md
+- Creating adapters guide: https://routecraft.dev/raw/docs/advanced/custom-adapters.md
+- Adapters introduction: https://routecraft.dev/raw/docs/introduction/adapters.md
+- All Routecraft AI-friendly docs index: https://routecraft.dev/llms.txt

--- a/skills/create-adapter/reference/examples-index.md
+++ b/skills/create-adapter/reference/examples-index.md
@@ -1,0 +1,22 @@
+# Adapter examples index
+
+Pick the row that best matches what the user is building. Then `WebFetch` both URLs in that row before writing.
+
+| If the user wants... | Read this doc | Then study this example |
+|---|---|---|
+| HTTP request or response (REST, webhook caller, JSON API) | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/http/index.ts |
+| Polling or scheduled trigger on an interval | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/cron/index.ts |
+| Reading or writing files on disk | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/file/index.ts |
+| Parsing CSV input (rows in, rows out) | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/csv/index.ts |
+| Parsing JSON or JSONL streams | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/jsonl/index.ts |
+| Two-sided protocol (server inbox plus client outbox, e.g. mail or queues) | https://routecraft.dev/raw/docs/advanced/custom-adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/mail/index.ts |
+| In-process direct-call routing (call one route from another) | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/direct/index.ts |
+| Logging or side-effect-only destination | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/log/index.ts |
+| HTML scraping or DOM querying | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/html/index.ts |
+| Cosine similarity or embedding-based search transformer | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/cosine/index.ts |
+| Simple in-memory source for tests or fixed payloads | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/simple/index.ts |
+| Group-by or stateful aggregation transformer | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/group/index.ts |
+
+If none of the rows are a clean match, pick the closest by **mechanism** (request/response, polling, streaming, two-sided) rather than by **domain**. The mechanism determines the file layout; the domain only changes the option types and the body shape.
+
+When you do not see a row that matches, recommend the closest one and flag the mismatch in your reply so the user can decide whether to add a new mapping to this index.

--- a/skills/create-capability/SKILL.md
+++ b/skills/create-capability/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: create-capability
+description: Author a new Routecraft capability (workflow, automation, MCP tool, webhook handler, or scheduled job). Use when the user asks to compose adapters into a pipeline.
+allowed-tools: Read Glob Grep WebFetch Bash(bun run lint:*) Bash(bun run typecheck:*) Bash(bun run test:*)
+---
+
+# Create a Routecraft capability
+
+A capability is the user-facing unit of automation in Routecraft. It is a typed pipeline that starts at a source (`from(...)`), flows through operations (`transform`, `enrich`, `filter`, `validate`, `split`, `aggregate`, `choice`, `process`, `tap`), and lands at one or more destinations (`to`). The codebase calls these "routes" internally because that is what the `craft()` builder returns; in user-facing language and in the docs they are capabilities.
+
+You are writing this capability for the user. Treat the linter (`bun run lint`) as authoritative once you have written the code: if it disagrees, the linter wins.
+
+## When to use this skill
+
+Use this skill when the user asks to:
+
+- Build a workflow, pipeline, or automation
+- Expose a tool to AI via MCP
+- Handle a webhook, scheduled trigger, or message
+- Compose adapters to integrate two or more systems
+- Wrap business logic so AI agents can call it
+
+If the user only needs a small utility function with no I/O and no orchestration, that does not need to be a capability. If it crosses systems, has retry semantics, or should be discoverable, it does.
+
+## Step 1: clarify
+
+Confirm answers to these questions before writing. Ask the user only the ones that are not already obvious from context.
+
+1. **What triggers the capability?** A direct call from another capability? An MCP tool invocation? A webhook (HTTP source)? A timer or cron? A mail inbox? A simple in-memory payload (typical for tests)?
+2. **What is the body shape on input and output?** Bodies are typed end to end; commit to a Zod or other Standard Schema for `input` and `output` if the user knows what they want
+3. **What does the pipeline do?** Linear (one transform, one destination)? Fan-out then fan-in (`split` then `aggregate`)? Branch (`choice`)? Conditional drop (`filter`)? Schema check (`validate`)?
+4. **Does it need batching?** If the source emits many small messages and the work batches naturally, set `.batch({...})` before `.from(...)`
+5. **Does it need resilience?** If failures should retry, time out, or fall back, plan to use the route- or step-scope wrappers (`.error(...)` is built in; others are coming)
+
+## Step 2: pick the closest example
+
+Read [`reference/examples-index.md`](reference/examples-index.md) and pick the row that best matches the answers above. The index maps intent to a public doc page and the closest existing capability on GitHub.
+
+Then, in this order:
+
+1. `WebFetch` the linked doc page (raw markdown variant on `routecraft.dev/raw/docs/...`)
+2. `WebFetch` the linked example file on GitHub (use the `raw.githubusercontent.com` URL)
+3. If the user is in this monorepo, `Read` `examples/src/<closest>.ts` end to end
+4. Only after that, write the new capability
+
+Do not write from memory. Capabilities look small but the operator order, schema placement, and direct-call id linking are easy to get wrong without a reference.
+
+## Step 3: write the capability
+
+The DSL is fluent and mostly self-documenting once you have an example open. Common shape:
+
+```ts
+import { craft, simple, http, log } from "@routecraft/routecraft";
+import { z } from "zod";
+
+const Input = z.object({ /* ... */ });
+type Input = z.infer<typeof Input>;
+
+export default craft()
+  .id("my-capability")              // required for direct-call routing
+  .title("Human-readable title")    // surfaced in MCP tools and the TUI
+  .description("What this does")    // surfaced in MCP tools
+  .input({ body: Input })           // typed and validated at the boundary
+  .from<Input>(/* source */)
+  // operations
+  .to(/* destination */);
+```
+
+Authoring rules to keep in mind:
+
+- **Metadata first**: `.id()`, `.title()`, `.description()`, `.input()`, `.output()`, `.error()`, `.batch()` come **before** `.from(...)`. Once you call `.from(...)`, you are in the pipeline and metadata methods no longer apply
+- **Typed bodies**: pass the input type to `.from<Input>(...)` so the operations downstream stay typed without casts
+- **No mutation**: pure transforms return new objects via spread. Side effects belong in `.tap(destination)`
+- **Choose the right destination operator**:
+  - `.to(dest)` -- send and ignore the destination's result body (terminal or pass-through with original body)
+  - `.enrich(dest)` -- merge the destination's result into the body
+  - `.tap(dest)` -- fire and forget; do not wait, do not change the body
+- **Split or aggregate** belongs together. After `.split()` you can chain operations on each item; close with `.aggregate()` to fan back in
+- **Resilience wrappers** stack outside-in. `.error(handler)` at route scope catches anything that escapes the pipeline; at step scope, attach it to a single step
+- **Schemas as the contract**: prefer Standard Schema (`@standard-schema/spec`). Zod and Valibot both work because both implement Standard Schema. Use `@routecraft/routecraft`'s helpers in shared code, not Zod directly
+
+## Step 4: write tests
+
+Tests live in the package's `test/` directory (`packages/<pkg>/test/<name>.test.ts` if you are inside this monorepo, or your project's existing `test/` directory otherwise). Do not colocate tests next to source. Every test must have JSDoc with `@case`, `@preconditions`, `@expectedResult`. Use `@routecraft/testing` and follow the canonical lifecycle:
+
+```ts
+import { describe, it, expect, afterEach } from "vitest";
+import { testContext, type TestContext } from "@routecraft/testing";
+import myCapability from "../src/my-capability";
+
+describe("my-capability", () => {
+  let t: TestContext | undefined;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case happy path
+   * @preconditions a valid input body
+   * @expectedResult the capability completes without errors
+   */
+  it("transforms the body and sends to destination", async () => {
+    t = await testContext().routes([myCapability]).build();
+    await t.test();
+    expect(t.errors).toHaveLength(0);
+  });
+});
+```
+
+Errors thrown inside handlers are caught at the boundary and surfaced on `t.errors`; do not expect `t.test()` to reject. Full test pattern: https://routecraft.dev/raw/docs/introduction/testing.md
+
+## Step 5: verify
+
+Run, in this order, until each is clean:
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+```
+
+Use `bun run <script>` (not `bun <script>`) so Bun invokes the package.json script rather than its built-in test runner. If `bun run lint` complains, fix the capability rather than silencing the rule. The linter encodes Routecraft's authoring rules. If it does not catch something the user expected it to catch, that is a follow-up for the lint package.
+
+## Useful URLs
+
+- Capabilities introduction: https://routecraft.dev/raw/docs/introduction/capabilities.md
+- Operations introduction: https://routecraft.dev/raw/docs/introduction/operations.md
+- Operations reference: https://routecraft.dev/raw/docs/reference/operations.md
+- Exchange model: https://routecraft.dev/raw/docs/introduction/exchange.md
+- Composing capabilities: https://routecraft.dev/raw/docs/advanced/composing-capabilities.md
+- Error handling: https://routecraft.dev/raw/docs/advanced/error-handling.md
+- Worked example (file to HTTP): https://routecraft.dev/raw/docs/examples/api-sync.md
+- All Routecraft AI-friendly docs index: https://routecraft.dev/llms.txt

--- a/skills/create-capability/reference/examples-index.md
+++ b/skills/create-capability/reference/examples-index.md
@@ -1,0 +1,25 @@
+# Capability examples index
+
+Pick the row that best matches the user's intent. Then `WebFetch` both URLs in that row before writing.
+
+| If the user wants... | Read this doc | Then study this example |
+|---|---|---|
+| The simplest possible capability (in-memory source, transform, log destination) | https://routecraft.dev/raw/docs/introduction/operations.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/examples/src/hello-world.ts (multi-purpose: also covers direct-call routing and HTTP enrichment) |
+| Direct-call routing between two capabilities (one capability invokes another by id) | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/examples/src/hello-world.ts (the same file; focus on the `direct(...)` source and the second capability calling the first by id) |
+| HTTP enrichment (call an API mid-pipeline and merge the result into the body) | https://routecraft.dev/raw/docs/reference/operations.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/examples/src/hello-world.ts (the same file; focus on the `.enrich(http(...))` step) |
+| Split a collection, process each item, then aggregate (fan-out / fan-in) | https://routecraft.dev/raw/docs/reference/operations.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/examples/src/split.ts |
+| Filter and validate before transform (per-item rejection with a reason) | https://routecraft.dev/raw/docs/reference/operations.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/examples/src/split.ts |
+| Expose a capability as an MCP tool callable by AI agents | https://routecraft.dev/raw/docs/advanced/expose-as-mcp.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/examples/src/mcp-greet.ts |
+| Call an LLM inside a capability (agent step) | https://routecraft.dev/raw/docs/advanced/call-an-mcp.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/examples/src/agent.ts |
+| Mail inbox watcher (IMAP source) plus mail sender (SMTP destination) | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/examples/src/mail-noreply-notify.ts |
+| File to HTTP synchronisation (read a file, post each row to an API) | https://routecraft.dev/raw/docs/examples/api-sync.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/examples/src/split.ts |
+
+## How to choose
+
+Filter on **shape of the pipeline** first, **trigger** second, **destinations** third:
+
+1. Linear vs split/aggregate vs choice -- this picks the example
+2. What triggers the capability (direct, MCP, mail, simple) -- this picks the source adapter
+3. Where the result goes (log, http, mail, direct) -- this picks the destination adapter
+
+If no row is a clean match, pick by pipeline shape and adapt the source and destination to the user's case.


### PR DESCRIPTION
## Summary

This PR introduces `@routecraft/skills`, a new package containing Claude Code skills that guide AI agents through authoring Routecraft adapters and capabilities. The skills are distributed both as an npm package and as a Claude Code plugin via a marketplace manifest.

## Key Changes

- **New `@routecraft/skills` package** with two skills:
  - `create-adapter` – guides authoring of Routecraft adapters (sources, destinations, transformers)
  - `create-capability` – guides authoring of Routecraft capabilities (pipelines built with `craft()`)

- **Skill structure** – each skill follows a consistent pattern:
  1. Clarifying questions to narrow intent
  2. Curated example index mapping intent to docs and GitHub examples
  3. Authoring checklist with DSL rules and patterns
  4. Verification loop (`pnpm lint`, `pnpm typecheck`, `pnpm test`)

- **Example indices** – reference tables in each skill that map user intent to:
  - Relevant public documentation pages on `routecraft.dev/raw/docs/`
  - Closest existing example on GitHub (raw.githubusercontent.com)

- **Plugin distribution**:
  - Added `.claude-plugin/plugin.json` to `packages/skills` for plugin metadata
  - Added root-level `.claude-plugin/marketplace.json` to register the plugin in the marketplace
  - Updated `set-version.mjs` to bump versions in both plugin manifests during releases

- **Documentation updates**:
  - Updated `DEFINITION_OF_DONE.md` to clarify scope (applies to packages that ship code)
  - Updated `CLAUDE.md` and `README.md` to reference the new skills package

## Implementation Details

- Skills are written as Markdown documents with YAML frontmatter (`name`, `description`, `allowed-tools`)
- Each skill emphasizes reading examples before writing and treating the linter as authoritative
- The skills link exclusively to AI-friendly docs (`routecraft.dev/raw/docs/`) and never to `.standards/*` (which target framework contributors)
- Version management is automated: `set-version.mjs` now updates plugin manifests alongside package.json files

https://claude.ai/code/session_01MiBTGyGwfZ6Ctce7pjLGsC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Agent Skills for authoring Routecraft adapters and capabilities, located in `skills/` and installable via the Vercel `skills` CLI or as a Claude Code plugin. Each skill links to the closest docs/examples and verifies with `bun run typecheck && bun run lint && bun run test`.

- New Features
  - Two skills: `create-adapter` and `create-capability`, each with a curated examples index, a short checklist, and a Bun-based verify loop.
  - Open-standard Agent Skills (work in many agents); install with `bunx skills add routecraftjs/routecraft` or `/plugin install routecraft-skills@routecraft`.

- Refactors
  - Added root `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`; `set-version.mjs` now updates package-level and root plugin manifests plus all marketplace entries; CI restore step includes these files.
  - Docs/policies: `skills/README.md` documents install and usage; `CLAUDE.md` adds an Agent Skills section; `README.md` lists `skills/`; `DEFINITION_OF_DONE.md` exempts docs-only packages from test rules; `.standards/naming-policy.md` formalizes the optional `XxxBaseOptions` pattern.

<sup>Written for commit c36263025a0a18054a626d20c3efe6042d5867ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

