### PR TITLE
docs: sweep pnpm references after bun migration

### DIFF
--- a/.proposals/adapter-sandbox-and-secrets.md
+++ b/.proposals/adapter-sandbox-and-secrets.md
@@ -156,7 +156,7 @@ True process isolation is the right answer for actively malicious code in a mult
 
 ## Verification
 
-- `pnpm typecheck`: removing the public `getExchangeContext` export should produce compile errors at every adapter call site that currently reaches the context. Convert each.
+- `bun run typecheck`: removing the public `getExchangeContext` export should produce compile errors at every adapter call site that currently reaches the context. Convert each.
 - New test: `JSON.stringify({ apiKey: new Secret("sk-..." )})` returns `[REDACTED]`. Same for `util.inspect` and template-string coercion.
 - New test: an adapter whose manifest does not declare `reads: ["@some/key"]` cannot read that key at runtime; `ctx.store.get("@some/key")` throws.
 - New test: an agent tool registered without `needsContext` cannot reach `CraftContext`. A tool that returns a `Secret` instance has its output redacted before reaching the model.

--- a/.standards/ci-cd.md
+++ b/.standards/ci-cd.md
@@ -9,12 +9,12 @@ What `.github/workflows/ci.yml` enforces and the policies contributors must know
 ```
   changes  ─┬─►  validate ─┐
             │              │
-   setup ───┼─►  test  ────┼─►  integration-test (npm + bun)  ──►  approve  ──►  merge
-            │              │                                         │
-            └─►  build ────┘                                         └─►  publish-canary  ──►  publish  ──►  deploy-pages
+   setup ───┼─►  test  ────┼─►  integration-test (bun + node)  ──►  approve  ──►  merge
+            │              │                                          │
+            └─►  build ────┘                                          └─►  publish-canary  ──►  publish  ──►  deploy-pages
 ```
 
-The `setup` job restores the pnpm cache. Every downstream job restores `**/node_modules` from the same cache key (`hashFiles('**/pnpm-lock.yaml')`), so `pnpm install` only runs on cache miss. `changes` skips downstream jobs when the diff doesn't touch package or workflow paths.
+The `setup` job runs `bun install --frozen-lockfile` and seeds the workspace's `**/node_modules`. Every downstream job restores that cache (key: `hashFiles('**/bun.lock')`), so the install only repeats on a cache miss. `changes` skips downstream jobs when the diff doesn't touch package or workflow paths.
 
 ## 2. The PR gates
 
@@ -22,12 +22,12 @@ Every PR must pass these jobs before merge. The first column matches the GitHub 
 
 | Job | Runs | Catches |
 |-----|------|---------|
-| `setup` | `pnpm install --frozen-lockfile` | Lockfile drift, install failures, dependabot lockfile updates. |
-| `validate` | `pnpm format && pnpm typecheck && pnpm lint && pnpm exec madge --circular .` | Prettier drift, TS errors, ESLint violations, circular imports. |
-| `test` | `pnpm test:coverage` (excludes `**/integration.test.ts`) | Unit-test regressions, coverage report uploaded as artifact. |
-| `build` | `pnpm run build` and `pnpm run limit:size` | Build failures, bundle size regressions (size-limit). |
-| `integration-test (npm)` | Smoke-test publishable + `pnpm test:integration` against a packed tarball | Tarball install path, `craft` CLI binary publishability. |
-| `integration-test (bun)` | `pnpm test:integration` under the Bun runtime | Bun runtime divergence in source / generated code. |
+| `setup` | `bun install --frozen-lockfile` | Lockfile drift, install failures, dependabot lockfile updates. |
+| `validate` | `bun run format && bun run typecheck && bun run lint && bunx madge --circular .` | Prettier drift, TS errors, ESLint violations, circular imports. |
+| `test` | `bun run test:coverage` (excludes `**/integration.test.ts`) | Unit-test regressions, coverage report uploaded as artifact. |
+| `build` | `bun run build` and `bun run limit:size` | Build failures, bundle size regressions (size-limit). |
+| `integration-test (bun)` | `bun run test:integration` with `TEST_PACKAGE_MANAGER=bun` and `TEST_PACKAGE_MANAGER=npm` | Scaffolder + `craft` CLI under Bun; scaffolder install + typecheck under npm. |
+| `integration-test (node)` | `node .github/scripts/smoke-test-embedding.mjs` | Embedding `@routecraft/routecraft` programmatically under plain Node, including a negative arm asserting `RC5017` fires when an optional peer is missing. |
 | `cubic · AI code reviewer` | External AI reviewer | Dual-use review signal; informational on PR but does not gate merge. |
 
 The `validate` job is the cheapest signal: if it's red, fix that first. The `test` job uploads `coverage-report` as an artifact; reviewers can download to inspect uncovered lines.
@@ -36,7 +36,7 @@ The `validate` job is the cheapest signal: if it's red, fix that first. The `tes
 
 ### 3.1. Hooks must succeed; never `--no-verify`
 
-Husky + lint-staged run `eslint --fix`, `prettier --write`, and `pnpm typecheck` on every commit. If a hook fails, fix the underlying issue. Bypassing hooks (`--no-verify`, `--no-gpg-sign`) is forbidden unless the user explicitly asks for it. A hook failure is a green light to investigate, not a green light to skip.
+Husky + lint-staged run `eslint --fix`, `prettier --write`, and `bun run typecheck` on every commit. If a hook fails, fix the underlying issue. Bypassing hooks (`--no-verify`, `--no-gpg-sign`) is forbidden unless the user explicitly asks for it. A hook failure is a green light to investigate, not a green light to skip.
 
 ### 3.2. New commits, never `--amend` after a hook failure
 
@@ -46,7 +46,7 @@ If a pre-commit hook fails, the commit didn't happen. `--amend` would modify the
 
 `changes` checks paths against:
 
-- `packages` filter: `packages/**`, `examples/**`, `pnpm-lock.yaml`, `tsconfig*.json`, `.github/workflows/**`, `.github/scripts/**`.
+- `packages` filter: `packages/**`, `examples/**`, `bun.lock`, `tsconfig*.json`, `.github/workflows/**`, `.github/scripts/**`.
 - `docs` filter: `apps/routecraft.dev/**`, `.github/workflows/**`.
 
 Pure docs-only PRs skip `integration-test`, `publish-canary`, and `publish`. If you add a new code path that should gate on CI, add it to the relevant filter.
@@ -57,14 +57,14 @@ CI uses `pull_request_target`, not `pull_request`. This gives forks access to re
 
 ## 4. Adding a new package to CI
 
-The CI doesn't enumerate packages; `pnpm -r run build`, `pnpm test`, etc. walk every workspace package. To make a new package CI-visible:
+The CI doesn't enumerate packages; `bun run --filter '*' build`, `bun run test`, etc. walk every workspace package. To make a new package CI-visible:
 
-1. Add it to `pnpm-workspace.yaml` (it'll get picked up automatically).
+1. Add it to the root `package.json` `workspaces` array (it'll get picked up automatically).
 2. Add `build`, `test` (if any tests exist), and ensure `tsc --noEmit` cleanliness from the workspace root.
 3. If the package publishes (`"private": false`), add it to:
    - `.github/scripts/set-version.mjs` so the `version:set` script bumps it.
    - The release-restore step in `integration-test` (the `git checkout --` line that resets package.jsons after `set-version` modifies them).
-   - `.github/scripts/smoke-test-publishable.mjs` if it should be exercised in the publish smoke test.
+   - The `for pkg in ...` loops in the `publish-canary` and `publish` jobs.
 4. If it depends on another workspace package, follow the dual-spec convention (see 5).
 
 ## 5. Peer-dependency policy on `@routecraft/*`
@@ -82,28 +82,30 @@ Every `@routecraft/*` workspace package that's a peer of another carries TWO ent
 
 Why both:
 
-- The `devDependencies` `workspace:^0.5.0` keeps local development synced. pnpm's `workspace:` protocol resolves to the in-tree package, so editing `@routecraft/routecraft` is immediately visible.
+- The `devDependencies` `workspace:^0.5.0` keeps local development synced. Bun's `workspace:` protocol resolves to the in-tree package, so editing `@routecraft/routecraft` is immediately visible.
 - The `peerDependencies` `*` is what users see after publish. Bundling the peer would cause duplicate-instance bugs (two `RoutecraftError` classes, two adapter registries). `*` lets the user pick the version and forces a single instance.
 
 This is enforced informally by review. When adding a new internal package that other packages depend on, mirror this pattern.
 
 ## 6. Optional peer dependencies (provider SDKs)
 
-External SDKs that a package only needs when a specific feature is used (Vercel AI SDK adapters, `@huggingface/transformers`, `@modelcontextprotocol/sdk`, etc.) live in `peerDependencies` AND `peerDependenciesMeta.<name>.optional = true`. The framework dynamically imports them inside the relevant code path and throws a friendly install message when the import fails. Don't add such deps to `dependencies`; that bloats every install.
+External SDKs that a package only needs when a specific feature is used (Vercel AI SDK adapters, `@huggingface/transformers`, `@modelcontextprotocol/sdk`, `croner`, `cheerio`, etc.) live in `peerDependencies` AND `peerDependenciesMeta.<name>.optional = true`. The adapter dynamically imports them via `loadOptionalPeer` (`packages/routecraft/src/adapters/shared/optional-peer.ts`) and throws **`RC5017`** with an install hint when the import fails. Don't add such deps to `dependencies`; that bloats every install. Don't write a bespoke try/catch; use the helper so the error code and message shape stay consistent across adapters.
+
+The cron source (`packages/routecraft/src/adapters/cron/source.ts`) and the html adapter (`packages/routecraft/src/adapters/html/shared.ts`) are the canonical references.
 
 ## 7. Local pre-PR checklist
 
 Run before opening a PR; matches what CI runs:
 
 ```sh
-pnpm format     # prettier --check
-pnpm typecheck  # tsc --noEmit
-pnpm lint       # eslint
-pnpm test       # unit tests
-pnpm build      # all packages
+bun run format     # prettier --check
+bun run typecheck  # tsc --noEmit
+bun run lint       # eslint
+bun run test       # unit tests
+bun run build      # all packages
 ```
 
-Or the bundled `pnpm all`, which runs `lint --fix`, `format:write`, `typecheck`, `build`, `test` in one pass.
+Or the bundled `bun run all`, which runs `lint --fix`, `format:write`, `typecheck`, `build`, `test` in one pass.
 
 Integration tests require a tarball + global CLI install and aren't expected to run locally for every PR. CI covers that path.
 
@@ -115,13 +117,15 @@ Integration tests require a tarball + global CLI install and aren't expected to 
 | GitHub release created | Runs CI; on success the `approve` + `merge` + `publish` chain publishes the tagged version to npm and `deploy-pages` deploys the docs site. |
 | `workflow_dispatch` (manual) | Runs CI without publish steps (useful for sanity-checking a PR-target run). |
 
-Versions are uniformly bumped via `pnpm run version:set <version>` (see `.github/scripts/set-version.mjs`), which patches every `package.json`, the CLI's `--version` constant, and the docs site's version selector. Don't hand-edit individual `package.json` versions.
+Versions are uniformly bumped via `bun run version:set <version>` (see `.github/scripts/set-version.mjs`), which patches every `package.json`, the CLI's `--version` constant, and the docs site's version selector. Don't hand-edit individual `package.json` versions.
+
+The publish step (`npm publish` per package) is package-manager-agnostic. It uses npm even though the workspace is Bun, because npm publishing remains the canonical registry path and `prepublishOnly` hooks call `bun run build` to assemble dist.
 
 ---
 
 ## References
 
 - Workflow source: `.github/workflows/ci.yml`
-- Scripts: `.github/scripts/set-version.mjs`, `.github/scripts/smoke-test-publishable.mjs`
+- Scripts: `.github/scripts/set-version.mjs`, `.github/scripts/smoke-test-embedding.mjs`
 - Definition of Done: `DEFINITION_OF_DONE.md`
 - Testing standards: `./testing.md`

--- a/.standards/ci-cd.md
+++ b/.standards/ci-cd.md
@@ -89,11 +89,19 @@ This is enforced informally by review. When adding a new internal package that o
 
 ## 6. Optional peer dependencies (provider SDKs)
 
-External SDKs that a package only needs when a specific feature is used (Vercel AI SDK adapters, `@huggingface/transformers`, `@modelcontextprotocol/sdk`, `croner`, `cheerio`, etc.) live in `peerDependencies` AND `peerDependenciesMeta.<name>.optional = true`. The adapter dynamically imports them via `loadOptionalPeer` (`packages/routecraft/src/adapters/shared/optional-peer.ts`) and throws **`RC5017`** with an install hint when the import fails. Don't add such deps to `dependencies`; that bloats every install. Don't write a bespoke try/catch; use the helper so the error code and message shape stay consistent across adapters.
+External SDKs that a package only needs when a specific feature is used (Vercel AI SDK adapters, `@huggingface/transformers`, `@modelcontextprotocol/sdk`, `croner`, `cheerio`, etc.) live in `peerDependencies` AND `peerDependenciesMeta.<name>.optional = true`. The adapter dynamically imports them via `loadOptionalPeer` (`packages/routecraft/src/adapters/shared/optional-peer.ts`) and throws **`RC5017`** with an install hint when the import fails. Don't add such deps to `dependencies`; that bloats every install.
 
-The cron source (`packages/routecraft/src/adapters/cron/source.ts`) and the html adapter (`packages/routecraft/src/adapters/html/shared.ts`) are the canonical references.
+**New code MUST use `loadOptionalPeer`.** The cron source (`packages/routecraft/src/adapters/cron/source.ts`) and the html adapter (`packages/routecraft/src/adapters/html/shared.ts`) are the canonical references; copy the shape (lazy import via the thunk, RC5017 message, type-only `import type` at the top of the file).
 
-## 7. Local pre-PR checklist
+A pre-existing migration backlog of bespoke try/catch sites in `packages/ai/src/mcp/*`, `packages/routecraft/src/auth/jwks.ts`, `packages/routecraft/src/telemetry/plugin.ts`, `packages/routecraft/src/adapters/mail/strict-verify.ts`, and `packages/cli/src/tui/db.ts` is tracked in [#287](https://github.com/routecraftjs/routecraft/issues/287). When touching one of those files for an unrelated reason, opportunistically migrate it as part of the PR. They surface inconsistent error shapes today (some `Error`, one `RC5003`, none `RC5017`); the migration normalises them.
+
+## 7. Bun command conventions
+
+- Use `bun run <script>` for any `package.json` script (root or workspace). E.g. `bun run lint`, `bun run --filter routecraft.dev dev`.
+- Use `bunx <bin>` for one-shot binary execution from a `node_modules/.bin` entry. E.g. `bunx madge --circular .`, `bunx create-routecraft`.
+- Don't mix conventions in the same doc or script. If you find an inconsistency, fix it and call it out in the PR description.
+
+## 8. Local pre-PR checklist
 
 Run before opening a PR; matches what CI runs:
 
@@ -109,7 +117,7 @@ Or the bundled `bun run all`, which runs `lint --fix`, `format:write`, `typechec
 
 Integration tests require a tarball + global CLI install and aren't expected to run locally for every PR. CI covers that path.
 
-## 8. Release flow
+## 9. Release flow
 
 | Trigger | Result |
 |---------|--------|

--- a/.standards/testing.md
+++ b/.standards/testing.md
@@ -123,7 +123,7 @@ If you reach for a snapshot, prefer inline (`toMatchInlineSnapshot()`) over a se
 
 ## 10. What runs in CI
 
-- `bun run test` (excludes `*.integration.test.ts`) runs on the main `test` job.
+- The main `test` job runs `bun run test:coverage` (which excludes `*.integration.test.ts` and uploads a `coverage-report` artifact). Locally, `bun run test` runs the same exclusion without the coverage instrumentation.
 - The dedicated `integration-test` job runs a two-arm matrix:
   - `bun` arm: `bun run test:integration` exercises the scaffolder twice -- once with `TEST_PACKAGE_MANAGER=bun` (full scaffold + `craft run` dispatch) and once with `TEST_PACKAGE_MANAGER=npm` (install + typecheck only; the dispatch test skips because the CLI is Bun-only).
   - `node` arm: `node .github/scripts/smoke-test-embedding.mjs` packs `@routecraft/routecraft`, npm-installs it into a fresh temp dir, and runs a `runner.ts` under plain Node to verify the embedding path. Includes a negative arm asserting `RC5017` fires when `cron()` is used without `croner` installed.

--- a/.standards/testing.md
+++ b/.standards/testing.md
@@ -124,8 +124,10 @@ If you reach for a snapshot, prefer inline (`toMatchInlineSnapshot()`) over a se
 ## 10. What runs in CI
 
 - `bun run test` (excludes `*.integration.test.ts`) runs on the main `test` job.
-- `bun run test:integration` runs on the dedicated `integration-test` matrix (bun + node) against published-shaped tarballs and an embedding smoke test.
-- Both must pass for a PR to be mergeable. See [CI/CD](./ci-cd.md).
+- The dedicated `integration-test` job runs a two-arm matrix:
+  - `bun` arm: `bun run test:integration` exercises the scaffolder twice -- once with `TEST_PACKAGE_MANAGER=bun` (full scaffold + `craft run` dispatch) and once with `TEST_PACKAGE_MANAGER=npm` (install + typecheck only; the dispatch test skips because the CLI is Bun-only).
+  - `node` arm: `node .github/scripts/smoke-test-embedding.mjs` packs `@routecraft/routecraft`, npm-installs it into a fresh temp dir, and runs a `runner.ts` under plain Node to verify the embedding path. Includes a negative arm asserting `RC5017` fires when `cron()` is used without `croner` installed.
+- Both arms must pass for a PR to be mergeable. See [CI/CD](./ci-cd.md).
 
 ---
 

--- a/.standards/testing.md
+++ b/.standards/testing.md
@@ -9,7 +9,7 @@ Authoritative rules and conventions for tests in Routecraft.
 - **Runner:** Vitest. Same config across packages; the workspace `vitest --run` is the source of truth (root `package.json` script `test`).
 - **File placement:** colocated with the package they exercise.
   - Unit tests: `packages/<name>/test/*.test.ts`.
-  - Integration tests (real network, real subprocesses, slow setup): `packages/<name>/test/*.integration.test.ts` and run via `pnpm test:integration`. The default `pnpm test` excludes them.
+  - Integration tests (real network, real subprocesses, slow setup): `packages/<name>/test/*.integration.test.ts` and run via `bun run test:integration`. The default `bun run test` excludes them.
 - **One feature per file.** Group tests around the unit they exercise, not by category. A test file maps to a code file (or a closely related cluster), not to "all the validation tests in the package".
 
 ## 2. Every test gets a JSDoc header
@@ -123,8 +123,8 @@ If you reach for a snapshot, prefer inline (`toMatchInlineSnapshot()`) over a se
 
 ## 10. What runs in CI
 
-- `pnpm test` (excludes `*.integration.test.ts`) runs on the main `test` job.
-- `pnpm test:integration` runs on the dedicated `integration-test` matrix (bun + npm) against published-shaped tarballs.
+- `bun run test` (excludes `*.integration.test.ts`) runs on the main `test` job.
+- `bun run test:integration` runs on the dedicated `integration-test` matrix (bun + node) against published-shaped tarballs and an embedding smoke test.
 - Both must pass for a PR to be mergeable. See [CI/CD](./ci-cd.md).
 
 ---

--- a/.standards/type-safety-registries.md
+++ b/.standards/type-safety-registries.md
@@ -196,7 +196,7 @@ The core limitation is that TypeScript cannot scan your project to discover endp
 ### What `craft typegen` would do
 
 ```bash
-pnpm craft typegen
+bun run craft typegen
 ```
 
 1. **Direct endpoints** - scan all `.ts` files for `direct('name', {` and `direct('name', options)` patterns (the two-argument form = source). Collect all string literals. Write them into `DirectEndpointRegistry`.
@@ -234,7 +234,7 @@ declare module '@routecraft/ai' {
 ### Watch mode
 
 ```bash
-pnpm craft typegen --watch
+bun run craft typegen --watch
 ```
 
 Re-runs on file save. As soon as you add `craft().from(direct('invoices', {}))`, the `invoices` entry appears in the registry and `direct('invoices')` destinations immediately become valid.
@@ -244,7 +244,7 @@ Re-runs on file save. As soon as you add `craft().from(direct('invoices', {}))`,
 The generated file should be committed. This gives the team a clear diff when endpoints or providers change, and CI can verify the file is not stale:
 
 ```bash
-pnpm craft typegen && git diff --exit-code src/types/routecraft.generated.d.ts
+bun run craft typegen && git diff --exit-code src/types/routecraft.generated.d.ts
 ```
 
 ### What codegen still cannot fix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,9 @@ Type-safe integration and automation framework. Monorepo with Bun workspaces (>=
 - Follow Conventional Commits for commit messages; use `/git-commit-message` for detailed formatting
 - Source/Destination for interfaces; Server/Client for option type names only (two-sided adapters)
 - Every test must have JSDoc with `@case`, `@preconditions`, and `@expectedResult`
-- The `craft` CLI is Bun-only (`#!/usr/bin/env bun`, `engines.bun >= 1.1.0`); the core library targets both Node 22.6+ and Bun
-- Optional peer dependencies use `loadOptionalPeer` (`packages/routecraft/src/adapters/shared/optional-peer.ts`) to lazy-load drivers and emit `RC5017` with an install hint when missing
+- The published `craft` CLI binary uses `#!/usr/bin/env bun` and `engines.bun >= 1.1.0`; the core library targets both Node 22.0+ and Bun. The root `bun run craft` workspace shortcut invokes the built `dist/index.js` via `node` for development convenience -- this is intentional and does not loosen the binary's runtime requirement.
+- New optional-peer dynamic imports MUST go through `loadOptionalPeer` (`packages/routecraft/src/adapters/shared/optional-peer.ts`) and emit `RC5017` with an install hint. Existing bespoke try/catch sites (mail, jose, telemetry sqlite, several `@routecraft/ai` modules) are scheduled for migration in #287; cite that issue when touching them.
+- Use `bun run <script>` for `package.json` scripts and `bunx <bin>` for one-shot binary execution (e.g. `bunx madge`, `bunx create-routecraft`)
 
 ## Internal Standards
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,18 @@
 # Routecraft
 
-Type-safe integration and automation framework. Monorepo with pnpm workspaces.
+Type-safe integration and automation framework. Monorepo with Bun workspaces (>=1.1.0).
 
 ## Quick Reference
 
-- Build: `pnpm build`
-- Test: `pnpm test`
-- Lint: `pnpm lint`
-- Typecheck: `pnpm typecheck`
-- Format: `pnpm format`
-- Run examples: `pnpm craft run ./examples/dist/hello-world.js`
-- Run docs site: `pnpm docs`
+- Install: `bun install`
+- Build: `bun run build`
+- Test: `bun run test`
+- Lint: `bun run lint`
+- Typecheck: `bun run typecheck`
+- Format: `bun run format`
+- Run examples: `bun run craft run ./examples/dist/hello-world.js`
+- Run docs site: `bun run docs`
+- All-in-one pre-PR check: `bun run all`
 
 ## Key Rules
 
@@ -21,6 +23,8 @@ Type-safe integration and automation framework. Monorepo with pnpm workspaces.
 - Follow Conventional Commits for commit messages; use `/git-commit-message` for detailed formatting
 - Source/Destination for interfaces; Server/Client for option type names only (two-sided adapters)
 - Every test must have JSDoc with `@case`, `@preconditions`, and `@expectedResult`
+- The `craft` CLI is Bun-only (`#!/usr/bin/env bun`, `engines.bun >= 1.1.0`); the core library targets both Node 22.6+ and Bun
+- Optional peer dependencies use `loadOptionalPeer` (`packages/routecraft/src/adapters/shared/optional-peer.ts`) to lazy-load drivers and emit `RC5017` with an install hint when missing
 
 ## Internal Standards
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Claude discovers your tool and uses it automatically. ✨
 - **Calendar & Meetings** - [Schedule meetings automatically](https://routecraft.dev/docs/examples/ai-agent-tools)
 - **Travel & Booking** - [Search flights and book restaurants](https://routecraft.dev/docs/examples/ai-document-processor)
 
-Try it yourself: `pnpm craft run ./examples/mcp-echo.mjs`
+Try it yourself: `bun run craft run ./examples/mcp-echo.mjs`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Now talk to Claude: *"Send an email to john@example.com thanking him for yesterd
 
 Claude discovers your tool and uses it automatically. ✨
 
-📚 [Get Started](https://routecraft.dev/docs/introduction) | [AI Examples](https://routecraft.dev/docs/examples/ai-email-parser) | [API Docs](https://routecraft.dev/docs/reference)
+📚 [Get Started](https://routecraft.dev/docs/introduction) | [Examples](https://routecraft.dev/docs/examples) | [API Reference](https://routecraft.dev/docs/reference)
 
 ## Key Features
 
@@ -84,19 +84,29 @@ Claude discovers your tool and uses it automatically. ✨
 ## Monorepo Structure
 
 - `packages/routecraft` – Core library (builder, DSL, context, adapters, consumers)
-- `packages/ai` – AI and MCP integrations (`mcp()`, schema validation, discovery)
-- `packages/cli` – CLI to run files or folders of routes and start contexts
+- `packages/ai` – AI integrations: LLM providers, agents, embeddings, MCP server / client
+- `packages/browser` – Browser automation adapter (headless / headed via agent-browser)
+- `packages/cli` – `craft` CLI to run capabilities and start contexts (Bun >= 1.1.0)
+- `packages/create-routecraft` – Project scaffolder (`bunx create-routecraft`)
+- `packages/eslint-plugin-routecraft` – ESLint rules for capability authoring
+- `packages/os` – System-native adapters (shell, etc.) – placeholder, in development
+- `packages/testing` – Test utilities (`testContext`, spy logger, `mockAdapter`, fixtures)
 - `apps/routecraft.dev` – Documentation site (docs, examples, guides)
-- `examples/` – Runnable example routes and tests
+- `examples/` – Runnable example capabilities
 
 ## Examples
 
-**Real-world automation:**
-- **Email Assistant** - [Send and manage emails](https://routecraft.dev/docs/examples/ai-email-parser)
-- **Calendar & Meetings** - [Schedule meetings automatically](https://routecraft.dev/docs/examples/ai-agent-tools)
-- **Travel & Booking** - [Search flights and book restaurants](https://routecraft.dev/docs/examples/ai-document-processor)
+Browse runnable examples in [`examples/src/`](./examples/src/) — `hello-world.ts`, `mcp-greet.ts`, `agent.ts`, `mail-noreply-notify.ts`, `programmatic-invocation.ts`, `split.ts`. Each demonstrates a different feature combination.
 
-Try it yourself: `bun run craft run ./examples/mcp-echo.mjs`
+Try one:
+
+```bash
+bun install
+bun run build
+bunx craft run ./examples/dist/mcp-greet.js
+```
+
+For end-to-end walkthroughs, see [the docs site](https://routecraft.dev/docs/examples).
 
 ## Contributing
 

--- a/apps/routecraft.dev/scripts/generate-raw-docs.mjs
+++ b/apps/routecraft.dev/scripts/generate-raw-docs.mjs
@@ -93,9 +93,9 @@ let combined = parts.join('\n')
 combined = combined.replace(/^(# .+)\n\n# .+$/gm, '$1')
 // 2. Strip image lines (LLMs cannot see images)
 combined = combined.replace(/^!\[.*?\]\(.*?\)\n?/gm, '')
-// 3. Keep only pnpm install blocks, strip npm/yarn/bun variants
+// 3. Keep only bun install blocks, strip npm/yarn/pnpm variants
 combined = combined.replace(
-  /\*\*(?:npm|yarn|bun):?\*\*:?\n```\w*\n.*?\n```\n?/gs,
+  /\*\*(?:npm|yarn|pnpm):?\*\*:?\n```\w*\n.*?\n```\n?/gs,
   '',
 )
 // 4. Collapse whitespace

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -251,7 +251,7 @@ The returned `Principal` is a flat object tagged with `kind` (`"jwt"`, `"jwks"`,
 For the full OAuth 2.1 Authorization Code flow with an upstream IdP, use `oauth()`. It proxies the authorization and token endpoints and validates incoming bearer tokens. It requires `express` and (for JWKS verification) `jose` as optional peer dependencies:
 
 ```sh
-pnpm add express jose
+bun add express jose
 ```
 
 Compose `oauth()` with `jwks()` (or a raw verifier function) via the `verify` option:

--- a/apps/routecraft.dev/src/app/docs/community/contribution-guide/page.md
+++ b/apps/routecraft.dev/src/app/docs/community/contribution-guide/page.md
@@ -12,8 +12,8 @@ How to contribute to Routecraft. {% .lead %}
 
 ## Prerequisites
 
-- Node.js 22+
-- pnpm (workspace managed)
+- Bun 1.1.0+ (the workspace is Bun-managed; the `craft` CLI also requires Bun)
+- Node.js 22+ (some scripts and the embedding test path run on Node)
 - Git
 
 ## Local Development
@@ -22,19 +22,19 @@ How to contribute to Routecraft. {% .lead %}
 # Clone and install
 git clone https://github.com/routecraftjs/routecraft.git
 cd routecraft
-pnpm install
+bun install
 
 # Build, lint, typecheck, and test
-pnpm build
-pnpm lint
-pnpm typecheck
-pnpm test
+bun run build
+bun run lint
+bun run typecheck
+bun run test
 
 # Run example capabilities
-pnpm craft run ./examples/dist/hello-world.js
+bun run craft run ./examples/dist/hello-world.js
 
 # Run docs site locally
-pnpm docs
+bun run docs
 ```
 
 ## Project Structure
@@ -90,8 +90,8 @@ refactor(builder): simplify type inference for map()
 - Run tests and coverage locally:
 
 ```bash
-pnpm test
-pnpm test:coverage
+bun run test
+bun run test:coverage
 ```
 
 ## Pull Request Checklist
@@ -99,12 +99,14 @@ pnpm test:coverage
 Before opening a PR:
 
 ```bash
-pnpm format        # check formatting
-pnpm lint          # lint all packages
-pnpm typecheck     # TypeScript checks
-pnpm test          # run tests
-pnpm build         # build all packages
+bun run format        # check formatting
+bun run lint          # lint all packages
+bun run typecheck     # TypeScript checks
+bun run test          # run tests
+bun run build         # build all packages
 ```
+
+Or run the bundled `bun run all`, which executes lint --fix, format:write, typecheck, build, and test in one pass.
 
 Include in your PR description:
 

--- a/apps/routecraft.dev/src/app/docs/introduction/monitoring/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/monitoring/page.md
@@ -106,7 +106,7 @@ export const craftConfig = {
 The database is written to `.routecraft/telemetry.db` in the current working directory. `better-sqlite3` must be installed:
 
 ```bash
-pnpm add better-sqlite3
+bun add better-sqlite3
 ```
 
 ### Configuration
@@ -128,7 +128,7 @@ telemetry({
 Because the telemetry plugin uses OpenTelemetry, you can export traces to any OTel-compatible backend alongside the local SQLite database. Install the OTel SDK and an OTLP exporter:
 
 ```bash
-pnpm add @opentelemetry/sdk-trace-base @opentelemetry/exporter-trace-otlp-http
+bun add @opentelemetry/sdk-trace-base @opentelemetry/exporter-trace-otlp-http
 ```
 
 Then configure a `TracerProvider` and pass it to `telemetry()`. Here is an example using [Better Stack](https://betterstack.com/):

--- a/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
@@ -404,7 +404,7 @@ expect(new Set(captured).size).toBe(1);
 Use the CLI to run compiled capability files/folders as an integration check:
 
 ```bash
-pnpm craft run ./examples/dist/hello-world.js
+bun run craft run ./examples/dist/hello-world.js
 ```
 
 ## Troubleshooting

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -11,7 +11,7 @@ npm install @routecraft/ai
 or
 
 ```bash
-pnpm add @routecraft/ai
+bun add @routecraft/ai
 ```
 
 ## Quick Start

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -5,13 +5,13 @@ AI adapters and MCP integration for Routecraft. Call LLMs, run agents, generate 
 ## Installation
 
 ```bash
-npm install @routecraft/ai
-```
-
-or
-
-```bash
+# Bun (recommended)
 bun add @routecraft/ai
+
+# npm / pnpm / yarn
+npm install @routecraft/ai
+pnpm add @routecraft/ai
+yarn add @routecraft/ai
 ```
 
 ## Quick Start
@@ -41,10 +41,10 @@ const ctx = new ContextBuilder()
 await ctx.start();
 ```
 
-Run it as an MCP server:
+Run it as an MCP server (requires Bun on the host):
 
 ```bash
-npx @routecraft/cli run capabilities/fetch-webpage.ts
+bunx @routecraft/cli run capabilities/fetch-webpage.ts
 ```
 
 ## Two Modes

--- a/packages/ai/src/embedding/providers/index.ts
+++ b/packages/ai/src/embedding/providers/index.ts
@@ -53,7 +53,7 @@ function resolveHuggingFaceModel(modelName: string): string {
 }
 
 const HUGGINGFACE_INSTALL =
-  'The Hugging Face embedding provider requires "@huggingface/transformers". Install it with: pnpm add @huggingface/transformers';
+  'The Hugging Face embedding provider requires "@huggingface/transformers". Install it with: bun add @huggingface/transformers';
 
 function isModuleNotFoundFor(error: unknown, pkg: string): boolean {
   if (!(error instanceof Error)) return false;

--- a/packages/ai/src/llm/providers/index.ts
+++ b/packages/ai/src/llm/providers/index.ts
@@ -11,7 +11,7 @@ import type {
 
 function throwProviderInstallError(pkg: string, provider: string): never {
   throw new Error(
-    `The ${provider} LLM provider requires the "${pkg}" package. Install it with: pnpm add ${pkg}`,
+    `The ${provider} LLM provider requires the "${pkg}" package. Install it with: bun add ${pkg}`,
   );
 }
 

--- a/packages/ai/src/mcp/adapters/mcp/destination.ts
+++ b/packages/ai/src/mcp/adapters/mcp/destination.ts
@@ -236,7 +236,7 @@ export class McpDestinationAdapter implements Destination<unknown, unknown> {
         await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
     } catch {
       throw new Error(
-        'MCP client requires "@modelcontextprotocol/sdk". Install it with: pnpm add @modelcontextprotocol/sdk',
+        'MCP client requires "@modelcontextprotocol/sdk". Install it with: bun add @modelcontextprotocol/sdk',
       );
     }
     const Client = clientModule.Client;

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -40,7 +40,7 @@ type SdkAuthInfo = AuthInfo;
 const principalStore = new AsyncLocalStorage<Principal | undefined>();
 
 const MCP_SDK_INSTALL =
-  'MCP server requires "@modelcontextprotocol/sdk". Install it with: pnpm add @modelcontextprotocol/sdk';
+  'MCP server requires "@modelcontextprotocol/sdk". Install it with: bun add @modelcontextprotocol/sdk';
 
 /** Resolved options with defaults applied (internal use). */
 type McpServerResolvedOptions = Required<
@@ -437,7 +437,7 @@ export class McpServer {
       expressFn = (expressMod["default"] ?? expressMod) as typeof expressFn;
     } catch {
       throw new Error(
-        'OAuth auth requires "express" (optional peer dependency of @routecraft/ai). Install it with: pnpm add express',
+        'OAuth auth requires "express" (optional peer dependency of @routecraft/ai). Install it with: bun add express',
       );
     }
 
@@ -462,7 +462,7 @@ export class McpServer {
     } catch {
       throw new Error(
         "OAuth auth requires @modelcontextprotocol/sdk v1.27.0+ with OAuth support. " +
-          "Install it with: pnpm add @modelcontextprotocol/sdk",
+          "Install it with: bun add @modelcontextprotocol/sdk",
       );
     }
 

--- a/packages/ai/src/mcp/stdio-client-manager.ts
+++ b/packages/ai/src/mcp/stdio-client-manager.ts
@@ -2,7 +2,7 @@ import type { McpTool } from "./types.ts";
 import { extractContent } from "./extract-content.ts";
 
 const MCP_SDK_INSTALL =
-  'MCP stdio client requires "@modelcontextprotocol/sdk". Install it with: pnpm add @modelcontextprotocol/sdk';
+  'MCP stdio client requires "@modelcontextprotocol/sdk". Install it with: bun add @modelcontextprotocol/sdk';
 
 export interface StdioClientManagerOptions {
   serverId: string;

--- a/packages/ai/src/skill/markdown.ts
+++ b/packages/ai/src/skill/markdown.ts
@@ -46,7 +46,7 @@ async function loadYamlParse(): Promise<YamlParse> {
       err.message.includes("yaml")
     ) {
       throw new Error(
-        `The markdown loaders (agents()/skills()) require the "yaml" package. Install it with: pnpm add yaml`,
+        `The markdown loaders (agents()/skills()) require the "yaml" package. Install it with: bun add yaml`,
       );
     }
     throw err;

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -5,13 +5,13 @@ Browser automation adapter for Routecraft. Drive headless or headed browsers fro
 ## Installation
 
 ```bash
-npm install @routecraft/browser agent-browser
-```
-
-or
-
-```bash
+# Bun (recommended)
 bun add @routecraft/browser agent-browser
+
+# npm / pnpm / yarn
+npm install @routecraft/browser agent-browser
+pnpm add @routecraft/browser agent-browser
+yarn add @routecraft/browser agent-browser
 ```
 
 `agent-browser` is a peer dependency. The adapter loads it lazily, so it is optional at install time but required at runtime.

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -11,7 +11,7 @@ npm install @routecraft/browser agent-browser
 or
 
 ```bash
-pnpm add @routecraft/browser agent-browser
+bun add @routecraft/browser agent-browser
 ```
 
 `agent-browser` is a peer dependency. The adapter loads it lazily, so it is optional at install time but required at runtime.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,17 +1,17 @@
 # @routecraft/cli
 
-Run Routecraft capabilities from the terminal.
+Run Routecraft capabilities from the terminal. **Bun-only runtime** (>= 1.1.0); see the [Runtime reference](https://routecraft.dev/docs/reference/runtime) for the rationale and the Node embedding alternative.
 
 ## Installation
 
 ```bash
-npm install -g @routecraft/cli
-```
-
-or
-
-```bash
+# Bun (recommended)
 bun add -g @routecraft/cli
+
+# npm / pnpm / yarn (still requires Bun on the host at runtime)
+npm install -g @routecraft/cli
+pnpm add -g @routecraft/cli
+yarn global add @routecraft/cli
 ```
 
 ## Usage
@@ -22,7 +22,9 @@ craft run my-capability.ts
 
 The CLI loads your capability file, starts all registered capabilities, and keeps the process running. It handles graceful shutdown on `SIGINT`/`SIGTERM` and automatically loads a `.env` file from the current directory if present.
 
-TypeScript files are supported directly -- no build step required.
+TypeScript files are supported directly -- Bun strips types natively, no build step required.
+
+If Bun is missing, the CLI fails fast with a `[routecraft]` error pointing at the install instructions. Node users should embed `@routecraft/routecraft` programmatically rather than going through the CLI -- see [Programmatic Invocation](https://routecraft.dev/docs/advanced/programmatic-invocation).
 
 ## Options
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -11,7 +11,7 @@ npm install -g @routecraft/cli
 or
 
 ```bash
-pnpm add -g @routecraft/cli
+bun add -g @routecraft/cli
 ```
 
 ## Usage

--- a/packages/cli/src/tui/db.ts
+++ b/packages/cli/src/tui/db.ts
@@ -65,8 +65,8 @@ export class TelemetryDb {
   /**
    * Open a telemetry database in read-only mode.
    *
-   * Uses dynamic `import()` so the module resolves correctly under pnpm's
-   * strict hoisting (CJS `require()` from an ESM bundle does not follow
+   * Uses dynamic `import()` so the module resolves correctly under Bun's
+   * isolated linker (CJS `require()` from an ESM bundle does not follow
    * the package's own dependency graph).
    */
   static async open(dbPath: string): Promise<TelemetryDb> {
@@ -80,7 +80,7 @@ export class TelemetryDb {
       ) as DatabaseConstructor;
     } catch {
       throw new Error(
-        "better-sqlite3 is not installed. Install it with: pnpm add better-sqlite3",
+        "better-sqlite3 is not installed. Install it with: bun add better-sqlite3",
       );
     }
 

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -174,7 +174,7 @@ describe("CLI run command", () => {
 
   /**
    * Manual test for "two-copy" duck-typing (different CLI vs route package):
-   * 1. From repo root: pnpm build
+   * 1. From repo root: bun run build
    * 2. Run: npx @routecraft/cli@canary run examples/index.mjs
    * The CLI uses its own @routecraft/routecraft; the loaded file resolves to the
    * workspace package, so RouteBuilder is from a different copy. With duck-typing

--- a/packages/create-routecraft/README.md
+++ b/packages/create-routecraft/README.md
@@ -5,19 +5,17 @@ Scaffold a new Routecraft project with best practices and example capabilities.
 ## Usage
 
 ```bash
-npm create routecraft@latest
-```
-
-or
-
-```bash
+# Bun (recommended)
 bunx create-routecraft
-```
 
-or
+# npm
+npm create routecraft@latest
 
-```bash
-npx create-routecraft
+# pnpm
+pnpm create routecraft@latest
+
+# yarn
+yarn create routecraft
 ```
 
 ## What's Included
@@ -40,13 +38,21 @@ The CLI will guide you through:
 
 ## Next Steps
 
-After creating your project:
+After creating your project, install dependencies and start the dev loop. Substitute the install/run command for the package manager you chose at the prompt:
 
 ```bash
+# Bun
+cd your-project-name
+bun install
+bun run start
+
+# npm
 cd your-project-name
 npm install
-npm run dev
+npm run start
 ```
+
+The `start` script invokes the `craft` CLI under the hood, which requires Bun >= 1.1.0 on the host regardless of which package manager you chose for dependency management.
 
 ## Documentation
 

--- a/packages/create-routecraft/README.md
+++ b/packages/create-routecraft/README.md
@@ -11,7 +11,7 @@ npm create routecraft@latest
 or
 
 ```bash
-pnpm create routecraft
+bunx create-routecraft
 ```
 
 or
@@ -35,7 +35,7 @@ The scaffolded project includes:
 The CLI will guide you through:
 
 1. **Project name**: Choose a name for your project
-2. **Package manager**: Select npm, pnpm, or yarn
+2. **Package manager**: Select bun, npm, pnpm, or yarn
 3. **Template**: Pick from available starter templates
 
 ## Next Steps

--- a/packages/eslint-plugin-routecraft/README.md
+++ b/packages/eslint-plugin-routecraft/README.md
@@ -5,13 +5,13 @@ ESLint plugin for Routecraft with rules to enforce capability authoring best pra
 ## Installation
 
 ```bash
-npm install --save-dev @routecraft/eslint-plugin-routecraft eslint
-```
-
-or
-
-```bash
+# Bun (recommended)
 bun add -D @routecraft/eslint-plugin-routecraft eslint
+
+# npm / pnpm / yarn
+npm install --save-dev @routecraft/eslint-plugin-routecraft eslint
+pnpm add -D @routecraft/eslint-plugin-routecraft eslint
+yarn add -D @routecraft/eslint-plugin-routecraft eslint
 ```
 
 ## Requirements

--- a/packages/eslint-plugin-routecraft/README.md
+++ b/packages/eslint-plugin-routecraft/README.md
@@ -11,7 +11,7 @@ npm install --save-dev @routecraft/eslint-plugin-routecraft eslint
 or
 
 ```bash
-pnpm add -D @routecraft/eslint-plugin-routecraft eslint
+bun add -D @routecraft/eslint-plugin-routecraft eslint
 ```
 
 ## Requirements

--- a/packages/os/README.md
+++ b/packages/os/README.md
@@ -1,0 +1,33 @@
+# @routecraft/os
+
+System-native adapters for Routecraft -- shell execution, process management, and other OS-level primitives.
+
+## Status
+
+**Placeholder.** This package is reserved on npm and in the workspace; the first adapters are scheduled for a future release. The `dist/` published today contains an empty module surface.
+
+Track progress in the [Routecraft issue tracker](https://github.com/routecraftjs/routecraft/issues) and watch [`packages/os`](https://github.com/routecraftjs/routecraft/tree/main/packages/os) for the first PRs.
+
+## Planned scope
+
+- `shell()` -- run shell commands as a Source or Destination, with stdout / stderr / exit-code surfaced on the exchange.
+- `process()` -- spawn long-running subprocesses; lifecycle managed by the route.
+- Additional OS-level primitives as they're proven in real capabilities.
+
+## Installation
+
+Once the first adapter ships:
+
+```bash
+# Bun (recommended)
+bun add @routecraft/os
+
+# npm / pnpm / yarn
+npm install @routecraft/os
+pnpm add @routecraft/os
+yarn add @routecraft/os
+```
+
+## License
+
+Apache-2.0

--- a/packages/routecraft/README.md
+++ b/packages/routecraft/README.md
@@ -13,7 +13,7 @@ npm install @routecraft/routecraft
 or
 
 ```bash
-pnpm add @routecraft/routecraft
+bun add @routecraft/routecraft
 ```
 
 ## Quick Start

--- a/packages/routecraft/README.md
+++ b/packages/routecraft/README.md
@@ -7,13 +7,13 @@ Routecraft is a TypeScript-first framework for building automation capabilities 
 ## Installation
 
 ```bash
-npm install @routecraft/routecraft
-```
-
-or
-
-```bash
+# Bun (recommended)
 bun add @routecraft/routecraft
+
+# npm / pnpm / yarn
+npm install @routecraft/routecraft
+pnpm add @routecraft/routecraft
+yarn add @routecraft/routecraft
 ```
 
 ## Quick Start
@@ -29,11 +29,13 @@ export default craft()
   .to(log());
 ```
 
-Run it directly:
+Run it directly with the `craft` CLI (requires Bun on the host):
 
 ```bash
-npx @routecraft/cli run capabilities/timer-ping.ts
+bunx @routecraft/cli run capabilities/timer-ping.ts
 ```
+
+For Node-based projects, embed the library programmatically instead of using the CLI -- see [Programmatic Invocation](https://routecraft.dev/docs/advanced/programmatic-invocation).
 
 ## Core Concepts
 

--- a/packages/routecraft/src/adapters/mail/strict-verify.ts
+++ b/packages/routecraft/src/adapters/mail/strict-verify.ts
@@ -50,7 +50,7 @@ export async function verifyStrict(
       } catch (error) {
         throw rcError("RC5003", error instanceof Error ? error : undefined, {
           message:
-            "Mail adapter verify: 'strict' requires the optional `mailauth` package. Install it with `pnpm add mailauth`.",
+            "Mail adapter verify: 'strict' requires the optional `mailauth` package. Install it with `bun add mailauth`.",
         });
       }
     })();

--- a/packages/routecraft/src/auth/jwks.ts
+++ b/packages/routecraft/src/auth/jwks.ts
@@ -101,7 +101,7 @@ export interface JwksOptions {
  *
  * Requires the optional peer dependency `jose`:
  * ```sh
- * pnpm add jose
+ * bun add jose
  * ```
  *
  * @example
@@ -136,7 +136,7 @@ export function jwks(options: JwksOptions): OAuthValidatorAuthOptions {
           joseMod = (await import("jose")) as unknown as JoseSubset;
         } catch {
           throw new Error(
-            'jwks() requires the optional peer dependency "jose". Install it with: pnpm add jose',
+            'jwks() requires the optional peer dependency "jose". Install it with: bun add jose',
           );
         }
       }

--- a/packages/routecraft/src/telemetry/plugin.ts
+++ b/packages/routecraft/src/telemetry/plugin.ts
@@ -121,7 +121,7 @@ class TelemetryPlugin implements CraftPlugin {
       } else {
         ctx.logger.warn(
           {},
-          "better-sqlite3 is not installed. Telemetry SQLite backend disabled. Install it with: pnpm add better-sqlite3",
+          "better-sqlite3 is not installed. Telemetry SQLite backend disabled. Install it with: bun add better-sqlite3",
         );
       }
     }

--- a/packages/routecraft/test/auth/jwks-missing-jose.test.ts
+++ b/packages/routecraft/test/auth/jwks-missing-jose.test.ts
@@ -9,7 +9,7 @@ describe("jwks() without jose installed", () => {
   /**
    * @case Validator surfaces a clear install hint when `jose` cannot be resolved
    * @preconditions `jose` import is mocked to throw a module-not-found error
-   * @expectedResult Validator rejects with a message instructing `pnpm add jose`
+   * @expectedResult Validator rejects with a message instructing `bun add jose`
    */
   test("rejects with install hint when jose is missing", async () => {
     const { validator } = jwks({
@@ -19,7 +19,7 @@ describe("jwks() without jose installed", () => {
     });
 
     await expect(validator("irrelevant-token")).rejects.toThrow(
-      /jose.*pnpm add jose/,
+      /jose.*bun add jose/,
     );
   });
 });

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -5,13 +5,13 @@ Test utilities for Routecraft capabilities. Use with [Vitest](https://vitest.dev
 ## Installation
 
 ```bash
-npm install -D @routecraft/testing
-```
-
-or
-
-```bash
+# Bun (recommended)
 bun add -D @routecraft/testing
+
+# npm / pnpm / yarn
+npm install -D @routecraft/testing
+pnpm add -D @routecraft/testing
+yarn add -D @routecraft/testing
 ```
 
 Install as a devDependency. Requires `vitest` (>=4.0.0) and `@routecraft/routecraft`.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -11,7 +11,7 @@ npm install -D @routecraft/testing
 or
 
 ```bash
-pnpm add -D @routecraft/testing
+bun add -D @routecraft/testing
 ```
 
 Install as a devDependency. Requires `vitest` (>=4.0.0) and `@routecraft/routecraft`.


### PR DESCRIPTION
Closes the docs half of #220. Follow-up to #296 (tooling migration) which switched the workspace to Bun.

## Summary

Sweeps remaining `pnpm` references across:

- **Standards** — `.standards/ci-cd.md`, `testing.md`, `type-safety-registries.md` reflect the new Bun workflow and integration matrix (`runtime: [bun, node]`); `ci-cd.md` now documents the `loadOptionalPeer` pattern and RC5017 contract.
- **Root** — `CLAUDE.md` Quick Reference flipped to Bun + two new Key Rules covering Bun-only CLI and `loadOptionalPeer`. `README.md` example updated.
- **Per-package READMEs** — all 7 publishable packages: `pnpm add` → `bun add`. `create-routecraft/README.md` updated to lead with `bunx create-routecraft` and lists "bun, npm, pnpm, or yarn" as user-selectable PMs.
- **Source-code error messages** — every `Install it with: pnpm add <pkg>` hint across `packages/ai`, `packages/routecraft`, `packages/cli` flipped to `bun add <pkg>`. The matching test assertion in `jwks-missing-jose.test.ts` updated. The `cli/src/tui/db.ts` JSDoc reference to "pnpm's strict hoisting" updated to "Bun's isolated linker".
- **Contributor docs** — `apps/routecraft.dev/src/app/docs/community/contribution-guide/page.md` rewritten with Bun prerequisite + `bun run` commands + the bundled `bun run all` pre-PR check.
- **Single-PM doc snippets** — `introduction/testing/page.md`, `introduction/monitoring/page.md`, `advanced/expose-as-mcp/page.md`: `pnpm add` → `bun add`.
- **`apps/routecraft.dev/scripts/generate-raw-docs.mjs`** — filter inverted. The combined LLM-facing `docs.md` retains only bun install blocks; npm / yarn / pnpm variants are stripped. Per-page raw files keep all variants because they mirror the docs site's multi-PM tabs.
- **Proposals** — `.proposals/adapter-sandbox-and-secrets.md` verification step updated.

## What's intentionally LEFT alone

- **Multi-PM tabs in user-facing scaffolder docs** (`installation/page.md`, `reference/cli/page.md`, `advanced/linting/page.md`, `advanced/programmatic-invocation/page.md`, `app/page.md`). End users may scaffold with pnpm/npm/yarn via `create-routecraft`; the tabs reflect that choice. Per #220, the scaffolder's user PM choices are out of scope.
- **`create-routecraft` source code** (`lib.ts`, `index.test.ts`, scaffolded templates). Same rationale.
- **The deployment Dockerfile guidance** that mentions pnpm/npm as alternatives in the `deps` stage. The `CMD` is Bun-based; the dependency-install stage is intentionally PM-agnostic for users who prefer to keep their existing PM for dependency management.

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean.
- [x] `bun run format` clean.
- [x] `bun run test` — 1094 passed, 1 skipped (jwks regex updated for new error message).
- [x] `node apps/routecraft.dev/scripts/generate-raw-docs.mjs` regenerates `public/raw/`; combined `docs.md` retains only bun install blocks (verified `grep -c "pnpm" docs.md` = 2, both on legitimate alt-mention lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJGLj5rX8p5eZV41vPQJKq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sweeps remaining pnpm references after the Bun migration and makes the repo Bun-first across docs, READMEs, CI/testing standards, and install hints. Adds Bun command conventions, fixes example/docs links, introduces a placeholder `packages/os` README, and clarifies that CI runs `bun run test:coverage` (local `bun run test`).

- **Refactors**
  - Standards: CI matrix is `runtime: [bun, node]`; lockfile is `bun.lock`; use `bun run` and `bunx`; optional peers go through `loadOptionalPeer` with `RC5017`; publish stays `npm publish`; test job uses `bun run test:coverage` (local `bun run test`); migration backlog tracked in #287.
  - Root/docs: Contributor guide and `CLAUDE.md` flipped to Bun; new rule on `bun run` vs `bunx`; CLI noted as Bun-only with Node embedding alternative; root `README.md` links fixed, examples updated, monorepo list completed; new `packages/os/README.md` placeholder.
  - Package READMEs: Install snippets lead with `bun add`; run examples use `bunx @routecraft/cli`; `create-routecraft` leads with `bunx create-routecraft`, adds bun to PM choices, and clarifies `start` requires Bun on the host.
  - Code hints/tests: All “Install it with: …” messages now say `bun add …` across `@routecraft/*`; matching tests and comments updated (e.g., JWKS jose hint; Bun’s isolated linker note in the CLI DB).
  - Docs export: `generate-raw-docs.mjs` now keeps Bun install blocks and strips npm/yarn/pnpm variants; multi-PM tabs on the site remain.
  - Kept as-is: Scaffolder logic/templates and Dockerfile guidance that mentions alternative PMs.

<sup>Written for commit 8f6a7d442ab712bd8649fb7d06fba2dc06536ff5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

