### PR TITLE
fix(ci): skip postinstalls in scaffolder integration test (avoid bun node-gyp flake)

### DIFF
--- a/packages/create-routecraft/test/integration.test.ts
+++ b/packages/create-routecraft/test/integration.test.ts
@@ -30,18 +30,24 @@ interface PackageManagerDef {
 // level, since `lib.ts` still emits npm/pnpm/yarn variants. Node users
 // embedding @routecraft/routecraft programmatically are covered separately
 // by `.github/scripts/smoke-test-embedding.mjs`.
+// `--ignore-scripts` is intentional: the scaffolded hello-world test does not
+// exercise any code path that needs a compiled native binding (better-sqlite3
+// only loads inside the TUI / telemetry plugin, which the test does not hit).
+// Skipping postinstalls dodges a recurring CI flake where bun's transient
+// `bunx node-gyp@latest` cache is missing one of its own transitive deps
+// (env-paths, undici interceptors, etc.) when better-sqlite3 tries to compile.
 const PACKAGE_MANAGER_DEFS: Record<PackageManagerId, PackageManagerDef> = {
   bun: {
     id: "bun",
     pmOption: "bun",
-    install: "bun install",
+    install: "bun install --ignore-scripts",
     typecheck: "bunx tsc --noEmit",
     start: "bunx craft run index.ts",
   },
   npm: {
     id: "npm",
     pmOption: "npm",
-    install: "npm install --no-audit --no-fund",
+    install: "npm install --no-audit --no-fund --ignore-scripts",
     typecheck: "npx tsc --noEmit",
     start: null,
   },


### PR DESCRIPTION
## Summary

Stops the recurring `integration-test (bun)` flake on PRs.

The job intermittently fails inside the scaffolded project's `bun install`:

```
Cannot find module 'env-paths' Require stack:
  /tmp/bunx-1001-node-gyp@latest/node_modules/node-gyp/bin/node-gyp.js
```

(or, in another run, missing `undici/interceptor/redirect-interceptor.js` from the same node-gyp chain.)

## Root cause

When the scaffolded project pulls in `@routecraft/cli`, which transitively depends on `better-sqlite3`, bun runs that package's `postinstall` to compile the native binding. That invokes `bunx node-gyp@latest`, and bun's transient cache for that bunx call sometimes misses one of node-gyp's own transitive deps. The result is a flake that has nothing to do with the test logic or the scaffolder output.

## Fix

Add `--ignore-scripts` to both arms of the integration test's install step:

- `bun install` → `bun install --ignore-scripts`
- `npm install --no-audit --no-fund` → `npm install --no-audit --no-fund --ignore-scripts`

The hello-world test scenarios do not exercise any code path that needs the compiled native binding — `better-sqlite3` is loaded only inside the TUI / telemetry plugin via dynamic import, and neither runs in either arm. Skipping postinstalls sidesteps the compile entirely.

## Verified locally

- `TEST_PACKAGE_MANAGER=bun bun run test:integration` — 3 passed.
- `TEST_PACKAGE_MANAGER=npm bun run test:integration` — 2 passed, 1 skipped (the dispatch test correctly skips for npm).

## Trade-off

If a future test scenario actually needs the binary (e.g. a telemetry plugin smoke test), it should override the flag at the per-test level — not undo this default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJGLj5rX8p5eZV41vPQJKq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip postinstall scripts in the scaffolder integration test to remove the intermittent `bun` flake. This avoids `bunx`/`node-gyp` cache misses triggered by `better-sqlite3` from `@routecraft/cli`.

- **Bug Fixes**
  - Use `bun install --ignore-scripts` and `npm install --no-audit --no-fund --ignore-scripts` in the test.
  - The test doesn’t load the native module; future cases that need it can override per test.

<sup>Written for commit 891f4a05978a7e5c587c97adc0b8a21062a861ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

