### PR TITLE
fix(ci): skip docs stable-build for tags that predate the Bun migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,9 +516,17 @@ jobs:
         run: |
           set -eo pipefail
           if LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null); then
-            echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
-            echo "version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
-            echo "Latest stable tag: $LATEST_TAG"
+            # Skip pre-Bun-migration tags: they require pnpm to install,
+            # which is no longer available on the runner. The presence
+            # of `bun.lock` at the tagged commit is the gating signal.
+            if git show "${LATEST_TAG}:bun.lock" >/dev/null 2>&1; then
+              echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+              echo "version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
+              echo "Latest stable tag: $LATEST_TAG (bun.lock present)"
+            else
+              echo "tag=" >> "$GITHUB_OUTPUT"
+              echo "Latest stable tag $LATEST_TAG predates the Bun migration (no bun.lock); deploying canary only"
+            fi
           else
             echo "tag=" >> "$GITHUB_OUTPUT"
             echo "No stable tag found; deploying canary only"


### PR DESCRIPTION
## Summary

The `build-docs-site` job builds two doc trees on every release / docs-only push:

1. **Canary** from the current main — works fine.
2. **Stable** from the latest `v*` git tag — currently broken.

The latest stable tag today is `v0.4.0`, cut before the pnpm → bun migration (#296). That tagged commit has `pnpm-lock.yaml` and `pnpm-workspace.yaml`, no `bun.lock`. The job runs `bun install --frozen-lockfile` against the checked-out tag and fails immediately because there's no Bun lockfile to honour.

## Fix

Detect whether the tagged commit has a `bun.lock` before kicking off the stable build. If yes, build stable + canary as before. If no, skip stable and deploy canary-only.

```diff
       - name: Find latest stable tag
         id: latest
         working-directory: canary
         run: |
           set -eo pipefail
           if LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null); then
-            echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
-            echo "version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
-            echo "Latest stable tag: $LATEST_TAG"
+            if git show "${LATEST_TAG}:bun.lock" >/dev/null 2>&1; then
+              echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+              echo "version=${LATEST_TAG#v}" >> "$GITHUB_OUTPUT"
+              echo "Latest stable tag: $LATEST_TAG (bun.lock present)"
+            else
+              echo "tag=" >> "$GITHUB_OUTPUT"
+              echo "Latest stable tag $LATEST_TAG predates the Bun migration (no bun.lock); deploying canary only"
+            fi
           else
             echo "tag=" >> "$GITHUB_OUTPUT"
             echo "No stable tag found; deploying canary only"
           fi
```

The `Assemble merged site` step already handles the no-stable-tag fallback correctly — it deploys canary at root and writes a `versions.json` with just the canary entry.

## Behaviour

- **Today (latest tag `v0.4.0`):** stable build skipped; canary deployed at root.
- **After `v0.5.0` (or later) is cut on top of the Bun migration:** gating signal flips automatically; stable build resumes; both versions deployed (`v0.5.0+` at root, canary at `/next/`).

## Test plan

- [x] `git show "v0.4.0:bun.lock"` exits non-zero locally — confirms the gate triggers as intended.
- [x] `bun run format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJGLj5rX8p5eZV41vPQJKq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the stable docs build when the latest `v*` tag predates the Bun migration by checking for `bun.lock` on that tag. If it’s missing, we deploy canary only; once a post-migration tag exists, stable resumes automatically.

<sup>Written for commit 3ee4774148bd1782323a4af843b6ca6b963ce4f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

