### PR TITLE
ci: merge build-docs-site + deploy-pages, gate on integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,13 +555,38 @@ jobs:
             npm publish "./$pkg" --access public --provenance
           done
 
-  build-docs-site:
-    needs: [changes, validate, test, build]
+  build-and-deploy-docs:
+    needs:
+      [
+        changes,
+        validate,
+        test,
+        build,
+        scaffolder-smoke,
+        embedding-smoke,
+        adapter-cross-runtime,
+      ]
+    # Run when docs-or-release-or-manual triggers AND nothing required has failed.
+    # `!failure()` lets us proceed when the integration jobs were skipped (e.g.
+    # docs-only push where `changes.outputs.packages == 'false'`) but blocks
+    # deploy when they ran and failed.
     if: |
-      github.event_name == 'workflow_dispatch'
-      || github.event_name == 'release'
-      || (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.docs == 'true')
+      !cancelled() && !failure()
+      && (
+        github.event_name == 'workflow_dispatch'
+        || github.event_name == 'release'
+        || (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.docs == 'true')
+      )
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      id-token: write
+      pages: write
     steps:
       - name: Checkout main (canary)
         uses: actions/checkout@v6
@@ -682,23 +707,6 @@ jobs:
         with:
           path: site
 
-  deploy-pages:
-    needs: [changes, build-docs-site]
-    if: |
-      github.event_name == 'workflow_dispatch'
-      || github.event_name == 'release'
-      || (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.docs == 'true')
-    runs-on: ubuntu-latest
-    concurrency:
-      group: pages
-      cancel-in-progress: false
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    permissions:
-      id-token: write
-      pages: write
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,12 +566,15 @@ jobs:
         embedding-smoke,
         adapter-cross-runtime,
       ]
-    # Run when docs-or-release-or-manual triggers AND nothing required has failed.
-    # `!failure()` lets us proceed when the integration jobs were skipped (e.g.
-    # docs-only push where `changes.outputs.packages == 'false'`) but blocks
-    # deploy when they ran and failed.
+    # `always()` overrides GitHub's default of skipping a job when any of its
+    # `needs:` was skipped (which is what happens on docs-only pushes, where
+    # the integration jobs gate themselves out via `changes.outputs.packages`).
+    # The explicit `!contains(needs.*.result, ...)` checks then block deploy
+    # if any integration job actually ran and failed or was cancelled.
     if: |
-      !cancelled() && !failure()
+      always()
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
       && (
         github.event_name == 'workflow_dispatch'
         || github.event_name == 'release'

--- a/.standards/ci-cd.md
+++ b/.standards/ci-cd.md
@@ -8,13 +8,18 @@ What `.github/workflows/ci.yml` enforces and the policies contributors must know
 
 ```
   changes  ─┬─►  validate ─┐
-            │              │
-   setup ───┼─►  test  ────┼─►  integration-test (bun + node)  ──►  approve  ──►  merge
-            │              │                                          │
-            └─►  build ────┘                                          └─►  publish-canary  ──►  publish  ──►  deploy-pages
+            │              ├─►  scaffolder-smoke ─────────┬─►  approve ─►  merge
+   setup ───┼─►  test  ────┤                              │
+            │              ├─►  embedding-smoke ──────────┼─►  publish-canary
+            └─►  build ────┤                              │
+                           └─►  adapter-cross-runtime  ───┴─►  publish
+                                  (bun + node)            │
+                                                          └─►  build-and-deploy-docs
 ```
 
 The `setup` job runs `bun install --frozen-lockfile` and seeds the workspace's `**/node_modules`. Every downstream job restores that cache (key: `hashFiles('**/bun.lock')`), so the install only repeats on a cache miss. `changes` skips downstream jobs when the diff doesn't touch package or workflow paths.
+
+Docs deployment (`build-and-deploy-docs`) is gated on the same integration-test trio as `publish-canary` and `publish`, so we never ship docs from a build that failed integration. On docs-only pushes the integration jobs are skipped and the deploy proceeds (`if: !cancelled() && !failure()`).
 
 ## 2. The PR gates
 


### PR DESCRIPTION
## What

Collapses `build-docs-site` + `deploy-pages` into a single `build-and-deploy-docs` job, and gates docs deployment on the integration-test trio (`scaffolder-smoke`, `embedding-smoke`, `adapter-cross-runtime`) so docs never ship from a build whose integration tests were red.

## Why

Two issues with the previous shape:

1. **Wrong gate.** `deploy-pages` only depended on `build-docs-site`, not on the integration tests. A push to main with red integration tests would happily deploy docs from that commit. Inconsistent with `publish-canary` and `publish`, which already gate on integration.
2. **Overhead.** The split added ~30s of `setup-node` + `setup-bun` + cache-restore on the deploy job for a single `actions/deploy-pages@v5` step, plus an artifact handoff between jobs.

The split followed the GitHub-recommended pattern of scoping `pages: write` + `id-token: write` to a deploy-only job. For our usecase (deploying our own docs from trusted main-branch code) that permission isolation is paper risk versus the cost of the extra job.

## How

Single job inherits everything `deploy-pages` carried (elevated permissions, `github-pages` environment, `concurrency: pages` group), runs the existing build steps unchanged, and ends with the deploy step.

```yaml
build-and-deploy-docs:
  needs: [changes, validate, test, build, scaffolder-smoke, embedding-smoke, adapter-cross-runtime]
  if: |
    !cancelled() && !failure()
    && (
      github.event_name == 'workflow_dispatch'
      || github.event_name == 'release'
      || (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.docs == 'true')
    )
  concurrency: { group: pages, cancel-in-progress: false }
  environment: { name: github-pages, url: ${{ steps.deployment.outputs.page_url }} }
  permissions: { id-token: write, pages: write }
  steps:
    # ... existing build steps ...
    - actions/upload-pages-artifact@v5
    - actions/deploy-pages@v5
```

The `!cancelled() && !failure()` condition handles docs-only pushes correctly: when the diff doesn't touch packages, the integration jobs skip (their own `if:` gate excludes them), and a skipped need is not a failed need, so the deploy proceeds. When integration jobs run and fail, `!failure()` is false and the deploy is blocked.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly.
- [x] `bun run format` clean.
- [ ] Real-world verification waits until merge: docs-only push to main triggers the merged job (integration jobs skip → deploy runs), package-touching push triggers full chain (integration jobs run → deploy waits for them).

## Tradeoff

The build steps now run with `pages: write` + an OIDC token in scope. If a build-time npm dep were compromised, it could in theory write to Pages or exchange the OIDC token. For deploying our own docs from main, that's accepted as paper risk. Repos with stricter posture should keep the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJGLj5rX8p5eZV41vPQJKq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merged `build-docs-site` and `deploy-pages` into a single `build-and-deploy-docs` job and gated docs deploys on integration tests. Uses `always()` with explicit failure/cancel checks so docs-only pushes still deploy, while failed integrations block.

- **Refactors**
  - Collapse docs build and deploy into `build-and-deploy-docs`, retaining `github-pages` env, `concurrency: pages`, and elevated perms; removes extra setup and artifact handoff.
  - Gate deploy on `scaffolder-smoke`, `embedding-smoke`, and `adapter-cross-runtime`.
  - Use `if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')` to run when integrations are skipped, but block on failures or cancellations.

<sup>Written for commit 63ed1ea760556a2f5660bac724b9a01cd9b42da5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

