### PR TITLE
Upgrade to Next.js 16 and improve code quality

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,17 @@ updates:
       prefix: "chore"
       include: "scope"
 
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      semver-minor-days: 14
+      semver-patch-days: 7
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.prettierignore
+++ b/.prettierignore
@@ -18,6 +18,7 @@ coverage/
 
 # Next.js build output
 **/.next/
+**/next-env.d.ts
 
 *.md
 

--- a/apps/routecraft.dev/.eslintrc.json
+++ b/apps/routecraft.dev/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/apps/routecraft.dev/eslint.config.mjs
+++ b/apps/routecraft.dev/eslint.config.mjs
@@ -1,0 +1,11 @@
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+
+/** @type {import('eslint').Linter.Config[]} */
+const config = [
+  {
+    ignores: ['.next/**', 'out/**', 'public/raw/**'],
+  },
+  ...nextCoreWebVitals,
+]
+
+export default config

--- a/apps/routecraft.dev/eslint.config.mjs
+++ b/apps/routecraft.dev/eslint.config.mjs
@@ -1,4 +1,5 @@
 import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+import nextTypescript from 'eslint-config-next/typescript'
 
 /** @type {import('eslint').Linter.Config[]} */
 const config = [
@@ -6,6 +7,7 @@ const config = [
     ignores: ['.next/**', 'out/**', 'public/raw/**'],
   },
   ...nextCoreWebVitals,
+  ...nextTypescript,
 ]
 
 export default config

--- a/apps/routecraft.dev/next.config.mjs
+++ b/apps/routecraft.dev/next.config.mjs
@@ -1,3 +1,9 @@
+// IMPORTANT: package.json `dev` and `build` scripts pass `--webpack`. The
+// markdoc loader pipeline below (withMarkdoc + withSearch + withDocsMarkdown)
+// hooks `nextConfig.webpack(...)` and is webpack-only. Turbopack (the Next 16+
+// default) silently skips these hooks, which produces a "successful" build
+// where every `.md` page renders empty. Do not drop `--webpack` until the
+// markdoc pipeline (or a Turbopack equivalent) supports both.
 import withMarkdoc from '@markdoc/next.js'
 
 import withDocsMarkdown from './src/markdoc/docs-markdown.mjs'

--- a/apps/routecraft.dev/next.config.mjs
+++ b/apps/routecraft.dev/next.config.mjs
@@ -25,6 +25,13 @@ const nextConfig = {
   },
 }
 
+// nextjsExports: [] disables the auto-emitted `metadata` / `revalidate`
+// re-exports from `@markdoc/next.js`. No page sets `nextjs:` frontmatter,
+// so they were always `undefined`, and Next 16 rejects exporting `metadata`
+// from any module its RSC graph classifies as client (which the markdoc
+// schema imports trigger via tags like `<CodeTabs>` and `<Callout>`).
 export default withDocsMarkdown(
-  withSearch(withMarkdoc({ schemaPath: './src/markdoc' })(nextConfig)),
+  withSearch(
+    withMarkdoc({ schemaPath: './src/markdoc', nextjsExports: [] })(nextConfig),
+  ),
 )

--- a/apps/routecraft.dev/package.json
+++ b/apps/routecraft.dev/package.json
@@ -3,11 +3,11 @@
   "version": "0.5.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "prebuild": "node --experimental-strip-types scripts/generate-raw-docs.mjs",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "browserslist": "defaults, not ie <= 11",
   "dependencies": {
@@ -23,7 +23,7 @@
     "fast-glob": "^3.3.3",
     "flexsearch": "^0.8.212",
     "js-yaml": "^4.1.1",
-    "next": "^15.5.15",
+    "next": "^16.2.4",
     "next-themes": "^0.4.6",
     "posthog-js": "^1.372.6",
     "prism-react-renderer": "^2.4.1",
@@ -39,7 +39,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",
-    "eslint-config-next": "^15.5.15",
+    "eslint-config-next": "^16.2.4",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.7.4",
     "sharp": "^0.34.5"

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -51,7 +51,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
 {
   "mcpServers": {
     "my-tools": {
-      "command": "npx",
+      "command": "bunx",
       "args": [
         "@routecraft/cli",
         "run",
@@ -71,7 +71,7 @@ Open **Cursor Settings** > **Features** > **Model Context Protocol**, then add:
 ```json
 {
   "my-tools": {
-    "command": "npx",
+    "command": "bunx",
     "args": [
       "@routecraft/cli",
       "run",
@@ -89,7 +89,7 @@ Add the following to your `.mcp.json` (project-level) or `~/.claude/mcp.json` (g
 {
   "mcpServers": {
     "my-tools": {
-      "command": "npx",
+      "command": "bunx",
       "args": [
         "@routecraft/cli",
         "run",
@@ -315,7 +315,7 @@ Pin the CLI version so your capabilities do not break on package updates:
 {
   "mcpServers": {
     "my-tools": {
-      "command": "npx",
+      "command": "bunx",
       "args": [
         "@routecraft/cli@2.0.0",
         "run",

--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -487,7 +487,7 @@ Lets you invoke routes from outside the framework lifecycle (test runners, scrip
 
 The `mcp()` source can now sit behind an OAuth 2.1 authorisation server. The framework ships JWT and JWKS verifiers, an `oauth()` factory, and a typed `OAuthPrincipal` shape.
 
-### `.authorize()` route-entry guard {% badge color="orange" %}experimental{% /badge %}
+### `.authorize()` route-entry guard
 
 A new route-only `.authorize()` method declares an authorization requirement on a route. It runs at route entry, before any pipeline step, and verifies that the inbound exchange carries an authenticated `principal` and (optionally) that the principal carries every required role and scope.
 

--- a/apps/routecraft.dev/src/app/docs/reference/cli/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/cli/page.md
@@ -115,7 +115,3 @@ await context.start();
 **Second signal** (Ctrl+C again): forces an immediate exit for when graceful shutdown is stuck or taking too long.
 
 The function returns a cleanup callback that removes the signal handlers, useful in tests or when you manage the lifecycle yourself.
-
-{% callout type="warning" title="Experimental" %}
-`shutdownHandler` is marked `@experimental` and may change in future releases.
-{% /callout %}

--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -21,7 +21,7 @@ DSL operators with signatures and examples. {% .lead %}
 | [`id`](#id) | Route | Set the unique identifier for the route |
 | [`batch`](#batch) | Route | Process exchanges in batches instead of one at a time |
 | [`error`](#error) | Route + Wrapper | Configure error handling. Before `.from()` it catches every step (route scope); after `.from()` it wraps the next step and the pipeline continues after recovery (step scope). |
-| [`authorize`](#authorize) | Route | Route-entry guard: principal must be authenticated and (optionally) have required roles/scopes. Pre-from only. {% badge color="orange" %}experimental{% /badge %} |
+| [`authorize`](#authorize) | Route | Route-entry guard: principal must be authenticated and (optionally) have required roles/scopes. Pre-from only. |
 | [`from`](#from) | Route | Define the source of data for the capability |
 | [`retry`](#retry) | Wrapper | Retry the next operation on failure {% badge color="purple" %}planned{% /badge %} |
 | [`throttle`](#throttle) | Wrapper | Rate limit the next operation {% badge color="purple" %}planned{% /badge %} |
@@ -209,7 +209,7 @@ For the architectural pattern wrappers follow, see [`.standards/resilience-wrapp
 
 **Note about direct destinations:** Direct destinations with their own routes have their own error handlers. Errors in direct destinations are handled by their route's error handler, not the calling route.
 
-### authorize {% badge color="orange" %}experimental{% /badge %}
+### authorize
 
 ```ts
 authorize(options?: AuthorizeOptions): RouteBuilder<Current>

--- a/apps/routecraft.dev/src/app/page.md
+++ b/apps/routecraft.dev/src/app/page.md
@@ -37,7 +37,7 @@ export default craft()
 Run it instantly without any setup:
 
 ```bash
-npx @routecraft/cli run capabilities/hello-world.ts
+bunx @routecraft/cli run capabilities/hello-world.ts
 ```
 
 This pattern (source, enrich, transform, destination) is the foundation of every Routecraft capability.

--- a/apps/routecraft.dev/src/components/Badge.tsx
+++ b/apps/routecraft.dev/src/components/Badge.tsx
@@ -1,24 +1,26 @@
 import clsx from 'clsx'
 
+export type BadgeColor =
+  | 'yellow'
+  | 'red'
+  | 'green'
+  | 'gray'
+  | 'blue'
+  | 'indigo'
+  | 'purple'
+  | 'pink'
+  // Back-compat aliases
+  | 'amber'
+  | 'sky'
+  | 'slate'
+  | 'rose'
+
 export function Badge({
   color = 'yellow',
   className,
   children,
 }: {
-  color?:
-    | 'yellow'
-    | 'red'
-    | 'green'
-    | 'gray'
-    | 'blue'
-    | 'indigo'
-    | 'purple'
-    | 'pink'
-    // Back-compat aliases
-    | 'amber'
-    | 'sky'
-    | 'slate'
-    | 'rose'
+  color?: BadgeColor
   className?: string
   children: React.ReactNode
 }) {

--- a/apps/routecraft.dev/src/components/Callout.tsx
+++ b/apps/routecraft.dev/src/components/Callout.tsx
@@ -33,7 +33,7 @@ export function Callout({
   children: React.ReactNode
   type?: keyof typeof styles
 }) {
-  let IconComponent = icons[type]
+  const IconComponent = icons[type]
 
   return (
     <div className={clsx('my-8 flex rounded-3xl p-6', styles[type].container)}>

--- a/apps/routecraft.dev/src/components/DocsHeader.tsx
+++ b/apps/routecraft.dev/src/components/DocsHeader.tsx
@@ -6,15 +6,17 @@ import { navigation } from '@/lib/navigation'
 import { Badge } from '@/components/Badge'
 import { CopyDocsButton } from '@/components/CopyDocsButton'
 
+type BadgeColor = React.ComponentProps<typeof Badge>['color']
+
 export function DocsHeader({
   title,
   titleBadges,
 }: {
   title?: string
-  titleBadges?: Array<{ text: string; color?: string }>
+  titleBadges?: Array<{ text: string; color?: BadgeColor }>
 }) {
-  let pathname = usePathname().replace(/\/+$/, '') || '/'
-  let section = navigation.find((section) =>
+  const pathname = usePathname().replace(/\/+$/, '') || '/'
+  const section = navigation.find((section) =>
     section.links.find((link) => link.href === pathname),
   )
 
@@ -39,7 +41,7 @@ export function DocsHeader({
           <span className="inline-flex items-center gap-2">
             <span>{title}</span>
             {titleBadges?.map((b, i) => (
-              <Badge key={i} color={(b.color as any) ?? 'yellow'}>
+              <Badge key={i} color={b.color ?? 'yellow'}>
                 {b.text}
               </Badge>
             ))}

--- a/apps/routecraft.dev/src/components/DocsLayout.tsx
+++ b/apps/routecraft.dev/src/components/DocsLayout.tsx
@@ -1,5 +1,6 @@
 import { type Node } from '@markdoc/markdoc'
 
+import { type BadgeColor } from '@/components/Badge'
 import { DocsHeader } from '@/components/DocsHeader'
 import { PrevNextLinks } from '@/components/PrevNextLinks'
 import { Prose } from '@/components/Prose'
@@ -14,11 +15,11 @@ export function DocsLayout({
   children: React.ReactNode
   frontmatter: {
     title?: string
-    titleBadges?: Array<{ text: string; color?: string }>
+    titleBadges?: Array<{ text: string; color?: BadgeColor }>
   }
   nodes: Array<Node>
 }) {
-  let tableOfContents = collectSections(nodes)
+  const tableOfContents = collectSections(nodes)
 
   return (
     <>

--- a/apps/routecraft.dev/src/components/HeroBackground.tsx
+++ b/apps/routecraft.dev/src/components/HeroBackground.tsx
@@ -1,7 +1,7 @@
 import { useId } from 'react'
 
 export function HeroBackground(props: React.ComponentPropsWithoutRef<'svg'>) {
-  let id = useId()
+  const id = useId()
 
   return (
     <svg

--- a/apps/routecraft.dev/src/components/Icon.tsx
+++ b/apps/routecraft.dev/src/components/Icon.tsx
@@ -32,8 +32,8 @@ export function Icon({
   color?: keyof typeof iconStyles
   icon: keyof typeof icons
 } & Omit<React.ComponentPropsWithoutRef<'svg'>, 'color'>) {
-  let id = useId()
-  let IconComponent = icons[icon]
+  const id = useId()
+  const IconComponent = icons[icon]
 
   return (
     <svg

--- a/apps/routecraft.dev/src/components/Layout.tsx
+++ b/apps/routecraft.dev/src/components/Layout.tsx
@@ -22,7 +22,7 @@ function GitHubIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
 }
 
 function Header() {
-  let [isScrolled, setIsScrolled] = useState(false)
+  const [isScrolled, setIsScrolled] = useState(false)
 
   useEffect(() => {
     function onScroll() {
@@ -78,8 +78,8 @@ function Header() {
 }
 
 export function Layout({ children }: { children: React.ReactNode }) {
-  let pathname = usePathname()
-  let isHomePage = pathname === '/'
+  const pathname = usePathname()
+  const isHomePage = pathname === '/'
 
   return (
     <div className="flex w-full flex-col">

--- a/apps/routecraft.dev/src/components/MobileNavigation.tsx
+++ b/apps/routecraft.dev/src/components/MobileNavigation.tsx
@@ -39,8 +39,8 @@ function CloseIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
 }
 
 function CloseOnNavigation({ close }: { close: () => void }) {
-  let pathname = usePathname()
-  let searchParams = useSearchParams()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
 
   useEffect(() => {
     close()
@@ -50,11 +50,11 @@ function CloseOnNavigation({ close }: { close: () => void }) {
 }
 
 export function MobileNavigation() {
-  let [isOpen, setIsOpen] = useState(false)
-  let close = useCallback(() => setIsOpen(false), [setIsOpen])
+  const [isOpen, setIsOpen] = useState(false)
+  const close = useCallback(() => setIsOpen(false), [setIsOpen])
 
   function onLinkClick(event: React.MouseEvent<HTMLAnchorElement>) {
-    let link = event.currentTarget
+    const link = event.currentTarget
     if (
       link.pathname + link.search + link.hash ===
       window.location.pathname + window.location.search + window.location.hash

--- a/apps/routecraft.dev/src/components/PrevNextLinks.tsx
+++ b/apps/routecraft.dev/src/components/PrevNextLinks.tsx
@@ -51,12 +51,12 @@ function PageLink({
 }
 
 export function PrevNextLinks() {
-  let rawPathname = usePathname()
-  let pathname = rawPathname === '/' ? '/' : rawPathname.replace(/\/$/, '')
-  let allLinks = navigation.flatMap((section) => section.links)
-  let linkIndex = allLinks.findIndex((link) => link.href === pathname)
-  let previousPage = linkIndex > -1 ? allLinks[linkIndex - 1] : null
-  let nextPage = linkIndex > -1 ? allLinks[linkIndex + 1] : null
+  const rawPathname = usePathname()
+  const pathname = rawPathname === '/' ? '/' : rawPathname.replace(/\/$/, '')
+  const allLinks = navigation.flatMap((section) => section.links)
+  const linkIndex = allLinks.findIndex((link) => link.href === pathname)
+  const previousPage = linkIndex > -1 ? allLinks[linkIndex - 1] : null
+  const nextPage = linkIndex > -1 ? allLinks[linkIndex + 1] : null
 
   if (!nextPage && !previousPage) {
     return null

--- a/apps/routecraft.dev/src/components/Prose.tsx
+++ b/apps/routecraft.dev/src/components/Prose.tsx
@@ -7,7 +7,7 @@ export function Prose<T extends React.ElementType = 'div'>({
 }: React.ComponentPropsWithoutRef<T> & {
   as?: T
 }) {
-  let Component = as ?? 'div'
+  const Component = as ?? 'div'
 
   return (
     <Component

--- a/apps/routecraft.dev/src/components/Search.tsx
+++ b/apps/routecraft.dev/src/components/Search.tsx
@@ -9,7 +9,6 @@ import {
   useId,
   useRef,
   useState,
-  useSyncExternalStore,
 } from 'react'
 import Highlighter from 'react-highlight-words'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -23,6 +22,7 @@ import { Dialog, DialogPanel } from '@headlessui/react'
 import clsx from 'clsx'
 
 import { navigation } from '@/lib/navigation'
+import { useClientValue } from '@/lib/use-client-value'
 import { type Result } from '@/markdoc/search.mjs'
 
 type EmptyObject = Record<string, never>
@@ -47,14 +47,21 @@ function useAutocomplete({
 }: {
   close: (autocomplete: Autocomplete) => void
 }) {
-  let id = useId()
-  let router = useRouter()
-  let [autocompleteState, setAutocompleteState] = useState<
+  const id = useId()
+  const router = useRouter()
+  const [autocompleteState, setAutocompleteState] = useState<
     AutocompleteState<Result> | EmptyObject
   >({})
 
-  let [autocomplete] = useState<Autocomplete>(() => {
-    let instance: Autocomplete
+  const [autocomplete] = useState<Autocomplete>(() => {
+    // `navigate` and the autocomplete instance reference each other:
+    // `createAutocomplete({ navigator: { navigate } })` captures `navigate`,
+    // and `navigate` calls `close(instance)` after a successful navigation.
+    // The library only invokes `navigator.navigate` from user-driven event
+    // handlers (never during construction), so by the time the closure runs
+    // `holder.current` is set. The explicit holder avoids a non-null
+    // assertion and makes the ordering assumption visible.
+    const holder: { current: Autocomplete | null } = { current: null }
 
     function navigate({ itemUrl }: { itemUrl?: string }) {
       if (!itemUrl) {
@@ -65,13 +72,16 @@ function useAutocomplete({
 
       if (
         itemUrl ===
-        window.location.pathname + window.location.search + window.location.hash
+          window.location.pathname +
+            window.location.search +
+            window.location.hash &&
+        holder.current
       ) {
-        close(instance!)
+        close(holder.current)
       }
     }
 
-    instance = createAutocomplete<
+    holder.current = createAutocomplete<
       Result,
       React.SyntheticEvent,
       React.MouseEvent,
@@ -107,14 +117,14 @@ function useAutocomplete({
       },
     })
 
-    return instance
+    return holder.current
   })
 
   return { autocomplete, autocompleteState }
 }
 
 function LoadingIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
-  let id = useId()
+  const id = useId()
 
   return (
     <svg viewBox="0 0 20 20" fill="none" aria-hidden="true" {...props}>
@@ -164,12 +174,12 @@ function SearchResult({
   collection: AutocompleteCollection<Result>
   query: string
 }) {
-  let id = useId()
+  const id = useId()
 
-  let sectionTitle = navigation.find((section) =>
+  const sectionTitle = navigation.find((section) =>
     section.links.find((link) => link.href === result.url.split('#')[0]),
   )?.title
-  let hierarchy = [sectionTitle, result.pageTitle].filter(
+  const hierarchy = [sectionTitle, result.pageTitle].filter(
     (x): x is string => typeof x === 'string',
   )
 
@@ -252,14 +262,14 @@ function SearchResults({
 }
 
 const SearchInput = forwardRef<
-  React.ElementRef<'input'>,
+  HTMLInputElement,
   {
     autocomplete: Autocomplete
     autocompleteState: AutocompleteState<Result> | EmptyObject
     onClose: () => void
   }
 >(function SearchInput({ autocomplete, autocompleteState, onClose }, inputRef) {
-  let inputProps = autocomplete.getInputProps({ inputElement: null })
+  const inputProps = autocomplete.getInputProps({ inputElement: null })
 
   return (
     <div className="group relative flex h-12">
@@ -306,8 +316,8 @@ function CloseOnNavigation({
   close: (autocomplete: Autocomplete) => void
   autocomplete: Autocomplete
 }) {
-  let pathname = usePathname()
-  let searchParams = useSearchParams()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
 
   useEffect(() => {
     close(autocomplete)
@@ -325,17 +335,17 @@ function SearchDialog({
   setOpen: (open: boolean) => void
   className?: string
 }) {
-  let formRef = useRef<React.ElementRef<'form'>>(null)
-  let panelRef = useRef<React.ElementRef<'div'>>(null)
+  const formRef = useRef<HTMLFormElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
   // Tracked as state (not a ref) so the autocomplete library receives the
   // input element via render props. Reading `inputRef.current` during render
   // is flagged by `react-hooks/refs`, and the autocomplete API needs the
   // element to wire up keyboard/focus handling.
-  let [inputElement, setInputElement] = useState<React.ElementRef<
-    typeof SearchInput
-  > | null>(null)
+  const [inputElement, setInputElement] = useState<HTMLInputElement | null>(
+    null,
+  )
 
-  let close = useCallback(
+  const close = useCallback(
     (autocomplete: Autocomplete) => {
       setOpen(false)
       autocomplete.setQuery('')
@@ -343,7 +353,7 @@ function SearchDialog({
     [setOpen],
   )
 
-  let { autocomplete, autocompleteState } = useAutocomplete({
+  const { autocomplete, autocompleteState } = useAutocomplete({
     close() {
       close(autocomplete)
     },
@@ -418,8 +428,8 @@ function SearchDialog({
 }
 
 function useSearchProps() {
-  let buttonRef = useRef<React.ElementRef<'button'>>(null)
-  let [open, setOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const [open, setOpen] = useState(false)
 
   return {
     buttonProps: {
@@ -431,7 +441,7 @@ function useSearchProps() {
     dialogProps: {
       open,
       setOpen: useCallback((open: boolean) => {
-        let { width = 0, height = 0 } =
+        const { width = 0, height = 0 } =
           buttonRef.current?.getBoundingClientRect() ?? {}
         if (!open || (width !== 0 && height !== 0)) {
           setOpen(open)
@@ -442,12 +452,11 @@ function useSearchProps() {
 }
 
 export function Search() {
-  let modifierKey = useSyncExternalStore(
-    () => () => {},
+  const modifierKey = useClientValue<string | undefined>(
     () => (/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? '⌘' : 'Ctrl '),
-    () => undefined,
+    undefined,
   )
-  let { buttonProps, dialogProps } = useSearchProps()
+  const { buttonProps, dialogProps } = useSearchProps()
 
   return (
     <>

--- a/apps/routecraft.dev/src/components/Search.tsx
+++ b/apps/routecraft.dev/src/components/Search.tsx
@@ -9,6 +9,7 @@ import {
   useId,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react'
 import Highlighter from 'react-highlight-words'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -52,23 +53,25 @@ function useAutocomplete({
     AutocompleteState<Result> | EmptyObject
   >({})
 
-  function navigate({ itemUrl }: { itemUrl?: string }) {
-    if (!itemUrl) {
-      return
+  let [autocomplete] = useState<Autocomplete>(() => {
+    let instance: Autocomplete
+
+    function navigate({ itemUrl }: { itemUrl?: string }) {
+      if (!itemUrl) {
+        return
+      }
+
+      router.push(itemUrl)
+
+      if (
+        itemUrl ===
+        window.location.pathname + window.location.search + window.location.hash
+      ) {
+        close(instance!)
+      }
     }
 
-    router.push(itemUrl)
-
-    if (
-      itemUrl ===
-      window.location.pathname + window.location.search + window.location.hash
-    ) {
-      close(autocomplete)
-    }
-  }
-
-  let [autocomplete] = useState<Autocomplete>(() =>
-    createAutocomplete<
+    instance = createAutocomplete<
       Result,
       React.SyntheticEvent,
       React.MouseEvent,
@@ -102,8 +105,10 @@ function useAutocomplete({
           ]
         })
       },
-    }),
-  )
+    })
+
+    return instance
+  })
 
   return { autocomplete, autocompleteState }
 }
@@ -322,7 +327,13 @@ function SearchDialog({
 }) {
   let formRef = useRef<React.ElementRef<'form'>>(null)
   let panelRef = useRef<React.ElementRef<'div'>>(null)
-  let inputRef = useRef<React.ElementRef<typeof SearchInput>>(null)
+  // Tracked as state (not a ref) so the autocomplete library receives the
+  // input element via render props. Reading `inputRef.current` during render
+  // is flagged by `react-hooks/refs`, and the autocomplete API needs the
+  // element to wire up keyboard/focus handling.
+  let [inputElement, setInputElement] = useState<React.ElementRef<
+    typeof SearchInput
+  > | null>(null)
 
   let close = useCallback(
     (autocomplete: Autocomplete) => {
@@ -375,11 +386,11 @@ function SearchDialog({
               <form
                 ref={formRef}
                 {...autocomplete.getFormProps({
-                  inputElement: inputRef.current,
+                  inputElement,
                 })}
               >
                 <SearchInput
-                  ref={inputRef}
+                  ref={setInputElement}
                   autocomplete={autocomplete}
                   autocompleteState={autocompleteState}
                   onClose={() => setOpen(false)}
@@ -431,14 +442,12 @@ function useSearchProps() {
 }
 
 export function Search() {
-  let [modifierKey, setModifierKey] = useState<string>()
+  let modifierKey = useSyncExternalStore(
+    () => () => {},
+    () => (/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? '⌘' : 'Ctrl '),
+    () => undefined,
+  )
   let { buttonProps, dialogProps } = useSearchProps()
-
-  useEffect(() => {
-    setModifierKey(
-      /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? '⌘' : 'Ctrl ',
-    )
-  }, [])
 
   return (
     <>

--- a/apps/routecraft.dev/src/components/TableOfContents.tsx
+++ b/apps/routecraft.dev/src/components/TableOfContents.tsx
@@ -12,19 +12,19 @@ export function TableOfContents({
 }: {
   tableOfContents: Array<Section>
 }) {
-  let [currentSection, setCurrentSection] = useState(tableOfContents[0]?.id)
+  const [currentSection, setCurrentSection] = useState(tableOfContents[0]?.id)
 
-  let getHeadings = useCallback((tableOfContents: Array<Section>) => {
+  const getHeadings = useCallback((tableOfContents: Array<Section>) => {
     return tableOfContents
       .flatMap((node) => [node.id, ...node.children.map((child) => child.id)])
       .map((id) => {
-        let el = document.getElementById(id)
+        const el = document.getElementById(id)
         if (!el) return null
 
-        let style = window.getComputedStyle(el)
-        let scrollMt = parseFloat(style.scrollMarginTop)
+        const style = window.getComputedStyle(el)
+        const scrollMt = parseFloat(style.scrollMarginTop)
 
-        let top = window.scrollY + el.getBoundingClientRect().top - scrollMt
+        const top = window.scrollY + el.getBoundingClientRect().top - scrollMt
         return { id, top }
       })
       .filter((x): x is { id: string; top: number } => x !== null)
@@ -32,11 +32,11 @@ export function TableOfContents({
 
   useEffect(() => {
     if (tableOfContents.length === 0) return
-    let headings = getHeadings(tableOfContents)
+    const headings = getHeadings(tableOfContents)
     function onScroll() {
-      let top = window.scrollY
+      const top = window.scrollY
       let current = headings[0].id
-      for (let heading of headings) {
+      for (const heading of headings) {
         if (top >= heading.top - 10) {
           current = heading.id
         } else {
@@ -88,7 +88,7 @@ export function TableOfContents({
                       {section.title}
                     </Link>
                     {section.badges?.map((b, i) => (
-                      <Badge key={i} color={(b.color as any) ?? 'yellow'}>
+                      <Badge key={i} color={b.color ?? 'yellow'}>
                         {b.text}
                       </Badge>
                     ))}
@@ -112,10 +112,7 @@ export function TableOfContents({
                               {subSection.title}
                             </Link>
                             {subSection.badges?.map((b, i) => (
-                              <Badge
-                                key={i}
-                                color={(b.color as any) ?? 'yellow'}
-                              >
+                              <Badge key={i} color={b.color ?? 'yellow'}>
                                 {b.text}
                               </Badge>
                             ))}

--- a/apps/routecraft.dev/src/components/ThemeSelector.tsx
+++ b/apps/routecraft.dev/src/components/ThemeSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
 import { useTheme } from 'next-themes'
 import {
   Label,
@@ -55,11 +55,11 @@ export function ThemeSelector(
   props: React.ComponentPropsWithoutRef<typeof Listbox<'div'>>,
 ) {
   let { theme, setTheme } = useTheme()
-  let [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  let mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  )
 
   if (!mounted) {
     return <div className="h-6 w-6" />

--- a/apps/routecraft.dev/src/components/ThemeSelector.tsx
+++ b/apps/routecraft.dev/src/components/ThemeSelector.tsx
@@ -1,5 +1,6 @@
-import { useSyncExternalStore } from 'react'
 import { useTheme } from 'next-themes'
+
+import { useClientValue } from '@/lib/use-client-value'
 import {
   Label,
   Listbox,
@@ -54,12 +55,8 @@ function SystemIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
 export function ThemeSelector(
   props: React.ComponentPropsWithoutRef<typeof Listbox<'div'>>,
 ) {
-  let { theme, setTheme } = useTheme()
-  let mounted = useSyncExternalStore(
-    () => () => {},
-    () => true,
-    () => false,
-  )
+  const { theme, setTheme } = useTheme()
+  const mounted = useClientValue(() => true, false)
 
   if (!mounted) {
     return <div className="h-6 w-6" />

--- a/apps/routecraft.dev/src/lib/sections.ts
+++ b/apps/routecraft.dev/src/lib/sections.ts
@@ -1,6 +1,8 @@
 import { type Node } from '@markdoc/markdoc'
 import { slugifyWithCounter } from '@sindresorhus/slugify'
 
+import { type BadgeColor } from '@/components/Badge'
+
 interface HeadingNode extends Node {
   type: 'heading'
   attributes: {
@@ -39,39 +41,23 @@ function isH3Node(node: Node): node is H3Node {
   return isHeadingNode(node) && node.attributes.level === 3
 }
 
-function getNodeText(node: Node) {
-  let text = ''
-  for (let child of node.children ?? []) {
-    if (child.type === 'text') {
-      text += child.attributes.content
-    }
-    text += getNodeText(child)
-  }
-  return text
-}
-
 function extractHeadingContent(node: Node): {
   title: string
-  badges: Array<{ text: string; color?: string }>
+  badges: Array<{ text: string; color?: BadgeColor }>
 } {
   let title = ''
-  let badges: Array<{ text: string; color?: string }> = []
+  const badges: Array<{ text: string; color?: BadgeColor }> = []
 
-  for (let child of node.children ?? []) {
+  for (const child of node.children ?? []) {
     if (child.type === 'text') {
-      title += String((child as any).attributes?.content ?? '')
+      title += String(child.attributes?.content ?? '')
       continue
     }
 
-    const isTag = child.type === 'tag'
-    const tagName = isTag
-      ? ((child as any).name ?? (child as any).tag)
-      : undefined
-
-    if (isTag && tagName === 'badge') {
+    if (child.type === 'tag' && child.tag === 'badge') {
       // Extract inner text for badge label, do not include in title
       const inner = extractHeadingContent(child)
-      const color = (child as any).attributes?.color as string | undefined
+      const color = child.attributes?.color as BadgeColor | undefined
       const text = inner.title.trim()
       if (text) badges.push({ text, color })
       continue
@@ -89,14 +75,14 @@ function extractHeadingContent(node: Node): {
 export type Subsection = H3Node['attributes'] & {
   id: string
   title: string
-  badges?: Array<{ text: string; color?: string }>
+  badges?: Array<{ text: string; color?: BadgeColor }>
   children?: undefined
 }
 
 export type Section = H2Node['attributes'] & {
   id: string
   title: string
-  badges?: Array<{ text: string; color?: string }>
+  badges?: Array<{ text: string; color?: BadgeColor }>
   children: Array<Subsection>
 }
 
@@ -104,13 +90,13 @@ export function collectSections(
   nodes: Array<Node>,
   slugify = slugifyWithCounter(),
 ) {
-  let sections: Array<Section> = []
+  const sections: Array<Section> = []
 
-  for (let node of nodes) {
+  for (const node of nodes) {
     if (isH2Node(node) || isH3Node(node)) {
       const { title, badges } = extractHeadingContent(node)
       if (title) {
-        let id = slugify(title)
+        const id = slugify(title)
         if (isH3Node(node)) {
           if (!sections[sections.length - 1]) {
             throw new Error(

--- a/apps/routecraft.dev/src/lib/use-client-value.ts
+++ b/apps/routecraft.dev/src/lib/use-client-value.ts
@@ -1,0 +1,17 @@
+import { useSyncExternalStore } from 'react'
+
+const subscribe = () => () => {}
+
+/**
+ * Returns `getClientValue()` after hydration and `serverValue` during SSR /
+ * the initial client render. Replaces the legacy
+ * `useState(false) + useEffect(() => setMounted(true), [])` hydration guard,
+ * which is now flagged by the `react-hooks/set-state-in-effect` rule shipped
+ * in eslint-plugin-react-hooks v6 (bundled with eslint-config-next 16).
+ *
+ * The client snapshot is lazy so callers can read browser-only globals
+ * (`navigator`, `window`, ...) without crashing on the server.
+ */
+export function useClientValue<T>(getClientValue: () => T, serverValue: T): T {
+  return useSyncExternalStore(subscribe, getClientValue, () => serverValue)
+}

--- a/apps/routecraft.dev/tsconfig.json
+++ b/apps/routecraft.dev/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -23,6 +23,12 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "fast-glob": "^3.3.3",
         "flexsearch": "^0.8.212",
         "js-yaml": "^4.1.1",
-        "next": "^15.5.15",
+        "next": "^16.2.4",
         "next-themes": "^0.4.6",
         "posthog-js": "^1.372.6",
         "prism-react-renderer": "^2.4.1",
@@ -64,7 +64,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.39.4",
-        "eslint-config-next": "^15.5.15",
+        "eslint-config-next": "^16.2.4",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.7.4",
         "sharp": "^0.34.5",
@@ -362,11 +362,35 @@
 
     "@ark/util": ["@ark/util@0.56.0", "", {}, "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="],
 
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.3", "", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
     "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
@@ -600,25 +624,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
-    "@next/env": ["@next/env@15.5.15", "", {}, "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg=="],
+    "@next/env": ["@next/env@16.2.4", "", {}, "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw=="],
 
-    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.5.15", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA=="],
+    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.4", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.15", "", { "os": "win32", "cpu": "x64" }, "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -797,8 +821,6 @@
     "@routecraft/testing": ["@routecraft/testing@workspace:packages/testing"],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
-
-    "@rushstack/eslint-patch": ["@rushstack/eslint-patch@1.16.1", "", {}, "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag=="],
 
     "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
@@ -1122,6 +1144,8 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.27", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA=="],
+
     "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
 
     "better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
@@ -1143,6 +1167,8 @@
     "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
@@ -1352,6 +1378,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.349", "", {}, "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "emojis-list": ["emojis-list@3.0.0", "", {}, "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="],
@@ -1404,7 +1432,7 @@
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
-    "eslint-config-next": ["eslint-config-next@15.5.15", "", { "dependencies": { "@next/eslint-plugin-next": "15.5.15", "@rushstack/eslint-patch": "^1.10.3", "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0", "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.31.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^5.0.0" }, "peerDependencies": { "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-mI5KIONOIosjF3jK2z9a8fY2LePNeW5C4lRJ+XZoJHAKkwx2MQjMPQ2/kL7tsMRPcQPZc/UBtCfqxElluL1CBg=="],
+    "eslint-config-next": ["eslint-config-next@16.2.4", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.4", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 
@@ -1420,7 +1448,7 @@
 
     "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
 
-    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@5.2.0", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg=="],
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
@@ -1548,6 +1576,8 @@
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "get-amd-module-type": ["get-amd-module-type@6.0.2", "", { "dependencies": { "ast-module-types": "^6.0.1", "node-source-walk": "^7.0.1" } }, "sha512-7zShVYAYtMnj9S65CfN+hvpBCByfuB1OY8xID01nZEzXTZbx4YyysAfi+nMl95JSR6odt4q8TCj2W63KAoyVLQ=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
@@ -1611,6 +1641,10 @@
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "highlight-words-core": ["highlight-words-core@1.2.3", "", {}, "sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ=="],
 
@@ -1763,6 +1797,8 @@
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -1942,13 +1978,15 @@
 
     "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
 
-    "next": ["next@15.5.15", "", { "dependencies": { "@next/env": "15.5.15", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.15", "@next/swc-darwin-x64": "15.5.15", "@next/swc-linux-arm64-gnu": "15.5.15", "@next/swc-linux-arm64-musl": "15.5.15", "@next/swc-linux-x64-gnu": "15.5.15", "@next/swc-linux-x64-musl": "15.5.15", "@next/swc-win32-arm64-msvc": "15.5.15", "@next/swc-win32-x64-msvc": "15.5.15", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ=="],
+    "next": ["next@16.2.4", "", { "dependencies": { "@next/env": "16.2.4", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.4", "@next/swc-darwin-x64": "16.2.4", "@next/swc-linux-arm64-gnu": "16.2.4", "@next/swc-linux-arm64-musl": "16.2.4", "@next/swc-linux-x64-gnu": "16.2.4", "@next/swc-linux-x64-musl": "16.2.4", "@next/swc-win32-arm64-msvc": "16.2.4", "@next/swc-win32-x64-msvc": "16.2.4", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "node-abi": ["node-abi@3.90.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA=="],
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
+
+    "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
     "node-simctl": ["node-simctl@7.7.5", "", { "dependencies": { "@appium/logger": "^1.3.0", "asyncbox": "^3.0.0", "bluebird": "^3.5.1", "lodash": "^4.2.1", "rimraf": "^5.0.0", "semver": "^7.0.0", "source-map-support": "^0.x", "teen_process": "^2.2.0", "uuid": "^11.0.1", "which": "^5.0.0" } }, "sha512-lWflzDW9xLuOOvR6mTJ9efbDtO/iSCH6rEGjxFxTV0vGgz5XjoZlW2BkNCCZib0B6Y23tCOiYhYJaMQYB8FKIQ=="],
 
@@ -2466,6 +2504,8 @@
 
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
@@ -2550,7 +2590,17 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
     "@appium/logger/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -2665,6 +2715,8 @@
     "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "eslint-config-next/globals": ["globals@16.4.0", "", {}, "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
@@ -2831,6 +2883,8 @@
     "yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "zip-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 


### PR DESCRIPTION
## Summary
This PR upgrades the routecraft.dev app to Next.js 16, modernizes the codebase to align with current React and Next.js best practices, and improves type safety throughout the application.

## Key Changes

### Next.js and Dependencies
- Upgraded Next.js from 15.5.15 to 16.2.4
- Updated eslint-config-next to 16.2.4
- Added `--webpack` flag to dev and build scripts (required for markdoc loader pipeline compatibility with Next.js 16)
- Updated next.config.mjs with webpack requirement documentation and markdoc configuration adjustments

### Code Quality and Type Safety
- Replaced all `let` declarations with `const` throughout the codebase for better immutability practices
- Extracted `BadgeColor` type to a dedicated export in Badge.tsx and used it consistently across components (DocsHeader, DocsLayout, TableOfContents, sections.ts)
- Improved TypeScript ref typing by replacing `React.ElementRef<'element'>` with concrete types like `HTMLInputElement`, `HTMLFormElement`, etc.
- Removed unnecessary type assertions (`as any`) in Badge color handling

### Hydration and Client-Side Logic
- Created new `useClientValue` hook using `useSyncExternalStore` to replace the legacy `useState(false) + useEffect` hydration pattern
- Applied the new hook to Search.tsx (modifier key detection) and ThemeSelector.tsx
- This addresses the `react-hooks/set-state-in-effect` rule from eslint-plugin-react-hooks v6

### Search Component Refactoring
- Refactored `useAutocomplete` hook to properly manage autocomplete instance lifecycle using a holder pattern
- Changed SearchInput ref from callback ref to state-based tracking (`inputElement` state) to comply with react-hooks/refs rules while maintaining autocomplete library compatibility
- Added detailed comments explaining the closure and holder pattern

### Linting Configuration
- Migrated from .eslintrc.json to eslint.config.mjs (flat config format)
- Updated lint script to use `eslint .` instead of `next lint`
- Added ignores for .next, out, and public/raw directories

### TypeScript Configuration
- Changed JSX setting from "preserve" to "react-jsx" (modern JSX transform)
- Added .next/dev/types to include paths for Next.js 16 compatibility

### Documentation Updates
- Updated MCP server command examples from `npx` to `bunx` in multiple documentation files
- Removed experimental warning from shutdownHandler documentation
- Updated homepage example command to use `bunx`

### Dependency Management
- Switched Dependabot from npm to bun package manager
- Reduced open-pull-requests-limit from 10 to 3
- Added semver cooldown periods for minor and patch updates

https://claude.ai/code/session_01NJbMQ7QRNwVi1o9JybqRMY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades routecraft.dev to `next` 16.2.4 and cleans up linting, types, and client-only logic. Builds run with Webpack to keep the Markdoc loader chain working in Next 16.

- **Dependencies**
  - Upgrade `next` to 16.2.4 and `eslint-config-next` to 16; dev/build scripts now pass `--webpack`.
  - Migrate to flat ESLint config (`eslint.config.mjs`) with `eslint-config-next/core-web-vitals` and `eslint-config-next/typescript`; switch lint script to `eslint .`.
  - Update `next.config.mjs` for `@markdoc/next.js` with `nextjsExports: []` and inline docs on the Webpack requirement.
  - TypeScript: `jsx: react-jsx`; include `.next/dev/types`; add `**/next-env.d.ts` to Prettier ignore.
  - Dependabot: switch to Bun ecosystem, limit PRs to 3, add minor/patch cooldowns.

- **Refactors**
  - Add `useClientValue` (via `useSyncExternalStore`) and use it in Search modifier-key detection and ThemeSelector.
  - Search: fix autocomplete lifecycle with an explicit holder; track the input element in state to satisfy hooks/refs rules.
  - Prefer `const`; extract `BadgeColor` type and remove casts; tighten refs to concrete `HTML*Element`; tidy Markdoc heading parsing.
  - Docs: prefer `bunx` over `npx`; remove “experimental” labels for `.authorize()` and `shutdownHandler`.

<sup>Written for commit 5085d0bffebd489e07e8801508b27402846e2874. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

