### PR TITLE
fix(example): correct JWT placeholders and drop unused OPENROUTER_API_KEY

### DIFF
--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,7 +1,7 @@
 # MCP plugin -- used by the MCP adapter to expose routes as tools
-JWT_ISSUER=change-me
-JWT_AUDIENCE=https://idp.example.com
-JWT_SECRET=https://mcp.example.com
+JWT_ISSUER=https://idp.example.com
+JWT_AUDIENCE=https://mcp.example.com
+JWT_SECRET=change-me-to-a-strong-random-secret
 
 # Mail adapter -- Gmail IMAP/SMTP (requires an App Password, not your login password)
 MAIL_USER=you@gmail.com
@@ -11,4 +11,3 @@ NOTIFY_TO=you@gmail.com
 
 # LLM plugin -- API keys for model providers used by the llm() adapter
 GEMINI_API_KEY=AIza
-OPENROUTER_API_KEY=sk-or-v1

--- a/examples/src/env.ts
+++ b/examples/src/env.ts
@@ -7,7 +7,6 @@ const envSchema = z.object({
   MAIL_USER: z.string().min(1),
   MAIL_APP_PASSWORD: z.string().min(1),
   GEMINI_API_KEY: z.string().min(1),
-  OPENROUTER_API_KEY: z.string().min(1),
 });
 
 export const env = envSchema.parse(process.env);


### PR DESCRIPTION
## Summary

Two leftover follow-ups to the merged #263 (`feat(example): agent example`) that never made it back to `main`. Cherry-picked from the now-stale `claude/address-pr-263-comments-j6LFv` branch (rebased fresh on `main`); the other fixes on that branch were superseded by later PRs.

### 1. JWT placeholders in the wrong slots

`examples/.env.example` currently ships:

```
JWT_ISSUER=change-me
JWT_AUDIENCE=https://idp.example.com
JWT_SECRET=https://mcp.example.com
```

The `if (!JWT_SECRET)` guard in `craft.config.ts` only checks emptiness, so the URL passes and the example "works", but anyone copying the file is taught that a URL is a fine HMAC secret. They end up signing tokens with a publicly visible string. Rotated into the right slots:

```
JWT_ISSUER=https://idp.example.com
JWT_AUDIENCE=https://mcp.example.com
JWT_SECRET=change-me-to-a-strong-random-secret
```

### 2. Required-but-unused `OPENROUTER_API_KEY`

`examples/src/env.ts` declares `OPENROUTER_API_KEY: z.string().min(1)` and `.env.example` ships a placeholder for it, but nothing in `craft.config.ts` registers an openrouter provider. The variable is consumed nowhere. A user who customises their `.env` and removes the key crashes at startup on a value the example never reads. Dropped from the schema and the example file.

## Test plan

- [ ] `bun run typecheck` clean.
- [ ] `bun run lint` clean.
- [ ] `bun run build` clean.
- [ ] `bun run test` green.
- [ ] Reviewer sanity-checks the JWT slot rotation against the issuer/audience values used by the MCP example route.


---
_Generated by [Claude Code](https://claude.ai/code/session_017WmgJqrz13sa3GpkXJ3tkN)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the JWT placeholders in the example env and removes the unused `OPENROUTER_API_KEY` from the schema. Prevents weak JWT secrets and startup failures when the unused key is omitted.

- **Migration**
  - Update your example `.env`: set JWT_ISSUER to your IdP URL, JWT_AUDIENCE to your MCP URL, and choose a strong random JWT_SECRET.
  - Remove OPENROUTER_API_KEY from your `.env`; it’s not used or validated.

<sup>Written for commit 104785c7a10e9ee4d53c8e9ca4b7130d25c196aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

