### PR TITLE
ci: defensive bun install after cache restore (fix tar exit 2 flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,13 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
+      # Defensive: cache restore can corrupt node_modules under tar
+      # contention (parallel jobs), surfacing as "tar exit 2". Re-run
+      # bun install to ensure node_modules matches bun.lock; this is
+      # fast (~1-2s) when the cache restored cleanly.
+      - name: Verify dependencies
+        run: bun install --frozen-lockfile
+
       - name: Run checks
         run: |
           bun run format
@@ -163,6 +170,13 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
+
+      # Defensive: cache restore can corrupt node_modules under tar
+      # contention (parallel jobs), surfacing as "tar exit 2". Re-run
+      # bun install to ensure node_modules matches bun.lock; this is
+      # fast (~1-2s) when the cache restored cleanly.
+      - name: Verify dependencies
+        run: bun install --frozen-lockfile
 
       - name: Run tests
         run: bun run test:coverage
@@ -198,6 +212,13 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
+
+      # Defensive: cache restore can corrupt node_modules under tar
+      # contention (parallel jobs), surfacing as "tar exit 2". Re-run
+      # bun install to ensure node_modules matches bun.lock; this is
+      # fast (~1-2s) when the cache restored cleanly.
+      - name: Verify dependencies
+        run: bun install --frozen-lockfile
 
       - name: Build packages
         run: bun run build
@@ -240,6 +261,13 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
+
+      # Defensive: cache restore can corrupt node_modules under tar
+      # contention (parallel jobs), surfacing as "tar exit 2". Re-run
+      # bun install to ensure node_modules matches bun.lock; this is
+      # fast (~1-2s) when the cache restored cleanly.
+      - name: Verify dependencies
+        run: bun install --frozen-lockfile
 
       - name: Restore build artifacts
         uses: actions/cache@v5
@@ -300,6 +328,13 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
+      # Defensive: cache restore can corrupt node_modules under tar
+      # contention (parallel jobs), surfacing as "tar exit 2". Re-run
+      # bun install to ensure node_modules matches bun.lock; this is
+      # fast (~1-2s) when the cache restored cleanly.
+      - name: Verify dependencies
+        run: bun install --frozen-lockfile
+
       - name: Restore build artifacts
         uses: actions/cache@v5
         with:
@@ -359,6 +394,13 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
+      # Defensive: cache restore can corrupt node_modules under tar
+      # contention (parallel jobs), surfacing as "tar exit 2". Re-run
+      # bun install to ensure node_modules matches bun.lock; this is
+      # fast (~1-2s) when the cache restored cleanly.
+      - name: Verify dependencies
+        run: bun install --frozen-lockfile
+
       - name: Restore build artifacts
         uses: actions/cache@v5
         with:
@@ -404,6 +446,13 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
+
+      # Defensive: cache restore can corrupt node_modules under tar
+      # contention (parallel jobs), surfacing as "tar exit 2". Re-run
+      # bun install to ensure node_modules matches bun.lock; this is
+      # fast (~1-2s) when the cache restored cleanly.
+      - name: Verify dependencies
+        run: bun install --frozen-lockfile
 
       - name: Restore build artifacts
         uses: actions/cache@v5
@@ -527,6 +576,13 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
+
+      # Defensive: cache restore can corrupt node_modules under tar
+      # contention (parallel jobs), surfacing as "tar exit 2". Re-run
+      # bun install to ensure node_modules matches bun.lock; this is
+      # fast (~1-2s) when the cache restored cleanly.
+      - name: Verify dependencies
+        run: bun install --frozen-lockfile
 
       - name: Restore build artifacts
         uses: actions/cache@v5


### PR DESCRIPTION
## What

After every `Restore node_modules` cache step, run `bun install --frozen-lockfile` defensively. On a clean restore this is ~1-2s and a no-op (lockfile already satisfied). On a partial restore (or cache miss) it self-heals.

## Why

PR CI runs have been hitting `Failed to restore: '/usr/bin/tar' failed with exit code 2` repeatedly. Multiple parallel jobs (validate, test, build, scaffolder-smoke, embedding-smoke, adapter-cross-runtime) restoring from the same cache key concurrently appear to race the tar extraction. `actions/cache@v5` treats the failure as a soft warning and the job continues with a partial `node_modules`, after which the actual test failure looks like an unrelated bug — the most common surface is `jose`'s webapi JWKS loader throwing `TypeError: undefined is not an object (evaluating 'fetchImpl(url, ...)')` because `dist/webapi/jwks/remote.js` wasn't unpacked.

## How

Every job that has a `Restore node_modules` step now has a follow-up `Verify dependencies` step that runs `bun install --frozen-lockfile`. Eight jobs total:

- `validate`, `test`, `build`
- `scaffolder-smoke`, `embedding-smoke`, `adapter-cross-runtime`
- `publish-canary`, `publish`

The `setup` job already runs install (it's the producer that seeds the cache), no change needed there.

## Tradeoff

Adds ~1-2 seconds per job on clean cache hits. ~16s total per workflow run when everything's good. In exchange, the recurring tar-exit-2 flake stops blocking PRs.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly.
- [x] `bun run format` clean.
- [ ] Real verification arrives once this lands and a flaky-cache run no longer fails downstream tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJGLj5rX8p5eZV41vPQJKq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a defensive `bun install --frozen-lockfile` after each node_modules cache restore to fix flaky restores from parallel CI tar failures. This self-heals partial `node_modules` and stabilizes PR runs, with ~1–2s overhead per job on clean hits.

- **Bug Fixes**
  - Run the verify step after “Restore node_modules” in: `validate`, `test`, `build`, `scaffolder-smoke`, `embedding-smoke`, `adapter-cross-runtime`, `publish-canary`, `publish` (no change to `setup`).
  - Prevents partial restores from `actions/cache@v5` under tar contention (“tar exit 2”), which led to unrelated failures (e.g., missing `jose` files).

<sup>Written for commit 21d1b9933b19306dd6b35ba9ffd0ae7663b317d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

