### PR TITLE
test: fix two skipped bun:test tests (mcp 401 + batch:stopped)

### DIFF
--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -812,6 +812,15 @@ export class McpServer {
         }
         this.httpSessions.clear();
 
+        // Force-close any lingering connections (e.g. SSE streams that keep
+        // the socket open indefinitely). closeAllConnections() is available
+        // in Node 18.2+ and Bun; without it, server.close() would hang
+        // forever waiting for long-lived SSE connections to drain.
+        const srv = this.httpServer as unknown as Record<string, unknown>;
+        if (typeof srv["closeAllConnections"] === "function") {
+          (srv["closeAllConnections"] as () => void)();
+        }
+
         await new Promise<void>((resolve) => {
           this.httpServer!.close(() => resolve());
         });

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -849,10 +849,7 @@ describe("McpServer", () => {
        *                dynamically wired plugin or `as any` escape hatch in user code)
        * @expectedResult HTTP 401 response; auth:rejected event emitted with reason "missing_expires_at"
        */
-      // Skip: bun 1.3.11 + MCP SSE transport leaves the response stream open even
-      // for 401 rejections, so r.on("end") never fires and afterEach times out.
-      // The runtime guard is exercised by server-unit tests. Re-enable once resolved.
-      test.skip("rejects principal without expiresAt and emits auth:rejected", async () => {
+      test("rejects principal without expiresAt and emits auth:rejected", async () => {
         const { oauth } = await import("../src/mcp/oauth.ts");
 
         const rejections: Array<Record<string, unknown>> = [];
@@ -898,12 +895,14 @@ describe("McpServer", () => {
         await server.start();
         const port = server.getHttpPort()!;
 
-        // Use Accept: application/json (not text/event-stream) so the server
-        // sends a plain JSON error response and closes the connection. An SSE
-        // Accept causes the MCP transport to keep the response stream open even
-        // for 401 rejections, making r.on("end") never fire.
+        // Resolve as soon as response headers arrive -- the statusCode is
+        // available immediately, and we don't need the body. Destroy the
+        // socket right after to close the connection on both sides; otherwise
+        // the MCP SSE transport holds the connection open and server.stop()
+        // blocks waiting for all connections to drain.
         const res = await new Promise<{ statusCode: number }>(
           (resolve, reject) => {
+            let resolved = false;
             const req = http.request(
               {
                 host: "127.0.0.1",
@@ -918,15 +917,15 @@ describe("McpServer", () => {
                 },
               },
               (r) => {
-                let body = "";
-                r.on("data", (chunk) => (body += chunk));
-                r.on("end", () => {
-                  r.socket?.destroy();
-                  resolve({ statusCode: r.statusCode ?? 0 });
-                });
+                resolved = true;
+                resolve({ statusCode: r.statusCode ?? 0 });
+                r.resume();
+                r.socket?.destroy();
               },
             );
-            req.on("error", reject);
+            req.on("error", (err) => {
+              if (!resolved) reject(err);
+            });
             req.write(
               JSON.stringify({
                 jsonrpc: "2.0",

--- a/packages/routecraft/test/batch.bun.test.ts
+++ b/packages/routecraft/test/batch.bun.test.ts
@@ -5,7 +5,7 @@ import { CraftContext } from "../src/context.ts";
 import { InMemoryProcessingQueue } from "../src/queue.ts";
 import type { Exchange } from "../src/exchange.ts";
 import type { RouteDefinition } from "../src/route.ts";
-import type { Message } from "../src/types.ts";
+import type { EventName, Message } from "../src/types.ts";
 
 function createRouteDefinition(id: string): RouteDefinition {
   return {
@@ -273,5 +273,46 @@ describe("BatchConsumer", () => {
     // One merged invocation; last-wins on the principal header.
     expect(calls).toHaveLength(1);
     expect(calls[0].principal).toEqual(principalB);
+  });
+
+  /**
+   * @case batch:stopped is emitted when the route stopping signal fires
+   * @preconditions BatchConsumer registered; route:stopping emitted for the same route id
+   * @expectedResult batch:stopped event fires with routeId and batchId
+   */
+  test("emits batch:stopped when route:stopping fires for the same route", async () => {
+    const routeId = "batched-stopped-route";
+    const ctx = new CraftContext();
+    const queue = new InMemoryProcessingQueue<Message>();
+    const consumer = new BatchConsumer(
+      ctx,
+      createRouteDefinition(routeId),
+      queue,
+      { size: 10, time: 50 },
+    );
+
+    const stopped: unknown[] = [];
+    ctx.on(`route:${routeId}:batch:stopped` as EventName, ({ details }) => {
+      stopped.push(details);
+    });
+
+    await consumer.register(async (message) => {
+      return {
+        id: "exchange-id",
+        body: message,
+        headers: {},
+        logger: ctx.logger,
+      } as Exchange;
+    });
+
+    ctx.emit(
+      `route:${routeId}:stopping` as EventName,
+      {
+        route: { definition: { id: routeId } },
+      } as never,
+    );
+
+    expect(stopped).toHaveLength(1);
+    expect(stopped[0]).toMatchObject({ routeId });
   });
 });

--- a/packages/routecraft/test/events.bun.test.ts
+++ b/packages/routecraft/test/events.bun.test.ts
@@ -402,18 +402,8 @@ describe("Events API", () => {
     expect(events.filter((e) => e.includes("context")).length).toBe(0);
   });
 
-  /**
-   * @case batch:stopped is emitted when route with batch consumer stops
-   * @preconditions Route with batch consumer
-   * @expectedResult batch:stopped event fires when route stops
-   *
-   * NOTE: This test is manually verified via integration tests. The batch:stopped event
-   * is correctly emitted in batch.ts when route:stopping is fired. Automated testing is
-   * challenging due to test context lifecycle timing.
-   */
-  test.skip("emits batch:stopped when batch consumer route stops", async () => {
-    // Implementation verified in batch.ts - event emitted when route:stopping fires
-  });
+  // batch:stopped is covered by the BatchConsumer unit test in batch.bun.test.ts,
+  // which emits route:stopping directly to avoid integration lifecycle races.
 
   /**
    * @case once via builder fires exactly once


### PR DESCRIPTION
## Summary

Two tests were left as `test.skip` in the bun:test migration (#308) because they couldn't pass as-is. This PR resolves both.

- **`mcp-server.bun.test.ts` — "rejects principal without expiresAt and emits auth:rejected"**: The test was hanging because `McpServer.stop()` called `httpServer.close()` which waited indefinitely for the SSE connection to drain. Fixed by calling `closeAllConnections()` on the HTTP server before `close()` in `McpServer.stop()` (production correctness fix), and updating the test to resolve on headers arrival + destroy the socket instead of waiting for `r.on("end")` which never fires on an SSE stream.

- **`events.bun.test.ts` — "emits batch:stopped when batch consumer route stops"**: The original test used the full route lifecycle but the `batch:stopped` listener is registered inside `register()`, creating a race where a synchronous source completes before the listener is in place. Moved to `batch.bun.test.ts` as a unit test that uses `ctx.emit()` to trigger the stopping event directly, bypassing the race entirely.

## Test plan

- [ ] `bun test packages/ai/test/mcp-server.bun.test.ts` — previously skipped test now passes
- [ ] `bun test packages/routecraft/test/batch.bun.test.ts` — new `batch:stopped` test passes
- [ ] `bun test packages/routecraft/test/events.bun.test.ts` — no regressions, skipped test replaced with comment
- [ ] Full suite: `bun run test` — 0 skipped

https://claude.ai/code/session_01EkLMCJ1DTf98aZYNUESrcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkLMCJ1DTf98aZYNUESrcx)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unskipped two tests by fixing SSE shutdown behavior and rewriting the batch stop test to avoid a race. Also adds a production fix so `McpServer.stop()` doesn’t hang when SSE connections are open.

- **Bug Fixes**
  - Prevent server shutdown hang by calling `closeAllConnections()` before `close()` in `McpServer.stop()` (handles long-lived SSE connections).
  - Update the 401 rejection test to resolve on headers and destroy the socket, instead of waiting for `end` on an SSE stream.
  - Move the `batch:stopped` check to a unit test in `batch.bun.test.ts` using `ctx.emit('route:stopping')`, and replace the skipped integration test with a comment.

<sup>Written for commit 45b331b876eace7a55fe0d20c82b7cbf9655228e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

