### PR TITLE
Support distinct input/output types in direct adapter

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -246,6 +246,9 @@ direct(options?: Partial<DirectServerOptions>): Source<unknown>
 
 // Destination (names a target route)
 direct<T>(endpoint: string | ((exchange: Exchange<T>) => string)): Destination<T, T>
+
+// Destination with explicit input != output (e.g. in-process agent call)
+direct<TInput, TOutput>(endpoint: string): Destination<TInput, TOutput>
 ```
 
 Enable synchronous inter-route communication. Perfect for composable route architectures where you need request-response patterns. The source form uses the route's `.id()` as the endpoint name; destinations address the target by id.
@@ -311,6 +314,14 @@ craft()
   .input({ body: z.object({ query: z.string() }) })
   .from(direct())
   .process(fetchSnippets)
+
+// Destination where the callee returns a different body shape than the caller sends.
+// Supply two type arguments to express the response shape (e.g. an in-process agent).
+craft()
+  .id('agent-caller')
+  .from(httpSource)
+  .transform((body) => ({ name: body.agent, query: body.text }))
+  .enrich(direct<{ name: string; query: string }, AgentResult>('agent'))
 ```
 
 **Source options (adapter-specific only):**

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -244,12 +244,19 @@ Options:
 // layer; schemas live on the route builder via `.input()` / `.output()`.
 direct(options?: Partial<DirectServerOptions>): Source<unknown>
 
+// Destination (registry-aware: body type resolves from DirectEndpointRegistry when populated)
+direct<K extends RegisteredDirectEndpoint>(endpoint: K): Destination<ResolveBody<DirectEndpointRegistry, K>, unknown>
+
 // Destination (names a target route)
 direct<T>(endpoint: string | ((exchange: Exchange<T>) => string)): Destination<T, T>
 
 // Destination with explicit input != output (e.g. in-process agent call)
-direct<TInput, TOutput>(endpoint: string): Destination<TInput, TOutput>
+direct<TIn, TOut>(
+  endpoint: RegisteredDirectEndpoint | ((exchange: Exchange<TIn>) => string),
+): Destination<TIn, TOut>
 ```
+
+See [Type Safety: Registries](https://github.com/routecraftjs/routecraft/blob/main/.standards/type-safety-registries.md) for how to populate `DirectEndpointRegistry`.
 
 Enable synchronous inter-route communication. Perfect for composable route architectures where you need request-response patterns. The source form uses the route's `.id()` as the endpoint name; destinations address the target by id.
 

--- a/packages/routecraft/src/adapters/direct/destination.ts
+++ b/packages/routecraft/src/adapters/direct/destination.ts
@@ -11,26 +11,31 @@ import { getDirectChannel, sanitizeEndpoint } from "./shared";
  * - `direct((exchange) => endpoint)` where endpoint is a function
  *
  * It sends messages to a specific endpoint (static or dynamic).
+ *
+ * The two generics model the in-process request/response shape: `TIn` is the
+ * body type the caller sends, `TOut` is the body type the target route
+ * returns. They default to being equal for backwards compatibility with the
+ * symmetric `Destination<T, T>` overload of `direct()`.
  */
-export class DirectDestinationAdapter<T = unknown> implements Destination<
-  T,
-  T
-> {
+export class DirectDestinationAdapter<
+  TIn = unknown,
+  TOut = TIn,
+> implements Destination<TIn, TOut> {
   readonly adapterId: string = "routecraft.adapter.direct";
 
-  private rawEndpoint: DirectEndpoint<T>;
+  private rawEndpoint: DirectEndpoint<TIn>;
   public options: DirectClientOptions;
   private lastResolvedEndpoint?: string;
 
   constructor(
-    rawEndpoint: DirectEndpoint<T>,
+    rawEndpoint: DirectEndpoint<TIn>,
     options: DirectClientOptions = {},
   ) {
     this.rawEndpoint = rawEndpoint;
     this.options = options;
   }
 
-  async send(exchange: Exchange<T>): Promise<T> {
+  async send(exchange: Exchange<TIn>): Promise<TOut> {
     // Import dynamically to avoid circular dependency
     const { getExchangeContext } = await import("../../exchange");
     const context = getExchangeContext(exchange);
@@ -47,13 +52,15 @@ export class DirectDestinationAdapter<T = unknown> implements Destination<
       "Preparing to send message to direct endpoint",
     );
 
-    const channel = getDirectChannel<T>(context, endpoint, this.options);
+    const channel = getDirectChannel<TIn>(context, endpoint, this.options);
 
     // Send and wait for result - this is synchronous blocking behavior
     const result = await channel.send(endpoint, exchange);
 
-    // Return the body from the result exchange
-    return result.body;
+    // The wire-level channel is body-symmetric, but the consumer route may
+    // produce a body whose shape differs from the caller's input. That shape
+    // is opaque to this adapter at compile time, so we widen here.
+    return result.body as unknown as TOut;
   }
 
   /**
@@ -67,7 +74,7 @@ export class DirectDestinationAdapter<T = unknown> implements Destination<
     };
   }
 
-  private resolveEndpoint(exchange: Exchange<T>): string {
+  private resolveEndpoint(exchange: Exchange<TIn>): string {
     const endpoint =
       typeof this.rawEndpoint === "function"
         ? this.rawEndpoint(exchange)

--- a/packages/routecraft/src/adapters/direct/index.ts
+++ b/packages/routecraft/src/adapters/direct/index.ts
@@ -1,3 +1,4 @@
+import type { Exchange } from "../../exchange";
 import type { Source } from "../../operations/from";
 import type { Destination } from "../../operations/to";
 import type {
@@ -22,6 +23,9 @@ import type { DirectEndpoint, DirectServerOptions } from "./types";
  * - **Destination with explicit input/output types:** Supply two type
  *   arguments to express a route whose response body shape differs from
  *   the caller's input shape, e.g. `direct<ChatInput, AgentResult>("agent")`.
+ *   Works with both string and function endpoints. When
+ *   `DirectEndpointRegistry` is populated, the endpoint string is still
+ *   constrained to registered keys.
  *
  * Semantics: single consumer per endpoint (last subscriber wins), blocking
  * send (sender waits for response).
@@ -47,8 +51,8 @@ import type { DirectEndpoint, DirectServerOptions } from "./types";
  * .to(direct((ex) => ex.headers["x-endpoint"] as string))
  *
  * // Destination with input != output (e.g. in-process agent call)
- * .transform((b) => ({ name: b.agent, body: b.text }))
- * .enrich(direct<{ name: string; body: string }, AgentResult>("agent"))
+ * .transform((b) => ({ name: b.agent, query: b.text }))
+ * .enrich(direct<{ name: string; query: string }, AgentResult>("agent"))
  * ```
  */
 export function direct(options: DirectServerOptions): Source<unknown>;
@@ -59,7 +63,23 @@ export function direct<K extends RegisteredDirectEndpoint>(
 export function direct<T = unknown>(
   endpoint: DirectEndpoint<T>,
 ): Destination<T, T>;
-export function direct<TIn, TOut>(endpoint: string): Destination<TIn, TOut>;
+/**
+ * Destination with explicit input and output body types. Use when the
+ * target route's response body shape differs from the caller's input
+ * shape (e.g. an in-process agent or RPC-style call). Accepts a string
+ * endpoint (constrained to registered keys when `DirectEndpointRegistry`
+ * is populated) or a function endpoint resolved from the exchange.
+ *
+ * @experimental The framework does not validate that the target route
+ *   actually returns a value matching `TOut`. The caller asserts the
+ *   output shape. A future release may require a matching
+ *   `.output({ body: schema })` on the callee and validate the response
+ *   automatically; until then, treat `TOut` as a caller-side assertion
+ *   rather than a framework-enforced contract.
+ */
+export function direct<TIn, TOut>(
+  endpoint: RegisteredDirectEndpoint | ((exchange: Exchange<TIn>) => string),
+): Destination<TIn, TOut>;
 export function direct<TIn = unknown, TOut = TIn>(
   arg?: DirectEndpoint<TIn> | DirectServerOptions,
 ): Source<unknown> | Destination<TIn, TOut> {

--- a/packages/routecraft/src/adapters/direct/index.ts
+++ b/packages/routecraft/src/adapters/direct/index.ts
@@ -19,6 +19,9 @@ import type { DirectEndpoint, DirectServerOptions } from "./types";
  * - **Destination (for `.to()` / `.tap()`):** Call with a string or function
  *   naming the target route: `direct("fetch-order")` or
  *   `direct((exchange) => exchange.headers["x-endpoint"] as string)`.
+ * - **Destination with explicit input/output types:** Supply two type
+ *   arguments to express a route whose response body shape differs from
+ *   the caller's input shape, e.g. `direct<ChatInput, AgentResult>("agent")`.
  *
  * Semantics: single consumer per endpoint (last subscriber wins), blocking
  * send (sender waits for response).
@@ -42,6 +45,10 @@ import type { DirectEndpoint, DirectServerOptions } from "./types";
  * // Destination
  * .to(direct("ingest"))
  * .to(direct((ex) => ex.headers["x-endpoint"] as string))
+ *
+ * // Destination with input != output (e.g. in-process agent call)
+ * .transform((b) => ({ name: b.agent, body: b.text }))
+ * .enrich(direct<{ name: string; body: string }, AgentResult>("agent"))
  * ```
  */
 export function direct(options: DirectServerOptions): Source<unknown>;
@@ -52,12 +59,13 @@ export function direct<K extends RegisteredDirectEndpoint>(
 export function direct<T = unknown>(
   endpoint: DirectEndpoint<T>,
 ): Destination<T, T>;
-export function direct<T = unknown>(
-  arg?: DirectEndpoint<T> | DirectServerOptions,
-): Source<unknown> | Destination<T, T> {
+export function direct<TIn, TOut>(endpoint: string): Destination<TIn, TOut>;
+export function direct<TIn = unknown, TOut = TIn>(
+  arg?: DirectEndpoint<TIn> | DirectServerOptions,
+): Source<unknown> | Destination<TIn, TOut> {
   // String or function first-arg -> Destination (names a target route).
   if (typeof arg === "string" || typeof arg === "function") {
-    return new DirectDestinationAdapter<T>(arg) as Destination<T, T>;
+    return new DirectDestinationAdapter<TIn, TOut>(arg);
   }
   // Undefined or options object -> Source (endpoint resolved from route id).
   return new DirectSourceAdapter(arg ?? {}) as Source<unknown>;

--- a/packages/routecraft/test/direct-simple.bun.test.ts
+++ b/packages/routecraft/test/direct-simple.bun.test.ts
@@ -314,6 +314,50 @@ describe("Direct adapter", () => {
   });
 
   /**
+   * @case A direct destination can be typed with distinct input and output bodies
+   * @preconditions Caller route uses `.enrich(direct<TIn, TOut>("callee"))`
+   *                where the callee returns a body shape different from the caller's
+   * @expectedResult The merged body downstream has both the caller's input fields
+   *                 and the callee's output fields, with runtime values intact
+   */
+  test("enriches with a typed direct destination where input != output", async () => {
+    type AgentInput = { name: string; query: string };
+    type AgentResult = { answer: string; tokens: number };
+
+    let downstreamBody: unknown;
+
+    t = await testContext()
+      .routes([
+        craft()
+          .id("agent-caller")
+          .from(simple<AgentInput>({ name: "kb", query: "hello" }))
+          .enrich(direct<AgentInput, AgentResult>("agent"))
+          .tap((ex) => {
+            downstreamBody = ex.body;
+          }),
+        craft()
+          .id("agent")
+          .from(direct())
+          .transform(
+            (body): AgentResult => ({
+              answer: `echo:${(body as AgentInput).query}`,
+              tokens: 42,
+            }),
+          ),
+      ])
+      .build();
+
+    await t.test();
+
+    expect(downstreamBody).toEqual({
+      name: "kb",
+      query: "hello",
+      answer: "echo:hello",
+      tokens: 42,
+    });
+  });
+
+  /**
    * @case Principal flows from caller to callee across direct()
    * @preconditions Producer route attaches a custom principal under headers["routecraft.auth.principal"] and forwards via direct()
    * @expectedResult The callee's exchange carries the same principal so .authorize() / route handlers see the caller's identity

--- a/packages/routecraft/test/direct-type-safety.bun.test.ts
+++ b/packages/routecraft/test/direct-type-safety.bun.test.ts
@@ -1,4 +1,5 @@
 import { describe, expectTypeOf, test } from "bun:test";
+import { craft, simple } from "@routecraft/routecraft";
 import { direct } from "../src/adapters/direct/index.ts";
 import type { Source } from "../src/operations/from.ts";
 import type { Destination } from "../src/operations/to.ts";
@@ -118,5 +119,39 @@ describe("Direct adapter type safety", () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars -- param only for type
       direct((_ex: { body: X; headers: Record<string, unknown> }) => "ep"),
     ).toMatchTypeOf<Destination<X, X>>();
+  });
+
+  /**
+   * @case Explicit two-generic form accepts a function endpoint
+   * @preconditions direct<TIn, TOut>((ex: Exchange<TIn>) => "ep")
+   * @expectedResult Type matches Destination<TIn, TOut>
+   */
+  test("direct<TIn, TOut>(function) returns Destination<TIn, TOut>", () => {
+    type In = { kind: "lookup"; id: string };
+    type Out = { found: boolean; value: number };
+    expectTypeOf(
+      direct<In, Out>(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- param only for type
+        (_ex: { body: In; headers: Record<string, unknown> }) => "ep",
+      ),
+    ).toMatchTypeOf<Destination<In, Out>>();
+  });
+
+  /**
+   * @case .enrich(direct<TIn, TOut>(...)) propagates TIn & TOut to downstream body
+   * @preconditions Builder chain: from(simple<TIn>(...)).enrich(direct<TIn, TOut>("ep")).tap(...)
+   * @expectedResult The tap's exchange.body type is TIn & TOut
+   */
+  test(".enrich(direct<TIn, TOut>(string)) narrows downstream body to TIn & TOut", () => {
+    type In = { query: string };
+    type Out = { answer: string; tokens: number };
+
+    craft()
+      .id("type-test-caller")
+      .from(simple<In>({ query: "hi" }))
+      .enrich(direct<In, Out>("type-test-callee"))
+      .tap((ex) => {
+        expectTypeOf(ex.body).toEqualTypeOf<In & Out>();
+      });
   });
 });

--- a/packages/routecraft/test/direct-type-safety.bun.test.ts
+++ b/packages/routecraft/test/direct-type-safety.bun.test.ts
@@ -85,4 +85,38 @@ describe("Direct adapter type safety", () => {
       Source<unknown>
     >();
   });
+
+  /**
+   * @case Explicit two-generic form produces Destination<TIn, TOut>
+   * @preconditions direct<{ name: string }, { result: number }>("ep")
+   * @expectedResult Type matches Destination<{ name: string }, { result: number }>
+   */
+  test("direct<TIn, TOut>(string) returns Destination<TIn, TOut>", () => {
+    type In = { name: string; body: string };
+    type Out = { result: number; latencyMs: number };
+    expectTypeOf(direct<In, Out>("ep")).toMatchTypeOf<Destination<In, Out>>();
+  });
+
+  /**
+   * @case Explicit two-generic form does not collapse to the symmetric variant
+   * @preconditions direct<{ a: 1 }, { b: 2 }>("ep")
+   * @expectedResult Type does not match Destination<{ a: 1 }, { a: 1 }>
+   */
+  test("direct<TIn, TOut> with TIn != TOut is not assignable to Destination<TIn, TIn>", () => {
+    const dest = direct<{ a: 1 }, { b: 2 }>("ep");
+    expectTypeOf(dest).not.toMatchTypeOf<Destination<{ a: 1 }, { a: 1 }>>();
+  });
+
+  /**
+   * @case Function-form endpoint still resolves to the symmetric overload
+   * @preconditions direct((ex) => "ep") with Exchange<X>
+   * @expectedResult Type matches Destination<X, X>
+   */
+  test("direct(function) still returns Destination<T, T>", () => {
+    type X = { id: string };
+    expectTypeOf(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- param only for type
+      direct((_ex: { body: X; headers: Record<string, unknown> }) => "ep"),
+    ).toMatchTypeOf<Destination<X, X>>();
+  });
 });


### PR DESCRIPTION
## Summary

Extends the `direct()` adapter to support routes where the callee's response body shape differs from the caller's input shape. This enables typed in-process agent calls, RPC-style patterns, and other scenarios where request and response bodies are structurally different.

## Changes

- **New overload:** `direct<TIn, TOut>(endpoint)` returns `Destination<TIn, TOut>` instead of the symmetric `Destination<T, T>`. Works with both string and function endpoints.
- **DirectDestinationAdapter:** Updated to accept two type parameters (`TIn`, `TOut`) with `TOut` defaulting to `TIn` for backward compatibility. The `send()` method now returns `Promise<TOut>` and casts the wire-level response appropriately.
- **Type safety:** Added comprehensive type tests verifying:
  - Explicit two-generic form produces correct `Destination<TIn, TOut>`
  - Asymmetric types do not collapse to symmetric variant
  - Function-form endpoints still resolve to symmetric overload when only one generic is supplied
  - `.enrich(direct<TIn, TOut>(...))` correctly narrows downstream body to `TIn & TOut`
- **Runtime test:** Added integration test demonstrating enrichment with distinct input/output types, verifying merged body contains both caller input fields and callee output fields.
- **Documentation:** Updated JSDoc, examples, and reference docs to explain the new pattern with an in-process agent call example. Added `@experimental` note clarifying that output shape validation is caller-asserted (not framework-enforced).

## Implementation Details

- The wire-level `DirectChannel` remains body-symmetric; the asymmetry is modeled at the adapter's public API only.
- The `send()` method casts `result.body as unknown as TOut` to bridge the symmetric wire protocol to the asymmetric type contract.
- Backward compatibility is preserved: single-generic `direct<T>(endpoint)` still returns `Destination<T, T>`.
- Function endpoints with explicit generics now accept `Exchange<TIn>` parameter type, allowing the endpoint resolver to access the caller's input shape if needed.

https://claude.ai/code/session_01R1DzunvSyZEM84C4rvrfMd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit input and output typing to the `direct()` destination so callers can send one body shape and receive a different one. This enables typed in-process agent/RPC calls without breaking existing symmetric routes.

- New Features
  - Added `direct<TIn, TOut>(endpoint)` returning `Destination<TIn, TOut>` for asymmetric request/response. Works with string or function endpoints; string endpoints remain constrained to `RegisteredDirectEndpoint`.
  - Backward compatible: `direct<T>(endpoint)` still returns `Destination<T, T>`.
  - Updated `DirectDestinationAdapter` to `<TIn, TOut = TIn>`; `send()` now returns `Promise<TOut>` (wire is still symmetric; cast at the adapter boundary).
  - Added type and integration tests for the two-generic form, function endpoints, and `.enrich(...)` propagation to `TIn & TOut`. Updated docs with examples and an `@experimental` note that the output shape is caller-asserted.

<sup>Written for commit 2e1e4f4d12c31705cb3d27d9606164bcf3a077e3. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/319?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

