### PR TITLE
ci: harden against pull_request_target supply chain attack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - "**/README.md"
       - ".github/ISSUE_TEMPLATE/**"
       - ".cursor/**"
-  pull_request_target:
+  pull_request:
     branches: ["main"]
     paths-ignore:
       - "**/README.md"
@@ -17,8 +17,11 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -29,12 +32,10 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect changed paths
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -53,56 +54,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "package.json"
 
-      - name: Checkout PR branch for lockfile update
-        if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
-      - name: Update lockfile
-        if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
-        run: |
-          bun install
-
-      - name: Commit lockfile changes
-        if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add bun.lock
-          if git diff --cached --quiet; then
-            echo "No lockfile changes needed"
-          else
-            git commit --amend --no-edit
-            git push --force-with-lease
-          fi
-
       - name: Install dependencies
-        run: |
-          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
-            bun install
-          else
-            bun install --frozen-lockfile
-          fi
+        run: bun install --frozen-lockfile
 
       - name: Cache node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
@@ -112,22 +80,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "package.json"
 
       - name: Restore node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
@@ -144,22 +110,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "package.json"
 
       - name: Restore node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
@@ -168,7 +132,7 @@ jobs:
         run: bun run test:coverage
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage/
@@ -179,22 +143,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "package.json"
 
       - name: Restore node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
@@ -202,14 +164,16 @@ jobs:
       - name: Build packages
         run: bun run build
         env:
-          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
-          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+          # PostHog keys are NEXT_PUBLIC_* so technically safe to expose, but
+          # the PR build artifact is thrown away. Only inject on trusted triggers.
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ github.event_name != 'pull_request' && secrets.NEXT_PUBLIC_POSTHOG_KEY || '' }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ github.event_name != 'pull_request' && secrets.NEXT_PUBLIC_POSTHOG_HOST || '' }}
 
       - name: Check bundle size
         run: bun run limit:size
 
       - name: Cache build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/dist"
           key: build-${{ github.event.pull_request.head.sha || github.sha }}
@@ -221,28 +185,26 @@ jobs:
     name: scaffolder-smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "package.json"
 
       - name: Restore node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Restore build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/dist"
           key: build-${{ github.event.pull_request.head.sha || github.sha }}
@@ -280,28 +242,26 @@ jobs:
     name: embedding-smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "package.json"
 
       - name: Restore node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Restore build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/dist"
           key: build-${{ github.event.pull_request.head.sha || github.sha }}
@@ -338,29 +298,27 @@ jobs:
     name: adapter-cross-runtime (${{ matrix.runtime }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
 
       - name: Install bun
         if: matrix.runtime == 'bun'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "package.json"
 
       - name: Restore node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Restore build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/dist"
           key: build-${{ github.event.pull_request.head.sha || github.sha }}
@@ -386,27 +344,27 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "package.json"
 
       - name: Restore node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Restore build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/dist"
           key: build-${{ github.event.pull_request.head.sha || github.sha }}
@@ -451,54 +409,13 @@ jobs:
             npm publish "./$pkg" --tag canary --access public --provenance
           done
 
-  approve:
-    name: approve
-    runs-on: ubuntu-latest
-    needs: [scaffolder-smoke, embedding-smoke, adapter-cross-runtime]
-    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' && !failure() && !cancelled()
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Approve PR
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              event: 'APPROVE'
-            })
-
-  merge:
-    name: merge
-    runs-on: ubuntu-latest
-    needs: [approve]
-    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' && success()
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Merge PR
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              merge_method: 'squash'
-            })
-
   publish:
     needs: [build, scaffolder-smoke, embedding-smoke, adapter-cross-runtime]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
+      id-token: write
     steps:
       - name: Validate release name matches tag
         run: |
@@ -509,27 +426,27 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "package.json"
 
       - name: Restore node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}
 
       - name: Restore build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/dist"
           key: build-${{ github.event.pull_request.head.sha || github.sha }}
@@ -588,11 +505,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     permissions:
+      contents: read
       id-token: write
       pages: write
     steps:
       - name: Checkout main (canary)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: canary
           fetch-depth: 0
@@ -626,12 +544,12 @@ jobs:
           fi
 
       - name: Use Node.js from .nvmrc
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: canary/.nvmrc
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: canary/package.json
 
@@ -654,7 +572,7 @@ jobs:
 
       - name: Checkout stable tag
         if: steps.latest.outputs.tag != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.latest.outputs.tag }}
           path: stable
@@ -706,10 +624,10 @@ jobs:
           fi
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Include event_name so the new pull_request-triggered run doesn't collide
+  # with main's still-live pull_request_target workflow during the transition.
+  # After this PR merges, only pull_request fires, so the event_name segment
+  # becomes a no-op and concurrency works as before.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# This is the ONLY workflow that uses `pull_request_target`. It runs with
+# repo-write trust, so it MUST NOT check out or execute PR-controlled code.
+# It just enables auto-merge; branch protection enforces required checks
+# from the untrusted `pull_request`-triggered CI run before the merge fires.
+
+on:
+  pull_request_target:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Approve PR
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Closes the same attack surface that produced the TanStack "Mini Shai-Hulud" npm supply-chain compromise on 2026-05-11/12. That attack chained three weaknesses in GitHub Actions:

1. `pull_request_target` running PR code with base-repo trust ("Pwn Request")
2. `actions/cache` poisoning across the fork ↔ base trust boundary
3. OIDC token extraction from a publish runner to publish malicious npm versions

Routecraft's `ci.yml` had links 1 and 2 fully present, plus an OIDC publish (`publish-canary`, `publish`) downstream of the same caches. A malicious PR that didn't touch `bun.lock` could poison `**/node_modules` via a `postinstall` hook in any sub-package, and the poisoned cache key (`${{ runner.os }}-modules-${{ hashFiles('**/bun.lock') }}`) would be restored by a later `publish` run.

## Changes

- **`.github/workflows/ci.yml`**: replace `pull_request_target` with `pull_request` for all PR validation (`changes`, `setup`, `validate`, `test`, `build`, smoke jobs, cross-runtime). PR code no longer executes with secrets or a write token; GitHub's cache scoping now isolates PR caches from main, so the poisoning vector is closed by design.
- **`.github/workflows/dependabot-merge.yml`** (new): the only workflow that still uses `pull_request_target`. It does **not** check out or run PR code. It calls `gh pr review --approve` and `gh pr merge --auto --squash`. Branch protection enforces the required checks from the untrusted PR workflow before the auto-merge actually fires.
- **Drop the dependabot lockfile-amend block.** It ran `bun install` with a write token under attacker-influenceable input. Bun-native dependabot (`package-ecosystem: bun`, already configured) keeps `bun.lock` in sync; if a PR occasionally needs manual `bun install`, that's an acceptable tradeoff for closing a real injection point.
- **Gate PostHog secrets**: `NEXT_PUBLIC_POSTHOG_KEY/HOST` only flow into `bun run build` on `push`/`release`/`workflow_dispatch`, not on `pull_request`. They're `NEXT_PUBLIC_*` so impact was low, but no reason to ship them into PR builds whose artifact gets thrown away.
- **Permissions**: add workflow-level `permissions: contents: read` and per-job opt-ins (`id-token: write` on publish jobs, `pages: write` on docs deploy, `contents: write` + `pull-requests: write` on dependabot-merge only).
- **Pin actions to commit SHAs** with `# v6.0.2`-style comments so dependabot's `github-actions` updater keeps bumping them safely. Covers `actions/checkout`, `actions/setup-node`, `oven-sh/setup-bun`, `actions/cache`, `dorny/paths-filter`, `actions/upload-artifact`, `actions/upload-pages-artifact`, `actions/deploy-pages`. Removes `actions/github-script` entirely (the new dependabot-merge uses `gh` CLI directly).

## What's intentionally NOT in this PR

- Wrapping `publish`/`publish-canary` in a GitHub Environment with manual approval on stable releases. That's the next biggest blast-radius reduction (a human eyeballs version+tag before npm sees the OIDC token), but it touches deployment process and warrants a separate decision.
- Restricting dependabot auto-merge to `patch`-only updates via `dependabot/fetch-metadata`. Closes most historical compromise vectors (`eslint-config-prettier`-style) but is a policy choice.
- Pre-Bun migration docs deploy logic is untouched (`build-and-deploy-docs` checks out a stable tag and runs `bun install --frozen-lockfile`); not part of this attack chain.

## Test plan

- [ ] On open: this PR triggers `ci.yml` via `pull_request` only. Verify `changes`, `setup`, `validate`, `test`, `build`, `scaffolder-smoke`, `embedding-smoke`, `adapter-cross-runtime` all run with no secrets and no write token.
- [ ] Verify `publish-canary`, `publish`, and `build-and-deploy-docs` are **skipped** on this PR (they're gated to `push`/`release`).
- [ ] Verify the `dependabot-merge` workflow shows up but its `auto-merge` job is skipped (gated to `dependabot[bot]` author).
- [ ] After merge to main: confirm `publish-canary` runs and successfully publishes with `--provenance`.
- [ ] Confirm the next dependabot PR triggers `dependabot-merge.yml`, approves itself, and enables auto-merge (assumes "Allow auto-merge" is on in repo settings; if not, the command will fail with a clear error and we re-enable it).
- [ ] Branch protection: confirm required status checks point at the new `pull_request`-triggered job names, otherwise dependabot auto-merge will fire without gates.

## Threat model after this change

| TanStack link | Status |
|---|---|
| 1. Pwn Request (`pull_request_target` runs PR code) | Closed — only `dependabot-merge.yml` uses `pull_request_target`, with no checkout |
| 2. Cache poisoning across fork/base | Closed — PR caches scoped to PR ref by `pull_request` trigger |
| 3. OIDC → npm publish | Surface intact (still trusted publisher with `--provenance`), but no longer downstream of attacker-poisonable cache; further hardening via Environments tracked as follow-up |

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVLbUfF4zvWR1Ey1Dg5XF3)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CI to close the `pull_request_target` supply‑chain attack path. PR code no longer runs with repo trust, caches are isolated, and publish stays on trusted runners.

- **CI Hardening**
  - Switch PR validation to `pull_request` (remove `pull_request_target` from CI).
  - Add `dependabot-merge.yml` using `pull_request_target` without checkout; uses `gh` to approve and enable auto-merge behind branch protection.
  - Remove lockfile amend; rely on Dependabot (`package-ecosystem: bun`); always `bun install --frozen-lockfile`.
  - Gate `NEXT_PUBLIC_POSTHOG_*` so they only inject on trusted triggers (`push`, `release`, `workflow_dispatch`).
  - Default `permissions: contents: read`; per-job least privilege (e.g., `id-token: write` on publish, `pages: write` on docs).
  - Pin Actions to SHAs; drop `actions/github-script` in favor of `gh` CLI.
  - Keep `actions/cache` but rely on `pull_request` scoping to prevent cross-fork cache poisoning.
  - Scope concurrency by `event_name` during the transition to avoid PR runs cancelling the legacy workflow; becomes a no-op after merge.

- **Migration**
  - Update branch protection to require the new `pull_request` job names.
  - Ensure repo setting “Allow auto-merge” is enabled for Dependabot auto-merge.

<sup>Written for commit c957008fe0f61b11240b4823a1a492cbd55c0229. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/321?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

