### PR TITLE
Add OAuth principal enrichment via userinfo endpoint

### DIFF
--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -305,7 +305,9 @@ auth: oauth({
 
 #### Principal enrichment via `userinfo`
 
-OAuth access tokens are intentionally thin: they authorize but rarely identify. Identity fields needed to gate routes (`email`, `name`, `roles`, org membership) usually live behind the IdP's userinfo endpoint, not in the token itself. The optional `userinfo` slot on `oauth({})` runs after `verify` succeeds and merges enrichment onto the verified principal. Three shapes are accepted:
+OAuth access tokens are intentionally thin: they authorize but rarely identify. Identity fields needed to gate routes (`email`, `name`, `roles`, org membership) usually live behind the IdP's userinfo endpoint, not in the token itself. The optional `userinfo` slot on `oauth({})` runs after `verify` succeeds and merges enrichment onto the verified principal. Three shapes are accepted; choose exactly one per `oauth({})` call.
+
+**Shape 1: auto-discover via OIDC Discovery.** Requires a single-string `issuer` on the verify helper (`jwks({ issuer })` / `jwt({ issuer })`). The framework resolves the userinfo endpoint from the discovery document at `${issuer}/.well-known/openid-configuration` and caches the URL honouring `Cache-Control: max-age` (default 1 hour).
 
 ```ts
 auth: oauth({
@@ -313,14 +315,30 @@ auth: oauth({
   endpoints: { ... },
   verify: jwks({ jwksUrl, issuer: 'https://idp.example.com', audience }),
   client: { ... },
-
-  // 1. Auto-discover via OIDC Discovery (requires single-string `issuer` on verify).
   userinfo: true,
+})
+```
 
-  // 2. Explicit userinfo endpoint URL.
+**Shape 2: explicit userinfo endpoint URL.** Skips discovery; use when the IdP does not advertise OIDC Discovery or you want to pin the URL explicitly.
+
+```ts
+auth: oauth({
+  resourceIssuerUrl: '...',
+  endpoints: { ... },
+  verify: jwks({ jwksUrl, issuer: 'https://idp.example.com', audience }),
+  client: { ... },
   userinfo: 'https://idp.example.com/oauth/userinfo',
+})
+```
 
-  // 3. Custom function for any non-OIDC backend.
+**Shape 3: custom function** for non-OIDC backends (Clerk Backend API, internal DB, etc.). Sub-invariant enforcement is the caller's responsibility in this mode.
+
+```ts
+auth: oauth({
+  resourceIssuerUrl: '...',
+  endpoints: { ... },
+  verify: jwks({ jwksUrl, issuer: 'https://idp.example.com', audience }),
+  client: { ... },
   userinfo: async (principal, token) => {
     const [profile, roles] = await Promise.all([
       fetch('https://idp.example.com/oauth/userinfo', {
@@ -339,7 +357,7 @@ Semantics:
 - **Verify wins on protected fields.** `subject`, `issuer`, `audience`, `expiresAt`, and `claims` always come from the token. An enrichment that tries to overwrite them is silently dropped. The raw userinfo response is surfaced on a separate `userinfoClaims` field so `principal.claims` keeps its meaning ("verified JWT payload") regardless of whether enrichment ran.
 - **`sub` invariant (URL and discovery modes).** The userinfo response MUST include `sub` and it MUST equal the verified token's `sub` (OIDC Core §5.3.2). Mismatches reject the request with `RC5022`. The function variant is trusted by contract.
 - **Auto-discovery (`userinfo: true`).** The framework fetches the OIDC Discovery document relative to the verify helper's `issuer` (preserving the issuer's path, so Keycloak realms and tenant-prefixed IdPs work), reads `userinfo_endpoint`, and caches the resolved URL honouring the response's `Cache-Control: max-age` (default one hour). A missing `userinfo_endpoint` or an unreachable discovery doc raises `RC5021` on the first request.
-- **Token-bound caching with coalescing.** Enriched principals are memoised by token (keyed by a SHA-256 hash, not the raw bearer) and evicted at `expiresAt`. The cache has a default cap of 10,000 entries with insertion-order eviction. Concurrent verifies of the same token share a single in-flight enrichment, so the IdP receives one userinfo fetch per token, not one per inbound request.
+- **Token-bound enrichment caching with coalescing.** The base verifier (`verify`) runs on every request, so dynamic checks (introspection, revocation, clock comparisons) still fire per request. Only the enrichment payload is memoised, keyed by SHA-256 of the bearer (not the raw bearer) and evicted at `expiresAt`. The cache has a default cap of 10,000 entries with insertion-order eviction. Concurrent first-callers for the same token share a single in-flight enrichment, so the IdP receives one userinfo fetch per token, not one per inbound request.
 - **Fail-closed.** Userinfo fetch, parse, and discovery errors raise `RC5021`; sub-invariant violations raise `RC5022`. There is no opt-in "best effort" mode; if you need that, write a function variant that swallows its own errors.
 
 If `authorize()` runs mid-pipeline after a slow step, set `authorize({ clockToleranceSec })` to the same value used on the source-side verifier so a token accepted at the route boundary is not rejected by a fraction of a second.

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -336,11 +336,13 @@ auth: oauth({
 Semantics:
 
 - **Runs after verify.** The verified principal is the starting point; userinfo only adds or overwrites non-protected fields.
-- **Verify wins on protected fields.** `subject`, `issuer`, `audience`, and `expiresAt` always come from the token. An enrichment that tries to overwrite them is silently dropped.
-- **`sub` invariant (URL and discovery modes).** The userinfo response MUST include `sub` and it MUST equal the verified token's `sub` (OIDC Core §5.3.2). Mismatches reject the request. The function variant is trusted by contract.
-- **Auto-discovery (`userinfo: true`).** The framework fetches `${issuer}/.well-known/openid-configuration` once at first use, reads `userinfo_endpoint`, and caches the URL for the server lifetime. A discovery doc missing `userinfo_endpoint` (or unreachable) raises a clear error on the first request rather than silently degrading.
-- **Token-bound caching.** Enriched principals are memoised by token and evicted at `expiresAt`. No `cache:` knob, no TTL to pick. Refresh-token rotation triggers one re-enrichment for the new token.
-- **Fail-closed.** Any userinfo fetch, parse, or merge error rejects the request. There is no opt-in "best effort" mode; if you need that, write a function variant that swallows its own errors.
+- **Verify wins on protected fields.** `subject`, `issuer`, `audience`, `expiresAt`, and `claims` always come from the token. An enrichment that tries to overwrite them is silently dropped. The raw userinfo response is surfaced on a separate `userinfoClaims` field so `principal.claims` keeps its meaning ("verified JWT payload") regardless of whether enrichment ran.
+- **`sub` invariant (URL and discovery modes).** The userinfo response MUST include `sub` and it MUST equal the verified token's `sub` (OIDC Core §5.3.2). Mismatches reject the request with `RC5022`. The function variant is trusted by contract.
+- **Auto-discovery (`userinfo: true`).** The framework fetches the OIDC Discovery document relative to the verify helper's `issuer` (preserving the issuer's path, so Keycloak realms and tenant-prefixed IdPs work), reads `userinfo_endpoint`, and caches the resolved URL honouring the response's `Cache-Control: max-age` (default one hour). A missing `userinfo_endpoint` or an unreachable discovery doc raises `RC5021` on the first request.
+- **Token-bound caching with coalescing.** Enriched principals are memoised by token (keyed by a SHA-256 hash, not the raw bearer) and evicted at `expiresAt`. The cache has a default cap of 10,000 entries with insertion-order eviction. Concurrent verifies of the same token share a single in-flight enrichment, so the IdP receives one userinfo fetch per token, not one per inbound request.
+- **Fail-closed.** Userinfo fetch, parse, and discovery errors raise `RC5021`; sub-invariant violations raise `RC5022`. There is no opt-in "best effort" mode; if you need that, write a function variant that swallows its own errors.
+
+If `authorize()` runs mid-pipeline after a slow step, set `authorize({ clockToleranceSec })` to the same value used on the source-side verifier so a token accepted at the route boundary is not rejected by a fraction of a second.
 
 Use `userinfo` when the bearer alone does not carry the identity fields you need. Skip it when the token already contains everything (e.g. a Clerk JWT with `email` and `roles` claims).
 

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -303,6 +303,47 @@ auth: oauth({
 
 `expiresAt` is required by the MCP SDK's bearer middleware; the server will throw if the verifier returns a principal without it.
 
+#### Principal enrichment via `userinfo`
+
+OAuth access tokens are intentionally thin: they authorize but rarely identify. Identity fields needed to gate routes (`email`, `name`, `roles`, org membership) usually live behind the IdP's userinfo endpoint, not in the token itself. The optional `userinfo` slot on `oauth({})` runs after `verify` succeeds and merges enrichment onto the verified principal. Three shapes are accepted:
+
+```ts
+auth: oauth({
+  resourceIssuerUrl: '...',
+  endpoints: { ... },
+  verify: jwks({ jwksUrl, issuer: 'https://idp.example.com', audience }),
+  client: { ... },
+
+  // 1. Auto-discover via OIDC Discovery (requires single-string `issuer` on verify).
+  userinfo: true,
+
+  // 2. Explicit userinfo endpoint URL.
+  userinfo: 'https://idp.example.com/oauth/userinfo',
+
+  // 3. Custom function for any non-OIDC backend.
+  userinfo: async (principal, token) => {
+    const [profile, roles] = await Promise.all([
+      fetch('https://idp.example.com/oauth/userinfo', {
+        headers: { Authorization: `Bearer ${token}` },
+      }).then((r) => r.json()),
+      myService.getRoles(principal.subject),
+    ])
+    return { ...profile, roles }
+  },
+})
+```
+
+Semantics:
+
+- **Runs after verify.** The verified principal is the starting point; userinfo only adds or overwrites non-protected fields.
+- **Verify wins on protected fields.** `subject`, `issuer`, `audience`, and `expiresAt` always come from the token. An enrichment that tries to overwrite them is silently dropped.
+- **`sub` invariant (URL and discovery modes).** The userinfo response MUST include `sub` and it MUST equal the verified token's `sub` (OIDC Core §5.3.2). Mismatches reject the request. The function variant is trusted by contract.
+- **Auto-discovery (`userinfo: true`).** The framework fetches `${issuer}/.well-known/openid-configuration` once at first use, reads `userinfo_endpoint`, and caches the URL for the server lifetime. A discovery doc missing `userinfo_endpoint` (or unreachable) raises a clear error on the first request rather than silently degrading.
+- **Token-bound caching.** Enriched principals are memoised by token and evicted at `expiresAt`. No `cache:` knob, no TTL to pick. Refresh-token rotation triggers one re-enrichment for the new token.
+- **Fail-closed.** Any userinfo fetch, parse, or merge error rejects the request. There is no opt-in "best effort" mode; if you need that, write a function variant that swallows its own errors.
+
+Use `userinfo` when the bearer alone does not carry the identity fields you need. Skip it when the token already contains everything (e.g. a Clerk JWT with `email` and `roles` claims).
+
 The populated `Principal` rides on the exchange as a single structured header (`routecraft.auth.principal`) and is exposed ergonomically via the `ex.principal` getter, e.g. `ex.principal?.subject`, `ex.principal?.scopes`, `ex.principal?.claims`.
 
 See the [plugins reference](/docs/reference/plugins#mcpplugin) for the full `Principal` field list.

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -260,13 +260,16 @@ The error message names the adapter (`cron`, `html`, ...) and the missing packag
 Authorization failed: token expired during processing
 
 **Why it happens**  
-A mid-pipeline `.validate(authorize(...))` (or the pre-from `.authorize()` guard) ran on an exchange whose principal carries an `expiresAt` (Unix epoch seconds) in the past. The token was valid when verify ran at the route boundary, but a long-running step in between (LLM call, slow downstream, queue wait) outlived the credential. The framework refuses to authorize on an expired token.
+A mid-pipeline `.validate(authorize(...))` (or the pre-from `.authorize()` guard) ran on an exchange whose principal carries an `expiresAt` (Unix epoch seconds) that is beyond the configured `clockToleranceSec` window. The token was valid when verify ran at the route boundary, but a long-running step in between (LLM call, slow downstream, queue wait) outlived the credential. The framework refuses to authorize once the tolerance-adjusted expiry is exceeded.
+
+The check is also raised fail-closed when either `expiresAt` or `clockToleranceSec` is non-finite (`NaN`, `Infinity`); a numeric-coercion bug must not silently bypass the guard.
 
 The check is distinct from `RC5012` (no principal at all) and `RC5015` (principal failed a role / scope / predicate check) so clients can react accordingly: a `RC5020` signal almost always means "refresh and retry," whereas `RC5015` is a permanent denial under the current credentials.
 
 **Suggestion**  
 - The client should refresh the bearer and retry the request.
 - To recover server-side, restructure the pipeline so `authorize()` runs before the slow step, or attach a fresh principal in a `.process()` step before the validator.
+- If your source-side verifier (`jwt()` / `jwks()`) sets a `clockToleranceSec`, pass the same value to `authorize({ clockToleranceSec })` so the boundary and mid-pipeline checks agree on a token's validity window.
 - If the principal genuinely has no expiry (e.g. an API key with infinite lifetime), leave `expiresAt` unset on the `Principal` so the check is skipped.
 
 ## RC5021

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -30,6 +30,7 @@ The `retryable` property indicates whether the [`retry`](/docs/reference/operati
 | [RC5015](#rc5015) | Adapter | Permission denied | No |
 | [RC5016](#rc5016) | Adapter | Source payload parse failed | No |
 | [RC5017](#rc5017) | Adapter | Optional peer dependency missing | No |
+| [RC5020](#rc5020) | Adapter | Authorization failed: token expired during processing | No |
 | [RC9901](#rc9901) | Runtime | Unknown error | Yes |
 
 ---
@@ -252,6 +253,19 @@ bun add croner   # or: npm install croner
 ```
 
 The error message names the adapter (`cron`, `html`, ...) and the missing package, so the install line is copyable from the log. If you see this for a feature you do not use, find the route or capability that imports the adapter and remove it.
+
+## RC5020
+Authorization failed: token expired during processing
+
+**Why it happens**  
+A mid-pipeline `.validate(authorize(...))` (or the pre-from `.authorize()` guard) ran on an exchange whose principal carries an `expiresAt` (Unix epoch seconds) in the past. The token was valid when verify ran at the route boundary, but a long-running step in between (LLM call, slow downstream, queue wait) outlived the credential. The framework refuses to authorize on an expired token.
+
+The check is distinct from `RC5012` (no principal at all) and `RC5015` (principal failed a role / scope / predicate check) so clients can react accordingly: a `RC5020` signal almost always means "refresh and retry," whereas `RC5015` is a permanent denial under the current credentials.
+
+**Suggestion**  
+- The client should refresh the bearer and retry the request.
+- To recover server-side, restructure the pipeline so `authorize()` runs before the slow step, or attach a fresh principal in a `.process()` step before the validator.
+- If the principal genuinely has no expiry (e.g. an API key with infinite lifetime), leave `expiresAt` unset on the `Principal` so the check is skipped.
 
 ## RC9901
 Unknown error

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -31,6 +31,8 @@ The `retryable` property indicates whether the [`retry`](/docs/reference/operati
 | [RC5016](#rc5016) | Adapter | Source payload parse failed | No |
 | [RC5017](#rc5017) | Adapter | Optional peer dependency missing | No |
 | [RC5020](#rc5020) | Adapter | Authorization failed: token expired during processing | No |
+| [RC5021](#rc5021) | Adapter | Principal enrichment failed | No |
+| [RC5022](#rc5022) | Adapter | Userinfo sub invariant violated | No |
 | [RC9901](#rc9901) | Runtime | Unknown error | Yes |
 
 ---
@@ -266,6 +268,30 @@ The check is distinct from `RC5012` (no principal at all) and `RC5015` (principa
 - The client should refresh the bearer and retry the request.
 - To recover server-side, restructure the pipeline so `authorize()` runs before the slow step, or attach a fresh principal in a `.process()` step before the validator.
 - If the principal genuinely has no expiry (e.g. an API key with infinite lifetime), leave `expiresAt` unset on the `Principal` so the check is skipped.
+
+## RC5021
+Principal enrichment failed
+
+**Why it happens**  
+The `userinfo` slot on `oauth({})` could not enrich the verified principal. Causes include: a non-2xx response from the userinfo endpoint (rate limit, bearer scope insufficient, IdP outage), a network error reaching the userinfo or OIDC Discovery URL, malformed JSON, or a Discovery document that does not advertise a `userinfo_endpoint`. The framework is fail-closed: any enrichment error rejects the request rather than authorize on a partial principal.
+
+**Suggestion**  
+- Inspect the underlying cause attached to the error: it names the URL and HTTP status.
+- Check that the bearer token has the scopes the IdP requires for `/userinfo` (typically `openid`, `email`, `profile`).
+- If the IdP does not advertise OIDC Discovery (or advertises it without a `userinfo_endpoint`), pass an explicit `userinfo: "https://..."` or a function variant.
+- Verify outbound network access from the MCP server to the IdP.
+
+## RC5022
+Userinfo sub invariant violated
+
+**Why it happens**  
+Per [OIDC Core §5.3.2](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse), the userinfo response MUST carry a `sub` claim equal to the verified token's `sub`. The framework throws RC5022 when the response is missing `sub` or when it differs from the token's `sub`. This guards against a compromised userinfo endpoint impersonating a different user on the principal, or a misconfigured userinfo URL paired with the wrong issuer.
+
+This check applies only to URL and OIDC-discovery `userinfo` modes; the function variant is trusted by contract (the caller owns the backend).
+
+**Suggestion**  
+- Verify the `userinfo` URL matches the issuer of the bearer token. A common cause is configuring a `userinfo` URL for a different tenant or realm.
+- Do not silence this error. If a legitimate IdP returns a non-standard subject under a different field, switch to a function-mode `userinfo` and map the response yourself.
 
 ## RC9901
 Unknown error

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -321,12 +321,11 @@ auth: oauth({
 
 | Field | Default when omitted |
 |-------|----------------------|
-| `subject` | `payload.sub` |
-| `clientId` | `payload.client_id` |
-| `email` | `payload.email` |
-| `name` | `payload.name` |
+| `subject` | `payload.sub`, then `payload.client_id`, then `payload.azp` |
+| `clientId` | `payload.client_id`, then `payload.azp` |
 | `scopes` | space-split `payload.scope` |
-| `roles` | `payload.roles` when it is `string[]` |
+
+`email`, `name`, and `roles` are not mappable here. They are read from the standard claim names (`email`, `name`, `roles`) when present in the token. For identity fields that do not live in the bearer (most IdPs do not put them there), use the [`userinfo` slot on `oauth({})`](/docs/advanced/expose-as-mcp#principal-enrichment-via-userinfo) — function variant for custom mappings, OIDC Discovery or an explicit URL for the standard `/userinfo` endpoint.
 
 **Claim overrides for non-standard IdPs:**
 
@@ -337,7 +336,6 @@ jwt: {
   audience: '<app-id>',
   claims: {
     subject: (p) => p.oid as string,
-    roles: (p) => p['roles'] as string[] | undefined,
   },
 }
 ```

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -100,6 +100,8 @@ export {
   type OAuthFactoryOptions,
   type OAuthProxyEndpoints,
   type OAuthVerifier,
+  type UserinfoFn,
+  type UserinfoOption,
 } from "./mcp/index.ts";
 export type {
   McpClientAuthOptions,

--- a/packages/ai/src/mcp/index.ts
+++ b/packages/ai/src/mcp/index.ts
@@ -9,6 +9,8 @@ export type {
   OAuthFactoryOptions,
   OAuthClientSupplier,
   OAuthVerifier,
+  UserinfoFn,
+  UserinfoOption,
 } from "./oauth.ts";
 export { mcpPlugin } from "./plugin.ts";
 export { McpServer } from "./server.ts";

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -234,6 +234,11 @@ export function oauth(options: OAuthFactoryOptions): OAuthAuthOptions {
     );
   }
 
+  if (!options.verify) {
+    throw new TypeError(
+      "oauth: `verify` is required. Pass jwks(...), jwt(...), or a custom (token) => OAuthPrincipal function.",
+    );
+  }
   const verifyAccessToken =
     options.userinfo !== undefined
       ? buildEnrichedVerifier(options.verify, options.userinfo)

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -8,6 +8,9 @@ import type {
   OAuthClientInfo,
   OAuthProxyEndpoints,
 } from "./types.ts";
+import { buildEnrichedVerifier, type UserinfoOption } from "./userinfo.ts";
+
+export type { UserinfoFn, UserinfoOption } from "./userinfo.ts";
 
 /**
  * Supplier for a registered OAuth client.
@@ -91,6 +94,29 @@ export interface OAuthFactoryOptions {
   serviceDocumentationUrl?: string | URL;
   /** Human-readable resource name (included in OAuth metadata). */
   resourceName?: string;
+  /**
+   * Principal enrichment after `verify` succeeds. Three input shapes:
+   *
+   * - `true`: auto-discover the userinfo endpoint via OIDC Discovery at
+   *   `${issuer}/.well-known/openid-configuration`. Requires the `verify`
+   *   helper to expose a single-string `issuer` (`jwks()` / `jwt()` do).
+   * - `string | URL`: explicit userinfo endpoint URL. The framework fetches
+   *   it with the bearer token and lifts standard OIDC claims (`email`,
+   *   `name`, `roles`, etc.) onto the principal.
+   * - `(principal, token) => Promise<Partial<OAuthPrincipal>>`: custom
+   *   enrichment from any backend (Clerk Backend API, internal DB, etc.).
+   *
+   * For URL and discovery modes the userinfo response `sub` MUST equal the
+   * verified token's `sub` (OIDC Core §5.3.2); mismatches reject the
+   * request. Verify wins on `subject`, `issuer`, `audience`, `expiresAt`;
+   * other fields are overwritten by the enrichment payload. Results are
+   * cached per token and evicted at `principal.expiresAt`. All enrichment
+   * errors are fail-closed (the request is rejected; no silent
+   * degradation).
+   *
+   * @experimental
+   */
+  userinfo?: UserinfoOption;
 }
 
 /**
@@ -208,7 +234,10 @@ export function oauth(options: OAuthFactoryOptions): OAuthAuthOptions {
     );
   }
 
-  const verifyAccessToken = buildVerifier(options.verify);
+  const verifyAccessToken =
+    options.userinfo !== undefined
+      ? buildEnrichedVerifier(options.verify, options.userinfo)
+      : buildVerifier(options.verify);
   const getClient = normaliseClientSupplier(options.client);
 
   const result: OAuthAuthOptions = {

--- a/packages/ai/src/mcp/userinfo.ts
+++ b/packages/ai/src/mcp/userinfo.ts
@@ -1,0 +1,291 @@
+import type {
+  OAuthPrincipal,
+  OAuthValidatorAuthOptions,
+} from "@routecraft/routecraft";
+import type { OAuthVerifier } from "./oauth.ts";
+
+/**
+ * Custom enrichment function. Receives the verified principal and the raw
+ * bearer token and returns a partial principal whose non-protected fields are
+ * merged onto the result.
+ *
+ * Trusted by contract: the framework does not enforce the `sub` invariant for
+ * the function variant (unlike URL / discovery modes), since the caller is
+ * already free to consult any backend they choose. Protected fields
+ * (`subject`, `issuer`, `audience`, `expiresAt`) from the verified token
+ * always win regardless of what the function returns.
+ *
+ * @experimental
+ */
+export type UserinfoFn = (
+  principal: OAuthPrincipal,
+  token: string,
+) => Promise<Partial<OAuthPrincipal>>;
+
+/**
+ * Input shape for the `userinfo` slot on `oauth({})`.
+ *
+ * - `true`: auto-discover the userinfo endpoint via OIDC Discovery
+ *   (`${issuer}/.well-known/openid-configuration`). Requires the underlying
+ *   `verify` helper to expose a single-string `issuer`.
+ * - `string | URL`: explicit userinfo endpoint URL.
+ * - `UserinfoFn`: custom enrichment function for non-OIDC sources (Clerk
+ *   Backend API, internal DB, etc.).
+ *
+ * @experimental
+ */
+export type UserinfoOption = true | string | URL | UserinfoFn;
+
+/** Protected fields that come from the verified token and cannot be overridden by enrichment. */
+const PROTECTED_FIELDS = [
+  "subject",
+  "issuer",
+  "audience",
+  "expiresAt",
+] as const;
+
+interface CacheEntry {
+  principal: OAuthPrincipal;
+  expiresAt: number;
+}
+
+/**
+ * Token-bound enrichment cache. Entries are keyed by the raw token and
+ * evicted lazily at the principal's `expiresAt`. Memory is bounded by the set
+ * of currently-active tokens because each entry self-evicts at expiry.
+ *
+ * @internal
+ */
+export class UserinfoCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  get(token: string): OAuthPrincipal | undefined {
+    const entry = this.entries.get(token);
+    if (!entry) return undefined;
+    if (Date.now() / 1000 > entry.expiresAt) {
+      this.entries.delete(token);
+      return undefined;
+    }
+    return entry.principal;
+  }
+
+  set(token: string, principal: OAuthPrincipal): void {
+    this.entries.set(token, { principal, expiresAt: principal.expiresAt });
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+interface OidcDiscoveryDoc {
+  userinfo_endpoint?: string;
+}
+
+/**
+ * Resolve the userinfo endpoint URL from the `userinfo` option.
+ *
+ * For literal `string | URL`, returns it directly. For `true`, fetches the
+ * OIDC Discovery document at `${issuer}/.well-known/openid-configuration`
+ * once and reads `userinfo_endpoint`. The discovery doc is cached for the
+ * lifetime of the resolver closure (i.e. per `oauth()` call).
+ *
+ * Throws a `TypeError` when:
+ * - `userinfo: true` is set but no issuer can be resolved from `verify`.
+ * - the resolved issuer is `string[]` (OIDC Discovery requires a single issuer).
+ * - the discovery document does not advertise a `userinfo_endpoint`.
+ * - the discovery document fetch fails or returns a non-2xx response.
+ *
+ * @internal
+ */
+function createUserinfoUrlResolver(
+  option: true | string | URL,
+  issuer: string | string[] | undefined,
+): () => Promise<URL> {
+  if (option !== true) {
+    const url = new URL(option.toString());
+    return async () => url;
+  }
+
+  if (issuer === undefined) {
+    throw new TypeError(
+      "oauth: `userinfo: true` requires the verify helper to expose an `issuer`. " +
+        "Use `jwks({ issuer, ... })` / `jwt({ issuer, ... })`, pass an explicit " +
+        '`userinfo: "https://idp.example.com/oauth/userinfo"`, or use a function.',
+    );
+  }
+  if (Array.isArray(issuer)) {
+    throw new TypeError(
+      "oauth: `userinfo: true` requires a single-string `issuer`; got an array. " +
+        "OIDC Discovery resolves one issuer to one userinfo endpoint. Pass an " +
+        "explicit userinfo URL or function instead.",
+    );
+  }
+
+  let cached: URL | null = null;
+  return async () => {
+    if (cached) return cached;
+    const discoveryUrl = new URL(
+      "/.well-known/openid-configuration",
+      issuer.endsWith("/") ? issuer : `${issuer}/`,
+    );
+    const response = await fetch(discoveryUrl);
+    if (!response.ok) {
+      throw new TypeError(
+        `oauth: OIDC Discovery fetch failed at ${discoveryUrl.toString()} (status ${response.status}). ` +
+          "Pass an explicit `userinfo` URL or function if the IdP does not advertise discovery.",
+      );
+    }
+    const doc = (await response.json()) as OidcDiscoveryDoc;
+    if (typeof doc.userinfo_endpoint !== "string" || !doc.userinfo_endpoint) {
+      throw new TypeError(
+        `oauth: OIDC Discovery document at ${discoveryUrl.toString()} does not advertise a userinfo_endpoint. ` +
+          "Pass an explicit `userinfo` URL or function for this IdP.",
+      );
+    }
+    cached = new URL(doc.userinfo_endpoint);
+    return cached;
+  };
+}
+
+/**
+ * Fetch the userinfo response from the given endpoint using the bearer token.
+ * Throws when the response is non-2xx or not valid JSON; all errors are
+ * surfaced to the verifier which rejects the request (fail-closed).
+ */
+async function fetchUserinfo(
+  url: URL,
+  token: string,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `userinfo fetch failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  return (await response.json()) as Record<string, unknown>;
+}
+
+/**
+ * Merge an enrichment payload onto the verified principal. Protected fields
+ * (`subject`, `issuer`, `audience`, `expiresAt`) from the verified token
+ * always win; everything else is overwritten by the enrichment.
+ */
+function mergeEnrichment(
+  principal: OAuthPrincipal,
+  enrichment: Partial<OAuthPrincipal> | Record<string, unknown>,
+): OAuthPrincipal {
+  const merged = { ...principal } as OAuthPrincipal & Record<string, unknown>;
+  for (const [key, value] of Object.entries(enrichment)) {
+    if ((PROTECTED_FIELDS as readonly string[]).includes(key)) continue;
+    if (value === undefined) continue;
+    merged[key] = value;
+  }
+  return merged;
+}
+
+/**
+ * Lift standard OIDC claims off a userinfo response payload onto an
+ * `OAuthPrincipal` shape. Per OIDC Core §5.3.2 the response is a flat JSON
+ * object keyed by claim name; the framework lifts the identity claims onto
+ * named fields and stashes the remainder under `claims` for callers that want
+ * the raw payload.
+ */
+function liftOidcClaims(
+  payload: Record<string, unknown>,
+): Partial<OAuthPrincipal> {
+  const out: Partial<OAuthPrincipal> = { claims: payload };
+  if (typeof payload["email"] === "string") out.email = payload["email"];
+  if (typeof payload["name"] === "string") out.name = payload["name"];
+  if (Array.isArray(payload["roles"])) {
+    out.roles = (payload["roles"] as unknown[]).filter(
+      (r): r is string => typeof r === "string",
+    );
+  }
+  return out;
+}
+
+/**
+ * Normalise the `verify` option into a `(token) => Promise<OAuthPrincipal>`
+ * callback. Mirrors the inner helper in `oauth.ts` but exposed for the
+ * enrichment wrapper.
+ */
+function callBaseVerifier(
+  verify: OAuthVerifier,
+): (token: string) => Promise<OAuthPrincipal> {
+  if (typeof verify === "function") {
+    return async (token) => verify(token);
+  }
+  return async (token) => verify.validator(token);
+}
+
+/**
+ * Wrap a base verifier with userinfo enrichment. After the base verify
+ * succeeds:
+ *
+ * 1. Cache lookup keyed by the raw token. Hit -> return cached principal.
+ * 2. Miss -> fetch userinfo (URL or discovery modes) or invoke the user
+ *    function, enforce the `sub` invariant (URL / discovery modes only),
+ *    merge onto the principal with protected fields preserved, and cache
+ *    the result with TTL = `principal.expiresAt`.
+ *
+ * Fail-closed: every error (network, parse, sub mismatch) rejects the
+ * request.
+ *
+ * @internal
+ */
+export function buildEnrichedVerifier(
+  verify: OAuthVerifier,
+  userinfo: UserinfoOption,
+): (token: string) => Promise<OAuthPrincipal> {
+  const baseVerifier = callBaseVerifier(verify);
+  const cache = new UserinfoCache();
+
+  if (typeof userinfo === "function") {
+    return async (token: string) => {
+      const cached = cache.get(token);
+      if (cached) return cached;
+      const principal = await baseVerifier(token);
+      const enrichment = await userinfo(principal, token);
+      const enriched = mergeEnrichment(principal, enrichment);
+      cache.set(token, enriched);
+      return enriched;
+    };
+  }
+
+  const verifyIssuer = typeof verify === "function" ? undefined : verify.issuer;
+  const resolveUserinfoUrl = createUserinfoUrlResolver(userinfo, verifyIssuer);
+
+  return async (token: string) => {
+    const cached = cache.get(token);
+    if (cached) return cached;
+    const principal = await baseVerifier(token);
+    const url = await resolveUserinfoUrl();
+    const payload = await fetchUserinfo(url, token);
+    const responseSub = payload["sub"];
+    if (typeof responseSub !== "string" || responseSub.length === 0) {
+      throw new Error(
+        "userinfo response is missing `sub` (required per OIDC Core §5.3.2)",
+      );
+    }
+    if (responseSub !== principal.subject) {
+      throw new Error(
+        `userinfo \`sub\` (${responseSub}) does not match token \`sub\` (${principal.subject}); rejecting per OIDC Core §5.3.2`,
+      );
+    }
+    const enrichment = liftOidcClaims(payload);
+    const enriched = mergeEnrichment(principal, enrichment);
+    cache.set(token, enriched);
+    return enriched;
+  };
+}
+
+/**
+ * Type-only re-export hook so consumers can refer to the issuer field on
+ * `OAuthValidatorAuthOptions` without importing the parent type. Internal.
+ *
+ * @internal
+ */
+export type IssuerCarrier = Pick<OAuthValidatorAuthOptions, "issuer">;

--- a/packages/ai/src/mcp/userinfo.ts
+++ b/packages/ai/src/mcp/userinfo.ts
@@ -1,7 +1,5 @@
-import type {
-  OAuthPrincipal,
-  OAuthValidatorAuthOptions,
-} from "@routecraft/routecraft";
+import { createHash } from "node:crypto";
+import { rcError, type OAuthPrincipal } from "@routecraft/routecraft";
 import type { OAuthVerifier } from "./oauth.ts";
 
 /**
@@ -12,8 +10,9 @@ import type { OAuthVerifier } from "./oauth.ts";
  * Trusted by contract: the framework does not enforce the `sub` invariant for
  * the function variant (unlike URL / discovery modes), since the caller is
  * already free to consult any backend they choose. Protected fields
- * (`subject`, `issuer`, `audience`, `expiresAt`) from the verified token
- * always win regardless of what the function returns.
+ * (`subject`, `issuer`, `audience`, `expiresAt`, `claims`) from the verified
+ * token always win regardless of what the function returns. If you want the
+ * raw upstream response surfaced, return `{ userinfoClaims: ... }`.
  *
  * @experimental
  */
@@ -25,9 +24,9 @@ export type UserinfoFn = (
 /**
  * Input shape for the `userinfo` slot on `oauth({})`.
  *
- * - `true`: auto-discover the userinfo endpoint via OIDC Discovery
- *   (`${issuer}/.well-known/openid-configuration`). Requires the underlying
- *   `verify` helper to expose a single-string `issuer`.
+ * - `true`: auto-discover the userinfo endpoint via OIDC Discovery. The
+ *   discovery document is fetched relative to the verify helper's `issuer`,
+ *   so a single-string issuer (with or without a path) is required.
  * - `string | URL`: explicit userinfo endpoint URL.
  * - `UserinfoFn`: custom enrichment function for non-OIDC sources (Clerk
  *   Backend API, internal DB, etc.).
@@ -36,13 +35,25 @@ export type UserinfoFn = (
  */
 export type UserinfoOption = true | string | URL | UserinfoFn;
 
-/** Protected fields that come from the verified token and cannot be overridden by enrichment. */
+/**
+ * Fields that come from the verified token and cannot be overridden by
+ * enrichment. `claims` is protected so URL / discovery enrichment does not
+ * clobber the JWT payload that consumers expect on `principal.claims`; the
+ * raw userinfo response lives on `userinfoClaims` instead.
+ */
 const PROTECTED_FIELDS = [
   "subject",
   "issuer",
   "audience",
   "expiresAt",
+  "claims",
 ] as const;
+
+/** Default cap on cached enriched principals. Tuned for typical MCP fleets; tokens self-evict at `expiresAt`. */
+const DEFAULT_CACHE_MAX_ENTRIES = 10_000;
+
+/** Default discovery-document TTL when the IdP does not advertise `Cache-Control: max-age`. */
+const DEFAULT_DISCOVERY_TTL_SEC = 3600;
 
 interface CacheEntry {
   principal: OAuthPrincipal;
@@ -50,32 +61,86 @@ interface CacheEntry {
 }
 
 /**
- * Token-bound enrichment cache. Entries are keyed by the raw token and
- * evicted lazily at the principal's `expiresAt`. Memory is bounded by the set
- * of currently-active tokens because each entry self-evicts at expiry.
+ * Token-bound enrichment cache with in-flight request coalescing.
+ *
+ * Entries are keyed by a SHA-256 hash of the bearer token (not the raw
+ * token) so a heap dump or accidental log snapshot does not expose
+ * plaintext bearers. Entries self-evict at the principal's `expiresAt`; a
+ * configurable insertion-order cap (`maxEntries`) provides a hard memory
+ * ceiling so a misbehaving client that never reuses a token cannot grow the
+ * map without bound.
+ *
+ * Concurrent calls for the same uncached token share a single in-flight
+ * enrichment promise; the IdP receives one userinfo fetch per
+ * (token, expiresAt) window, not one per inbound request.
  *
  * @internal
  */
 export class UserinfoCache {
   private readonly entries = new Map<string, CacheEntry>();
+  private readonly inFlight = new Map<string, Promise<OAuthPrincipal>>();
+  private readonly maxEntries: number;
 
-  get(token: string): OAuthPrincipal | undefined {
-    const entry = this.entries.get(token);
-    if (!entry) return undefined;
-    if (Date.now() / 1000 > entry.expiresAt) {
-      this.entries.delete(token);
-      return undefined;
+  constructor(maxEntries: number = DEFAULT_CACHE_MAX_ENTRIES) {
+    this.maxEntries = maxEntries;
+  }
+
+  /**
+   * Return the cached enriched principal for the token, or run `compute()`
+   * to produce one and cache the result. Concurrent callers for the same
+   * token share the in-flight promise.
+   */
+  async getOrCompute(
+    token: string,
+    compute: () => Promise<OAuthPrincipal>,
+  ): Promise<OAuthPrincipal> {
+    const key = hashToken(token);
+    const cached = this.entries.get(key);
+    if (cached) {
+      if (Date.now() / 1000 < cached.expiresAt) return cached.principal;
+      this.entries.delete(key);
     }
-    return entry.principal;
+
+    const pending = this.inFlight.get(key);
+    if (pending) return pending;
+
+    const promise = compute().then(
+      (principal) => {
+        this.store(key, principal);
+        this.inFlight.delete(key);
+        return principal;
+      },
+      (err: unknown) => {
+        this.inFlight.delete(key);
+        throw err;
+      },
+    );
+    this.inFlight.set(key, promise);
+    return promise;
   }
 
-  set(token: string, principal: OAuthPrincipal): void {
-    this.entries.set(token, { principal, expiresAt: principal.expiresAt });
-  }
-
+  /** Clear every cached entry. Intended for tests. */
   clear(): void {
     this.entries.clear();
+    this.inFlight.clear();
   }
+
+  private store(key: string, principal: OAuthPrincipal): void {
+    if (this.entries.has(key)) this.entries.delete(key);
+    this.entries.set(key, {
+      principal,
+      expiresAt: principal.expiresAt,
+    });
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+}
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
 }
 
 interface OidcDiscoveryDoc {
@@ -83,18 +148,34 @@ interface OidcDiscoveryDoc {
 }
 
 /**
+ * Parse `Cache-Control: max-age=<seconds>` (RFC 9111). Returns the parsed TTL
+ * in seconds, or `undefined` if the header is absent or unparseable.
+ */
+function parseMaxAge(headerValue: string | null): number | undefined {
+  if (!headerValue) return undefined;
+  const match = headerValue.match(/(?:^|,\s*)max-age=(\d+)/i);
+  if (!match) return undefined;
+  const value = Number.parseInt(match[1]!, 10);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+/**
  * Resolve the userinfo endpoint URL from the `userinfo` option.
  *
  * For literal `string | URL`, returns it directly. For `true`, fetches the
- * OIDC Discovery document at `${issuer}/.well-known/openid-configuration`
- * once and reads `userinfo_endpoint`. The discovery doc is cached for the
- * lifetime of the resolver closure (i.e. per `oauth()` call).
+ * OIDC Discovery document relative to the issuer (preserving the issuer's
+ * path component, so Keycloak realms and tenant-prefixed IdPs resolve
+ * correctly) and reads `userinfo_endpoint`. The discovery URL is cached for
+ * the lifetime advertised by `Cache-Control: max-age`, defaulting to one
+ * hour. Concurrent first-callers share a single in-flight fetch.
  *
- * Throws a `TypeError` when:
- * - `userinfo: true` is set but no issuer can be resolved from `verify`.
- * - the resolved issuer is `string[]` (OIDC Discovery requires a single issuer).
- * - the discovery document does not advertise a `userinfo_endpoint`.
- * - the discovery document fetch fails or returns a non-2xx response.
+ * Sync errors at construction time:
+ * - `TypeError` if `userinfo: true` and no issuer is exposed by `verify`.
+ * - `TypeError` if `userinfo: true` and the resolved issuer is an array.
+ *
+ * Async errors (per call, wrapped in `RC5021`):
+ * - Discovery fetch failure (non-2xx, network error, malformed JSON).
+ * - Discovery document missing `userinfo_endpoint`.
  *
  * @internal
  */
@@ -122,56 +203,126 @@ function createUserinfoUrlResolver(
     );
   }
 
-  let cached: URL | null = null;
-  return async () => {
-    if (cached) return cached;
-    const discoveryUrl = new URL(
-      "/.well-known/openid-configuration",
-      issuer.endsWith("/") ? issuer : `${issuer}/`,
-    );
-    const response = await fetch(discoveryUrl);
+  const base = issuer.endsWith("/") ? issuer : `${issuer}/`;
+  const discoveryUrl = new URL(".well-known/openid-configuration", base);
+
+  let cachedUrl: URL | null = null;
+  let cachedUntil = 0;
+  let inFlight: Promise<URL> | null = null;
+
+  const fetchAndCache = async (): Promise<URL> => {
+    let response: Response;
+    try {
+      response = await fetch(discoveryUrl);
+    } catch (cause) {
+      throw rcError("RC5021", cause, {
+        message: `OIDC Discovery fetch failed at ${discoveryUrl.toString()}`,
+        suggestion:
+          "Verify network access to the IdP and that the issuer URL is reachable. Pass an explicit `userinfo` URL or function if the IdP does not advertise discovery.",
+      });
+    }
     if (!response.ok) {
-      throw new TypeError(
-        `oauth: OIDC Discovery fetch failed at ${discoveryUrl.toString()} (status ${response.status}). ` +
-          "Pass an explicit `userinfo` URL or function if the IdP does not advertise discovery.",
+      throw rcError(
+        "RC5021",
+        new Error(
+          `OIDC Discovery fetch returned ${response.status} ${response.statusText}`,
+        ),
+        {
+          message: `OIDC Discovery fetch failed at ${discoveryUrl.toString()} (status ${response.status})`,
+          suggestion:
+            "Verify the issuer hosts an OIDC Discovery document. Pass an explicit `userinfo` URL or function if it does not.",
+        },
       );
     }
-    const doc = (await response.json()) as OidcDiscoveryDoc;
+    let doc: OidcDiscoveryDoc;
+    try {
+      doc = (await response.json()) as OidcDiscoveryDoc;
+    } catch (cause) {
+      throw rcError("RC5021", cause, {
+        message: `OIDC Discovery document at ${discoveryUrl.toString()} is not valid JSON`,
+        suggestion:
+          "Inspect the discovery endpoint manually. Pass an explicit `userinfo` URL or function if the IdP is non-compliant.",
+      });
+    }
     if (typeof doc.userinfo_endpoint !== "string" || !doc.userinfo_endpoint) {
-      throw new TypeError(
-        `oauth: OIDC Discovery document at ${discoveryUrl.toString()} does not advertise a userinfo_endpoint. ` +
-          "Pass an explicit `userinfo` URL or function for this IdP.",
+      throw rcError(
+        "RC5021",
+        new Error("missing userinfo_endpoint in discovery document"),
+        {
+          message: `OIDC Discovery document at ${discoveryUrl.toString()} does not advertise a userinfo_endpoint`,
+          suggestion:
+            "Pass an explicit `userinfo` URL or function for this IdP; it does not advertise auto-discoverable userinfo.",
+        },
       );
     }
-    cached = new URL(doc.userinfo_endpoint);
-    return cached;
+    const resolved = new URL(doc.userinfo_endpoint);
+    const ttl =
+      parseMaxAge(response.headers.get("cache-control")) ??
+      DEFAULT_DISCOVERY_TTL_SEC;
+    cachedUrl = resolved;
+    cachedUntil = Date.now() / 1000 + ttl;
+    return resolved;
+  };
+
+  return async () => {
+    if (cachedUrl && Date.now() / 1000 < cachedUntil) return cachedUrl;
+    if (inFlight) return inFlight;
+    inFlight = fetchAndCache().finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
   };
 }
 
 /**
  * Fetch the userinfo response from the given endpoint using the bearer token.
- * Throws when the response is non-2xx or not valid JSON; all errors are
- * surfaced to the verifier which rejects the request (fail-closed).
+ * Throws `RC5021` when the response is non-2xx or not valid JSON. All errors
+ * are surfaced to the verifier which rejects the request (fail-closed).
  */
 async function fetchUserinfo(
   url: URL,
   token: string,
 ): Promise<Record<string, unknown>> {
-  const response = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch (cause) {
+    throw rcError("RC5021", cause, {
+      message: `userinfo fetch failed at ${url.toString()}`,
+      suggestion:
+        "Verify network access to the IdP's userinfo endpoint and that the bearer token's scopes permit it.",
+    });
+  }
   if (!response.ok) {
-    throw new Error(
-      `userinfo fetch failed: ${response.status} ${response.statusText}`,
+    throw rcError(
+      "RC5021",
+      new Error(`userinfo returned ${response.status} ${response.statusText}`),
+      {
+        message: `userinfo fetch failed at ${url.toString()} (status ${response.status})`,
+        suggestion:
+          "Check the bearer token has the scopes required by the IdP's userinfo endpoint (typically `openid`, `email`, `profile`).",
+      },
     );
   }
-  return (await response.json()) as Record<string, unknown>;
+  try {
+    return (await response.json()) as Record<string, unknown>;
+  } catch (cause) {
+    throw rcError("RC5021", cause, {
+      message: `userinfo response at ${url.toString()} is not valid JSON`,
+      suggestion:
+        "Inspect the userinfo endpoint manually; it must return a JSON object per OIDC Core §5.3.2.",
+    });
+  }
 }
 
 /**
  * Merge an enrichment payload onto the verified principal. Protected fields
- * (`subject`, `issuer`, `audience`, `expiresAt`) from the verified token
- * always win; everything else is overwritten by the enrichment.
+ * (`subject`, `issuer`, `audience`, `expiresAt`, `claims`) from the verified
+ * token always win; every other field on the enrichment overwrites the
+ * principal's. The raw userinfo response lives on `userinfoClaims` in URL /
+ * discovery mode; function-mode enrichment can populate it explicitly.
  */
 function mergeEnrichment(
   principal: OAuthPrincipal,
@@ -187,16 +338,18 @@ function mergeEnrichment(
 }
 
 /**
- * Lift standard OIDC claims off a userinfo response payload onto an
- * `OAuthPrincipal` shape. Per OIDC Core §5.3.2 the response is a flat JSON
- * object keyed by claim name; the framework lifts the identity claims onto
- * named fields and stashes the remainder under `claims` for callers that want
- * the raw payload.
+ * Lift standard OIDC claims off a userinfo response payload onto a
+ * `Partial<OAuthPrincipal>` shape. Per OIDC Core §5.3.2 the response is a
+ * flat JSON object keyed by claim name. The framework lifts the identity
+ * claims that have a first-class field on `Principal` (`email`, `name`,
+ * `roles`) and stashes the full response under `userinfoClaims` for callers
+ * that want the raw payload. The verified JWT payload on `principal.claims`
+ * is preserved.
  */
 function liftOidcClaims(
   payload: Record<string, unknown>,
 ): Partial<OAuthPrincipal> {
-  const out: Partial<OAuthPrincipal> = { claims: payload };
+  const out: Partial<OAuthPrincipal> = { userinfoClaims: payload };
   if (typeof payload["email"] === "string") out.email = payload["email"];
   if (typeof payload["name"] === "string") out.name = payload["name"];
   if (Array.isArray(payload["roles"])) {
@@ -225,14 +378,17 @@ function callBaseVerifier(
  * Wrap a base verifier with userinfo enrichment. After the base verify
  * succeeds:
  *
- * 1. Cache lookup keyed by the raw token. Hit -> return cached principal.
+ * 1. Cache + in-flight lookup keyed by SHA-256(token). Hit -> return cached
+ *    principal. In-flight -> share the pending enrichment.
  * 2. Miss -> fetch userinfo (URL or discovery modes) or invoke the user
- *    function, enforce the `sub` invariant (URL / discovery modes only),
- *    merge onto the principal with protected fields preserved, and cache
- *    the result with TTL = `principal.expiresAt`.
+ *    function, enforce the `sub` invariant for URL / discovery modes
+ *    (RC5022 on mismatch / missing sub), merge onto the principal with
+ *    protected fields preserved, and cache the result with TTL =
+ *    `principal.expiresAt`.
  *
  * Fail-closed: every error (network, parse, sub mismatch) rejects the
- * request.
+ * request. Network / fetch failures wrap as `RC5021`; sub-invariant
+ * violations wrap as `RC5022`.
  *
  * @internal
  */
@@ -244,48 +400,50 @@ export function buildEnrichedVerifier(
   const cache = new UserinfoCache();
 
   if (typeof userinfo === "function") {
-    return async (token: string) => {
-      const cached = cache.get(token);
-      if (cached) return cached;
-      const principal = await baseVerifier(token);
-      const enrichment = await userinfo(principal, token);
-      const enriched = mergeEnrichment(principal, enrichment);
-      cache.set(token, enriched);
-      return enriched;
-    };
+    return (token: string) =>
+      cache.getOrCompute(token, async () => {
+        const principal = await baseVerifier(token);
+        const enrichment = await userinfo(principal, token);
+        return mergeEnrichment(principal, enrichment);
+      });
   }
 
   const verifyIssuer = typeof verify === "function" ? undefined : verify.issuer;
   const resolveUserinfoUrl = createUserinfoUrlResolver(userinfo, verifyIssuer);
 
-  return async (token: string) => {
-    const cached = cache.get(token);
-    if (cached) return cached;
-    const principal = await baseVerifier(token);
-    const url = await resolveUserinfoUrl();
-    const payload = await fetchUserinfo(url, token);
-    const responseSub = payload["sub"];
-    if (typeof responseSub !== "string" || responseSub.length === 0) {
-      throw new Error(
-        "userinfo response is missing `sub` (required per OIDC Core §5.3.2)",
-      );
-    }
-    if (responseSub !== principal.subject) {
-      throw new Error(
-        `userinfo \`sub\` (${responseSub}) does not match token \`sub\` (${principal.subject}); rejecting per OIDC Core §5.3.2`,
-      );
-    }
-    const enrichment = liftOidcClaims(payload);
-    const enriched = mergeEnrichment(principal, enrichment);
-    cache.set(token, enriched);
-    return enriched;
-  };
+  return (token: string) =>
+    cache.getOrCompute(token, async () => {
+      const principal = await baseVerifier(token);
+      const url = await resolveUserinfoUrl();
+      const payload = await fetchUserinfo(url, token);
+      const responseSub = payload["sub"];
+      if (typeof responseSub !== "string" || responseSub.length === 0) {
+        throw rcError(
+          "RC5022",
+          new Error("userinfo response is missing `sub`"),
+          {
+            message:
+              "userinfo response is missing `sub` (required per OIDC Core §5.3.2)",
+            suggestion:
+              "Inspect the userinfo endpoint manually; the response MUST include a `sub` claim. If the IdP returns a non-standard identifier, use a function-mode `userinfo` and map it yourself.",
+          },
+        );
+      }
+      if (responseSub !== principal.subject) {
+        throw rcError(
+          "RC5022",
+          new Error(
+            `userinfo \`sub\` (${responseSub}) does not match token \`sub\` (${principal.subject})`,
+          ),
+          {
+            message:
+              "userinfo response `sub` does not match the verified token's `sub` (OIDC Core §5.3.2 violation)",
+            suggestion:
+              "This indicates a compromised userinfo endpoint or a misconfigured userinfo URL. Verify the issuer / userinfo mapping; do not relax this check.",
+          },
+        );
+      }
+      const enrichment = liftOidcClaims(payload);
+      return mergeEnrichment(principal, enrichment);
+    });
 }
-
-/**
- * Type-only re-export hook so consumers can refer to the issuer field on
- * `OAuthValidatorAuthOptions` without importing the parent type. Internal.
- *
- * @internal
- */
-export type IssuerCarrier = Pick<OAuthValidatorAuthOptions, "issuer">;

--- a/packages/ai/src/mcp/userinfo.ts
+++ b/packages/ai/src/mcp/userinfo.ts
@@ -56,19 +56,25 @@ const DEFAULT_CACHE_MAX_ENTRIES = 10_000;
 const DEFAULT_DISCOVERY_TTL_SEC = 3600;
 
 interface CacheEntry {
-  principal: OAuthPrincipal;
+  enrichment: Partial<OAuthPrincipal>;
   expiresAt: number;
 }
 
 /**
  * Token-bound enrichment cache with in-flight request coalescing.
  *
- * Entries are keyed by a SHA-256 hash of the bearer token (not the raw
- * token) so a heap dump or accidental log snapshot does not expose
- * plaintext bearers. Entries self-evict at the principal's `expiresAt`; a
- * configurable insertion-order cap (`maxEntries`) provides a hard memory
- * ceiling so a misbehaving client that never reuses a token cannot grow the
- * map without bound.
+ * Caches the enrichment payload (a `Partial<OAuthPrincipal>`), NOT the
+ * fully merged principal. The base verifier runs on every request so any
+ * dynamic checks the verifier performs (introspection, revocation, clock
+ * comparisons) still fire per request; only the userinfo / function-mode
+ * enrichment is memoised.
+ *
+ * Entries are keyed by a SHA-256 hash of the bearer token so a heap dump
+ * or accidental log snapshot does not expose plaintext bearers. Entries
+ * self-evict at the principal's `expiresAt`; a configurable
+ * insertion-order cap (`maxEntries`) provides a hard memory ceiling so a
+ * misbehaving client that never reuses a token cannot grow the map
+ * without bound.
  *
  * Concurrent calls for the same uncached token share a single in-flight
  * enrichment promise; the IdP receives one userinfo fetch per
@@ -78,7 +84,10 @@ interface CacheEntry {
  */
 export class UserinfoCache {
   private readonly entries = new Map<string, CacheEntry>();
-  private readonly inFlight = new Map<string, Promise<OAuthPrincipal>>();
+  private readonly inFlight = new Map<
+    string,
+    Promise<Partial<OAuthPrincipal>>
+  >();
   private readonly maxEntries: number;
 
   constructor(maxEntries: number = DEFAULT_CACHE_MAX_ENTRIES) {
@@ -86,18 +95,20 @@ export class UserinfoCache {
   }
 
   /**
-   * Return the cached enriched principal for the token, or run `compute()`
-   * to produce one and cache the result. Concurrent callers for the same
-   * token share the in-flight promise.
+   * Return the cached enrichment for the token, or run `compute()` to
+   * produce one and cache the result. Concurrent callers for the same
+   * token share the in-flight promise. The cached entry self-evicts at
+   * `expiresAt` (Unix epoch seconds, typically the principal's expiry).
    */
   async getOrCompute(
     token: string,
-    compute: () => Promise<OAuthPrincipal>,
-  ): Promise<OAuthPrincipal> {
+    expiresAt: number,
+    compute: () => Promise<Partial<OAuthPrincipal>>,
+  ): Promise<Partial<OAuthPrincipal>> {
     const key = hashToken(token);
     const cached = this.entries.get(key);
     if (cached) {
-      if (Date.now() / 1000 < cached.expiresAt) return cached.principal;
+      if (Date.now() / 1000 < cached.expiresAt) return cached.enrichment;
       this.entries.delete(key);
     }
 
@@ -105,10 +116,10 @@ export class UserinfoCache {
     if (pending) return pending;
 
     const promise = compute().then(
-      (principal) => {
-        this.store(key, principal);
+      (enrichment) => {
+        this.store(key, enrichment, expiresAt);
         this.inFlight.delete(key);
-        return principal;
+        return enrichment;
       },
       (err: unknown) => {
         this.inFlight.delete(key);
@@ -125,12 +136,13 @@ export class UserinfoCache {
     this.inFlight.clear();
   }
 
-  private store(key: string, principal: OAuthPrincipal): void {
+  private store(
+    key: string,
+    enrichment: Partial<OAuthPrincipal>,
+    expiresAt: number,
+  ): void {
     if (this.entries.has(key)) this.entries.delete(key);
-    this.entries.set(key, {
-      principal,
-      expiresAt: principal.expiresAt,
-    });
+    this.entries.set(key, { enrichment, expiresAt });
     while (this.entries.size > this.maxEntries) {
       const oldest = this.entries.keys().next().value;
       if (oldest === undefined) break;
@@ -156,7 +168,7 @@ function parseMaxAge(headerValue: string | null): number | undefined {
   const match = headerValue.match(/(?:^|,\s*)max-age=(\d+)/i);
   if (!match) return undefined;
   const value = Number.parseInt(match[1]!, 10);
-  return Number.isFinite(value) && value > 0 ? value : undefined;
+  return Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 /**
@@ -375,20 +387,24 @@ function callBaseVerifier(
 }
 
 /**
- * Wrap a base verifier with userinfo enrichment. After the base verify
- * succeeds:
+ * Wrap a base verifier with userinfo enrichment.
  *
- * 1. Cache + in-flight lookup keyed by SHA-256(token). Hit -> return cached
- *    principal. In-flight -> share the pending enrichment.
- * 2. Miss -> fetch userinfo (URL or discovery modes) or invoke the user
- *    function, enforce the `sub` invariant for URL / discovery modes
- *    (RC5022 on mismatch / missing sub), merge onto the principal with
- *    protected fields preserved, and cache the result with TTL =
- *    `principal.expiresAt`.
+ * The base verifier runs on every request so any dynamic checks it
+ * performs (introspection, revocation, clock comparisons) still fire per
+ * request. Only the enrichment payload is memoised, keyed by
+ * SHA-256(token) and TTL'd to `principal.expiresAt`.
  *
- * Fail-closed: every error (network, parse, sub mismatch) rejects the
- * request. Network / fetch failures wrap as `RC5021`; sub-invariant
- * violations wrap as `RC5022`.
+ * Concurrent first-callers for the same token share a single in-flight
+ * enrichment promise, so the IdP receives one userinfo fetch per
+ * (token, expiresAt) window. The merge is recomputed on every request
+ * against the freshly-verified principal, so the returned object is never
+ * a shared reference into the cache.
+ *
+ * Sub-invariant enforcement (URL / discovery modes only): the userinfo
+ * response `sub` MUST match the first verified principal's `subject` (per
+ * OIDC Core §5.3.2). Mismatches raise `RC5022`; the function variant is
+ * trusted by contract. Network / fetch / parse failures raise `RC5021`.
+ * Fail-closed throughout.
  *
  * @internal
  */
@@ -400,50 +416,58 @@ export function buildEnrichedVerifier(
   const cache = new UserinfoCache();
 
   if (typeof userinfo === "function") {
-    return (token: string) =>
-      cache.getOrCompute(token, async () => {
-        const principal = await baseVerifier(token);
-        const enrichment = await userinfo(principal, token);
-        return mergeEnrichment(principal, enrichment);
-      });
+    return async (token: string) => {
+      const principal = await baseVerifier(token);
+      const enrichment = await cache.getOrCompute(
+        token,
+        principal.expiresAt,
+        () => userinfo(principal, token),
+      );
+      return mergeEnrichment(principal, enrichment);
+    };
   }
 
   const verifyIssuer = typeof verify === "function" ? undefined : verify.issuer;
   const resolveUserinfoUrl = createUserinfoUrlResolver(userinfo, verifyIssuer);
 
-  return (token: string) =>
-    cache.getOrCompute(token, async () => {
-      const principal = await baseVerifier(token);
-      const url = await resolveUserinfoUrl();
-      const payload = await fetchUserinfo(url, token);
-      const responseSub = payload["sub"];
-      if (typeof responseSub !== "string" || responseSub.length === 0) {
-        throw rcError(
-          "RC5022",
-          new Error("userinfo response is missing `sub`"),
-          {
-            message:
-              "userinfo response is missing `sub` (required per OIDC Core §5.3.2)",
-            suggestion:
-              "Inspect the userinfo endpoint manually; the response MUST include a `sub` claim. If the IdP returns a non-standard identifier, use a function-mode `userinfo` and map it yourself.",
-          },
-        );
-      }
-      if (responseSub !== principal.subject) {
-        throw rcError(
-          "RC5022",
-          new Error(
-            `userinfo \`sub\` (${responseSub}) does not match token \`sub\` (${principal.subject})`,
-          ),
-          {
-            message:
-              "userinfo response `sub` does not match the verified token's `sub` (OIDC Core §5.3.2 violation)",
-            suggestion:
-              "This indicates a compromised userinfo endpoint or a misconfigured userinfo URL. Verify the issuer / userinfo mapping; do not relax this check.",
-          },
-        );
-      }
-      const enrichment = liftOidcClaims(payload);
-      return mergeEnrichment(principal, enrichment);
-    });
+  return async (token: string) => {
+    const principal = await baseVerifier(token);
+    const enrichment = await cache.getOrCompute(
+      token,
+      principal.expiresAt,
+      async () => {
+        const url = await resolveUserinfoUrl();
+        const payload = await fetchUserinfo(url, token);
+        const responseSub = payload["sub"];
+        if (typeof responseSub !== "string" || responseSub.length === 0) {
+          throw rcError(
+            "RC5022",
+            new Error("userinfo response is missing `sub`"),
+            {
+              message:
+                "userinfo response is missing `sub` (required per OIDC Core §5.3.2)",
+              suggestion:
+                "Inspect the userinfo endpoint manually; the response MUST include a `sub` claim. If the IdP returns a non-standard identifier, use a function-mode `userinfo` and map it yourself.",
+            },
+          );
+        }
+        if (responseSub !== principal.subject) {
+          throw rcError(
+            "RC5022",
+            new Error(
+              `userinfo \`sub\` (${responseSub}) does not match token \`sub\` (${principal.subject})`,
+            ),
+            {
+              message:
+                "userinfo response `sub` does not match the verified token's `sub` (OIDC Core §5.3.2 violation)",
+              suggestion:
+                "This indicates a compromised userinfo endpoint or a misconfigured userinfo URL. Verify the issuer / userinfo mapping; do not relax this check.",
+            },
+          );
+        }
+        return liftOidcClaims(payload);
+      },
+    );
+    return mergeEnrichment(principal, enrichment);
+  };
 }

--- a/packages/ai/test/oauth.bun.test.ts
+++ b/packages/ai/test/oauth.bun.test.ts
@@ -569,15 +569,126 @@ describe("oauth({ userinfo }) enrichment", () => {
   /**
    * @case userinfo absent leaves oauth() behaviour unchanged (regression guard)
    * @preconditions Same options minus userinfo; verify resolves a thin principal
-   * @expectedResult Principal matches verify output exactly; no enrichment
+   * @expectedResult Principal returned by verifyAccessToken matches the raw verify output via deep equality
    */
   test("oauth() without userinfo is unchanged", async () => {
-    const config = oauth({
-      ...BASE_OPTIONS,
-      verify: makeVerify("user-42"),
-    });
+    const verify = makeVerify("user-42");
+    const baseline = await verify();
+    const config = oauth({ ...BASE_OPTIONS, verify });
     const principal = await config.verifyAccessToken("token");
-    expect(principal.subject).toBe("user-42");
-    expect(principal.email).toBeUndefined();
+    expect(principal).toEqual(baseline);
+  });
+
+  /**
+   * @case URL-mode enrichment preserves the verified JWT payload on principal.claims
+   * @preconditions verify returns a principal with claims = {iat, custom}; userinfo response carries different fields
+   * @expectedResult principal.claims is unchanged; userinfo response lives on principal.userinfoClaims
+   */
+  test("URL-mode enrichment preserves principal.claims and stashes userinfo on userinfoClaims", async () => {
+    const jwtClaims = { iat: 1700000000, custom: "v" };
+    const verify = async (): Promise<OAuthPrincipal> => ({
+      kind: "jwks",
+      scheme: "bearer",
+      subject: "user-42",
+      expiresAt: Math.floor(Date.now() / 1000) + 60,
+      claims: jwtClaims,
+    });
+    const { baseUrl, close } = await serveJson(({ url }) => {
+      if (url === "/userinfo") {
+        return {
+          body: {
+            sub: "user-42",
+            email: "ada@example.com",
+            picture: "https://example.com/p.png",
+          },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const config = oauth({
+        ...BASE_OPTIONS,
+        verify,
+        userinfo: `${baseUrl}/userinfo`,
+      });
+      const principal = await config.verifyAccessToken("token");
+      expect(principal.claims).toEqual(jwtClaims);
+      expect(principal.userinfoClaims).toEqual({
+        sub: "user-42",
+        email: "ada@example.com",
+        picture: "https://example.com/p.png",
+      });
+      expect(principal.email).toBe("ada@example.com");
+    } finally {
+      await close();
+    }
+  });
+
+  /**
+   * @case OIDC discovery retries on transient failure rather than caching the rejection
+   * @preconditions Discovery endpoint returns 500 on first call and 200 on second
+   * @expectedResult First verifyAccessToken rejects with RC5021; second succeeds
+   */
+  test("OIDC discovery retries after a transient failure", async () => {
+    let calls = 0;
+    const { baseUrl, close } = await serveJson(({ url }) => {
+      if (url === "/.well-known/openid-configuration") {
+        calls += 1;
+        if (calls === 1) return { status: 500, body: { error: "boom" } };
+        return { body: { userinfo_endpoint: `${baseUrl}/userinfo` } };
+      }
+      if (url === "/userinfo") {
+        return { body: { sub: "user-42", email: "ada@example.com" } };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const config = oauth({
+        ...BASE_OPTIONS,
+        verify: { validator: makeVerify("user-42"), issuer: baseUrl },
+        userinfo: true,
+      });
+      await expect(config.verifyAccessToken("token-a")).rejects.toThrow(
+        /RC5021|Discovery/,
+      );
+      const principal = await config.verifyAccessToken("token-b");
+      expect(principal.email).toBe("ada@example.com");
+      expect(calls).toBe(2);
+    } finally {
+      await close();
+    }
+  });
+
+  /**
+   * @case OIDC discovery preserves the issuer's path component (Keycloak realm, Azure tenant)
+   * @preconditions issuer ends with "/realms/test"; discovery doc is served under that prefix
+   * @expectedResult Discovery resolves at "/realms/test/.well-known/openid-configuration" and enrichment succeeds
+   */
+  test("OIDC discovery preserves issuer path component", async () => {
+    const { baseUrl, close } = await serveJson(({ url }) => {
+      if (url === "/realms/test/.well-known/openid-configuration") {
+        return {
+          body: { userinfo_endpoint: `${baseUrl}/realms/test/userinfo` },
+        };
+      }
+      if (url === "/realms/test/userinfo") {
+        return { body: { sub: "user-42", email: "ada@example.com" } };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const config = oauth({
+        ...BASE_OPTIONS,
+        verify: {
+          validator: makeVerify("user-42"),
+          issuer: `${baseUrl}/realms/test`,
+        },
+        userinfo: true,
+      });
+      const principal = await config.verifyAccessToken("token");
+      expect(principal.email).toBe("ada@example.com");
+    } finally {
+      await close();
+    }
   });
 });

--- a/packages/ai/test/oauth.bun.test.ts
+++ b/packages/ai/test/oauth.bun.test.ts
@@ -266,3 +266,318 @@ describe("oauth({ verify: jwks(...) }) end-to-end", () => {
     }
   });
 });
+
+/** Serve a configurable JSON response at a local URL. Handler receives each request. */
+async function serveJson(
+  handler: (req: {
+    url: string;
+    headers: Record<string, string | string[] | undefined>;
+  }) =>
+    | { status?: number; body: unknown }
+    | Promise<{ status?: number; body: unknown }>,
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const server = createServer(async (req, res) => {
+    const url = req.url ?? "/";
+    const headers = req.headers as Record<
+      string,
+      string | string[] | undefined
+    >;
+    const result = await handler({ url, headers });
+    res.statusCode = result.status ?? 200;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(result.body));
+  });
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve()),
+  );
+  const port = (server.address() as AddressInfo).port;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+describe("oauth({ userinfo }) enrichment", () => {
+  function makeVerify(subject: string, expiresIn = 60) {
+    return async (): Promise<OAuthPrincipal> => ({
+      kind: "custom",
+      scheme: "bearer",
+      subject,
+      expiresAt: Math.floor(Date.now() / 1000) + expiresIn,
+    });
+  }
+
+  /**
+   * @case Function userinfo enriches the verified principal
+   * @preconditions verify resolves a thin principal; userinfo function returns email and roles
+   * @expectedResult Returned principal carries the enrichment, verify fields preserved
+   */
+  test("function userinfo merges onto the verified principal", async () => {
+    const verify = makeVerify("user-42");
+    const config = oauth({
+      ...BASE_OPTIONS,
+      verify,
+      userinfo: async (principal) => {
+        expect(principal.subject).toBe("user-42");
+        return { email: "ada@example.com", roles: ["admin"] };
+      },
+    });
+
+    const principal = await config.verifyAccessToken("token");
+    expect(principal.subject).toBe("user-42");
+    expect(principal.email).toBe("ada@example.com");
+    expect(principal.roles).toEqual(["admin"]);
+  });
+
+  /**
+   * @case Verify-wins merge rule: enrichment cannot overwrite subject / issuer / audience / expiresAt
+   * @preconditions Function userinfo tries to overwrite all protected fields
+   * @expectedResult Protected fields remain the verify values; only non-protected fields are merged
+   */
+  test("protected fields cannot be overwritten by userinfo", async () => {
+    const verify = makeVerify("verified-sub", 120);
+    const verifiedExp = (await verify()).expiresAt;
+    const config = oauth({
+      ...BASE_OPTIONS,
+      verify,
+      userinfo: async () =>
+        ({
+          subject: "evil-sub",
+          issuer: "https://evil.example.com",
+          audience: ["https://evil.example.com"],
+          expiresAt: 0,
+          email: "good@example.com",
+        }) as unknown as Partial<OAuthPrincipal>,
+    });
+
+    const principal = await config.verifyAccessToken("token");
+    expect(principal.subject).toBe("verified-sub");
+    expect(principal.issuer).toBeUndefined();
+    expect(principal.audience).toBeUndefined();
+    expect(principal.expiresAt).toBe(verifiedExp);
+    expect(principal.email).toBe("good@example.com");
+  });
+
+  /**
+   * @case Explicit URL userinfo fetches the endpoint and lifts OIDC claims
+   * @preconditions verify resolves sub "user-99"; local /userinfo returns sub + email
+   * @expectedResult Principal.email is populated; sub invariant passes
+   */
+  test("string-URL userinfo lifts OIDC claims from the response", async () => {
+    const { baseUrl, close } = await serveJson(({ url }) => {
+      if (url === "/userinfo") {
+        return {
+          body: { sub: "user-99", email: "ada@example.com", name: "Ada" },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const config = oauth({
+        ...BASE_OPTIONS,
+        verify: makeVerify("user-99"),
+        userinfo: `${baseUrl}/userinfo`,
+      });
+      const principal = await config.verifyAccessToken("token");
+      expect(principal.email).toBe("ada@example.com");
+      expect(principal.name).toBe("Ada");
+    } finally {
+      await close();
+    }
+  });
+
+  /**
+   * @case Sub mismatch between verified token and userinfo response rejects the request
+   * @preconditions verify resolves sub "user-A"; userinfo response carries sub "user-B"
+   * @expectedResult verifyAccessToken throws and message mentions sub mismatch
+   */
+  test("rejects when userinfo sub does not match token sub", async () => {
+    const { baseUrl, close } = await serveJson(() => ({
+      body: { sub: "user-B", email: "evil@example.com" },
+    }));
+    try {
+      const config = oauth({
+        ...BASE_OPTIONS,
+        verify: makeVerify("user-A"),
+        userinfo: `${baseUrl}/userinfo`,
+      });
+      await expect(config.verifyAccessToken("token")).rejects.toThrow(/sub/i);
+    } finally {
+      await close();
+    }
+  });
+
+  /**
+   * @case Missing sub in userinfo response rejects per OIDC Core §5.3.2
+   * @preconditions Userinfo response omits sub entirely
+   * @expectedResult verifyAccessToken throws with a sub-related error
+   */
+  test("rejects when userinfo response is missing sub", async () => {
+    const { baseUrl, close } = await serveJson(() => ({
+      body: { email: "x@example.com" },
+    }));
+    try {
+      const config = oauth({
+        ...BASE_OPTIONS,
+        verify: makeVerify("user-A"),
+        userinfo: `${baseUrl}/userinfo`,
+      });
+      await expect(config.verifyAccessToken("token")).rejects.toThrow(/sub/i);
+    } finally {
+      await close();
+    }
+  });
+
+  /**
+   * @case Userinfo fetch failure rejects the request (fail-closed)
+   * @preconditions Userinfo URL returns 500
+   * @expectedResult verifyAccessToken throws; no principal returned
+   */
+  test("rejects when the userinfo endpoint returns a non-2xx response", async () => {
+    const { baseUrl, close } = await serveJson(() => ({
+      status: 500,
+      body: { error: "boom" },
+    }));
+    try {
+      const config = oauth({
+        ...BASE_OPTIONS,
+        verify: makeVerify("user-A"),
+        userinfo: `${baseUrl}/userinfo`,
+      });
+      await expect(config.verifyAccessToken("token")).rejects.toThrow();
+    } finally {
+      await close();
+    }
+  });
+
+  /**
+   * @case Token-bound cache: identical tokens skip the userinfo call on subsequent verifies
+   * @preconditions Function userinfo increments a counter on each call
+   * @expectedResult Counter is 1 after two verifies with the same token
+   */
+  test("caches the enrichment per token", async () => {
+    let calls = 0;
+    const config = oauth({
+      ...BASE_OPTIONS,
+      verify: makeVerify("user-42"),
+      userinfo: async () => {
+        calls += 1;
+        return { email: "ada@example.com" };
+      },
+    });
+
+    const a = await config.verifyAccessToken("token");
+    const b = await config.verifyAccessToken("token");
+    expect(calls).toBe(1);
+    expect(a.email).toBe("ada@example.com");
+    expect(b.email).toBe("ada@example.com");
+
+    await config.verifyAccessToken("other-token");
+    expect(calls).toBe(2);
+  });
+
+  /**
+   * @case userinfo: true auto-discovers the userinfo endpoint via OIDC Discovery
+   * @preconditions Local server serves /.well-known/openid-configuration and /userinfo
+   * @expectedResult Principal is enriched from the discovered endpoint
+   */
+  test("userinfo: true resolves the endpoint via OIDC Discovery", async () => {
+    const { baseUrl, close } = await serveJson(({ url }) => {
+      if (url === "/.well-known/openid-configuration") {
+        return { body: { userinfo_endpoint: `${baseUrl}/userinfo` } };
+      }
+      if (url === "/userinfo") {
+        return { body: { sub: "user-42", email: "ada@example.com" } };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const config = oauth({
+        ...BASE_OPTIONS,
+        verify: { validator: makeVerify("user-42"), issuer: baseUrl },
+        userinfo: true,
+      });
+      const principal = await config.verifyAccessToken("token");
+      expect(principal.email).toBe("ada@example.com");
+    } finally {
+      await close();
+    }
+  });
+
+  /**
+   * @case userinfo: true throws when the discovery document does not advertise userinfo_endpoint
+   * @preconditions Discovery doc returns {} (no userinfo_endpoint field)
+   * @expectedResult verifyAccessToken throws a clear TypeError on first use
+   */
+  test("userinfo: true rejects when the discovery doc lacks userinfo_endpoint", async () => {
+    const { baseUrl, close } = await serveJson(({ url }) => {
+      if (url === "/.well-known/openid-configuration") {
+        return { body: {} };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const config = oauth({
+        ...BASE_OPTIONS,
+        verify: { validator: makeVerify("user-42"), issuer: baseUrl },
+        userinfo: true,
+      });
+      await expect(config.verifyAccessToken("token")).rejects.toThrow(
+        /userinfo_endpoint/,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  /**
+   * @case userinfo: true throws at construction time when verify exposes no issuer
+   * @preconditions verify is a raw function (no issuer metadata)
+   * @expectedResult oauth() throws TypeError mentioning issuer
+   */
+  test("userinfo: true requires issuer to be exposed by the verifier", () => {
+    expect(() =>
+      oauth({
+        ...BASE_OPTIONS,
+        verify: makeVerify("user-42"),
+        userinfo: true,
+      }),
+    ).toThrow(/issuer/i);
+  });
+
+  /**
+   * @case userinfo: true with array issuer is rejected at construction time
+   * @preconditions Verifier exposes issuer as a string[]
+   * @expectedResult oauth() throws TypeError mentioning array
+   */
+  test("userinfo: true rejects an array issuer", () => {
+    expect(() =>
+      oauth({
+        ...BASE_OPTIONS,
+        verify: {
+          validator: makeVerify("user-42"),
+          issuer: ["https://a", "https://b"],
+        },
+        userinfo: true,
+      }),
+    ).toThrow(/array|single/i);
+  });
+
+  /**
+   * @case userinfo absent leaves oauth() behaviour unchanged (regression guard)
+   * @preconditions Same options minus userinfo; verify resolves a thin principal
+   * @expectedResult Principal matches verify output exactly; no enrichment
+   */
+  test("oauth() without userinfo is unchanged", async () => {
+    const config = oauth({
+      ...BASE_OPTIONS,
+      verify: makeVerify("user-42"),
+    });
+    const principal = await config.verifyAccessToken("token");
+    expect(principal.subject).toBe("user-42");
+    expect(principal.email).toBeUndefined();
+  });
+});

--- a/packages/ai/test/oauth.bun.test.ts
+++ b/packages/ai/test/oauth.bun.test.ts
@@ -302,11 +302,15 @@ async function serveJson(
 
 describe("oauth({ userinfo }) enrichment", () => {
   function makeVerify(subject: string, expiresIn = 60) {
+    // Snapshot expiresAt at helper-creation time. Recomputing per call would
+    // make deep-equality assertions (and the cache-hit tests) flaky if the
+    // calls straddle a second boundary.
+    const expiresAt = Math.floor(Date.now() / 1000) + expiresIn;
     return async (): Promise<OAuthPrincipal> => ({
       kind: "custom",
       scheme: "bearer",
       subject,
-      expiresAt: Math.floor(Date.now() / 1000) + expiresIn,
+      expiresAt,
     });
   }
 
@@ -480,6 +484,35 @@ describe("oauth({ userinfo }) enrichment", () => {
   });
 
   /**
+   * @case Base verifier runs on every request, even on cache hits
+   * @preconditions Custom verify increments a counter; userinfo is cheap
+   * @expectedResult verify is called once per verifyAccessToken; dynamic checks (introspection, revocation) keep firing
+   */
+  test("base verifier runs on every request (cache hits do not bypass verify)", async () => {
+    let verifyCalls = 0;
+    const verify = async (): Promise<OAuthPrincipal> => {
+      verifyCalls += 1;
+      return {
+        kind: "custom",
+        scheme: "bearer",
+        subject: "user-42",
+        expiresAt: Math.floor(Date.now() / 1000) + 60,
+      };
+    };
+    const config = oauth({
+      ...BASE_OPTIONS,
+      verify,
+      userinfo: async () => ({ email: "ada@example.com" }),
+    });
+
+    await config.verifyAccessToken("token");
+    await config.verifyAccessToken("token");
+    await config.verifyAccessToken("token");
+
+    expect(verifyCalls).toBe(3);
+  });
+
+  /**
    * @case userinfo: true auto-discovers the userinfo endpoint via OIDC Discovery
    * @preconditions Local server serves /.well-known/openid-configuration and /userinfo
    * @expectedResult Principal is enriched from the discovered endpoint
@@ -564,6 +597,21 @@ describe("oauth({ userinfo }) enrichment", () => {
         userinfo: true,
       }),
     ).toThrow(/array|single/i);
+  });
+
+  /**
+   * @case oauth() throws fail-fast when verify is missing, even with userinfo set
+   * @preconditions options.verify is undefined; options.userinfo is set (would have masked the check)
+   * @expectedResult Factory throws TypeError mentioning verify at construction time
+   */
+  test("oauth() rejects missing verify even when userinfo is set", () => {
+    expect(() =>
+      oauth({
+        ...BASE_OPTIONS,
+        verify: undefined as unknown as ReturnType<typeof makeVerify>,
+        userinfo: async () => ({}),
+      }),
+    ).toThrow(/verify/i);
   });
 
   /**

--- a/packages/routecraft/src/auth/authorize.ts
+++ b/packages/routecraft/src/auth/authorize.ts
@@ -34,8 +34,9 @@ export interface AuthorizeOptions {
  * existing identity meets the criteria. It does NOT issue, mint, or attach
  * credentials to the exchange.
  *
- * Throws `RC5012` when no principal is present and `RC5015` when the
- * principal fails the role / scope / predicate check.
+ * Throws `RC5012` when no principal is present, `RC5020` when the principal
+ * carries an `expiresAt` in the past (mid-pipeline token expiry), and `RC5015`
+ * when the principal fails the role / scope / predicate check.
  *
  * Most routes should declare authorization at the route boundary using the
  * pre-from `.authorize()` builder method, which wires this validator as a
@@ -77,6 +78,17 @@ export function authorize(
         message: "Authorization failed: no authenticated principal",
         suggestion:
           "Configure auth on the source so it emits a Principal (e.g. mcp({ auth: jwt(...) })). For a mid-pipeline .validate(authorize(...)) check, attach a custom principal in an earlier .process() step.",
+      });
+    }
+
+    if (
+      principal.expiresAt !== undefined &&
+      Date.now() / 1000 > principal.expiresAt
+    ) {
+      throw rcError("RC5020", new Error("Token expired"), {
+        message: "Authorization failed: token expired during processing",
+        suggestion:
+          "The token's `exp` is in the past. A long-running step likely outlived the credential; the client should refresh and retry. To recover in-route, restructure the pipeline so authorize() runs before the slow step or attach a fresh principal in a .process() before the validator.",
       });
     }
 

--- a/packages/routecraft/src/auth/authorize.ts
+++ b/packages/routecraft/src/auth/authorize.ts
@@ -25,6 +25,16 @@ export interface AuthorizeOptions {
    * after the role and scope checks.
    */
   predicate?: (principal: Principal) => boolean;
+  /**
+   * Clock skew tolerance in seconds applied to the `expiresAt` check.
+   * Matches the semantics of `jwt({ clockToleranceSec })` and
+   * `jwks({ clockToleranceSec })`: a token whose `expiresAt` is less than
+   * `clockToleranceSec` seconds in the past is still accepted. Defaults to
+   * `0` (strict). Set to the same value used on the source-side verifier so
+   * a token accepted at the route boundary is not rejected mid-pipeline by
+   * a fraction of a second.
+   */
+  clockToleranceSec?: number;
 }
 
 /**
@@ -70,7 +80,7 @@ export interface AuthorizeOptions {
 export function authorize(
   options: AuthorizeOptions = {},
 ): CallableValidator<unknown, unknown> {
-  const { roles, scopes, predicate } = options;
+  const { roles, scopes, predicate, clockToleranceSec = 0 } = options;
   return (exchange: Exchange<unknown>) => {
     const principal = exchange.principal;
     if (!principal) {
@@ -83,7 +93,7 @@ export function authorize(
 
     if (
       principal.expiresAt !== undefined &&
-      Date.now() / 1000 > principal.expiresAt
+      Date.now() / 1000 > principal.expiresAt + clockToleranceSec
     ) {
       throw rcError("RC5020", new Error("Token expired"), {
         message: "Authorization failed: token expired during processing",

--- a/packages/routecraft/src/auth/authorize.ts
+++ b/packages/routecraft/src/auth/authorize.ts
@@ -91,15 +91,22 @@ export function authorize(
       });
     }
 
-    if (
-      principal.expiresAt !== undefined &&
-      Date.now() / 1000 > principal.expiresAt + clockToleranceSec
-    ) {
-      throw rcError("RC5020", new Error("Token expired"), {
-        message: "Authorization failed: token expired during processing",
-        suggestion:
-          "The token's `exp` is in the past. A long-running step likely outlived the credential; the client should refresh and retry. To recover in-route, restructure the pipeline so authorize() runs before the slow step or attach a fresh principal in a .process() before the validator.",
-      });
+    if (principal.expiresAt !== undefined) {
+      // Fail closed on non-finite inputs: a NaN `expiresAt` or
+      // `clockToleranceSec` would make every `>` comparison false and
+      // silently bypass the check, so treat that as expired rather than
+      // valid.
+      if (
+        !Number.isFinite(principal.expiresAt) ||
+        !Number.isFinite(clockToleranceSec) ||
+        Date.now() / 1000 > principal.expiresAt + clockToleranceSec
+      ) {
+        throw rcError("RC5020", new Error("Token expired"), {
+          message: "Authorization failed: token expired during processing",
+          suggestion:
+            "The token's `exp` is in the past (or `expiresAt` / `clockToleranceSec` was non-finite). A long-running step likely outlived the credential; the client should refresh and retry. To recover in-route, restructure the pipeline so authorize() runs before the slow step or attach a fresh principal in a .process() before the validator.",
+        });
+      }
     }
 
     if (roles && roles.length > 0) {

--- a/packages/routecraft/src/auth/jwks.ts
+++ b/packages/routecraft/src/auth/jwks.ts
@@ -147,6 +147,7 @@ export function jwks(options: JwksOptions): OAuthValidatorAuthOptions {
   const algorithms = options.algorithms ?? DEFAULT_JWKS_ALGORITHMS;
 
   return {
+    issuer: options.issuer,
     validator: async (token: string) => {
       if (joseMod === null) {
         joseMod = await __jwksLoaders.loadJose();

--- a/packages/routecraft/src/auth/jwt-utils.ts
+++ b/packages/routecraft/src/auth/jwt-utils.ts
@@ -105,11 +105,10 @@ export function principalFromJwtPayload(
 
   if (clientIdValue !== undefined) principal.clientId = clientIdValue;
 
-  const email =
-    options.claims?.email?.(payload) ?? stringClaim(payload["email"]);
+  const email = stringClaim(payload["email"]);
   if (email) principal.email = email;
 
-  const name = options.claims?.name?.(payload) ?? stringClaim(payload["name"]);
+  const name = stringClaim(payload["name"]);
   if (name) principal.name = name;
 
   if (typeof payload["iss"] === "string") principal.issuer = payload["iss"];
@@ -122,13 +121,11 @@ export function principalFromJwtPayload(
       : undefined);
   if (scopes !== undefined) principal.scopes = scopes;
 
-  const roles =
-    options.claims?.roles?.(payload) ??
-    (Array.isArray(payload["roles"])
-      ? (payload["roles"] as unknown[]).filter(
-          (r): r is string => typeof r === "string",
-        )
-      : undefined);
+  const roles = Array.isArray(payload["roles"])
+    ? (payload["roles"] as unknown[]).filter(
+        (r): r is string => typeof r === "string",
+      )
+    : undefined;
   if (roles !== undefined) principal.roles = roles;
 
   return principal;

--- a/packages/routecraft/src/auth/jwt.ts
+++ b/packages/routecraft/src/auth/jwt.ts
@@ -362,5 +362,5 @@ export function jwt(options: JwtAuthOptions): OAuthValidatorAuthOptions {
     ? createHmacValidator(options)
     : createRsaValidator(options);
 
-  return { validator };
+  return { validator, issuer: options.issuer };
 }

--- a/packages/routecraft/src/auth/types.ts
+++ b/packages/routecraft/src/auth/types.ts
@@ -22,14 +22,8 @@ export interface ClaimMappers {
   subject?: (payload: Record<string, unknown>) => string;
   /** Map to `Principal.clientId`. Default: `payload.client_id` then `azp`. */
   clientId?: (payload: Record<string, unknown>) => string;
-  /** Map to `Principal.email`. Default: `payload.email`. */
-  email?: (payload: Record<string, unknown>) => string | undefined;
-  /** Map to `Principal.name`. Default: `payload.name`. */
-  name?: (payload: Record<string, unknown>) => string | undefined;
   /** Map to `Principal.scopes`. Default: space-split `payload.scope`. */
   scopes?: (payload: Record<string, unknown>) => string[] | undefined;
-  /** Map to `Principal.roles`. Default: `payload.roles` when it is `string[]`. */
-  roles?: (payload: Record<string, unknown>) => string[] | undefined;
 }
 
 /**
@@ -142,6 +136,14 @@ export interface ValidatorAuthOptions {
 export interface OAuthValidatorAuthOptions {
   /** Verifier called with the raw bearer token on every request. Throw to reject. */
   validator: OAuthTokenVerifier;
+  /**
+   * Expected token issuer(s), surfaced from the underlying helper (`jwt()` /
+   * `jwks()`). Read by `oauth({ userinfo: true })` to locate the OIDC Discovery
+   * document. Optional because custom validators may not declare an issuer; if
+   * absent, OIDC auto-discovery cannot be used and the caller must pass an
+   * explicit userinfo URL or function.
+   */
+  issuer?: string | string[];
 }
 
 // See .standards/type-safety-and-schemas.md#module-augmentation for why this

--- a/packages/routecraft/src/auth/types.ts
+++ b/packages/routecraft/src/auth/types.ts
@@ -63,6 +63,17 @@ export interface Principal {
   expiresAt?: number;
   /** Full decoded JWT payload (when available). */
   claims?: Record<string, unknown>;
+  /**
+   * Raw OIDC userinfo response (when available). Populated only when
+   * `oauth({ userinfo: ... })` runs in URL or auto-discovery mode and the
+   * userinfo endpoint returns a non-empty JSON body. Distinct from `claims`,
+   * which always carries the verified JWT payload.
+   *
+   * Function-mode enrichment is free to merge into this field directly if
+   * the user wants the raw upstream response surfaced; the framework does
+   * not populate it automatically for the function variant.
+   */
+  userinfoClaims?: Record<string, unknown>;
 }
 
 /**

--- a/packages/routecraft/src/error.ts
+++ b/packages/routecraft/src/error.ts
@@ -19,6 +19,7 @@ export type RCCode =
   | "RC5015"
   | "RC5016"
   | "RC5017"
+  | "RC5020"
   | "RC9901";
 
 export type RCMeta = {
@@ -168,6 +169,14 @@ export const RC: Record<RCCode, RCMeta> = {
     suggestion:
       "Install the optional peer the adapter requires (the error message names the package).",
     docs: `${DOCS_BASE}#rc-5017`,
+    retryable: false,
+  },
+  RC5020: {
+    category: "Adapter",
+    message: "Authorization failed: token expired during processing",
+    suggestion:
+      "The verified principal carried an `expiresAt` that is now in the past; a long-running step (LLM call, slow downstream) outlived the credential. The client should refresh and retry. Distinct from RC5012 (no principal) and RC5015 (wrong roles/scopes) so callers can react accordingly.",
+    docs: `${DOCS_BASE}#rc-5020`,
     retryable: false,
   },
   RC9901: {

--- a/packages/routecraft/src/error.ts
+++ b/packages/routecraft/src/error.ts
@@ -20,6 +20,8 @@ export type RCCode =
   | "RC5016"
   | "RC5017"
   | "RC5020"
+  | "RC5021"
+  | "RC5022"
   | "RC9901";
 
 export type RCMeta = {
@@ -177,6 +179,22 @@ export const RC: Record<RCCode, RCMeta> = {
     suggestion:
       "The verified principal carried an `expiresAt` that is now in the past; a long-running step (LLM call, slow downstream) outlived the credential. The client should refresh and retry. Distinct from RC5012 (no principal) and RC5015 (wrong roles/scopes) so callers can react accordingly.",
     docs: `${DOCS_BASE}#rc-5020`,
+    retryable: false,
+  },
+  RC5021: {
+    category: "Adapter",
+    message: "Principal enrichment failed",
+    suggestion:
+      "The `userinfo` slot on `oauth({})` could not enrich the verified principal. The cause names the underlying problem (HTTP status, network error, malformed JSON, missing `userinfo_endpoint` in the OIDC Discovery document). Verify the userinfo endpoint URL, IdP availability, and the bearer token's scope grants. Fail-closed: the request is rejected to prevent silent identity gaps.",
+    docs: `${DOCS_BASE}#rc-5021`,
+    retryable: false,
+  },
+  RC5022: {
+    category: "Adapter",
+    message: "Userinfo sub invariant violated",
+    suggestion:
+      "Per OIDC Core §5.3.2, the userinfo response MUST carry a `sub` matching the verified token's `sub`. A mismatch (or missing `sub`) indicates a compromised userinfo endpoint or a configuration error mapping the wrong userinfo URL to the bearer's issuer. The request is rejected to prevent identity confusion.",
+    docs: `${DOCS_BASE}#rc-5022`,
     retryable: false,
   },
   RC9901: {

--- a/packages/routecraft/test/auth/authorize.bun.test.ts
+++ b/packages/routecraft/test/auth/authorize.bun.test.ts
@@ -983,6 +983,87 @@ describe("authorize() expiresAt enforcement", () => {
   });
 
   /**
+   * @case clockToleranceSec admits a token whose expiresAt is within tolerance
+   * @preconditions Principal expiresAt is now - 2s; authorize({ clockToleranceSec: 5 })
+   * @expectedResult Validator passes through; matches the boundary-side clock tolerance
+   */
+  test("clockToleranceSec admits a token within tolerance", async () => {
+    const s = spy<string>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      expiresAt: Math.floor(Date.now() / 1000) - 2,
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("exp-tolerated")
+          .from(simple("hello"))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
+          .validate(authorize({ clockToleranceSec: 5 }))
+          .to(s),
+      )
+      .build();
+    await t.test();
+
+    expect(s.receivedBodies()).toEqual(["hello"]);
+  });
+
+  /**
+   * @case clockToleranceSec still rejects when expiresAt is past the tolerance window
+   * @preconditions Principal expiresAt is now - 60s; authorize({ clockToleranceSec: 5 })
+   * @expectedResult exchange:failed fires with RC5020
+   */
+  test("clockToleranceSec still rejects past the tolerance window", async () => {
+    const s = spy<string>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("exp-beyond-tolerance")
+          .from(simple("hello"))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
+          .validate(authorize({ clockToleranceSec: 5 }))
+          .to(s),
+      )
+      .build();
+
+    const failures: unknown[] = [];
+    t.ctx.on(
+      "route:exp-beyond-tolerance:exchange:failed" as EventName,
+      ((payload: FailedEventDetails) => {
+        failures.push(payload.details.error);
+      }) as Parameters<typeof t.ctx.on>[1],
+    );
+
+    await t.test();
+
+    expect(s.received).toHaveLength(0);
+    expect(failures).toHaveLength(1);
+    expect(String(failures[0])).toContain("RC5020");
+  });
+
+  /**
    * @case RC5020 is distinct from RC5012 (no principal) and RC5015 (wrong roles)
    * @preconditions Expired principal also lacks a required role
    * @expectedResult RC5020 wins (expiry check runs before role check)

--- a/packages/routecraft/test/auth/authorize.bun.test.ts
+++ b/packages/routecraft/test/auth/authorize.bun.test.ts
@@ -859,6 +859,178 @@ describe("exchange.principal propagation", () => {
   });
 });
 
+describe("authorize() expiresAt enforcement", () => {
+  let t: TestContext;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+  });
+
+  /**
+   * @case Validator passes through when principal.expiresAt is in the future
+   * @preconditions Principal has expiresAt = now + 60s
+   * @expectedResult Spy destination receives the body; no RC5020 fires
+   */
+  test("passes through when expiresAt is in the future", async () => {
+    const s = spy<string>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      expiresAt: Math.floor(Date.now() / 1000) + 60,
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("exp-future")
+          .from(simple("hello"))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
+          .validate(authorize())
+          .to(s),
+      )
+      .build();
+    await t.test();
+
+    expect(s.receivedBodies()).toEqual(["hello"]);
+  });
+
+  /**
+   * @case Validator passes through when principal carries no expiresAt
+   * @preconditions Principal has no expiresAt field (custom auth, opaque token)
+   * @expectedResult Spy destination receives the body; no RC5020 fires
+   */
+  test("passes through when expiresAt is absent", async () => {
+    const s = spy<string>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("exp-absent")
+          .from(simple("hello"))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
+          .validate(authorize())
+          .to(s),
+      )
+      .build();
+    await t.test();
+
+    expect(s.receivedBodies()).toEqual(["hello"]);
+  });
+
+  /**
+   * @case Validator throws RC5020 when principal.expiresAt is in the past
+   * @preconditions Principal has expiresAt = now - 60s (mid-pipeline expiry)
+   * @expectedResult exchange:failed fires with RC5020; destination is skipped
+   */
+  test("rejects with RC5020 when expiresAt has passed", async () => {
+    const s = spy<string>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("exp-past")
+          .from(simple("hello"))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
+          .validate(authorize())
+          .to(s),
+      )
+      .build();
+
+    const failures: unknown[] = [];
+    t.ctx.on(
+      "route:exp-past:exchange:failed" as EventName,
+      ((payload: FailedEventDetails) => {
+        failures.push(payload.details.error);
+      }) as Parameters<typeof t.ctx.on>[1],
+    );
+
+    await t.test();
+
+    expect(s.received).toHaveLength(0);
+    expect(failures).toHaveLength(1);
+    expect(String(failures[0])).toContain("RC5020");
+    expect(String(failures[0])).toContain("expired");
+  });
+
+  /**
+   * @case RC5020 is distinct from RC5012 (no principal) and RC5015 (wrong roles)
+   * @preconditions Expired principal also lacks a required role
+   * @expectedResult RC5020 wins (expiry check runs before role check)
+   */
+  test("RC5020 fires before role / scope checks when expired", async () => {
+    const s = spy<string>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      roles: ["user"],
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("exp-precedence")
+          .from(simple("hello"))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
+          .validate(authorize({ roles: ["admin"] }))
+          .to(s),
+      )
+      .build();
+
+    const failures: unknown[] = [];
+    t.ctx.on(
+      "route:exp-precedence:exchange:failed" as EventName,
+      ((payload: FailedEventDetails) => {
+        failures.push(payload.details.error);
+      }) as Parameters<typeof t.ctx.on>[1],
+    );
+
+    await t.test();
+
+    expect(failures).toHaveLength(1);
+    const msg = String(failures[0]);
+    expect(msg).toContain("RC5020");
+    expect(msg).not.toContain("RC5015");
+  });
+});
+
 describe(".authorize() type checks", () => {
   /**
    * @case Pre-from .authorize() preserves the body type that .from() introduces

--- a/packages/routecraft/test/auth/authorize.bun.test.ts
+++ b/packages/routecraft/test/auth/authorize.bun.test.ts
@@ -1064,6 +1064,52 @@ describe("authorize() expiresAt enforcement", () => {
   });
 
   /**
+   * @case Non-finite expiresAt fails closed (does not silently bypass the check)
+   * @preconditions Principal expiresAt is NaN (e.g. attached by a buggy .process() step)
+   * @expectedResult RC5020 fires; NaN cannot mask the guard
+   */
+  test("non-finite expiresAt fails closed with RC5020", async () => {
+    const s = spy<string>();
+    const principal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "user-1",
+      expiresAt: Number.NaN,
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("exp-nan")
+          .from(simple("hello"))
+          .process((ex) => ({
+            ...ex,
+            headers: {
+              ...ex.headers,
+              "routecraft.auth.principal": principal,
+            },
+          }))
+          .validate(authorize())
+          .to(s),
+      )
+      .build();
+
+    const failures: unknown[] = [];
+    t.ctx.on(
+      "route:exp-nan:exchange:failed" as EventName,
+      ((payload: FailedEventDetails) => {
+        failures.push(payload.details.error);
+      }) as Parameters<typeof t.ctx.on>[1],
+    );
+
+    await t.test();
+
+    expect(s.received).toHaveLength(0);
+    expect(failures).toHaveLength(1);
+    expect(String(failures[0])).toContain("RC5020");
+  });
+
+  /**
    * @case RC5020 is distinct from RC5012 (no principal) and RC5015 (wrong roles)
    * @preconditions Expired principal also lacks a required role
    * @expectedResult RC5020 wins (expiry check runs before role check)

--- a/packages/routecraft/test/auth/jwks.bun.test.ts
+++ b/packages/routecraft/test/auth/jwks.bun.test.ts
@@ -339,4 +339,35 @@ describe("jwks()", () => {
       }
     });
   });
+
+  describe("issuer propagation", () => {
+    /**
+     * @case jwks() surfaces a string issuer on its returned options
+     * @preconditions jwks({ issuer: "https://idp.example.com", ... })
+     * @expectedResult Returned object carries `issuer` equal to the configured value
+     */
+    test("string issuer is exposed on the returned options", () => {
+      const result = jwks({
+        jwksUrl: "http://localhost/jwks.json",
+        issuer: ISSUER,
+        audience: AUDIENCE,
+      });
+      expect(result.issuer).toBe(ISSUER);
+    });
+
+    /**
+     * @case jwks() preserves an array issuer on its returned options
+     * @preconditions jwks({ issuer: [a, b], ... })
+     * @expectedResult Returned object carries the exact issuer array
+     */
+    test("string[] issuer is exposed on the returned options", () => {
+      const issuers = [ISSUER, "https://alt.example.com"];
+      const result = jwks({
+        jwksUrl: "http://localhost/jwks.json",
+        issuer: issuers,
+        audience: AUDIENCE,
+      });
+      expect(result.issuer).toEqual(issuers);
+    });
+  });
 });

--- a/packages/routecraft/test/auth/jwt.bun.test.ts
+++ b/packages/routecraft/test/auth/jwt.bun.test.ts
@@ -348,34 +348,6 @@ describe("jwt()", () => {
       const result = await validator(token);
       expect(result.subject).toBe("azure-oid");
     });
-
-    /**
-     * @case Custom roles mapper overrides the default roles extraction
-     * @preconditions jwt() with claims.roles override; token carries roles under non-standard key
-     * @expectedResult Principal.roles comes from the override callback
-     */
-    test("applies claims.roles override", async () => {
-      const { validator } = jwt({
-        secret: SECRET,
-        issuer: ISSUER,
-        audience: AUDIENCE,
-        claims: {
-          roles: (p) => p["groups"] as string[],
-        },
-      });
-      const token = signHs256(
-        {
-          sub: "u",
-          iss: ISSUER,
-          aud: AUDIENCE,
-          exp: FUTURE,
-          groups: ["admin"],
-        },
-        SECRET,
-      );
-      const result = await validator(token);
-      expect(result.roles).toEqual(["admin"]);
-    });
   });
 
   describe("principal shape", () => {
@@ -436,6 +408,37 @@ describe("jwt()", () => {
       );
       const result = await validator(token);
       expect(result.subject).toBe("svc-account");
+    });
+  });
+
+  describe("issuer propagation", () => {
+    /**
+     * @case jwt() surfaces a string issuer on its returned options
+     * @preconditions jwt({ issuer: "https://idp.example.com", ... })
+     * @expectedResult Returned object carries `issuer` equal to the configured value
+     */
+    test("string issuer is exposed on the returned options", () => {
+      const result = jwt({
+        secret: SECRET,
+        issuer: ISSUER,
+        audience: AUDIENCE,
+      });
+      expect(result.issuer).toBe(ISSUER);
+    });
+
+    /**
+     * @case jwt() preserves an array issuer on its returned options
+     * @preconditions jwt({ issuer: [a, b], ... })
+     * @expectedResult Returned object carries the exact issuer array
+     */
+    test("string[] issuer is exposed on the returned options", () => {
+      const issuers = [ISSUER, "https://alt.example.com"];
+      const result = jwt({
+        secret: SECRET,
+        issuer: issuers,
+        audience: AUDIENCE,
+      });
+      expect(result.issuer).toEqual(issuers);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds optional principal enrichment to the OAuth flow via the `userinfo` option on `oauth({})`. After token verification succeeds, the framework can fetch identity claims from the IdP's userinfo endpoint (via OIDC Discovery, explicit URL, or custom function) and merge them onto the verified principal. This enables thin access tokens to be enriched with identity fields (`email`, `name`, `roles`) needed for route authorization.

## Key Changes

- **New `userinfo.ts` module** (`packages/ai/src/mcp/userinfo.ts`):
  - `UserinfoCache`: Token-bound enrichment cache with SHA-256 token hashing and in-flight request coalescing. Entries self-evict at `principal.expiresAt`; configurable insertion-order cap prevents unbounded growth.
  - `UserinfoOption`: Union type accepting `true` (auto-discover), `string | URL` (explicit endpoint), or `UserinfoFn` (custom function).
  - `buildEnrichedVerifier()`: Wraps a base verifier to run enrichment after verification. Enforces `sub` invariant for URL/discovery modes (RC5022 on mismatch); function mode is trusted by contract.
  - OIDC Discovery resolver with `Cache-Control: max-age` parsing, concurrent fetch coalescing, and retry-on-transient-failure semantics.
  - Protected field enforcement: `subject`, `issuer`, `audience`, `expiresAt`, `claims` from the verified token always win; enrichment cannot override them.

- **OAuth integration** (`packages/ai/src/mcp/oauth.ts`):
  - Added `userinfo?: UserinfoOption` to `OAuthFactoryOptions`.
  - Exported `UserinfoFn` and `UserinfoOption` types from the public API.

- **Issuer propagation** (`packages/routecraft/src/auth/jwt.ts`, `jwks.ts`):
  - `jwt()` and `jwks()` now expose their `issuer` on the returned `OAuthValidatorAuthOptions` so `userinfo: true` can auto-discover without requiring the caller to pass issuer twice.

- **Token expiry enforcement** (`packages/routecraft/src/auth/authorize.ts`):
  - Added `clockToleranceSec?: number` option to `authorize()` to admit tokens within a clock skew tolerance (matching JWT verifier semantics).
  - Mid-pipeline expiry check throws RC5020 if `principal.expiresAt` is in the past (beyond tolerance).

- **Error codes** (`packages/routecraft/src/error.ts`):
  - RC5020: Token expired during processing (distinct from RC5012 no-principal and RC5015 wrong-roles).
  - RC5021: Principal enrichment failed (network, parse, discovery errors).
  - RC5022: Userinfo `sub` invariant violated (mismatch or missing).

- **Comprehensive test coverage** (`packages/ai/test/oauth.bun.test.ts`, `packages/routecraft/test/auth/authorize.bun.test.ts`, `packages/routecraft/test/auth/jwt.bun.test.ts`, `packages/routecraft/test/auth/jwks.bun.test.ts`):
  - Function userinfo enrichment and protected field merge rules.
  - Explicit URL and OIDC Discovery modes with sub-invariant enforcement.
  - Cache hit/miss and in-flight coalescing.
  - Discovery retry on transient failure and path-component preservation (Keycloak realms, Azure tenants).
  - Token expiry checks with clock tolerance.
  - Issuer propagation on `jwt()` and `jwks()`.

- **Documentation** (`apps/routecraft.dev/src/app/docs/`):
  - Added "Principal enrichment via `userinfo`" section to the OAuth advanced guide with examples of all three input shapes.
  - Updated error reference with RC5020, RC5021, RC5022 descriptions.
  - Removed obsolete `claims.email`, `claims.name`, `claims.roles` overrides from JWT/JWKS docs (now

https://claude.ai/code/session_01GHdjQWD6or2TkGVuQUmiVS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional OAuth principal enrichment via a userinfo endpoint and enforces mid-pipeline token expiry to keep identities accurate. Thin access tokens can be augmented with identity fields like email, name, and roles without changing issuers.

- **New Features**
  - `oauth({ userinfo })`: enrich principals via OIDC discovery (`true`), explicit URL, or a `UserinfoFn`; enforces OIDC `sub` match (URL/discovery); protected fields (`subject`, `issuer`, `audience`, `expiresAt`, `claims`) cannot be overridden; raw response is exposed on `userinfoClaims`. Types `UserinfoFn` and `UserinfoOption` are re-exported; `oauth()` now validates that `verify` is provided.
  - Caching and discovery: per-token SHA-256 cache stores only the enrichment payload (not the merged principal); the base verifier still runs on every request; in-flight coalescing; eviction at `expiresAt`; OIDC discovery preserves issuer path and honors `Cache-Control: max-age` (including `0`).
  - Authorization: `authorize()` rejects expired principals with `RC5020`, supports `clockToleranceSec`, and fails closed if `expiresAt` or `clockToleranceSec` is non-finite.
  - `jwt()` and `jwks()` now expose `issuer` so `userinfo: true` can auto-discover; new errors: `RC5021` (enrichment failed), `RC5022` (userinfo sub invariant).

- **Migration**
  - If you used `claims.email`, `claims.name`, or `claims.roles` in `jwt()`/`jwks()`, move that logic to `oauth({ userinfo })` (use the function variant for custom mappings).
  - For long-running routes, set `authorize({ clockToleranceSec })` to the same value as your JWT verifier.
  - To use `userinfo: true`, ensure `jwt()`/`jwks()` expose a single-string `issuer`, or pass an explicit userinfo URL or function.

<sup>Written for commit 310188d786b6f57fe588e5f49ab6fd49d8972a46. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/322?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

