### PR TITLE
RFC 9728 protected-resource metadata and server identity

### DIFF
--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -254,27 +254,30 @@ For the full OAuth 2.1 Authorization Code flow with an upstream IdP, use `oauth(
 bun add express jose
 ```
 
-Compose `oauth()` with `jwks()` (or a raw verifier function) via the `verify` option:
+Compose `oauth()` with `jwks()` (or a raw verifier function) via the `verify` option. The protected-resource identity (`resource.url`) lives on the plugin, not on `oauth()`:
 
 ```ts
-import { oauth, jwks } from '@routecraft/ai'
+import { mcpPlugin, oauth, jwks } from '@routecraft/ai'
 
 // Clerk example
-auth: oauth({
-  resourceIssuerUrl: 'https://mcp.example.com',
-  endpoints: {
-    authorizationUrl: 'https://clerk.example.com/oauth/authorize',
-    tokenUrl: 'https://clerk.example.com/oauth/token',
-  },
-  verify: jwks({
-    jwksUrl: 'https://clerk.example.com/.well-known/jwks.json',
-    issuer: 'https://clerk.example.com',
-    audience: 'https://mcp.example.com',
+mcpPlugin({
+  transport: 'http',
+  resource: { url: 'https://mcp.example.com' },
+  auth: oauth({
+    endpoints: {
+      authorizationUrl: 'https://clerk.example.com/oauth/authorize',
+      tokenUrl: 'https://clerk.example.com/oauth/token',
+    },
+    verify: jwks({
+      jwksUrl: 'https://clerk.example.com/.well-known/jwks.json',
+      issuer: 'https://clerk.example.com',
+      audience: 'https://mcp.example.com',
+    }),
+    client: {
+      client_id: 'my-mcp-server',
+      redirect_uris: ['http://localhost:3000/callback'],
+    },
   }),
-  client: {
-    client_id: 'my-mcp-server',
-    redirect_uris: ['http://localhost:3000/callback'],
-  },
 })
 ```
 
@@ -282,7 +285,6 @@ For opaque tokens or custom introspection, pass a raw `verify` function instead:
 
 ```ts
 auth: oauth({
-  resourceIssuerUrl: 'https://mcp.example.com',
   endpoints: { authorizationUrl: '...', tokenUrl: '...' },
   verify: async (token) => {
     const info = await myIntrospectionCall(token)
@@ -311,7 +313,6 @@ OAuth access tokens are intentionally thin: they authorize but rarely identify. 
 
 ```ts
 auth: oauth({
-  resourceIssuerUrl: '...',
   endpoints: { ... },
   verify: jwks({ jwksUrl, issuer: 'https://idp.example.com', audience }),
   client: { ... },
@@ -323,7 +324,6 @@ auth: oauth({
 
 ```ts
 auth: oauth({
-  resourceIssuerUrl: '...',
   endpoints: { ... },
   verify: jwks({ jwksUrl, issuer: 'https://idp.example.com', audience }),
   client: { ... },
@@ -335,7 +335,6 @@ auth: oauth({
 
 ```ts
 auth: oauth({
-  resourceIssuerUrl: '...',
   endpoints: { ... },
   verify: jwks({ jwksUrl, issuer: 'https://idp.example.com', audience }),
   client: { ... },
@@ -367,6 +366,38 @@ Use `userinfo` when the bearer alone does not carry the identity fields you need
 The populated `Principal` rides on the exchange as a single structured header (`routecraft.auth.principal`) and is exposed ergonomically via the `ex.principal` getter, e.g. `ex.principal?.subject`, `ex.principal?.scopes`, `ex.principal?.claims`.
 
 See the [plugins reference](/docs/reference/plugins#mcpplugin) for the full `Principal` field list.
+
+### Protected-resource metadata (RFC 9728)
+
+Auto-discovering MCP clients (Claude.ai custom connectors, MCP Inspector, `mcp-remote`, Claude Desktop) probe `/mcp`, receive a 401, then fetch `/.well-known/oauth-protected-resource` to find out which authorization server to use. The framework serves this RFC 9728 metadata document in both validator and OAuth-proxy auth modes, and appends a `resource_metadata="..."` parameter to the 401 `WWW-Authenticate` header so clients know where the document lives.
+
+Protected-resource identity is configured on the plugin, not on the auth helper. It is orthogonal to the auth mode: the same `resource: {...}` block works whether you use `jwt()` / `jwks()` (validator mode) or `oauth()` (proxy mode).
+
+```ts
+mcpPlugin({
+  name: 'eywa',                          // machine identifier (MCP `serverInfo.name`)
+  title: 'Eywa MCP',                     // human display; also the metadata `resource_name`
+  transport: 'http',
+  host: '0.0.0.0',
+  port: 3001,
+  resource: {
+    url: 'https://mcp.example.com',      // metadata `resource` field; defaults to bound URL
+    scopesSupported: ['read', 'write'],  // metadata `scopes_supported`
+    documentationUrl: 'https://docs.example.com',  // metadata `resource_documentation`
+  },
+  auth: jwks({
+    jwksUrl: 'https://idp.example.com/.well-known/jwks.json',
+    issuer: 'https://idp.example.com',
+    audience: 'https://mcp.example.com',
+  }),
+})
+```
+
+The metadata document populates `authorization_servers` from the validator's `issuer` (surfaced by `jwks()` / `jwt()`) when present. Custom validators with no declared issuer omit the field, which RFC 9728 allows. OAuth-proxy mode derives `authorization_servers` from the MCP SDK's `mcpAuthRouter`.
+
+When `resource.url` is omitted, the framework advertises the bound `http://{host}:{port}/mcp`. This is fine for local dev but should be overridden in production with the public-facing URL clients use to reach the server. In production, `resource.url` must be HTTPS or the plugin throws at startup.
+
+The motivating case is IdPs that do not support server-side Dynamic Client Registration (DCR) and therefore cannot use OAuth proxy mode -- WorkOS AuthKit is the canonical example. In that setup, validator mode (`auth: jwks(...)`) is the only correct integration, and the RFC 9728 metadata document is what lets MCP clients still auto-discover the IdP.
 
 ## Production
 

--- a/apps/routecraft.dev/src/app/docs/changelog/page.md
+++ b/apps/routecraft.dev/src/app/docs/changelog/page.md
@@ -22,14 +22,18 @@ Several breaking changes across the core, AI, mail, logger, and CLI surfaces. Se
 - **Choice operation** -- new conditional routing primitive with `transform()` and `enrich()` available on branch builders. Core operations are shared between routes and branches via a `StepBuilderBase`.
 - **Discovery metadata on the route builder** -- route id, description, and validation move from source options to the route builder itself.
 
-### AI & MCP
+### AI & MCP {% badge color="red" %}Breaking{% /badge %}
 
 - **Agent runtime** -- tool-calling loop, streaming via `onEvent` and `onDelta`, agent destination, and per-binding tool description overrides.
 - **`tools()` DSL** -- declarative tool registration, selection, and resolution.
 - **Agent configuration overhaul** -- `agentPlugin.agents` is a record (no `defineAgent`), `defaultOptions` set context-level defaults, `system`/`user` accept string or function, and agent enhancements (`toolCalls`, `validate`, skills + agents loaders) narrow `FnHandlerContext`.
 - **Config applier system** -- first-class AI plugin keys via a config applier hook.
 - **MCP OAuth 2.1 server** -- OAuth 2.1 authentication provider with principal hierarchy, plus a general MCP HTTP auth surface and tool annotations.
-- **MCP HTTP server identity and protected-resource metadata** -- new `mcpPlugin({ title, resource: { url, scopesSupported, documentationUrl } })` shape. Resource identity is now first-class on the plugin, orthogonal to the auth mode. Both validator-mode (`jwks()` / `jwt()`) and OAuth-proxy mode (`oauth()`) auto-mount `GET /.well-known/oauth-protected-resource` (RFC 9728) and append `resource_metadata="..."` to 401 `WWW-Authenticate` headers, so auto-discovering clients (Claude.ai connectors, MCP Inspector, `mcp-remote`) can locate the authorization server. `OAuthAuthOptions` is reduced to pure proxy mechanics: `resourceIssuerUrl`, `resourceName`, `scopesSupported`, and `serviceDocumentationUrl` move to the plugin-level `resource: {}` (and `title`) options.
+- **MCP HTTP server identity and protected-resource metadata** -- new `mcpPlugin({ title, resource: { url, scopesSupported, documentationUrl } })` shape. Resource identity is now first-class on the plugin, orthogonal to the auth mode. Both validator-mode (`jwks()` / `jwt()`) and OAuth-proxy mode (`oauth()`) auto-mount `GET /.well-known/oauth-protected-resource` (RFC 9728) with the same JSON shape (including `bearer_methods_supported`) and append an absolute `resource_metadata="..."` URL to 401 `WWW-Authenticate` headers, so auto-discovering clients (Claude.ai connectors, MCP Inspector, `mcp-remote`) can locate the authorization server. `OAuthAuthOptions` is reduced to pure proxy mechanics. Field migration:
+  - `oauth({ resourceIssuerUrl })` -> `mcpPlugin({ resource: { url } })`
+  - `oauth({ scopesSupported })` -> `mcpPlugin({ resource: { scopesSupported } })`
+  - `oauth({ serviceDocumentationUrl })` -> `mcpPlugin({ resource: { documentationUrl } })`
+  - `oauth({ resourceName })` -> `mcpPlugin({ title })` (with `name` as the final fallback)
 - **OAuth `userinfo` enrichment slot** -- post-verify principal enrichment on `oauth({ userinfo })` accepting `true` (auto-discover via OIDC Discovery), `string | URL` (explicit endpoint), or a custom function. The framework enforces the OIDC Core §5.3.2 `sub` invariant on URL / discovery modes, fails closed on any fetch / parse error, and memoises enrichment per token (SHA-256 hashed) with insertion-order eviction, in-flight coalescing, and TTL bound to `principal.expiresAt`. The raw userinfo response is surfaced on a separate `principal.userinfoClaims` field so `principal.claims` continues to mean "verified JWT payload."
 - **`OAuthValidatorAuthOptions.issuer`** -- `jwks()` and `jwt()` now surface the expected issuer on the returned options so `userinfo: true` discovery and RFC 9728 `authorization_servers` work without re-declaring the IdP.
 - **`ClaimMappers.{email,name,roles}` removed** -- superseded by the `userinfo` enrichment slot. `ClaimMappers.{subject,clientId,scopes}` remain for token-level claim mapping.

--- a/apps/routecraft.dev/src/app/docs/changelog/page.md
+++ b/apps/routecraft.dev/src/app/docs/changelog/page.md
@@ -18,7 +18,7 @@ Several breaking changes across the core, AI, mail, logger, and CLI surfaces. Se
 
 - **Dual-mode wrapper pattern** -- `.error()` is the first wrapper in a new dual-mode design; route-level error handling is now a wrapper rather than a top-level method. Source-level parse errors now flow through the same handler.
 - **Immutable Exchange** -- the `Exchange` is frozen and mutation is replaced with explicit copy-on-write. State is unified on `{ body, headers }`, with `principal`, `id`, and `logger` exposed as getters.
-- **`.authorize()` route-entry guard** -- new principal accessor on `Exchange` and a route-only authorization validator. Replaces the previous `requirePrincipal` validator.
+- **`.authorize()` route-entry guard** -- new principal accessor on `Exchange` and a route-only authorization validator. Replaces the previous `requirePrincipal` validator. The validator now also checks `principal.expiresAt` and raises `RC5020` when a long-running step has outlived the credential; pass `clockToleranceSec` to match the boundary-side verifier's tolerance.
 - **Choice operation** -- new conditional routing primitive with `transform()` and `enrich()` available on branch builders. Core operations are shared between routes and branches via a `StepBuilderBase`.
 - **Discovery metadata on the route builder** -- route id, description, and validation move from source options to the route builder itself.
 
@@ -29,12 +29,23 @@ Several breaking changes across the core, AI, mail, logger, and CLI surfaces. Se
 - **Agent configuration overhaul** -- `agentPlugin.agents` is a record (no `defineAgent`), `defaultOptions` set context-level defaults, `system`/`user` accept string or function, and agent enhancements (`toolCalls`, `validate`, skills + agents loaders) narrow `FnHandlerContext`.
 - **Config applier system** -- first-class AI plugin keys via a config applier hook.
 - **MCP OAuth 2.1 server** -- OAuth 2.1 authentication provider with principal hierarchy, plus a general MCP HTTP auth surface and tool annotations.
+- **MCP HTTP server identity and protected-resource metadata** -- new `mcpPlugin({ title, resource: { url, scopesSupported, documentationUrl } })` shape. Resource identity is now first-class on the plugin, orthogonal to the auth mode. Both validator-mode (`jwks()` / `jwt()`) and OAuth-proxy mode (`oauth()`) auto-mount `GET /.well-known/oauth-protected-resource` (RFC 9728) and append `resource_metadata="..."` to 401 `WWW-Authenticate` headers, so auto-discovering clients (Claude.ai connectors, MCP Inspector, `mcp-remote`) can locate the authorization server. `OAuthAuthOptions` is reduced to pure proxy mechanics: `resourceIssuerUrl`, `resourceName`, `scopesSupported`, and `serviceDocumentationUrl` move to the plugin-level `resource: {}` (and `title`) options.
+- **OAuth `userinfo` enrichment slot** -- post-verify principal enrichment on `oauth({ userinfo })` accepting `true` (auto-discover via OIDC Discovery), `string | URL` (explicit endpoint), or a custom function. The framework enforces the OIDC Core §5.3.2 `sub` invariant on URL / discovery modes, fails closed on any fetch / parse error, and memoises enrichment per token (SHA-256 hashed) with insertion-order eviction, in-flight coalescing, and TTL bound to `principal.expiresAt`. The raw userinfo response is surfaced on a separate `principal.userinfoClaims` field so `principal.claims` continues to mean "verified JWT payload."
+- **`OAuthValidatorAuthOptions.issuer`** -- `jwks()` and `jwt()` now surface the expected issuer on the returned options so `userinfo: true` discovery and RFC 9728 `authorization_servers` work without re-declaring the IdP.
+- **`ClaimMappers.{email,name,roles}` removed** -- superseded by the `userinfo` enrichment slot. `ClaimMappers.{subject,clientId,scopes}` remain for token-level claim mapping.
+- **Three new error codes** -- `RC5020` (token expired during processing), `RC5021` (principal enrichment failed), `RC5022` (userinfo `sub` invariant violated).
 - **Isolated local tool registry** -- MCP local tools live in a dedicated registry separate from direct routes.
 
 ### Adapters
 
 - **Adapter mocking** -- `mockAdapter` swaps any tagged adapter in tests; `file`, `csv`, `json`, `jsonl`, and `html` factories are tagged out of the box.
+- **Direct adapter distinct input/output types** -- `direct<TIn, TOut>()` lets a route accept one body shape and emit a different one when the registered consumer's transformer changes the type.
 - **Mail (IMAP)** -- the IMAP source is reliable across poll and re-evaluation workloads, with reconnect on transient fetch failures. `MailMessage` body is reshaped and a verify-sender option is available.
+- **Optional peer loader everywhere** -- every dynamic optional-peer import goes through `loadOptionalPeer` and emits `RC5017` with a copy-pasteable install hint. The remaining bespoke `try/catch` sites (mail, jose, telemetry sqlite, several `@routecraft/ai` modules) have all been migrated.
+
+### Telemetry {% badge color="red" %}Breaking{% /badge %}
+
+- **Bun-only SQLite sink** -- the embedded telemetry SQLite sink now uses Bun's built-in `bun:sqlite`. `better-sqlite3` has been removed from the runtime, including from peer dependencies. Deployments must run under Bun (`engines.bun >= 1.1.0`); Node deployments that previously relied on `better-sqlite3` need to bring their own sink.
 
 ### Logger
 
@@ -45,6 +56,7 @@ Several breaking changes across the core, AI, mail, logger, and CLI surfaces. Se
 - **Bun-only `craft` CLI** -- the published `craft` binary now requires Bun >= 1.1.0.
 - **Bun monorepo** -- the monorepo migrates from pnpm to Bun for installs, scripts, and lockfile.
 - **`create-routecraft` refactor** -- scaffolder library extracted with expanded test coverage.
+- **`bun:test` everywhere** -- the internal test suite has fully migrated from vitest to `bun:test`. Vitest is retained only for the cross-runtime suite (where Node-only test seams still apply).
 
 ### Docs
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -86,6 +86,7 @@ export {
   type McpLocalToolEntry,
   type McpOptions,
   type McpPluginOptions,
+  type McpResourceOptions,
   type McpServerOptions,
   type McpTool,
   type McpToolAnnotations,

--- a/packages/ai/src/mcp/index.ts
+++ b/packages/ai/src/mcp/index.ts
@@ -26,6 +26,7 @@ export {
   type McpLocalToolEntry,
   type McpOptions,
   type McpPluginOptions,
+  type McpResourceOptions,
   type McpServerOptions,
   type McpTool,
   type McpToolAnnotations,

--- a/packages/ai/src/mcp/oauth.ts
+++ b/packages/ai/src/mcp/oauth.ts
@@ -52,15 +52,7 @@ export type OAuthVerifier = OAuthValidatorAuthOptions | OAuthTokenVerifier;
  * @experimental
  */
 export interface OAuthFactoryOptions {
-  /**
-   * Issuer URL for this MCP server's OAuth metadata discovery endpoint.
-   * Must be HTTPS in production.
-   *
-   * Renamed from `issuerUrl` to avoid confusion with the IdP issuer inside
-   * the `verify` config.
-   */
-  resourceIssuerUrl: string | URL;
-  /** Base URL for OAuth endpoints (defaults to resourceIssuerUrl). */
+  /** Base URL for OAuth endpoints (defaults to the resolved resource URL). */
   baseUrl?: string | URL;
   /** Upstream OAuth provider endpoints to proxy. */
   endpoints: OAuthProxyEndpoints;
@@ -86,14 +78,8 @@ export interface OAuthFactoryOptions {
    * during every authorize/token/revoke call; treat it as a hot path.
    */
   client: OAuthClientInfo | OAuthClientSupplier;
-  /** OAuth scopes the server advertises as supported. */
-  scopesSupported?: string[];
-  /** Scopes required on every request to `/mcp`. */
+  /** Scopes required on every request to `/mcp`. Enforcement policy, not metadata. */
   requiredScopes?: string[];
-  /** URL to service documentation (included in OAuth metadata). */
-  serviceDocumentationUrl?: string | URL;
-  /** Human-readable resource name (included in OAuth metadata). */
-  resourceName?: string;
   /**
    * Principal enrichment after `verify` succeeds. Three input shapes:
    *
@@ -175,8 +161,8 @@ function buildVerifier(
  *
  * mcpPlugin({
  *   transport: "http",
+ *   resource: { url: "https://mcp.example.com" },
  *   auth: oauth({
- *     resourceIssuerUrl: "https://mcp.example.com",
  *     endpoints: {
  *       authorizationUrl: "https://idp.example.com/authorize",
  *       tokenUrl: "https://idp.example.com/token",
@@ -205,7 +191,6 @@ function buildVerifier(
  * @example Custom verification (opaque tokens, introspection, etc.)
  * ```ts
  * oauth({
- *   resourceIssuerUrl: "https://mcp.example.com",
  *   endpoints: { authorizationUrl: "...", tokenUrl: "..." },
  *   verify: async (token) => {
  *     const principal = await myIntrospectionCall(token);
@@ -224,16 +209,6 @@ function buildVerifier(
  * @experimental
  */
 export function oauth(options: OAuthFactoryOptions): OAuthAuthOptions {
-  const issuer = new URL(options.resourceIssuerUrl.toString());
-  if (
-    issuer.protocol !== "https:" &&
-    process.env["NODE_ENV"] === "production"
-  ) {
-    throw new TypeError(
-      "oauth: resourceIssuerUrl must use HTTPS in production",
-    );
-  }
-
   if (!options.verify) {
     throw new TypeError(
       "oauth: `verify` is required. Pass jwks(...), jwt(...), or a custom (token) => OAuthPrincipal function.",
@@ -247,22 +222,12 @@ export function oauth(options: OAuthFactoryOptions): OAuthAuthOptions {
 
   const result: OAuthAuthOptions = {
     provider: "oauth",
-    resourceIssuerUrl: options.resourceIssuerUrl,
     endpoints: options.endpoints,
     verifyAccessToken,
     getClient,
     ...(options.baseUrl !== undefined && { baseUrl: options.baseUrl }),
-    ...(options.scopesSupported !== undefined && {
-      scopesSupported: options.scopesSupported,
-    }),
     ...(options.requiredScopes !== undefined && {
       requiredScopes: options.requiredScopes,
-    }),
-    ...(options.serviceDocumentationUrl !== undefined && {
-      serviceDocumentationUrl: options.serviceDocumentationUrl,
-    }),
-    ...(options.resourceName !== undefined && {
-      resourceName: options.resourceName,
     }),
   };
 

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -11,6 +11,7 @@ import type { IncomingMessage } from "node:http";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type {
   OAuthPrincipal,
+  OAuthValidatorAuthOptions,
   Principal,
   ValidatorAuthOptions,
 } from "@routecraft/routecraft";
@@ -44,7 +45,27 @@ const principalStore = new AsyncLocalStorage<Principal | undefined>();
 type McpServerResolvedOptions = Required<
   Pick<McpPluginOptions, "name" | "version" | "transport" | "port" | "host">
 > &
-  Pick<McpPluginOptions, "tools" | "auth">;
+  Pick<McpPluginOptions, "tools" | "auth" | "title" | "resource">;
+
+/**
+ * RFC 9728 OAuth 2.0 Protected Resource Metadata payload returned by
+ * `GET /.well-known/oauth-protected-resource`. Optional fields are omitted
+ * from the JSON when unset.
+ *
+ * @internal
+ */
+interface ProtectedResourceMetadata {
+  resource: string;
+  resource_name?: string;
+  authorization_servers?: string[];
+  bearer_methods_supported: ["header"];
+  scopes_supported?: string[];
+  resource_documentation?: string;
+}
+
+/** Path of the RFC 9728 metadata document. Relative to the server origin. */
+const PROTECTED_RESOURCE_METADATA_PATH =
+  "/.well-known/oauth-protected-resource";
 
 /**
  * McpServer wraps the MCP SDK and bridges it to Routecraft's DirectChannel infrastructure.
@@ -133,7 +154,7 @@ export class McpServer {
       { adapterName: "mcp (stdio)", packageName: "@modelcontextprotocol/sdk" },
     );
     const Server = serverMod.Server as new (
-      info: { name: string; version: string },
+      info: { name: string; version: string; title?: string },
       options: { capabilities: { tools: Record<string, unknown> } },
     ) => unknown;
     const stdioMod = await loadOptionalPeer(
@@ -179,7 +200,7 @@ export class McpServer {
    */
   private async importSdkHttp(): Promise<{
     ServerCtor: new (
-      info: { name: string; version: string },
+      info: { name: string; version: string; title?: string },
       options: { capabilities: { tools: Record<string, unknown> } },
     ) => unknown;
     TransportClass: new (options?: {
@@ -193,7 +214,7 @@ export class McpServer {
       { adapterName: "mcp (http)", packageName: "@modelcontextprotocol/sdk" },
     );
     const ServerCtor = serverModule.Server as new (
-      info: { name: string; version: string },
+      info: { name: string; version: string; title?: string },
       options: { capabilities: { tools: Record<string, unknown> } },
     ) => unknown;
 
@@ -231,7 +252,7 @@ export class McpServer {
    */
   private async createSession(
     ServerCtor: new (
-      info: { name: string; version: string },
+      info: { name: string; version: string; title?: string },
       options: { capabilities: { tools: Record<string, unknown> } },
     ) => unknown,
     TransportClass: new (options?: {
@@ -248,7 +269,11 @@ export class McpServer {
     ) => Promise<void>;
   }> {
     const server = new ServerCtor(
-      { name: this.options.name, version: this.options.version },
+      {
+        name: this.options.name,
+        version: this.options.version,
+        ...(this.options.title !== undefined && { title: this.options.title }),
+      },
       { capabilities: { tools: {} } },
     );
 
@@ -359,6 +384,70 @@ export class McpServer {
   }
 
   /**
+   * Resolve the RFC 9728 `resource` URL. Resolution order:
+   *   1. `mcpPlugin({ resource: { url } })`
+   *   2. bound fallback `http://{host}:{port}/mcp`
+   *
+   * Must be called after `.listen()` so the bound port is known.
+   */
+  private resolveResourceUrl(): string {
+    const explicit = this.options.resource?.url;
+    if (explicit !== undefined) return explicit.toString();
+    const host = this.options.host;
+    const port = this.getHttpPort() ?? this.options.port;
+    return `http://${host}:${port}/mcp`;
+  }
+
+  /**
+   * Resolve the RFC 9728 `resource_name` value: `title` -> `name`.
+   */
+  private resolveResourceName(): string {
+    return this.options.title ?? this.options.name;
+  }
+
+  /**
+   * Build the RFC 9728 protected-resource metadata document.
+   *
+   * `authorization_servers` is populated from the validator's `issuer` (when
+   * `auth` is `OAuthValidatorAuthOptions` from `jwks()` / `jwt()`). When the
+   * verifier exposes no issuer, the field is omitted (RFC 9728 allows that).
+   *
+   * @internal
+   */
+  private buildProtectedResourceMetadata(): ProtectedResourceMetadata {
+    const metadata: ProtectedResourceMetadata = {
+      resource: this.resolveResourceUrl(),
+      bearer_methods_supported: ["header"],
+    };
+    metadata.resource_name = this.resolveResourceName();
+
+    const auth = this.options.auth;
+    if (auth && !("provider" in auth) && "issuer" in auth) {
+      const issuer = (auth as OAuthValidatorAuthOptions).issuer;
+      if (issuer !== undefined) {
+        metadata.authorization_servers = Array.isArray(issuer)
+          ? issuer
+          : [issuer];
+      }
+    }
+
+    const resource = this.options.resource;
+    if (resource?.scopesSupported && resource.scopesSupported.length > 0) {
+      metadata.scopes_supported = resource.scopesSupported;
+    }
+    if (resource?.documentationUrl !== undefined) {
+      metadata.resource_documentation = resource.documentationUrl.toString();
+    }
+
+    return metadata;
+  }
+
+  /** Build the `WWW-Authenticate` header value for a 401, with `resource_metadata` per RFC 9728. */
+  private buildWwwAuthenticateHeader(): string {
+    return `Bearer realm="mcp", resource_metadata="${PROTECTED_RESOURCE_METADATA_PATH}"`;
+  }
+
+  /**
    * Start HTTP transport with validator-based auth (existing behavior).
    * Uses raw Node.js `http.createServer`.
    */
@@ -372,6 +461,17 @@ export class McpServer {
 
     this.httpServer = createServer(async (req, res) => {
       const url = req.url?.split("?")[0] ?? "";
+
+      if (url === PROTECTED_RESOURCE_METADATA_PATH) {
+        const metadata = this.buildProtectedResourceMetadata();
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-store",
+        });
+        res.end(JSON.stringify(metadata));
+        return;
+      }
+
       if (url !== "/mcp" && url !== "/mcp/") {
         res.writeHead(404, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Not Found", path: url }));
@@ -384,7 +484,7 @@ export class McpServer {
         if (!result) {
           res.writeHead(401, {
             "Content-Type": "application/json",
-            "WWW-Authenticate": 'Bearer realm="mcp"',
+            "WWW-Authenticate": this.buildWwwAuthenticateHeader(),
           });
           res.end(JSON.stringify({ error: "Unauthorized" }));
           return;
@@ -545,29 +645,57 @@ export class McpServer {
 
     const app = expressFn();
 
+    // Resolve resource identity from `mcpPlugin({ resource })` / defaults.
+    const resourceUrlStr = this.options.resource?.url?.toString();
+    // For OAuth mode we need a concrete URL at startup (the SDK builds its own
+    // discovery doc from it). When `resource.url` is unset, fall back to the
+    // configured `http://{host}:{port}/mcp`. The post-listen rebind in
+    // `resolveResourceUrl` is for the validator path; OAuth uses the
+    // pre-listen value because the SDK middleware closes over it.
+    const resourceUrl = new URL(resourceUrlStr ?? `http://${host}:${port}/mcp`);
+    if (
+      resourceUrl.protocol !== "https:" &&
+      process.env["NODE_ENV"] === "production"
+    ) {
+      throw new TypeError(
+        "mcpPlugin: resource.url must use HTTPS in production",
+      );
+    }
+
     // Mount OAuth endpoints at root (discovery, authorize, token, revoke).
     const authRouterOptions: Record<string, unknown> = {
       provider,
-      issuerUrl: new URL(oauthOptions.resourceIssuerUrl.toString()),
+      issuerUrl: resourceUrl,
     };
     if (oauthOptions.baseUrl) {
       authRouterOptions["baseUrl"] = new URL(oauthOptions.baseUrl.toString());
     }
-    if (oauthOptions.scopesSupported) {
-      authRouterOptions["scopesSupported"] = oauthOptions.scopesSupported;
+    const resource = this.options.resource;
+    if (resource?.scopesSupported && resource.scopesSupported.length > 0) {
+      authRouterOptions["scopesSupported"] = resource.scopesSupported;
     }
-    if (oauthOptions.serviceDocumentationUrl) {
+    if (resource?.documentationUrl) {
       authRouterOptions["serviceDocumentationUrl"] = new URL(
-        oauthOptions.serviceDocumentationUrl.toString(),
+        resource.documentationUrl.toString(),
       );
     }
-    if (oauthOptions.resourceName) {
-      authRouterOptions["resourceName"] = oauthOptions.resourceName;
+    const resourceName = this.resolveResourceName();
+    if (resourceName) {
+      authRouterOptions["resourceName"] = resourceName;
     }
     app.use(mcpAuthRouter(authRouterOptions));
 
-    // Bearer auth middleware for /mcp.
-    const bearerOptions: Record<string, unknown> = { verifier: provider };
+    // Bearer auth middleware for /mcp. The SDK appends
+    // `resource_metadata="..."` to its 401 WWW-Authenticate header when
+    // `resourceMetadataUrl` is provided. Construct the URL relative to the
+    // resource origin so it matches what `mcpAuthRouter` mounts.
+    const bearerOptions: Record<string, unknown> = {
+      verifier: provider,
+      resourceMetadataUrl: new URL(
+        PROTECTED_RESOURCE_METADATA_PATH,
+        resourceUrl,
+      ).toString(),
+    };
     if (oauthOptions.requiredScopes) {
       bearerOptions["requiredScopes"] = oauthOptions.requiredScopes;
     }

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -104,6 +104,28 @@ export class McpServer {
       host: "localhost",
       ...options,
     };
+    this.validateResourceConfig();
+  }
+
+  /**
+   * Validate plugin-level resource config at construction time. Runs the
+   * HTTPS-in-production guard on an explicit `resource.url`. The default
+   * fallback `http://{host}:{port}/mcp` is permitted as a dev-only
+   * convenience; the guard only fires when the user explicitly opted in to
+   * an `http://` URL in production.
+   */
+  private validateResourceConfig(): void {
+    const explicit = this.options.resource?.url;
+    if (explicit === undefined) return;
+    const parsed = new URL(explicit.toString());
+    if (
+      parsed.protocol !== "https:" &&
+      process.env["NODE_ENV"] === "production"
+    ) {
+      throw new TypeError(
+        "mcpPlugin: resource.url must use HTTPS in production",
+      );
+    }
   }
 
   /**
@@ -388,7 +410,13 @@ export class McpServer {
    *   1. `mcpPlugin({ resource: { url } })`
    *   2. bound fallback `http://{host}:{port}/mcp`
    *
-   * Must be called after `.listen()` so the bound port is known.
+   * The HTTPS-in-production guard on an explicit `resource.url` runs eagerly
+   * in the constructor (see `validateResourceConfig`); this resolver is a
+   * pure projection. Should be called after `.listen()` so the bound port is
+   * known. The OAuth path resolves at startup (pre-listen) because the MCP
+   * SDK closes over the URL when middleware is registered; that path
+   * forbids `port: 0` with an unset `resource.url` separately to avoid
+   * baking `:0` into advertised URLs.
    */
   private resolveResourceUrl(): string {
     const explicit = this.options.resource?.url;
@@ -442,9 +470,49 @@ export class McpServer {
     return metadata;
   }
 
-  /** Build the `WWW-Authenticate` header value for a 401, with `resource_metadata` per RFC 9728. */
+  /**
+   * Build the absolute URL of the protected-resource metadata document.
+   * Combines `PROTECTED_RESOURCE_METADATA_PATH` (always rooted at origin)
+   * with the resolved `resource.url`'s origin.
+   *
+   * @internal
+   */
+  private resolveResourceMetadataUrl(): string {
+    return new URL(
+      PROTECTED_RESOURCE_METADATA_PATH,
+      this.resolveResourceUrl(),
+    ).toString();
+  }
+
+  /**
+   * Build the `WWW-Authenticate` header value for a 401, with an absolute
+   * `resource_metadata` URL per RFC 9728 §5.1.
+   */
   private buildWwwAuthenticateHeader(): string {
-    return `Bearer realm="mcp", resource_metadata="${PROTECTED_RESOURCE_METADATA_PATH}"`;
+    const metadataUrl = this.resolveResourceMetadataUrl();
+    return `Bearer realm="mcp", resource_metadata="${metadataUrl}"`;
+  }
+
+  /**
+   * Serve the RFC 9728 protected-resource metadata document.
+   *
+   * Shared between validator and OAuth-proxy modes so both produce the
+   * exact same JSON shape. Default `Cache-Control: public, max-age=3600`
+   * follows RFC 9728 §3.3's caching guidance; auto-discovering MCP clients
+   * fetch this document on every connection, so a short cache prevents the
+   * IdP from being polled needlessly.
+   *
+   * @internal
+   */
+  private serveProtectedResourceMetadata(
+    res: import("node:http").ServerResponse,
+  ): void {
+    const metadata = this.buildProtectedResourceMetadata();
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=3600",
+    });
+    res.end(JSON.stringify(metadata));
   }
 
   /**
@@ -463,12 +531,7 @@ export class McpServer {
       const url = req.url?.split("?")[0] ?? "";
 
       if (url === PROTECTED_RESOURCE_METADATA_PATH) {
-        const metadata = this.buildProtectedResourceMetadata();
-        res.writeHead(200, {
-          "Content-Type": "application/json",
-          "Cache-Control": "no-store",
-        });
-        res.end(JSON.stringify(metadata));
+        this.serveProtectedResourceMetadata(res);
         return;
       }
 
@@ -516,6 +579,7 @@ export class McpServer {
     // Express types are not available at compile time (transitive dep of SDK),
     // so all Express values are typed as unknown and accessed dynamically.
     let expressFn: (...args: unknown[]) => {
+      get: (...args: unknown[]) => void;
       use: (...args: unknown[]) => void;
       all: (...args: unknown[]) => void;
       listen: (
@@ -643,24 +707,42 @@ export class McpServer {
     const port = this.options.port;
     const host = this.options.host;
 
-    const app = expressFn();
-
-    // Resolve resource identity from `mcpPlugin({ resource })` / defaults.
-    const resourceUrlStr = this.options.resource?.url?.toString();
-    // For OAuth mode we need a concrete URL at startup (the SDK builds its own
-    // discovery doc from it). When `resource.url` is unset, fall back to the
-    // configured `http://{host}:{port}/mcp`. The post-listen rebind in
-    // `resolveResourceUrl` is for the validator path; OAuth uses the
-    // pre-listen value because the SDK middleware closes over it.
-    const resourceUrl = new URL(resourceUrlStr ?? `http://${host}:${port}/mcp`);
-    if (
-      resourceUrl.protocol !== "https:" &&
-      process.env["NODE_ENV"] === "production"
-    ) {
+    // OAuth-proxy mode resolves the resource URL at startup because the MCP
+    // SDK's `mcpAuthRouter` and `requireBearerAuth` middleware close over
+    // the URL when they are mounted. With `port: 0` (an ephemeral port,
+    // commonly used in tests) and no explicit `resource.url`, the bound
+    // port is unknown at this point and would be baked into the discovery
+    // document and `WWW-Authenticate` header as `:0`. Reject that
+    // combination loudly so the user picks a fixed port or a public URL.
+    if (port === 0 && this.options.resource?.url === undefined) {
       throw new TypeError(
-        "mcpPlugin: resource.url must use HTTPS in production",
+        "mcpPlugin: OAuth-proxy mode requires either a fixed `port` or an explicit `resource.url`. " +
+          "With `port: 0` (ephemeral) and no `resource.url`, the protected-resource metadata URL " +
+          'would advertise `:0`. Pass `resource: { url: "https://..." }` or a non-zero `port`.',
       );
     }
+
+    // Single source of truth for the resource URL (validates HTTPS in
+    // production when explicitly set; falls back to the configured port
+    // otherwise).
+    const resourceUrl = new URL(this.resolveResourceUrl());
+
+    const app = expressFn();
+
+    // Mount our own protected-resource metadata handler BEFORE
+    // `mcpAuthRouter`. The SDK's router also mounts a doc, but at a
+    // path-aware URL (`/.well-known/oauth-protected-resource{rsPath}`)
+    // and without the `bearer_methods_supported` field RFC 9728 §2
+    // recommends. Mounting ours first means clients fetching the URL we
+    // advertise in the 401 always get the same JSON shape as validator
+    // mode -- the design's "auto-mount, same shape, regardless of auth
+    // mode" promise. Express matches the more specific `app.get(...)`
+    // before the more general `router.use(...)` registered later.
+    app.get(PROTECTED_RESOURCE_METADATA_PATH, (_req: unknown, res: unknown) => {
+      this.serveProtectedResourceMetadata(
+        res as import("node:http").ServerResponse,
+      );
+    });
 
     // Mount OAuth endpoints at root (discovery, authorize, token, revoke).
     const authRouterOptions: Record<string, unknown> = {
@@ -674,7 +756,7 @@ export class McpServer {
     if (resource?.scopesSupported && resource.scopesSupported.length > 0) {
       authRouterOptions["scopesSupported"] = resource.scopesSupported;
     }
-    if (resource?.documentationUrl) {
+    if (resource?.documentationUrl !== undefined) {
       authRouterOptions["serviceDocumentationUrl"] = new URL(
         resource.documentationUrl.toString(),
       );
@@ -687,14 +769,11 @@ export class McpServer {
 
     // Bearer auth middleware for /mcp. The SDK appends
     // `resource_metadata="..."` to its 401 WWW-Authenticate header when
-    // `resourceMetadataUrl` is provided. Construct the URL relative to the
-    // resource origin so it matches what `mcpAuthRouter` mounts.
+    // `resourceMetadataUrl` is provided. Use an absolute URL (RFC 9728
+    // §5.1 SHOULD) that points at the doc we just mounted above.
     const bearerOptions: Record<string, unknown> = {
       verifier: provider,
-      resourceMetadataUrl: new URL(
-        PROTECTED_RESOURCE_METADATA_PATH,
-        resourceUrl,
-      ).toString(),
+      resourceMetadataUrl: this.resolveResourceMetadataUrl(),
     };
     if (oauthOptions.requiredScopes) {
       bearerOptions["requiredScopes"] = oauthOptions.requiredScopes;

--- a/packages/ai/src/mcp/types.ts
+++ b/packages/ai/src/mcp/types.ts
@@ -213,22 +213,52 @@ export interface OAuthProxyEndpoints {
 }
 
 /**
+ * Protected-resource (RFC 9728) metadata for the MCP server.
+ *
+ * Used by both validator-mode and OAuth-proxy auth to populate
+ * `/.well-known/oauth-protected-resource` and the `resource_metadata`
+ * parameter on 401 responses. Orthogonal to the auth mode: identifies WHAT
+ * is being protected, not HOW it authenticates.
+ *
+ * When omitted entirely, the framework still advertises a baseline metadata
+ * document built from the bound URL and (in validator mode) the IdP issuer
+ * surfaced by `jwks()` / `jwt()`.
+ *
+ * @experimental
+ */
+export interface McpResourceOptions {
+  /**
+   * Identifies this MCP server as an OAuth 2.0 Protected Resource (RFC 9728).
+   * Becomes the `resource` field in the metadata document. Must be HTTPS in
+   * production. Defaults to `http://{host}:{port}/mcp` when unset.
+   */
+  url?: string | URL;
+  /**
+   * OAuth scopes this resource advertises as supported.
+   * Becomes the `scopes_supported` field in the metadata document.
+   */
+  scopesSupported?: string[];
+  /**
+   * URL to human-readable documentation describing this protected resource.
+   * Becomes the `resource_documentation` field in the metadata document.
+   */
+  documentationUrl?: string | URL;
+}
+
+/**
  * OAuth provider auth: full OAuth 2.1 server flow with proxy to upstream IdP.
  * Mounts discovery, authorization, token, and revocation endpoints alongside `/mcp`.
  * Uses the MCP SDK's `ProxyOAuthServerProvider` and `mcpAuthRouter` internally.
+ *
+ * Protected-resource metadata (`resource`, `scopes_supported`, etc.) lives on
+ * `mcpPlugin({ resource })`, not here -- it is orthogonal to the auth mode.
  *
  * @experimental
  */
 export interface OAuthAuthOptions {
   /** Discriminant for the union. Always `"oauth"`. */
   provider: "oauth";
-  /**
-   * Issuer URL for OAuth metadata discovery (the MCP server's own issuer).
-   * Must be HTTPS in production. Renamed from `issuerUrl` to disambiguate from
-   * the IdP issuer inside the `verify` config.
-   */
-  resourceIssuerUrl: string | URL;
-  /** Base URL for OAuth endpoints (defaults to resourceIssuerUrl). */
+  /** Base URL for OAuth endpoints (defaults to the resolved resource URL). */
   baseUrl?: string | URL;
   /** Upstream OAuth provider endpoints to proxy. */
   endpoints: OAuthProxyEndpoints;
@@ -247,14 +277,8 @@ export interface OAuthAuthOptions {
    * Return `undefined` to reject the client.
    */
   getClient: (clientId: string) => Promise<OAuthClientInfo | undefined>;
-  /** OAuth scopes the server advertises as supported. */
-  scopesSupported?: string[];
-  /** Scopes required on every request to `/mcp`. */
+  /** Scopes required on every request to `/mcp`. Enforcement policy, not metadata. */
   requiredScopes?: string[];
-  /** URL to service documentation (included in OAuth metadata). */
-  serviceDocumentationUrl?: string | URL;
-  /** Human-readable resource name (included in OAuth metadata). */
-  resourceName?: string;
 }
 
 /**
@@ -315,8 +339,15 @@ export interface McpClientAuthOptions {
  * One plugin per adapter: this is the single options type for the MCP plugin.
  */
 export interface McpPluginOptions {
-  /** Server name in MCP protocol handshake. Default: "routecraft" */
+  /** Server name in MCP protocol handshake. Default: "routecraft". Machine identifier. */
   name?: string;
+
+  /**
+   * Human-readable display title for this MCP server. Defaults to `name` when unset.
+   * Used for MCP `serverInfo.title` (where the SDK protocol exposes it) and as
+   * the `resource_name` field in RFC 9728 protected-resource metadata.
+   */
+  title?: string;
 
   /** Server version. Default: "1.0.0" */
   version?: string;
@@ -329,6 +360,18 @@ export interface McpPluginOptions {
 
   /** Host to bind to. Default: "localhost" (only used with transport: "http") */
   host?: string;
+
+  /**
+   * Protected-resource (RFC 9728) metadata for the HTTP transport. When set,
+   * the server advertises `/.well-known/oauth-protected-resource` and adds
+   * `resource_metadata="..."` to 401 `WWW-Authenticate` headers. Used by both
+   * validator and OAuth-proxy auth modes; ignored for stdio.
+   *
+   * When omitted, baseline metadata is still served (deriving `resource` from
+   * the bound URL and `authorization_servers` from the validator's IdP
+   * issuer when present).
+   */
+  resource?: McpResourceOptions;
 
   /**
    * Authentication for the HTTP transport. When set, every request to `/mcp` must

--- a/packages/ai/src/mcp/types.ts
+++ b/packages/ai/src/mcp/types.ts
@@ -235,7 +235,9 @@ export interface McpResourceOptions {
   url?: string | URL;
   /**
    * OAuth scopes this resource advertises as supported.
-   * Becomes the `scopes_supported` field in the metadata document.
+   * Becomes the `scopes_supported` field in the metadata document. An empty
+   * array is treated as unset and the field is omitted entirely (RFC 9728
+   * §2 permits this; most MCP clients treat absence and empty as equivalent).
    */
   scopesSupported?: string[];
   /**

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -213,6 +213,8 @@ describe("McpServer", () => {
         port?: number;
         host?: string;
         auth?: import("../src/mcp/types.ts").McpHttpAuthOptions;
+        resource?: import("../src/mcp/types.ts").McpResourceOptions;
+        title?: string;
       } = {},
     ) {
       t = await testContext().routes(routes).store(MCP_STORE_KEY, true).build();
@@ -293,6 +295,40 @@ describe("McpServer", () => {
         });
       }
 
+      function get(path: string): Promise<{
+        statusCode: number;
+        body: string;
+        headers: Record<string, string | string[] | undefined>;
+      }> {
+        return new Promise((resolve, reject) => {
+          const req = http.request(
+            {
+              host: "127.0.0.1",
+              port,
+              path,
+              method: "GET",
+              headers: { Connection: "close" },
+            },
+            (res) => {
+              let data = "";
+              res.on("data", (chunk) => (data += chunk));
+              res.on("end", () =>
+                resolve({
+                  statusCode: res.statusCode ?? 0,
+                  body: data,
+                  headers: res.headers as Record<
+                    string,
+                    string | string[] | undefined
+                  >,
+                }),
+              );
+            },
+          );
+          req.on("error", reject);
+          req.end();
+        });
+      }
+
       async function initSession(
         authHeaders?: Record<string, string>,
       ): Promise<string> {
@@ -309,7 +345,7 @@ describe("McpServer", () => {
         return Array.isArray(sid) ? sid[0] : (sid as string);
       }
 
-      return { post, port, initSession };
+      return { post, get, port, initSession };
     }
 
     /**
@@ -505,7 +541,7 @@ describe("McpServer", () => {
       /**
        * @case Request without Authorization header returns 401 when auth is configured
        * @preconditions McpServer with auth.validator set; POST /mcp without Authorization header
-       * @expectedResult 401 status code with WWW-Authenticate header
+       * @expectedResult 401 status code with WWW-Authenticate header including realm and resource_metadata (RFC 9728)
        */
       test("returns 401 when no Authorization header and auth is configured", async () => {
         const { post } = await startHttpServer([], {
@@ -520,7 +556,12 @@ describe("McpServer", () => {
         });
         const res = await post(initBody);
         expect(res.statusCode).toBe(401);
-        expect(res.headers["www-authenticate"]).toMatch(/Bearer/);
+        const wwwAuth = res.headers["www-authenticate"];
+        expect(wwwAuth).toMatch(/Bearer/);
+        expect(wwwAuth).toMatch(/realm="mcp"/);
+        expect(wwwAuth).toMatch(
+          /resource_metadata="\/\.well-known\/oauth-protected-resource"/,
+        );
       });
 
       /**
@@ -675,6 +716,198 @@ describe("McpServer", () => {
       });
     });
 
+    describe("RFC 9728 protected-resource metadata (validator mode)", () => {
+      const validPrincipal = {
+        kind: "custom" as const,
+        subject: "user-1",
+        scheme: "bearer" as const,
+      };
+
+      /**
+       * @case Discovery endpoint is served at /.well-known/oauth-protected-resource without auth
+       * @preconditions McpServer with validator auth configured; GET without Authorization header
+       * @expectedResult 200 status code with application/json content-type and Cache-Control: no-store
+       */
+      test("GET /.well-known/oauth-protected-resource returns 200 JSON without auth", async () => {
+        const { get } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        expect(res.statusCode).toBe(200);
+        expect(res.headers["content-type"]).toMatch(/application\/json/);
+        expect(res.headers["cache-control"]).toBe("no-store");
+        expect(() => JSON.parse(res.body)).not.toThrow();
+      });
+
+      /**
+       * @case Metadata document carries the explicit `resource.url` when configured
+       * @preconditions resource.url is set to "https://mcp.example.com"
+       * @expectedResult `resource` field equals the configured value
+       */
+      test("resource field uses configured resource.url", async () => {
+        const { get } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+          resource: { url: "https://mcp.example.com" },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as { resource: string };
+        expect(doc.resource).toBe("https://mcp.example.com");
+      });
+
+      /**
+       * @case Metadata document falls back to bound URL when resource.url is unset
+       * @preconditions No resource.url; server bound on 127.0.0.1:{port}
+       * @expectedResult `resource` field is http://127.0.0.1:{port}/mcp
+       */
+      test("resource field falls back to http://host:port/mcp when unset", async () => {
+        const { get, port } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as { resource: string };
+        expect(doc.resource).toBe(`http://127.0.0.1:${port}/mcp`);
+      });
+
+      /**
+       * @case bearer_methods_supported is always ["header"]
+       * @preconditions Any validator-mode configuration
+       * @expectedResult Metadata `bearer_methods_supported` array is exactly ["header"]
+       */
+      test('bearer_methods_supported is ["header"]', async () => {
+        const { get } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as {
+          bearer_methods_supported: string[];
+        };
+        expect(doc.bearer_methods_supported).toEqual(["header"]);
+      });
+
+      /**
+       * @case authorization_servers is populated from the validator's `issuer` field
+       * @preconditions Validator carries issuer: "https://idp.example.com" (mirrors what jwks()/jwt() produce)
+       * @expectedResult Metadata `authorization_servers` is ["https://idp.example.com"]
+       */
+      test("authorization_servers is [validator.issuer] when present", async () => {
+        const { get } = await startHttpServer([], {
+          auth: {
+            validator: () => validPrincipal,
+            issuer: "https://idp.example.com",
+          },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as {
+          authorization_servers?: string[];
+        };
+        expect(doc.authorization_servers).toEqual(["https://idp.example.com"]);
+      });
+
+      /**
+       * @case authorization_servers forwards array issuers as-is
+       * @preconditions Validator carries issuer: ["https://a.example.com", "https://b.example.com"]
+       * @expectedResult Metadata `authorization_servers` contains both entries
+       */
+      test("authorization_servers forwards array issuers", async () => {
+        const { get } = await startHttpServer([], {
+          auth: {
+            validator: () => validPrincipal,
+            issuer: ["https://a.example.com", "https://b.example.com"],
+          },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as {
+          authorization_servers?: string[];
+        };
+        expect(doc.authorization_servers).toEqual([
+          "https://a.example.com",
+          "https://b.example.com",
+        ]);
+      });
+
+      /**
+       * @case authorization_servers is omitted when the validator has no issuer
+       * @preconditions Plain `{ validator }` with no `issuer` field (custom verifier)
+       * @expectedResult `authorization_servers` is absent from the metadata document
+       */
+      test("authorization_servers is omitted when validator has no issuer", async () => {
+        const { get } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as Record<string, unknown>;
+        expect(doc.authorization_servers).toBeUndefined();
+      });
+
+      /**
+       * @case resource_name derives from title when set, else falls back to name
+       * @preconditions title: "Eywa MCP" is set on the plugin options
+       * @expectedResult Metadata `resource_name` equals "Eywa MCP"
+       */
+      test("resource_name uses title when set", async () => {
+        const { get } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+          title: "Eywa MCP",
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as { resource_name?: string };
+        expect(doc.resource_name).toBe("Eywa MCP");
+      });
+
+      /**
+       * @case resource_name falls back to name when title is unset
+       * @preconditions No title; default name "routecraft" is used
+       * @expectedResult Metadata `resource_name` equals "routecraft"
+       */
+      test("resource_name falls back to name when title is unset", async () => {
+        const { get } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as { resource_name?: string };
+        expect(doc.resource_name).toBe("routecraft");
+      });
+
+      /**
+       * @case scopes_supported and resource_documentation come from resource: {...}
+       * @preconditions resource: { scopesSupported: ["read","write"], documentationUrl: "https://docs.example.com" }
+       * @expectedResult Both fields appear in the metadata document
+       */
+      test("scopes_supported and resource_documentation pass through from resource: {...}", async () => {
+        const { get } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+          resource: {
+            scopesSupported: ["read", "write"],
+            documentationUrl: "https://docs.example.com",
+          },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as {
+          scopes_supported?: string[];
+          resource_documentation?: string;
+        };
+        expect(doc.scopes_supported).toEqual(["read", "write"]);
+        expect(doc.resource_documentation).toBe("https://docs.example.com");
+      });
+
+      /**
+       * @case Metadata endpoint is served even when no auth is configured (baseline document)
+       * @preconditions No auth, no resource options; default plugin config
+       * @expectedResult Discovery returns 200 with at least `resource` and `bearer_methods_supported`
+       */
+      test("metadata endpoint is served without auth configured", async () => {
+        const { get, port } = await startHttpServer([]);
+        const res = await get("/.well-known/oauth-protected-resource");
+        expect(res.statusCode).toBe(200);
+        const doc = JSON.parse(res.body) as {
+          resource: string;
+          bearer_methods_supported: string[];
+        };
+        expect(doc.resource).toBe(`http://127.0.0.1:${port}/mcp`);
+        expect(doc.bearer_methods_supported).toEqual(["header"]);
+      });
+    });
+
     describe("oauth auth", () => {
       /**
        * @case oauth() verify returning a fully populated Principal rides as one structured header
@@ -687,7 +920,6 @@ describe("McpServer", () => {
         let capturedHeaders: Record<string, unknown> | undefined;
 
         const authConfig = oauth({
-          resourceIssuerUrl: "http://localhost:9999",
           endpoints: {
             authorizationUrl: "http://localhost:9999/authorize",
             tokenUrl: "http://localhost:9999/token",
@@ -728,7 +960,10 @@ describe("McpServer", () => {
               })
               .to(noop()),
           ],
-          { auth: authConfig },
+          {
+            auth: authConfig,
+            resource: { url: "http://localhost:9999" },
+          },
         );
 
         const sessionId = await initSession({
@@ -781,7 +1016,6 @@ describe("McpServer", () => {
         let capturedPrincipal: Principal | undefined;
 
         const authConfig = oauth({
-          resourceIssuerUrl: "http://localhost:9999",
           endpoints: {
             authorizationUrl: "http://localhost:9999/authorize",
             tokenUrl: "http://localhost:9999/token",
@@ -813,7 +1047,10 @@ describe("McpServer", () => {
               })
               .to(noop()),
           ],
-          { auth: authConfig },
+          {
+            auth: authConfig,
+            resource: { url: "http://localhost:9999" },
+          },
         );
 
         const sessionId = await initSession({
@@ -865,7 +1102,6 @@ describe("McpServer", () => {
         });
 
         const authConfig = oauth({
-          resourceIssuerUrl: "http://localhost:9999",
           endpoints: {
             authorizationUrl: "http://localhost:9999/authorize",
             tokenUrl: "http://localhost:9999/token",
@@ -885,6 +1121,7 @@ describe("McpServer", () => {
           port: 0,
           host: "127.0.0.1",
           auth: authConfig,
+          resource: { url: "http://localhost:9999" },
         });
 
         t.ctx.on("auth:rejected", (payload) => {

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -1,7 +1,13 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { McpServer } from "../src/mcp/server.ts";
 import { testContext, type TestContext } from "@routecraft/testing";
-import { craft, direct, noop, type Principal } from "@routecraft/routecraft";
+import {
+  craft,
+  direct,
+  jwks,
+  noop,
+  type Principal,
+} from "@routecraft/routecraft";
 import { mcp, MCP_PLUGIN_REGISTERED } from "../src/index.ts";
 import { buildAuthHeaders } from "../src/mcp/build-auth-headers.ts";
 import { z } from "zod";
@@ -559,8 +565,13 @@ describe("McpServer", () => {
         const wwwAuth = res.headers["www-authenticate"];
         expect(wwwAuth).toMatch(/Bearer/);
         expect(wwwAuth).toMatch(/realm="mcp"/);
+        // RFC 9728 §5.1: resource_metadata SHOULD be an absolute URL so a
+        // reverse proxy with a path prefix resolves it against the right
+        // origin. The validator path now derives the URL from the
+        // resolved `resource.url` (or bound fallback), matching what the
+        // OAuth path emits.
         expect(wwwAuth).toMatch(
-          /resource_metadata="\/\.well-known\/oauth-protected-resource"/,
+          /resource_metadata="https?:\/\/[^"]+\/\.well-known\/oauth-protected-resource"/,
         );
       });
 
@@ -726,7 +737,7 @@ describe("McpServer", () => {
       /**
        * @case Discovery endpoint is served at /.well-known/oauth-protected-resource without auth
        * @preconditions McpServer with validator auth configured; GET without Authorization header
-       * @expectedResult 200 status code with application/json content-type and Cache-Control: no-store
+       * @expectedResult 200 with application/json content-type and a non-zero Cache-Control max-age (RFC 9728 §3.3)
        */
       test("GET /.well-known/oauth-protected-resource returns 200 JSON without auth", async () => {
         const { get } = await startHttpServer([], {
@@ -735,7 +746,7 @@ describe("McpServer", () => {
         const res = await get("/.well-known/oauth-protected-resource");
         expect(res.statusCode).toBe(200);
         expect(res.headers["content-type"]).toMatch(/application\/json/);
-        expect(res.headers["cache-control"]).toBe("no-store");
+        expect(res.headers["cache-control"]).toMatch(/max-age=\d+/);
         expect(() => JSON.parse(res.body)).not.toThrow();
       });
 
@@ -905,6 +916,210 @@ describe("McpServer", () => {
         };
         expect(doc.resource).toBe(`http://127.0.0.1:${port}/mcp`);
         expect(doc.bearer_methods_supported).toEqual(["header"]);
+      });
+
+      /**
+       * @case End-to-end: `auth: jwks(...)` surfaces issuer into authorization_servers
+       * @preconditions auth is the actual `jwks()` result with issuer "https://idp.example.com"
+       * @expectedResult Metadata `authorization_servers` is ["https://idp.example.com"] -- the integration is exercised end-to-end, not via an inline `{ validator, issuer }` stub
+       */
+      test("authorization_servers is populated end-to-end from jwks()", async () => {
+        const { get } = await startHttpServer([], {
+          auth: jwks({
+            jwksUrl: "http://example.invalid/jwks.json",
+            issuer: "https://idp.example.com",
+            audience: "https://mcp.example.com",
+          }),
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const doc = JSON.parse(res.body) as {
+          authorization_servers?: string[];
+        };
+        expect(doc.authorization_servers).toEqual(["https://idp.example.com"]);
+      });
+
+      /**
+       * @case HTTPS-in-production guard fires eagerly when `resource.url` is http:// in production
+       * @preconditions NODE_ENV=production; resource.url is an http URL; validator auth
+       * @expectedResult `new McpServer(...)` (via startHttpServer) throws TypeError at construction; no request is ever served
+       */
+      test("HTTPS guard rejects http:// resource.url at construction in production", async () => {
+        const prev = process.env["NODE_ENV"];
+        process.env["NODE_ENV"] = "production";
+        try {
+          await expect(
+            startHttpServer([], {
+              auth: { validator: () => validPrincipal },
+              resource: { url: "http://insecure.example.com" },
+            }),
+          ).rejects.toThrow(/HTTPS/);
+        } finally {
+          if (prev === undefined) delete process.env["NODE_ENV"];
+          else process.env["NODE_ENV"] = prev;
+        }
+      });
+
+      /**
+       * @case Default fallback URL bypasses the HTTPS guard (dev convenience)
+       * @preconditions NODE_ENV=production; resource.url unset; the bound URL is http://127.0.0.1:{port}/mcp
+       * @expectedResult Metadata document still serves (the guard fires only when the user explicitly sets http:// in prod)
+       */
+      test("HTTPS guard does not fire on the default http://host:port/mcp fallback", async () => {
+        const prev = process.env["NODE_ENV"];
+        process.env["NODE_ENV"] = "production";
+        try {
+          const { get } = await startHttpServer([], {
+            auth: { validator: () => validPrincipal },
+          });
+          const res = await get("/.well-known/oauth-protected-resource");
+          expect(res.statusCode).toBe(200);
+        } finally {
+          if (prev === undefined) delete process.env["NODE_ENV"];
+          else process.env["NODE_ENV"] = prev;
+        }
+      });
+
+      /**
+       * @case Metadata response carries Cache-Control with a non-zero max-age
+       * @preconditions Validator auth; default plugin config
+       * @expectedResult Cache-Control header advertises a positive max-age per RFC 9728 §3.3
+       */
+      test("metadata response sets Cache-Control with a positive max-age", async () => {
+        const { get } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        const cacheControl = res.headers["cache-control"];
+        expect(typeof cacheControl).toBe("string");
+        expect(cacheControl as string).toMatch(/max-age=\d+/);
+        const match = (cacheControl as string).match(/max-age=(\d+)/);
+        expect(Number.parseInt(match![1]!, 10)).toBeGreaterThan(0);
+      });
+    });
+
+    describe("RFC 9728 protected-resource metadata (OAuth-proxy mode)", () => {
+      /**
+       * @case OAuth-proxy mode rejects port: 0 with no explicit resource.url
+       * @preconditions oauth({...}) auth, port: 0, no resource.url
+       * @expectedResult startHttpServer throws a TypeError mentioning port and resource.url; the SDK middleware would otherwise bake :0 into advertised URLs
+       */
+      test("rejects port: 0 with no resource.url", async () => {
+        const { oauth } = await import("../src/mcp/oauth.ts");
+        const authConfig = oauth({
+          endpoints: {
+            authorizationUrl: "http://localhost:9999/authorize",
+            tokenUrl: "http://localhost:9999/token",
+          },
+          verify: async () => ({
+            kind: "oauth" as const,
+            scheme: "bearer" as const,
+            subject: "u",
+            clientId: "u",
+            expiresAt: Math.floor(Date.now() / 1000) + 60,
+          }),
+          client: async (clientId) => ({
+            client_id: clientId,
+            redirect_uris: ["http://localhost:3000/callback"],
+          }),
+        });
+        await expect(startHttpServer([], { auth: authConfig })).rejects.toThrow(
+          /port|resource\.url/i,
+        );
+      });
+
+      /**
+       * @case OAuth-proxy mode metadata document is served by our handler, not the SDK's
+       * @preconditions oauth() auth with an explicit resource.url; GET /.well-known/oauth-protected-resource
+       * @expectedResult Document carries `bearer_methods_supported: ["header"]` -- proves our handler shadowed the SDK's (which omits this field)
+       */
+      test("OAuth-proxy mode serves the unified metadata shape (has bearer_methods_supported)", async () => {
+        const { oauth } = await import("../src/mcp/oauth.ts");
+        const authConfig = oauth({
+          endpoints: {
+            authorizationUrl: "http://localhost:9999/authorize",
+            tokenUrl: "http://localhost:9999/token",
+          },
+          verify: async () => ({
+            kind: "oauth" as const,
+            scheme: "bearer" as const,
+            subject: "u",
+            clientId: "u",
+            expiresAt: Math.floor(Date.now() / 1000) + 60,
+          }),
+          client: async (clientId) => ({
+            client_id: clientId,
+            redirect_uris: ["http://localhost:3000/callback"],
+          }),
+        });
+        const { get } = await startHttpServer([], {
+          auth: authConfig,
+          resource: { url: "http://localhost:9999" },
+        });
+        const res = await get("/.well-known/oauth-protected-resource");
+        expect(res.statusCode).toBe(200);
+        const doc = JSON.parse(res.body) as {
+          resource: string;
+          bearer_methods_supported?: string[];
+        };
+        expect(doc.bearer_methods_supported).toEqual(["header"]);
+        expect(doc.resource).toBe("http://localhost:9999");
+      });
+    });
+
+    describe("MCP server identity", () => {
+      /**
+       * @case title flows into MCP serverInfo.title in the initialize response
+       * @preconditions mcpPlugin({ name: "eywa", title: "Eywa MCP" }); client issues `initialize` JSON-RPC
+       * @expectedResult result.serverInfo carries name "eywa" and title "Eywa MCP"
+       */
+      test("serverInfo.title is populated from the title option", async () => {
+        const { post } = await startHttpServer([], {
+          title: "Eywa MCP",
+        });
+        const initBody = JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: INIT_PARAMS,
+        });
+        const res = await post(initBody);
+        expect(res.statusCode).toBe(200);
+        // The streamable-http transport may return the response either as
+        // plain JSON or as a single SSE `data:` line; handle both.
+        const trimmed = res.body.trim();
+        const jsonStr = trimmed.startsWith("data: ")
+          ? trimmed.slice(6).split("\n")[0]!
+          : trimmed;
+        const parsed = JSON.parse(jsonStr) as {
+          result: { serverInfo: { name: string; title?: string } };
+        };
+        expect(parsed.result.serverInfo.name).toBe("routecraft");
+        expect(parsed.result.serverInfo.title).toBe("Eywa MCP");
+      });
+
+      /**
+       * @case serverInfo.title is absent when title is unset (no defaulting to name in the protocol)
+       * @preconditions mcpPlugin({}) with no title; client issues `initialize`
+       * @expectedResult result.serverInfo.title is undefined; only name is populated
+       */
+      test("serverInfo.title is omitted when title is unset", async () => {
+        const { post } = await startHttpServer([]);
+        const initBody = JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: INIT_PARAMS,
+        });
+        const res = await post(initBody);
+        expect(res.statusCode).toBe(200);
+        const trimmed = res.body.trim();
+        const jsonStr = trimmed.startsWith("data: ")
+          ? trimmed.slice(6).split("\n")[0]!
+          : trimmed;
+        const parsed = JSON.parse(jsonStr) as {
+          result: { serverInfo: { name: string; title?: string } };
+        };
+        expect(parsed.result.serverInfo.title).toBeUndefined();
       });
     });
 

--- a/packages/ai/test/oauth.bun.test.ts
+++ b/packages/ai/test/oauth.bun.test.ts
@@ -30,7 +30,6 @@ async function serveJwks(jwkSet: {
 
 /** Handy stub for required factory options used across tests. */
 const BASE_OPTIONS = {
-  resourceIssuerUrl: "http://localhost:9999",
   endpoints: {
     authorizationUrl: "http://localhost:9999/authorize",
     tokenUrl: "http://localhost:9999/token",
@@ -159,11 +158,11 @@ describe("oauth() factory", () => {
   });
 
   /**
-   * @case resourceIssuerUrl is surfaced on the returned OAuthAuthOptions
-   * @preconditions Options with a valid resourceIssuerUrl
-   * @expectedResult Returned config.resourceIssuerUrl matches input
+   * @case oauth() carries only proxy-mechanics fields on the returned options (no protected-resource metadata)
+   * @preconditions Options include verify and client; no resource metadata is accepted by the factory
+   * @expectedResult Returned config has provider/endpoints/verify/client but no resourceIssuerUrl / scopesSupported / serviceDocumentationUrl / resourceName fields
    */
-  test("exposes resourceIssuerUrl on returned config", () => {
+  test("returns proxy-mechanics fields only (no resource metadata)", () => {
     const verify = async (): Promise<OAuthPrincipal> => ({
       kind: "custom",
       scheme: "bearer",
@@ -171,7 +170,16 @@ describe("oauth() factory", () => {
       expiresAt: 9999999999,
     });
     const result = oauth({ ...BASE_OPTIONS, verify });
-    expect(result.resourceIssuerUrl.toString()).toBe("http://localhost:9999");
+    expect(result.provider).toBe("oauth");
+    expect(result.endpoints.authorizationUrl).toBe(
+      BASE_OPTIONS.endpoints.authorizationUrl,
+    );
+    expect(typeof result.verifyAccessToken).toBe("function");
+    expect(typeof result.getClient).toBe("function");
+    expect(result).not.toHaveProperty("resourceIssuerUrl");
+    expect(result).not.toHaveProperty("scopesSupported");
+    expect(result).not.toHaveProperty("serviceDocumentationUrl");
+    expect(result).not.toHaveProperty("resourceName");
   });
 });
 


### PR DESCRIPTION
## Summary

Implements RFC 9728 OAuth 2.0 Protected Resource Metadata discovery for MCP servers, enabling auto-discovering clients (Claude.ai custom connectors, MCP Inspector, Claude Desktop) to locate authorization servers and understand resource capabilities. Adds a `title` option to MCP plugin for human-readable server identity separate from the machine name.

## Key Changes

- **Protected-resource metadata endpoint** (`/.well-known/oauth-protected-resource`): Serves RFC 9728-compliant JSON document in both validator and OAuth-proxy auth modes with consistent shape across modes
  - `resource`: Explicit `resource.url` or fallback to `http://{host}:{port}/mcp`
  - `resource_name`: Derives from `title` option, falls back to `name`
  - `authorization_servers`: Populated from validator's `issuer` field (when using `jwks()` / `jwt()`)
  - `bearer_methods_supported`: Always `["header"]`
  - `scopes_supported` and `resource_documentation`: Pass through from `resource: {...}` config

- **WWW-Authenticate header enhancement**: 401 responses now include `realm="mcp"` and absolute `resource_metadata` URL per RFC 9728 §5.1, enabling clients to discover the metadata endpoint from the challenge itself

- **New `McpResourceOptions` interface**: Orthogonal to auth mode, configures protected-resource identity
  - `url`: Explicit resource URL (HTTPS-enforced in production via constructor validation)
  - `scopesSupported`: OAuth scopes advertised as supported
  - `documentationUrl`: Human-readable resource documentation URL

- **New `title` option on `McpPluginOptions`**: Human-readable display name for the MCP server, used in `serverInfo.title` (MCP protocol) and `resource_name` (RFC 9728 metadata)

- **OAuth-proxy mode refactoring**: Removes `resourceIssuerUrl` from `oauth()` factory options; resource identity now lives exclusively on `mcpPlugin({ resource })` for consistency with validator mode. Adds validation to reject `port: 0` with unset `resource.url` (prevents `:0` from being baked into advertised URLs)

- **Metadata caching**: Sets `Cache-Control: public, max-age=3600` per RFC 9728 §3.3 guidance to reduce IdP polling by auto-discovering clients

## Implementation Details

- Metadata document is served without authentication to allow clients to discover authorization servers before attempting MCP connection
- HTTPS-in-production guard runs eagerly in constructor for explicit `resource.url`; default fallback `http://{host}:{port}/mcp` is permitted as dev-only convenience
- OAuth-proxy mode mounts metadata handler before SDK's `mcpAuthRouter` to ensure clients always receive the unified shape (with `bearer_methods_supported`) regardless of auth mode
- `resolveResourceUrl()` called after `.listen()` in validator mode to ensure bound port is known; OAuth-proxy mode validates at startup to prevent ephemeral port issues
- Comprehensive test coverage for both validator and OAuth-proxy modes, including HTTPS guard, issuer forwarding, and end-to-end `jwks()` integration

## Breaking Changes

- `oauth()` factory no longer accepts `resourceIssuerUrl`, `scopesSupported`, `serviceDocumentationUrl`, or `resourceName` options; these move to `mcpPlugin({ resource, title })`
- OAuth-proxy mode now requires either a fixed `port` or explicit `resource.url` (rejects `port: 0` with unset `resource.url`)

https://claude.ai/code/session_01GHdjQWD6or2TkGVuQUmiVS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RFC 9728 protected-resource discovery to MCP HTTP servers and moves server identity to `mcpPlugin({ title, resource })`, so clients can discover authorization servers in both validator (`jwks()`/`jwt()`) and OAuth-proxy (`oauth()`) modes. Also standardizes 401 challenges with an absolute `resource_metadata` URL and plumbs `serverInfo.title`.

- **New Features**
  - Serves `GET /.well-known/oauth-protected-resource` without auth in both modes; unified JSON shape with `bearer_methods_supported: ["header"]`, `resource` (from `resource.url` or `http://{host}:{port}/mcp`), `resource_name` (from `title` → `name`), `authorization_servers` (from validator `issuer`), plus passthrough `scopes_supported` and `resource_documentation`.
  - Adds `title` and `resource: { url, scopesSupported, documentationUrl }` on `mcpPlugin`; `title` also flows to MCP `serverInfo.title`.
  - 401 `WWW-Authenticate` now includes `realm="mcp"` and an absolute `resource_metadata` URL per RFC 9728 §5.1; OAuth-proxy path wires this via `resourceMetadataUrl`.
  - Caches metadata with `Cache-Control: public, max-age=3600` (RFC 9728 §3.3).
  - HTTPS guard: explicit `resource.url` must be HTTPS in production; OAuth-proxy mode rejects `port: 0` when `resource.url` is unset.

- **Migration**
  - Move resource identity from `oauth()` to the plugin:
    - `oauth({ resourceIssuerUrl })` -> `mcpPlugin({ resource: { url } })`
    - `oauth({ scopesSupported })` -> `mcpPlugin({ resource: { scopesSupported } })`
    - `oauth({ serviceDocumentationUrl })` -> `mcpPlugin({ resource: { documentationUrl } })`
    - `oauth({ resourceName })` -> `mcpPlugin({ title })`
  - OAuth-proxy mode now requires a fixed `port` or an explicit `resource.url` (no `port: 0` without it).

<sup>Written for commit a223d01c24eaa8c7b823ce50533e43fea57de806. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

