### PR TITLE
Support nested <name>/SKILL.md layout and accept unknown frontmatter fields

### DIFF
--- a/packages/ai/src/skill/loader.ts
+++ b/packages/ai/src/skill/loader.ts
@@ -7,14 +7,6 @@ import {
 import type { Skill } from "./types.ts";
 
 /**
- * Reject unknown frontmatter fields up front so a misspelt key never
- * silently disappears. The frontmatter shape mirrors a deliberately
- * narrow subset of Claude's subagent skills schema (`name`,
- * `description`); future fields will land incrementally.
- */
-const SUPPORTED_SKILL_KEYS = new Set(["name", "description"]);
-
-/**
  * Per-skill override applied on top of the markdown frontmatter.
  *
  * @experimental
@@ -26,9 +18,18 @@ export interface SkillOverride {
 
 /**
  * Convert a parsed markdown file into a `Skill`. Validates that
- * frontmatter `name` matches the filename so the registry id is
- * unambiguous, and that body is non-empty so the agent never injects
- * a hollow skill into its system prompt.
+ * frontmatter `name`, when present, matches the directory or
+ * filename so the registry id is unambiguous, and that body is
+ * non-empty so the agent never injects a hollow skill into its
+ * system prompt.
+ *
+ * Unknown top-level frontmatter keys are silently accepted: Claude
+ * Code's full skill frontmatter schema (`allowed-tools`,
+ * `argument-hint`, `disable-model-invocation`, `when_to_use`, etc.)
+ * is much wider than routecraft consumes, and tooling commonly
+ * layers further metadata on top. Keys other than `name` and
+ * `description` are ignored by the runtime; only those two are
+ * validated.
  *
  * @internal
  */
@@ -38,13 +39,6 @@ function toSkill(
   body: string,
   source: string,
 ): Skill {
-  for (const key of Object.keys(frontmatter)) {
-    if (!SUPPORTED_SKILL_KEYS.has(key)) {
-      throw rcError("RC5003", undefined, {
-        message: `Markdown file "${source}": unsupported frontmatter field "${key}". Skills currently support only "name" and "description"; further fields land in follow-up stories.`,
-      });
-    }
-  }
   const name = requireString(frontmatter["name"], "name", source);
   if (name !== filename) {
     throw rcError("RC5003", undefined, {
@@ -67,16 +61,30 @@ function toSkill(
 /**
  * Load skills from a markdown file or directory.
  *
- * - If `path` points to a directory, every `.md` file directly under it
- *   becomes one skill. The filename (without `.md`) is the skill name
- *   and must match the frontmatter `name`.
- * - If `path` points to a single `.md` file, the file becomes one
- *   skill keyed by its filename.
+ * Two directory layouts are supported and may coexist in the same
+ * folder, matching the [Claude Code skill convention](https://code.claude.com/docs/en/skills):
  *
- * Frontmatter currently supports only `name` (required) and
- * `description` (required). Body of the file becomes
- * `Skill.content` and is concatenated into the system prompt of any
- * agent that lists the skill name in its `skills` array.
+ * - **Flat:** a `.md` file directly under the directory. The filename
+ *   (without `.md`) is the skill name and must match frontmatter
+ *   `name`.
+ * - **Nested:** a `<name>/SKILL.md` file inside a subdirectory. The
+ *   subdirectory name is the skill name and must match frontmatter
+ *   `name`. The folder can also bundle supporting assets (scripts,
+ *   templates, examples); the loader only consumes `SKILL.md`.
+ *
+ * Subdirectories without a `SKILL.md` sentinel are silently skipped.
+ *
+ * If `path` points to a single `.md` file, the file becomes one
+ * skill keyed by its filename.
+ *
+ * Frontmatter requires `name` and `description`. Any other keys
+ * (including Claude Code fields like `allowed-tools`, `when_to_use`,
+ * `argument-hint`, `disable-model-invocation`, or arbitrary metadata
+ * blocks added by other tooling) are silently accepted and ignored.
+ *
+ * Body of the file becomes `Skill.content` and is concatenated into
+ * the system prompt of any agent that lists the skill name in its
+ * `skills` array.
  *
  * Pass `overrides` keyed by skill name to replace `description` or
  * `content` per skill without editing the markdown source.
@@ -101,7 +109,7 @@ export async function skills(
   const out: Record<string, Skill> = {};
   const docs = path.endsWith(".md")
     ? [await readMarkdownFile(path)]
-    : await readMarkdownDir(path);
+    : await readMarkdownDir(path, { sentinelFilename: "SKILL.md" });
   for (const doc of docs) {
     const skill = toSkill(doc.filename, doc.frontmatter, doc.body, doc.path);
     const override = overrides[skill.name];

--- a/packages/ai/src/skill/loader.ts
+++ b/packages/ai/src/skill/loader.ts
@@ -107,11 +107,22 @@ export async function skills(
   overrides: Record<string, SkillOverride> = {},
 ): Promise<Record<string, Skill>> {
   const out: Record<string, Skill> = {};
+  const sources = new Map<string, string>();
   const docs = path.endsWith(".md")
     ? [await readMarkdownFile(path)]
     : await readMarkdownDir(path, { sentinelFilename: "SKILL.md" });
   for (const doc of docs) {
     const skill = toSkill(doc.filename, doc.frontmatter, doc.body, doc.path);
+    // Flat `foo.md` and nested `foo/SKILL.md` can both resolve to the
+    // same skill name. Reject explicitly so the conflict is visible
+    // at load time instead of silently last-write-wins.
+    const previousSource = sources.get(skill.name);
+    if (previousSource) {
+      throw rcError("RC5003", undefined, {
+        message: `skills("${path}"): duplicate skill name "${skill.name}" loaded from both "${previousSource}" and "${doc.path}". Each skill name must be unique within a directory; rename or remove one source.`,
+      });
+    }
+    sources.set(skill.name, doc.path);
     const override = overrides[skill.name];
     out[skill.name] = override ? { ...skill, ...override } : skill;
   }

--- a/packages/ai/src/skill/markdown.ts
+++ b/packages/ai/src/skill/markdown.ts
@@ -129,14 +129,43 @@ export async function readMarkdownFile(path: string): Promise<ParsedMarkdown> {
 }
 
 /**
- * Read every `.md` file directly under `dir` and return one
- * `ParsedMarkdown` entry per file. Subdirectories are not recursed
- * (Claude's subagent layout is flat; supporting nesting would
- * complicate id derivation).
+ * Options controlling how {@link readMarkdownDir} discovers entries.
  *
  * @internal
  */
-export async function readMarkdownDir(dir: string): Promise<ParsedMarkdown[]> {
+export interface ReadMarkdownDirOptions {
+  /**
+   * When set, subdirectories of `dir` are also inspected. If a
+   * subdirectory contains a file with this exact name (e.g.
+   * `"SKILL.md"`), it is yielded as a single `ParsedMarkdown` whose
+   * `filename` is the **subdirectory name**, not the sentinel stem.
+   * This matches the Claude Code skill convention
+   * (`<name>/SKILL.md`), where the directory name is the identity and
+   * the folder can also bundle supporting assets. Subdirectories
+   * without the sentinel are silently skipped.
+   */
+  sentinelFilename?: string;
+}
+
+/**
+ * Read markdown documents from `dir` and return one `ParsedMarkdown`
+ * entry per discovered file.
+ *
+ * - Flat `.md` files directly under `dir` are always loaded.
+ * - When `sentinelFilename` is set, subdirectories containing that
+ *   exact file are loaded too, keyed by the **subdirectory name**.
+ *
+ * Subdirectories without the configured sentinel (or any
+ * subdirectories at all when the option is absent) are silently
+ * skipped, so a `node_modules`-style folder mixed in with real skills
+ * does not produce noise.
+ *
+ * @internal
+ */
+export async function readMarkdownDir(
+  dir: string,
+  options: ReadMarkdownDirOptions = {},
+): Promise<ParsedMarkdown[]> {
   const abs = resolve(process.cwd(), dir);
   let stats;
   try {
@@ -153,14 +182,33 @@ export async function readMarkdownDir(dir: string): Promise<ParsedMarkdown[]> {
   }
   const out: ParsedMarkdown[] = [];
   for (const entry of readdirSync(abs, { withFileTypes: true })) {
-    if (!entry.isFile()) continue;
-    if (extname(entry.name).toLowerCase() !== ".md") continue;
-    out.push(
-      await splitFrontmatter(
-        readFileSync(join(abs, entry.name), "utf-8"),
-        join(abs, entry.name),
-      ),
-    );
+    if (entry.isFile()) {
+      if (extname(entry.name).toLowerCase() !== ".md") continue;
+      out.push(
+        await splitFrontmatter(
+          readFileSync(join(abs, entry.name), "utf-8"),
+          join(abs, entry.name),
+        ),
+      );
+      continue;
+    }
+    if (entry.isDirectory() && options.sentinelFilename) {
+      const sentinelPath = join(abs, entry.name, options.sentinelFilename);
+      let sentinelStats;
+      try {
+        sentinelStats = statSync(sentinelPath);
+      } catch {
+        continue;
+      }
+      if (!sentinelStats.isFile()) continue;
+      const parsed = await splitFrontmatter(
+        readFileSync(sentinelPath, "utf-8"),
+        sentinelPath,
+      );
+      // The subdirectory name is the identity, not the sentinel stem.
+      parsed.filename = entry.name;
+      out.push(parsed);
+    }
   }
   // Sort so file order is deterministic regardless of filesystem
   // listing order. Useful for stable tests and reproducible builds.

--- a/packages/ai/test/skill-loader.bun.test.ts
+++ b/packages/ai/test/skill-loader.bun.test.ts
@@ -235,6 +235,20 @@ describe("skills() markdown loader", () => {
   });
 
   /**
+   * @case Flat and nested skills resolving to the same name are rejected
+   * @preconditions Both `foo.md` and `foo/SKILL.md` declare `name: foo`
+   * @expectedResult Throws RC5003 mentioning both source paths so the
+   *   conflict is visible at load time rather than silently last-write-wins
+   */
+  test("rejects duplicate skill names from flat and nested layouts", async () => {
+    const dir = makeDir({
+      "foo.md": "---\nname: foo\ndescription: flat\n---\nflat body",
+      "foo/SKILL.md": "---\nname: foo\ndescription: nested\n---\nnested body",
+    });
+    await expect(skills(dir)).rejects.toThrow(/duplicate skill name "foo"/);
+  });
+
+  /**
    * @case Nested layout coexists with bundled sibling files (Claude Code allows
    *   scripts/templates/examples alongside SKILL.md)
    * @preconditions `summarize/SKILL.md` plus a sibling `scripts/visualize.sh`

--- a/packages/ai/test/skill-loader.bun.test.ts
+++ b/packages/ai/test/skill-loader.bun.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { skills } from "../src/skill/index.ts";
 
@@ -19,7 +19,9 @@ describe("skills() markdown loader", () => {
     const dir = tmpDir();
     dirs.push(dir);
     for (const [name, content] of Object.entries(files)) {
-      writeFileSync(join(dir, name), content, "utf-8");
+      const filePath = join(dir, name);
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeFileSync(filePath, content, "utf-8");
     }
     return dir;
   }
@@ -78,17 +80,36 @@ describe("skills() markdown loader", () => {
   });
 
   /**
-   * @case Unsupported frontmatter field rejected with a clear message
-   * @preconditions File with `version: 1` in frontmatter
-   * @expectedResult Throws RC5003 listing the unsupported field
+   * @case Unknown frontmatter fields are silently accepted and ignored
+   * @preconditions File with Claude Code frontmatter fields the runtime does not consume
+   *   (`allowed-tools`, `argument-hint`, `disable-model-invocation`, a nested `metadata` block,
+   *   and an arbitrary unknown key)
+   * @expectedResult Loads successfully; `name`, `description`, and `content` are populated
+   *   from `name`, `description`, and the body; no other fields appear on the returned `Skill`
    */
-  test("rejects unsupported frontmatter fields", async () => {
+  test("accepts and ignores unknown frontmatter keys", async () => {
     const dir = makeDir({
-      "x.md": "---\nname: x\ndescription: ok\nversion: 1\n---\nbody",
+      "devoptix-hq.md": [
+        "---",
+        "name: devoptix-hq",
+        "description: ok",
+        "allowed-tools: Read Grep",
+        "argument-hint: '[query]'",
+        "disable-model-invocation: true",
+        "metadata:",
+        "  triggers: /devoptix-hq",
+        "  command: devoptix-hq",
+        "future-field: anything",
+        "---",
+        "body",
+      ].join("\n"),
     });
-    await expect(skills(dir)).rejects.toThrow(
-      /unsupported frontmatter field "version"/,
-    );
+    const result = await skills(dir);
+    expect(result["devoptix-hq"]).toEqual({
+      name: "devoptix-hq",
+      description: "ok",
+      content: "body",
+    });
   });
 
   /**
@@ -129,5 +150,107 @@ describe("skills() markdown loader", () => {
     await expect(skills(dir, { y: { description: "nope" } })).rejects.toThrow(
       /override for "y" but no skill with that name/,
     );
+  });
+
+  /**
+   * @case Nested `<name>/SKILL.md` layout (Claude Code convention)
+   * @preconditions Subdirectory `devoptix-hq/` containing `SKILL.md`
+   *   with frontmatter `name: devoptix-hq`
+   * @expectedResult Skill is registered under the directory name with
+   *   the body as content
+   */
+  test("loads nested <name>/SKILL.md layout", async () => {
+    const dir = makeDir({
+      "devoptix-hq/SKILL.md":
+        "---\nname: devoptix-hq\ndescription: DevOptix HQ knowledge\n---\nKnow the org.",
+    });
+    const result = await skills(dir);
+    expect(result).toEqual({
+      "devoptix-hq": {
+        name: "devoptix-hq",
+        description: "DevOptix HQ knowledge",
+        content: "Know the org.",
+      },
+    });
+  });
+
+  /**
+   * @case Flat `.md` files and nested `<name>/SKILL.md` coexist
+   * @preconditions One flat skill plus one nested skill in the same directory
+   * @expectedResult Both skills load, keyed by file stem and directory
+   *   name respectively
+   */
+  test("flat and nested layouts coexist in the same directory", async () => {
+    const dir = makeDir({
+      "cite-sources.md":
+        "---\nname: cite-sources\ndescription: Cite\n---\nAlways cite.",
+      "devoptix-hq/SKILL.md":
+        "---\nname: devoptix-hq\ndescription: Org context\n---\nKnow the org.",
+    });
+    const result = await skills(dir);
+    expect(Object.keys(result).sort()).toEqual(["cite-sources", "devoptix-hq"]);
+    expect(result["cite-sources"]?.content).toBe("Always cite.");
+    expect(result["devoptix-hq"]?.content).toBe("Know the org.");
+  });
+
+  /**
+   * @case Subdirectory without a `SKILL.md` sentinel is silently skipped
+   * @preconditions Directory `assets/` containing other files but no `SKILL.md`
+   * @expectedResult Loader returns only the flat skill, no error thrown
+   */
+  test("subdirectories without SKILL.md are silently skipped", async () => {
+    const dir = makeDir({
+      "real-skill.md":
+        "---\nname: real-skill\ndescription: real\n---\nreal body",
+      "assets/notes.md":
+        "---\nname: notes\ndescription: stray\n---\nstray body",
+      "assets/template.txt": "not markdown",
+    });
+    const result = await skills(dir);
+    expect(Object.keys(result)).toEqual(["real-skill"]);
+  });
+
+  /**
+   * @case Nested layout: frontmatter name must match directory name
+   * @preconditions `devoptix-hq/SKILL.md` declares `name: wrong`
+   * @expectedResult Throws RC5003 mentioning the mismatch
+   */
+  test("nested layout: name mismatch with directory name throws", async () => {
+    const dir = makeDir({
+      "devoptix-hq/SKILL.md": "---\nname: wrong\ndescription: ok\n---\nbody",
+    });
+    await expect(skills(dir)).rejects.toThrow(/must match the filename/);
+  });
+
+  /**
+   * @case Nested layout: empty body rejected
+   * @preconditions `devoptix-hq/SKILL.md` with frontmatter only
+   * @expectedResult Throws RC5003 mentioning empty body
+   */
+  test("nested layout: empty SKILL.md body throws", async () => {
+    const dir = makeDir({
+      "devoptix-hq/SKILL.md": "---\nname: devoptix-hq\ndescription: ok\n---\n",
+    });
+    await expect(skills(dir)).rejects.toThrow(/skill body is empty/);
+  });
+
+  /**
+   * @case Nested layout coexists with bundled sibling files (Claude Code allows
+   *   scripts/templates/examples alongside SKILL.md)
+   * @preconditions `summarize/SKILL.md` plus a sibling `scripts/visualize.sh`
+   * @expectedResult Only `SKILL.md` is consumed; sibling files are ignored,
+   *   no error thrown
+   */
+  test("nested layout ignores bundled sibling files", async () => {
+    const dir = makeDir({
+      "summarize/SKILL.md":
+        "---\nname: summarize\ndescription: Summarise\n---\nSummarise the diff.",
+      "summarize/scripts/visualize.sh": "#!/usr/bin/env bash\necho hi",
+      "summarize/examples/sample.md":
+        "---\nname: sample\ndescription: stray\n---\nstray",
+    });
+    const result = await skills(dir);
+    expect(Object.keys(result)).toEqual(["summarize"]);
+    expect(result["summarize"]?.content).toBe("Summarise the diff.");
   });
 });


### PR DESCRIPTION
## Summary

Extends the skill loader to support the Claude Code skill convention (`<name>/SKILL.md` nested layout) alongside the existing flat `.md` file layout, and relaxes frontmatter validation to silently accept and ignore unknown fields rather than rejecting them.

## Changes

- **Nested layout support:** `readMarkdownDir()` now accepts a `sentinelFilename` option. When set to `"SKILL.md"`, subdirectories containing that file are loaded as skills, keyed by the directory name rather than the sentinel stem. Subdirectories without the sentinel are silently skipped, allowing bundled assets (scripts, templates, examples) to coexist without noise.

- **Flat and nested coexistence:** Both layouts work in the same directory. A flat `cite-sources.md` and a nested `devoptix-hq/SKILL.md` can load together, each keyed by their respective identity (filename stem vs. directory name).

- **Relaxed frontmatter validation:** Removed the `SUPPORTED_SKILL_KEYS` allowlist that rejected unknown fields. The loader now silently accepts and ignores any top-level frontmatter keys other than `name` and `description`. This accommodates Claude Code's wider skill schema (`allowed-tools`, `argument-hint`, `disable-model-invocation`, `when_to_use`, nested `metadata` blocks, etc.) and arbitrary metadata added by other tooling.

- **Updated validation logic:** The `toSkill()` function now validates that frontmatter `name` matches the filename (flat layout) or directory name (nested layout), and that body is non-empty. Unknown keys are no longer validated.

- **Test infrastructure:** Updated `makeDir()` helper to create parent directories recursively using `mkdirSync()` with `{ recursive: true }`, enabling tests to define nested file structures.

## Implementation Details

- `readMarkdownDir()` now iterates over both files and directories. Files are processed as before; directories are checked for the sentinel file if `sentinelFilename` is provided.
- The `ParsedMarkdown.filename` field is overwritten to the directory name when loading from a nested layout, ensuring the skill registry key matches the directory identity.
- All new tests follow the JSDoc convention with `@case`, `@preconditions`, and `@expectedResult` sections.
- The change is backward compatible: existing flat layouts continue to work unchanged, and the nested layout is opt-in via the `sentinelFilename` parameter.

https://claude.ai/code/session_01DJoGixMAdiAiu7PySppipJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for nested `<name>/SKILL.md` skills alongside flat `.md` files, tolerates unknown frontmatter keys, and rejects duplicate names to prevent silent overrides. Aligns with the Claude Code skill layout and addresses #323.

- **New Features**
  - `readMarkdownDir(dir, { sentinelFilename: "SKILL.md" })` loads nested skills keyed by the directory name; `skills()` uses this by default. Subfolders without the sentinel are skipped.
  - Flat `.md` and nested `<name>/SKILL.md` can coexist in the same directory.
  - Frontmatter requires `name` and `description`; other keys are accepted and ignored. `name` must match the file/dir name, and the body must be non-empty.

- **Bug Fixes**
  - Detects duplicate skill names across flat and nested sources and throws RC5003 with both source paths.

<sup>Written for commit 5791c7227269946dc185bd4f51a244a451157323. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/326?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

