### PR TITLE
docs: add security standard and update definition of done

### DIFF
--- a/.standards/README.md
+++ b/.standards/README.md
@@ -17,6 +17,7 @@ Internal development standards for Routecraft contributors (human and AI). These
 | [Testing](./testing.md) | Runner conventions, JSDoc-on-every-test, helpers from `@routecraft/testing`, lifecycle pattern, assertion patterns |
 | [CI/CD](./ci-cd.md) | PR gates, hook policy, peer-dependency rules, optional peer dependencies, release flow |
 | [Resilience Wrappers](./resilience-wrappers.md) | Dual-mode wrapper pattern (`.error()` and future `.retry()`/`.timeout()`/`.cache()`/...), authoring contract, stacking + cascade rules |
+| [Security](./security.md) | JWT / JWKS verification rules, principal propagation across the exchange, bearer-token handling, OAuth `userinfo` enrichment, RFC 9728 metadata, `authorize()` semantics |
 
 ## Related
 

--- a/.standards/security.md
+++ b/.standards/security.md
@@ -1,0 +1,96 @@
+# Security Standard
+
+Authoritative rules for authentication, authorization, principal propagation, and the handling of secrets in Routecraft. Anchors the `packages/routecraft/src/auth/` directory and the `@routecraft/ai` OAuth surface.
+
+---
+
+## 1. JWT verification (`jwt()` / `jwks()`)
+
+- **`issuer` is required.** Both `jwt()` and `jwks()` throw at construction if `issuer` is unset or empty. There is no default. This prevents cross-issuer token replay.
+- **`audience` is required**, with an explicit `"*"` opt-out for IdPs that do not emit `aud` (e.g. Clerk without a configured API audience). The opt-out must be deliberate; an unset `audience` throws.
+- **`exp` is mandatory** on every verified token. `principalFromJwtPayload` rejects payloads without a numeric `exp`. The MCP SDK's bearer middleware depends on the resulting `OAuthPrincipal.expiresAt`; never relax this.
+- **Algorithm allowlist:**
+  - `jwt()` (HMAC / RSA via `node:crypto`): default `HS256` / `RS256`; rejects any token whose `alg` header is outside the supported map. Do not extend the map without security review.
+  - `jwks()` (asymmetric via `jose`): defaults to `RS*` / `PS*` / `ES*` / `EdDSA`. Symmetric `HS*` algorithms are **excluded by design** to prevent algorithm-confusion attacks where a malicious token signed with an `oct` key from the JWKS bypasses asymmetric verification. Do not add `HS*` to a JWKS allowlist.
+- **Clock tolerance** flows from the source-side helper into the route-side validator. When `jwt({ clockToleranceSec })` / `jwks({ clockToleranceSec })` is set, pass the same value to `authorize({ clockToleranceSec })` so a token accepted at the route boundary is not rejected mid-pipeline by a fraction of a second.
+
+## 2. JWKS rotation
+
+- `jwks()` builds its remote key set via `jose.createRemoteJWKSet`, which caches keys and rotates on signature mismatch. The set is constructed lazily on first verify and stored in the validator closure for the lifetime of the context.
+- Do not cache the verified principal across requests at the JWKS layer. The framework's token-bound enrichment cache (`UserinfoCache` in `packages/ai/src/mcp/userinfo.ts`) is the only sanctioned caching surface, and it caches only enrichment data, never the verify result. The base verifier runs on every request so dynamic checks (introspection, revocation, clock) keep firing.
+
+## 3. Principal propagation across the exchange
+
+- The verified `Principal` rides on the exchange as a single structured header: `headers["routecraft.auth.principal"]`. The `ex.principal` getter is sugar over this header. Read principal fields off the structured object; never look them up under flat header keys.
+- **Adapters MUST NOT mutate `ex.principal`.** Build a derived exchange via spread or `DefaultExchange.rewrap` if a `.process()` step needs to swap the principal (e.g. service-account exchange). Mutating the principal in place breaks event payload immutability and downstream `.authorize()` checks. See `.standards/exchange-state-model.md`.
+- **Principal fields are loggable; bearer tokens are not.** `principal.subject`, `principal.clientId`, `principal.email`, `principal.name`, `principal.scopes`, `principal.roles`, `principal.issuer`, `principal.audience` are safe to include in structured logs. Never log the raw bearer or anything derived from it that could be reversed.
+- **`principal.claims` is the verified JWT payload.** When `oauth({ userinfo })` enrichment runs, the framework writes the raw userinfo response to `principal.userinfoClaims` and leaves `principal.claims` untouched. This invariant is enforced by the protected-fields list in `userinfo.ts`; do not move userinfo data into `claims`.
+
+## 4. Bearer tokens are secrets
+
+- **Never log a bearer token.** Not in pino bindings, not in event payloads, not in error causes. If a token-shaped string is in scope at a log boundary, omit it or replace with a SHA-256 truncated fingerprint.
+- **Hash before using as a Map key.** `UserinfoCache.entries` is keyed by `createHash("sha256").update(token).digest("hex")`. A heap dump or accidental cache snapshot must not expose plaintext bearers. Any new in-memory token-keyed cache MUST follow the same pattern.
+- **Bound memory.** Token-keyed caches MUST have a hard upper bound (insertion-order LRU with `DEFAULT_CACHE_MAX_ENTRIES = 10_000` in `userinfo.ts`). A misbehaving client that never reuses a token must not be able to grow the map without bound.
+- **In-flight coalescing.** Concurrent enrichments for the same token share a single in-flight `Promise`; the IdP receives one userinfo fetch per `(token, expiresAt)` window. This both protects the IdP from request floods and ensures consistent behavior under load.
+
+## 5. OAuth `userinfo` enrichment
+
+- **`sub` invariant (OIDC Core §5.3.2):** for URL and discovery modes, the userinfo response's `sub` MUST equal the verified token's `sub`. Mismatches throw **`RC5022`**. Function-mode enrichment is trusted by contract (the user owns the backend) but the protected fields (`subject`, `issuer`, `audience`, `expiresAt`, `claims`) still cannot be overridden.
+- **Fail closed.** Every error path in `userinfo.ts` raises **`RC5021`** (fetch / parse / network / discovery failure) or **`RC5022`** (sub invariant). There is no opt-in "best effort" mode; if a user needs that, they write a function-mode `userinfo` that swallows its own errors. The framework's posture is "reject the request rather than authorize on a partial principal."
+- **Discovery document caching.** OIDC Discovery (`userinfo: true`) caches the resolved URL honouring `Cache-Control: max-age`, defaulting to one hour. Transient discovery failures clear the in-flight promise so the next call retries cleanly. Do not cache the *result* of a rejected fetch.
+- **OIDC path preservation.** Discovery resolves relative to the issuer URL (`new URL(".well-known/openid-configuration", issuer)`); do not use a leading slash, which would strip the issuer's path component and break Keycloak realms, Auth0 tenant prefixes, and Azure AD `/<tenant>/v2.0` issuers.
+
+## 6. RFC 9728 protected-resource metadata
+
+- **Resource identity lives on the plugin, not on the auth helper.** `mcpPlugin({ resource: { url, scopesSupported, documentationUrl }, title })` is the single source of truth for the RFC 9728 metadata document; both validator and OAuth-proxy modes read from it. The OAuth `oauth({...})` factory is reduced to proxy mechanics only.
+- **HTTPS in production is enforced at construction time.** `validateResourceConfig` throws if an explicit `resource.url` uses `http://` while `NODE_ENV === "production"`. The default `http://{host}:{port}/mcp` fallback is permitted as a dev-only convenience; only explicit user-supplied URLs trigger the guard.
+- **`port: 0` + OAuth + unset `resource.url` is rejected eagerly.** The MCP SDK's middleware closes over the resource URL pre-listen; an ephemeral port would bake `:0` into the discovery document and 401 headers.
+- **Both auth modes serve identical JSON.** Validator mode mounts the doc in raw Node HTTP; OAuth mode mounts our own handler on Express **before** `mcpAuthRouter` so the SDK's path-aware doc never wins for the URL we advertise.
+- **401 `WWW-Authenticate` carries an absolute `resource_metadata` URL** (RFC 9728 §5.1 SHOULD). Relative URLs break reverse-proxy deployments.
+
+## 7. `authorize()` is a verification primitive
+
+- **Checks, does not mint.** `authorize()` verifies that the exchange carries a principal that meets the criteria (roles, scopes, predicate, expiry). It does NOT issue, refresh, mint, or attach credentials. Authentication happens at the source boundary (`mcp({ auth: ... })`, future `http({ auth: ... })`) or in a `.process()` step that explicitly attaches a `Principal`.
+- **Error codes are stable and meaningful:**
+
+  | Code | Cause | Client expectation |
+  |------|-------|--------------------|
+  | `RC5012` | No principal on the exchange | Auth flow failed upstream; retry will not help without fresh credentials |
+  | `RC5015` | Principal failed role / scope / predicate | Permanent denial under current credentials |
+  | `RC5020` | `principal.expiresAt` in the past (beyond `clockToleranceSec`) | Refresh and retry |
+  | `RC5021` | `userinfo` enrichment failed | Investigate IdP availability; client cannot recover |
+  | `RC5022` | `userinfo` sub invariant violated | Investigate IdP / userinfo URL pairing; potential compromise |
+
+  Do not collapse RC5020 into RC5012 or RC5015; the distinction lets clients decide between "refresh" and "give up."
+
+- **Fail closed on non-finite inputs.** `Number.isFinite(principal.expiresAt) && Number.isFinite(clockToleranceSec)` is checked before comparison. A `NaN` would otherwise silently bypass the guard.
+
+## 8. `loadOptionalPeer` for cryptographic peers
+
+- `jose` is an optional peer of `@routecraft/routecraft` and is loaded via `loadOptionalPeer` from `packages/routecraft/src/auth/jwks.ts`. Missing-peer reports as `RC5017` with a copy-pasteable install hint.
+- **Never embed cryptographic libraries as a hard dependency** in the core package. The framework loads via dynamic import so consumers that do not use JWKS verification ship without `jose` in their tree.
+- See `.standards/ci-cd.md` § 6 for the canonical `loadOptionalPeer` pattern. New crypto / auth peers MUST follow the same shape.
+
+## 9. Removing or weakening a check
+
+- Any change that removes or relaxes a security check (algorithm allowlist, audience requirement, `exp` requirement, `sub` invariant, HTTPS-in-production guard, fail-closed posture) requires:
+  1. An explicit rationale in the commit message naming the threat model the original check addressed.
+  2. A test that asserts the new permissive behavior is bounded (e.g. only fires under a documented opt-in).
+  3. A docs update describing the user-visible behavior change.
+- Reviewers MUST push back on the easier path of "just delete the check." A working test suite without the original threat-model assertion is not evidence the change is safe.
+
+## 10. Event payloads
+
+- `auth:success` and `auth:rejected` events carry sanitised detail objects: `{ subject, scheme, source }` (success) or `{ reason, source }` (rejected). Do not extend these payloads to include the raw token or any high-cardinality identifier (full JWT, opaque session id) that an aggregator would index and retain.
+- Principal-shaped payloads on other events (e.g. `route:*:exchange:processed`) MAY include the full `Principal` object via `ex.principal` because the principal itself is sanitised; the bearer is not in it.
+
+---
+
+## Boundaries
+
+- **Source boundary** (`mcp()`, future `http()`): runs `verify` / `validator`; emits `auth:success` or `auth:rejected`; attaches `Principal` to the exchange.
+- **Route boundary** (`.authorize()` / `.validate(authorize(...))`): checks principal against role / scope / predicate / expiry; emits `exchange:failed` on rejection.
+- **Userinfo boundary** (`buildEnrichedVerifier`): runs after `verify` succeeds; merges enrichment with protected fields preserved; raises `RC5021` / `RC5022` on failure.
+- **HTTP transport boundary** (`startHttpWithValidator` / `startHttpWithOAuth`): serves RFC 9728 metadata; emits 401 with `resource_metadata`.
+
+Each boundary is the *only* place that handles its class of error (does not re-throw). Crossing a boundary without logging duplicates entries; not logging at the boundary loses the failure entirely.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Type-safe integration and automation framework. Monorepo with Bun workspaces (>=
 - Source/Destination for interfaces; Server/Client for option type names only (two-sided adapters)
 - Every test must have JSDoc with `@case`, `@preconditions`, and `@expectedResult`
 - The published `craft` CLI binary uses `#!/usr/bin/env bun` and `engines.bun >= 1.1.0`; the core library targets both Node 22.0+ and Bun. The root `bun run craft` workspace shortcut invokes the built `dist/index.js` via `node` for development convenience -- this is intentional and does not loosen the binary's runtime requirement.
-- New optional-peer dynamic imports MUST go through `loadOptionalPeer` (`packages/routecraft/src/adapters/shared/optional-peer.ts`) and emit `RC5017` with an install hint. Existing bespoke try/catch sites (mail, jose, telemetry sqlite, several `@routecraft/ai` modules) are scheduled for migration in #287; cite that issue when touching them.
+- Every optional-peer dynamic import MUST go through `loadOptionalPeer` (`packages/routecraft/src/adapters/shared/optional-peer.ts`) and emit `RC5017` with an install hint. The migration of legacy bespoke try/catch sites is complete (see [`.standards/ci-cd.md` § 6](.standards/ci-cd.md)); no bespoke shape remains. New code is reviewed against this contract.
 - Use `bun run <script>` for `package.json` scripts and `bunx <bin>` for one-shot binary execution (e.g. `bunx madge`, `bunx create-routecraft`)
 
 ## Internal Standards
@@ -40,6 +40,7 @@ Detailed coding standards for contributors live in `.standards/`:
 - [Testing](.standards/testing.md) -- runner conventions, JSDoc-on-every-test, helpers, lifecycle, assertion patterns
 - [CI/CD](.standards/ci-cd.md) -- PR gates, hook policy, peer-dependency rules, release flow
 - [Resilience Wrappers](.standards/resilience-wrappers.md) -- dual-mode wrapper pattern (`.error()` and future resilience ops), authoring contract
+- [Security](.standards/security.md) -- JWT / JWKS verification, principal propagation, bearer-token handling, `userinfo` enrichment, RFC 9728 metadata, `authorize()` semantics
 
 ## Merge Checklist
 

--- a/DEFINITION_OF_DONE.md
+++ b/DEFINITION_OF_DONE.md
@@ -20,6 +20,7 @@ The checklists below apply to **packages that ship code**: anything under `packa
 - [ ] Any meaningful behavior (lifecycle transition, operation execution, success, failure) emits a typed event via `CraftContext`. See the **Events and Tracing** checklist below
 - [ ] Write commit messages following [Conventional Commits](https://www.conventionalcommits.org/); use the `/git-commit-message` slash command for detailed formatting
 - [ ] Do not use em-dashes in documentation, JSDoc, comments, or written output
+- [ ] Coverage for modified packages does not regress against the base branch. The `test` job uploads a coverage report on every PR; reviewers compare against the `main` baseline. A net decrease for any package touched by the change requires either added tests or an explicit rationale in the PR description (e.g. removing dead code with its tests). New error paths and new public surfaces are covered by tests, not measured only as side-effect coverage of existing tests.
 
 ## Events and Tracing (every change that introduces observable behavior)
 
@@ -100,6 +101,19 @@ The checklists below apply to **packages that ship code**: anything under `packa
 
 - [ ] Add to the reference page with interface, options, and example
 - [ ] Update the conceptual guide if it introduces new plugin patterns
+
+## When you touch authentication, authorization, or token handling
+
+> Auth contract lives in `.standards/security.md`. Code in
+> `packages/routecraft/src/auth/` (`jwt.ts`, `jwks.ts`, `authorize.ts`,
+> `jwt-utils.ts`, `types.ts`) and the OAuth surface in
+> `packages/ai/src/mcp/` (`oauth.ts`, `userinfo.ts`).
+
+- [ ] Changes are reviewed against `.standards/security.md`. Any relaxation (algorithm allowlist, `iss` / `aud` requirement, `exp` requirement, `sub` invariant, HTTPS-in-production guard, fail-closed posture) includes the rationale, a bounding test, and a docs update -- see § 9 of the standard
+- [ ] Bearer tokens are not logged anywhere: not in pino bindings, not in event payloads, not in error causes, not as cache keys (hash with SHA-256 if you need a key)
+- [ ] New in-memory token-keyed caches have a hard upper bound and in-flight coalescing (mirror `UserinfoCache` in `packages/ai/src/mcp/userinfo.ts`)
+- [ ] New cryptographic dependencies load via `loadOptionalPeer`; missing-peer reports as `RC5017` with an install hint
+- [ ] If a new error code is added in the auth surface, it is distinct enough that clients can react meaningfully (refresh vs deny vs investigate); collapse only when the action is identical
 
 ## When you add or modify a CLI command
 


### PR DESCRIPTION
## Summary

Establishes a comprehensive security standard for authentication, authorization, principal propagation, and secret handling in Routecraft. Anchors the `packages/routecraft/src/auth/` directory and the `@routecraft/ai` OAuth surface with explicit rules, threat models, and error codes.

## Changes

- **Added `.standards/security.md`** — Authoritative security contract covering:
  - JWT verification requirements (`issuer`, `audience`, `exp` mandatory; algorithm allowlists)
  - JWKS rotation and caching policy (no principal caching at JWKS layer; token-bound enrichment cache only)
  - Principal propagation via structured header (`routecraft.auth.principal`); immutability contract
  - Bearer token secrecy (no logging, hash before use as map key, bounded in-memory caches with LRU)
  - OAuth `userinfo` enrichment (`sub` invariant, fail-closed posture, discovery caching, OIDC path preservation)
  - RFC 9728 protected-resource metadata (resource identity on plugin, HTTPS enforcement, identical JSON across auth modes)
  - `authorize()` as verification primitive with stable error codes (`RC5012`, `RC5015`, `RC5020`, `RC5021`, `RC5022`)
  - `loadOptionalPeer` pattern for cryptographic dependencies
  - Process for removing or weakening checks (rationale, bounding test, docs update)
  - Event payload sanitization (no raw tokens, no high-cardinality identifiers)
  - Boundary definitions (source, route, userinfo, HTTP transport)

- **Updated `DEFINITION_OF_DONE.md`**:
  - Added coverage regression check: net decrease in any touched package requires added tests or explicit rationale
  - Added "When you touch authentication, authorization, or token handling" checklist with 5 items:
    - Review against `.standards/security.md`; rationale + test + docs for any relaxation
    - No bearer tokens in logs, bindings, event payloads, or as cache keys
    - New token-keyed caches must have hard upper bound and in-flight coalescing
    - New crypto dependencies via `loadOptionalPeer` with `RC5017` on missing peer
    - Distinct error codes for meaningful client reactions

- **Updated `CLAUDE.md`**:
  - Clarified that **all** optional-peer dynamic imports must use `loadOptionalPeer` (not just new ones); legacy migration is complete
  - Removed reference to #287 as the migration is done

- **Updated `.standards/README.md`**:
  - Added Security standard to the index

## Notable Details

- Error codes are stable and distinct so clients can decide between refresh (`RC5020`), deny (`RC5015`), investigate (`RC5021`/`RC5022`), or retry (`RC5012`)
- `sub` invariant (OIDC Core §5.3.2) is enforced: userinfo response `sub` must equal verified token `sub`, raising `RC5022` on mismatch
- HTTPS-in-production guard is enforced at construction time for explicit `resource.url` (dev-only `http://{host}:{port}/mcp` fallback permitted)
- Symmetric `HS*` algorithms are excluded from JWKS allowlist by design to prevent algorithm-confusion attacks
- Clock tolerance flows from source to route boundary so tokens accepted at entry are not rejected mid-pipeline
- No principal caching at JWKS layer; only the framework's token-bound enrichment cache (`UserinfoCache`) is sanctioned

https://claude.ai/code/session_01GHdjQWD6or2TkGVuQUmiVS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a formal security standard for JWT/JWKS, principal propagation, bearer-token handling, and OAuth `userinfo` across Routecraft and `@routecraft/ai`. Updates the Definition of Done and standards index to enforce these rules and clarifies optional-peer guidance.

- New Features
  - Added `.standards/security.md`: rules for JWT/JWKS (require `issuer`, `audience` with explicit `*` opt-out, and `exp`; exclude `HS*` in JWKS), principal propagation via `routecraft.auth.principal`, bearer-token secrecy (no logs, SHA-256 keying, bounded LRU), OAuth `userinfo` fail-closed with `sub` invariant, RFC 9728 metadata and HTTPS guard, stable `authorize()` error codes (`RC5012`, `RC5015`, `RC5020`, `RC5021`, `RC5022`), and `loadOptionalPeer` with `RC5017` for crypto.
  - `DEFINITION_OF_DONE.md`: adds a coverage-floor check and an auth-specific checklist tied to the new standard.
  - `CLAUDE.md`: makes `loadOptionalPeer` mandatory for all optional peers; removes the stale migration note.
  - `.standards/README.md`: lists the new Security standard.

<sup>Written for commit bcbcb3a66edda4ca9311cb791e5de29bd2a6be8d. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/327?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

