### PR TITLE
feat: add CORS support to MCP HTTP transport

### DIFF
--- a/.standards/security.md
+++ b/.standards/security.md
@@ -53,16 +53,18 @@ Authoritative rules for authentication, authorization, principal propagation, an
 
 Defaults must be safe to ship to production. Where dev ergonomics conflict with production safety, relax the default explicitly in dev (gated on `NODE_ENV !== "production"`, an explicit loopback check, or a clearly named opt-in field), never the other way around.
 
-Worked examples in the codebase:
+The principle generalises across the security surface; it is not a network-exposure rule. Concrete instances already in the codebase, drawn from different parts of the stack:
 
-- **HTTPS-in-production guard** for `mcpPlugin({ resource.url })` (see §6 above). `http://` URLs throw in production; the dev fallback is permitted.
-- **CORS on the MCP HTTP transport** (§6 above). Default reflects loopback origins only; non-loopback browser origins require an explicit `cors: { origin }` opt-in.
+- **`audience` is required, with `"*"` as the named opt-out** (see §1). The default is rejection of any token whose audience is not the configured value; opting out is deliberate and visible at construction. The "easier" inverse (default to accepting any audience, opt-in to enforcement) would be the polarity inversion this policy forbids.
+- **`UserinfoCache` is bounded by default** (see §4). `DEFAULT_CACHE_MAX_ENTRIES = 10_000` is hard-coded; callers cannot accidentally create an unbounded cache. The dev relaxation (a higher cap) is a deliberate value change, not a flag flip.
+- **HTTPS-in-production guard** for `mcpPlugin({ resource.url })` (see §6). `http://` URLs throw in production; the dev fallback is permitted because the default URL is only used when no explicit one is supplied.
+- **CORS on the MCP HTTP transport** (see §6). Default reflects loopback origins only; non-loopback browser origins require an explicit `cors: { origin }` opt-in.
 
-When you add a new default that affects authentication, network exposure, or trust boundaries:
+When you add a new default that affects authentication, authorization, network exposure, secret material, or any trust boundary:
 
 1. Make the production-safe behaviour the unconfigured default.
 2. Surface the dev/relaxed mode behind an explicit, named opt-in (config field, env gate, or loopback / `NODE_ENV` check). Never invert the polarity (no `secure: true` flag where the default is insecure).
-3. Document the new default in this section and add a short rationale (what threat the default closes).
+3. Document the new default on its relevant docs reference page and in the section of this standard that governs the affected surface (§1 for token verification, §4 for caching, §6 for transport, etc.). Add a short rationale: what threat the default closes.
 4. The General Checklist in `DEFINITION_OF_DONE.md` references this policy; reviewers MUST push back if a new feature ships a permissive default that needs to be tightened.
 
 ## 7. `authorize()` is a verification primitive

--- a/.standards/security.md
+++ b/.standards/security.md
@@ -47,6 +47,23 @@ Authoritative rules for authentication, authorization, principal propagation, an
 - **`port: 0` + OAuth + unset `resource.url` is rejected eagerly.** The MCP SDK's middleware closes over the resource URL pre-listen; an ephemeral port would bake `:0` into the discovery document and 401 headers.
 - **Both auth modes serve identical JSON.** Validator mode mounts the doc in raw Node HTTP; OAuth mode mounts our own handler on Express **before** `mcpAuthRouter` so the SDK's path-aware doc never wins for the URL we advertise.
 - **401 `WWW-Authenticate` carries an absolute `resource_metadata` URL** (RFC 9728 §5.1 SHOULD). Relative URLs break reverse-proxy deployments.
+- **CORS on the MCP HTTP transport defaults to loopback-only.** `mcpPlugin({ cors })` controls `/mcp`, `/.well-known/oauth-protected-resource`, and the 401 `WWW-Authenticate` response. The default policy reflects loopback `Origin` headers (`localhost`, `127.0.0.1`, `[::1]`) so local browser MCP tooling works with zero config, and rejects everything else so non-loopback browser origins must be allowlisted explicitly via `cors: { origin }`. Server-to-server callers (no `Origin` header) are unaffected. `WWW-Authenticate` is exposed by default so browser clients can follow the RFC 9728 hint. The SDK-owned OAuth endpoints (`/register`, `/token`, `/revoke`, the SDK's own metadata) retain the SDK's permissive `cors()` defaults; we own `/mcp` and our metadata endpoint and apply the strict default there.
+
+## 6a. Security defaults policy
+
+Defaults must be safe to ship to production. Where dev ergonomics conflict with production safety, relax the default explicitly in dev (gated on `NODE_ENV !== "production"`, an explicit loopback check, or a clearly named opt-in field), never the other way around.
+
+Worked examples in the codebase:
+
+- **HTTPS-in-production guard** for `mcpPlugin({ resource.url })` (see §6 above). `http://` URLs throw in production; the dev fallback is permitted.
+- **CORS on the MCP HTTP transport** (§6 above). Default reflects loopback origins only; non-loopback browser origins require an explicit `cors: { origin }` opt-in.
+
+When you add a new default that affects authentication, network exposure, or trust boundaries:
+
+1. Make the production-safe behaviour the unconfigured default.
+2. Surface the dev/relaxed mode behind an explicit, named opt-in (config field, env gate, or loopback / `NODE_ENV` check). Never invert the polarity (no `secure: true` flag where the default is insecure).
+3. Document the new default in this section and add a short rationale (what threat the default closes).
+4. The General Checklist in `DEFINITION_OF_DONE.md` references this policy; reviewers MUST push back if a new feature ships a permissive default that needs to be tightened.
 
 ## 7. `authorize()` is a verification primitive
 

--- a/DEFINITION_OF_DONE.md
+++ b/DEFINITION_OF_DONE.md
@@ -21,6 +21,7 @@ The checklists below apply to **packages that ship code**: anything under `packa
 - [ ] Write commit messages following [Conventional Commits](https://www.conventionalcommits.org/); use the `/git-commit-message` slash command for detailed formatting
 - [ ] Do not use em-dashes in documentation, JSDoc, comments, or written output
 - [ ] Coverage for modified packages does not regress against the base branch. The `test` job uploads a coverage report on every PR; reviewers compare against the `main` baseline. A net decrease for any package touched by the change requires either added tests or an explicit rationale in the PR description (e.g. removing dead code with its tests). New error paths and new public surfaces are covered by tests, not measured only as side-effect coverage of existing tests.
+- [ ] Any new default that affects authentication, network exposure, or trust boundaries is safe in production by construction. Dev or local relaxations must be explicit opt-ins, named or gated (loopback check, `NODE_ENV` guard, dedicated config field). Never invert the polarity (no `secure: true` flag whose absence is insecure). See [`.standards/security.md` §6a "Security defaults policy"](.standards/security.md).
 
 ## Events and Tracing (every change that introduces observable behavior)
 

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -399,6 +399,48 @@ When `resource.url` is omitted, the framework advertises the bound `http://{host
 
 The motivating case is IdPs that do not support server-side Dynamic Client Registration (DCR) and therefore cannot use OAuth proxy mode -- WorkOS AuthKit is the canonical example. In that setup, validator mode (`auth: jwks(...)`) is the only correct integration, and the RFC 9728 metadata document is what lets MCP clients still auto-discover the IdP.
 
+### CORS
+
+Browser-based MCP clients (MCP Inspector UI, Claude.ai custom connectors, web-hosted Claude Desktop) need CORS headers on the MCP HTTP transport. The framework handles this on three surfaces: `/mcp`, `/.well-known/oauth-protected-resource`, and the 401 `WWW-Authenticate` response.
+
+The default policy is **loopback-only**: a browser request whose `Origin` is on `localhost`, `127.0.0.1`, or `[::1]` (any port, http or https) gets reflected; everything else gets no `Access-Control-Allow-Origin` and is blocked by the browser. This is production-safe by construction: local browser tooling like MCP Inspector at `http://localhost:6274` works with zero config, while production browser origins must be allowlisted explicitly.
+
+Server-to-server callers (`curl`, `mcp-remote`, the MCP CLI) do not send an `Origin` header and are unaffected by this policy regardless of configuration.
+
+```ts
+// Default: no config needed for local browser MCP tooling
+mcpPlugin({
+  transport: 'http',
+  auth: jwks({ jwksUrl: '...', issuer: '...' }),
+})
+
+// Production: allowlist your browser MCP client's origin
+mcpPlugin({
+  transport: 'http',
+  auth: jwks({ /* ... */ }),
+  cors: { origin: 'https://claude.ai' },
+})
+
+// Multi-origin allowlist
+mcpPlugin({
+  cors: { origin: ['https://claude.ai', 'https://inspector.example.com'] },
+})
+
+// Last-resort permissive (cannot combine with credentials)
+mcpPlugin({
+  cors: { origin: '*' },
+})
+
+// Disable entirely (e.g. when fronted by a CDN/proxy that owns CORS)
+mcpPlugin({
+  cors: false,
+})
+```
+
+`WWW-Authenticate` is exposed by default (`Access-Control-Expose-Headers: WWW-Authenticate`) so browser clients can read the RFC 9728 `resource_metadata` hint on a 401 and follow discovery. Custom `exposeHeaders` are additive with this default.
+
+The OAuth-proxy mode's SDK-owned endpoints (`/register`, `/token`, `/revoke`, the SDK's own metadata) keep their own permissive CORS handling from the MCP SDK. The `cors` slot governs only the routes the framework owns (`/mcp` and the protected-resource metadata).
+
 ## Production
 
 Pin the CLI version so your capabilities do not break on package updates:

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -407,6 +407,8 @@ The default policy is **loopback-only**: a browser request whose `Origin` is on 
 
 Server-to-server callers (`curl`, `mcp-remote`, the MCP CLI) do not send an `Origin` header and are unaffected by this policy regardless of configuration.
 
+The option surface is intentionally minimal: only `origin` is configurable. The framework controls allowed methods (`GET, POST, OPTIONS`), allowed headers (`*`), and exposed headers (`WWW-Authenticate`) so browser clients can read the RFC 9728 `resource_metadata` hint on a 401 and follow discovery.
+
 ```ts
 // Default: no config needed for local browser MCP tooling
 mcpPlugin({
@@ -426,7 +428,15 @@ mcpPlugin({
   cors: { origin: ['https://claude.ai', 'https://inspector.example.com'] },
 })
 
-// Last-resort permissive (cannot combine with credentials)
+// Custom resolver
+mcpPlugin({
+  cors: {
+    origin: (requestOrigin) =>
+      requestOrigin?.endsWith('.tenants.example.com') ? requestOrigin : false,
+  },
+})
+
+// Last-resort permissive
 mcpPlugin({
   cors: { origin: '*' },
 })
@@ -436,8 +446,6 @@ mcpPlugin({
   cors: false,
 })
 ```
-
-`WWW-Authenticate` is exposed by default (`Access-Control-Expose-Headers: WWW-Authenticate`) so browser clients can read the RFC 9728 `resource_metadata` hint on a 401 and follow discovery. Custom `exposeHeaders` are additive with this default.
 
 The OAuth-proxy mode's SDK-owned endpoints (`/register`, `/token`, `/revoke`, the SDK's own metadata) keep their own permissive CORS handling from the MCP SDK. The `cors` slot governs only the routes the framework owns (`/mcp` and the protected-resource metadata).
 

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -407,7 +407,7 @@ The default policy is **loopback-only**: a browser request whose `Origin` is on 
 
 Server-to-server callers (`curl`, `mcp-remote`, the MCP CLI) do not send an `Origin` header and are unaffected by this policy regardless of configuration.
 
-The option surface is intentionally minimal: only `origin` is configurable. The framework controls allowed methods (`GET, POST, OPTIONS`), allowed headers (`*`), and exposed headers (`WWW-Authenticate`) so browser clients can read the RFC 9728 `resource_metadata` hint on a 401 and follow discovery.
+The option surface is intentionally minimal: only `origin` is configurable. The framework controls allowed methods (`GET, POST, OPTIONS`), allowed headers (`*`), and exposed headers (`WWW-Authenticate, Mcp-Session-Id, Last-Event-ID`) so browser clients can read the RFC 9728 `resource_metadata` hint on a 401 and follow discovery, echo the SDK-issued `Mcp-Session-Id` on every request after `initialize` (stateful transport), and resume SSE streams via `Last-Event-ID`. Preflight responses also carry `Access-Control-Allow-Private-Network: true` so Chrome PNA crossings (e.g. a hosted browser client tunnelled to a local MCP server) are not blocked.
 
 ```ts
 // Default: no config needed for local browser MCP tooling

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -185,6 +185,7 @@ export default config
 | `port` | `number` | `3001` | HTTP port (http transport only) |
 | `host` | `string` | `'localhost'` | HTTP host (http transport only) |
 | `auth` | `McpHttpAuthOptions` | -- | Auth for the HTTP endpoint (http transport only; see below) |
+| `cors` | `false \| McpCorsOptions` | loopback-only | CORS for the HTTP transport. Default reflects loopback `Origin` headers; set to `false` to disable or `{ origin }` to allowlist production browser clients. See [Expose as MCP -> CORS](/docs/advanced/expose-as-mcp#cors). |
 | `tools` | `string[] \| (meta) => boolean` | -- | Allowlist of tool names to expose, or a filter function |
 | `clients` | `Record<string, McpClientHttpConfig \| McpClientStdioConfig>` | -- | Named remote MCP servers (see below) |
 | `maxRestarts` | `number` | `5` | Max automatic restarts for stdio clients before giving up |

--- a/packages/ai/src/mcp/cors.ts
+++ b/packages/ai/src/mcp/cors.ts
@@ -249,6 +249,16 @@ export function buildCorsHeaders(
   if (preflight) {
     headers["Access-Control-Allow-Methods"] = ALLOW_METHODS;
     headers["Access-Control-Allow-Headers"] = ALLOW_HEADERS;
+    // Chrome Private Network Access: when a non-loopback Origin reaches a
+    // loopback/private target (e.g. a hosted browser MCP client tunneled
+    // to a local MCP server during integration testing), Chrome blocks the
+    // preflight unless the server opts in via this header. The header is
+    // ignored by other browsers and by Chrome when the cross-network
+    // condition does not apply, so emitting it unconditionally on preflight
+    // -- gated on the origin already being allowlisted by the policy --
+    // is safe and avoids threading the request headers through the helper.
+    // Spec: https://wicg.github.io/private-network-access/
+    headers["Access-Control-Allow-Private-Network"] = "true";
   } else {
     headers["Access-Control-Expose-Headers"] = EXPOSE_HEADERS;
   }

--- a/packages/ai/src/mcp/cors.ts
+++ b/packages/ai/src/mcp/cors.ts
@@ -16,6 +16,12 @@
  * Server-to-server callers (curl, `mcp-remote`, the MCP CLI) are unaffected by
  * CORS because they do not send an `Origin` header.
  *
+ * The public option surface is intentionally minimal: only `origin` is
+ * configurable. Method, header, expose-header, credentials, and preflight-cache
+ * values are framework-controlled constants -- chosen to satisfy the RFC 9728
+ * discovery contract and the MCP JSON-RPC handshake -- and can be expanded
+ * later if a real use case demands it.
+ *
  * @experimental
  */
 
@@ -42,11 +48,11 @@ export type McpCorsOriginResolver = (
 
 /**
  * CORS configuration for the MCP HTTP transport. Passed via
- * `mcpPlugin({ cors: { ... } })`.
+ * `mcpPlugin({ cors: { origin: ... } })`.
  *
- * Omitting `cors` entirely applies the loopback-only default. Pass `cors: false`
- * on `McpPluginOptions` to disable CORS handling completely (useful when a
- * reverse proxy or CDN owns CORS).
+ * Omitting `cors` entirely applies the loopback-only default. Pass
+ * `cors: false` on `McpPluginOptions` to disable CORS handling completely
+ * (useful when a reverse proxy or CDN owns CORS).
  *
  * @experimental
  */
@@ -58,33 +64,13 @@ export interface McpCorsOptions {
    * - `string` -- exact match against the request `Origin`; non-match returns no allow header.
    * - `string[]` -- allowlist; if the request `Origin` matches one entry, it is reflected.
    * - {@link McpCorsOriginResolver} -- custom resolver, returns the value to echo or `false` to disallow.
-   *
-   * Omitting this property falls back to the loopback allowlist.
    */
-  origin?: "*" | string | string[] | McpCorsOriginResolver;
-  /** Methods allowed on `/mcp` and the metadata endpoint. Default: `["GET", "POST", "OPTIONS"]`. */
-  allowMethods?: string[];
-  /** Request headers permitted on cross-origin requests. Default: `["*"]`. */
-  allowHeaders?: string[];
-  /**
-   * Response headers exposed to the browser. `WWW-Authenticate` is always
-   * exposed by default so browser clients can read the RFC 9728
-   * `resource_metadata` hint on a 401. Custom values are additive with this default.
-   */
-  exposeHeaders?: string[];
-  /**
-   * Whether to set `Access-Control-Allow-Credentials: true`. Cannot be combined
-   * with `origin: "*"` per the CORS spec; an explicit origin or allowlist is required.
-   * Default: `false`.
-   */
-  credentials?: boolean;
-  /** Preflight cache duration in seconds. Default: omitted (browser default). */
-  maxAge?: number;
+  origin: "*" | string | string[] | McpCorsOriginResolver;
 }
 
 /**
- * Internal resolved CORS shape. Always fully populated; the consumer never has
- * to branch on string vs array vs function.
+ * Internal resolved CORS shape. The consumer never has to branch on string vs
+ * array vs function form of `origin`.
  *
  * @internal
  */
@@ -92,12 +78,24 @@ export interface ResolvedMcpCors {
   resolveOrigin: McpCorsOriginResolver;
   /** `true` when `origin` was the literal `"*"`. Skips `Vary: Origin`. */
   isWildcard: boolean;
-  allowMethods: string;
-  allowHeaders: string;
-  exposeHeaders: string;
-  credentials: boolean;
-  maxAge: number | undefined;
 }
+
+/**
+ * Framework-controlled CORS constants. Not user-configurable; chosen to
+ * satisfy the RFC 9728 discovery contract and the MCP JSON-RPC handshake.
+ *
+ * - `Access-Control-Allow-Methods`: the verbs the transport accepts.
+ * - `Access-Control-Allow-Headers`: `*` is the right default; `Authorization`,
+ *   `Content-Type`, and `MCP-Protocol-Version` are the headers MCP clients
+ *   send today, but the spec permits more and we do not want to gate.
+ * - `Access-Control-Expose-Headers`: `WWW-Authenticate` so browser clients
+ *   can read the RFC 9728 `resource_metadata` hint on a 401.
+ *
+ * @internal
+ */
+const ALLOW_METHODS = "GET, POST, OPTIONS";
+const ALLOW_HEADERS = "*";
+const EXPOSE_HEADERS = "WWW-Authenticate";
 
 /**
  * Hostnames recognised as loopback by the default policy.
@@ -139,10 +137,6 @@ export function defaultLoopbackOriginResolver(
   return LOOPBACK_HOSTS.has(parsed.hostname) ? requestOrigin : false;
 }
 
-const DEFAULT_ALLOW_METHODS = ["GET", "POST", "OPTIONS"];
-const DEFAULT_ALLOW_HEADERS = ["*"];
-const DEFAULT_EXPOSE_HEADERS = ["WWW-Authenticate"];
-
 /**
  * Resolve a `cors` config slot into either a fully-populated internal shape or
  * `null` (CORS disabled entirely). `undefined` produces the loopback default.
@@ -153,71 +147,41 @@ export function resolveCorsOptions(
   input: false | McpCorsOptions | undefined,
 ): ResolvedMcpCors | null {
   if (input === false) return null;
-  const opts = input ?? {};
-
-  const credentials = opts.credentials === true;
-
-  let resolveOrigin: McpCorsOriginResolver;
-  let isWildcard = false;
-  if (opts.origin === undefined) {
-    resolveOrigin = defaultLoopbackOriginResolver;
-  } else if (opts.origin === "*") {
-    if (credentials) {
-      throw new TypeError(
-        "mcpPlugin: cors.credentials cannot be true when cors.origin is '*' (per the CORS spec). " +
-          "Use an explicit origin string, an allowlist, or a resolver function.",
-      );
-    }
-    resolveOrigin = () => "*";
-    isWildcard = true;
-  } else if (typeof opts.origin === "string") {
-    const allowed = opts.origin;
-    resolveOrigin = (requestOrigin) =>
-      requestOrigin === allowed ? allowed : false;
-  } else if (Array.isArray(opts.origin)) {
-    const allowed = new Set(opts.origin);
-    resolveOrigin = (requestOrigin) =>
-      requestOrigin !== undefined && allowed.has(requestOrigin)
-        ? requestOrigin
-        : false;
-  } else if (typeof opts.origin === "function") {
-    resolveOrigin = opts.origin;
-  } else {
-    throw new TypeError(
-      "mcpPlugin: cors.origin must be '*', a string, a string array, or a function",
-    );
+  if (input === undefined) {
+    return {
+      resolveOrigin: defaultLoopbackOriginResolver,
+      isWildcard: false,
+    };
   }
 
-  const exposeHeaders = mergeExposeHeaders(opts.exposeHeaders);
-
-  return {
-    resolveOrigin,
-    isWildcard,
-    allowMethods: (opts.allowMethods ?? DEFAULT_ALLOW_METHODS).join(", "),
-    allowHeaders: (opts.allowHeaders ?? DEFAULT_ALLOW_HEADERS).join(", "),
-    exposeHeaders,
-    credentials,
-    maxAge: opts.maxAge,
-  };
-}
-
-/**
- * Merge user-supplied `exposeHeaders` with the `WWW-Authenticate` default,
- * deduplicating case-insensitively. The default exists so browser clients can
- * read the RFC 9728 `resource_metadata` hint on a 401.
- */
-function mergeExposeHeaders(user: string[] | undefined): string {
-  const merged = [...DEFAULT_EXPOSE_HEADERS];
-  if (user) {
-    const lower = new Set(merged.map((h) => h.toLowerCase()));
-    for (const h of user) {
-      if (!lower.has(h.toLowerCase())) {
-        merged.push(h);
-        lower.add(h.toLowerCase());
-      }
-    }
+  const { origin } = input;
+  if (origin === "*") {
+    return { resolveOrigin: () => "*", isWildcard: true };
   }
-  return merged.join(", ");
+  if (typeof origin === "string") {
+    const allowed = origin;
+    return {
+      resolveOrigin: (requestOrigin) =>
+        requestOrigin === allowed ? allowed : false,
+      isWildcard: false,
+    };
+  }
+  if (Array.isArray(origin)) {
+    const allowed = new Set(origin);
+    return {
+      resolveOrigin: (requestOrigin) =>
+        requestOrigin !== undefined && allowed.has(requestOrigin)
+          ? requestOrigin
+          : false,
+      isWildcard: false,
+    };
+  }
+  if (typeof origin === "function") {
+    return { resolveOrigin: origin, isWildcard: false };
+  }
+  throw new TypeError(
+    "mcpPlugin: cors.origin must be '*', a string, a string array, or a function",
+  );
 }
 
 /**
@@ -253,7 +217,7 @@ function safeResolveOrigin(
  *
  * @param cors Resolved CORS options, or `null` to short-circuit.
  * @param requestOrigin Value of the request's `Origin` header.
- * @param preflight `true` to include `Access-Control-Allow-Methods/Headers/Max-Age`.
+ * @param preflight `true` to include `Access-Control-Allow-Methods/Headers`.
  * @internal
  */
 export function buildCorsHeaders(
@@ -272,16 +236,10 @@ export function buildCorsHeaders(
   if (allowed === false) return headers;
 
   headers["Access-Control-Allow-Origin"] = allowed;
-  headers["Access-Control-Expose-Headers"] = cors.exposeHeaders;
-  if (cors.credentials) {
-    headers["Access-Control-Allow-Credentials"] = "true";
-  }
+  headers["Access-Control-Expose-Headers"] = EXPOSE_HEADERS;
   if (preflight) {
-    headers["Access-Control-Allow-Methods"] = cors.allowMethods;
-    headers["Access-Control-Allow-Headers"] = cors.allowHeaders;
-    if (cors.maxAge !== undefined) {
-      headers["Access-Control-Max-Age"] = String(cors.maxAge);
-    }
+    headers["Access-Control-Allow-Methods"] = ALLOW_METHODS;
+    headers["Access-Control-Allow-Headers"] = ALLOW_HEADERS;
   }
   return headers;
 }

--- a/packages/ai/src/mcp/cors.ts
+++ b/packages/ai/src/mcp/cors.ts
@@ -70,11 +70,11 @@ export interface McpCorsOptions {
 
 /**
  * Internal resolved CORS shape. The consumer never has to branch on string vs
- * array vs function form of `origin`.
+ * array vs function form of `origin`. Not exported beyond this file.
  *
  * @internal
  */
-export interface ResolvedMcpCors {
+interface ResolvedMcpCors {
   resolveOrigin: McpCorsOriginResolver;
   /** `true` when `origin` was the literal `"*"`. Skips `Vary: Origin`. */
   isWildcard: boolean;
@@ -88,14 +88,21 @@ export interface ResolvedMcpCors {
  * - `Access-Control-Allow-Headers`: `*` is the right default; `Authorization`,
  *   `Content-Type`, and `MCP-Protocol-Version` are the headers MCP clients
  *   send today, but the spec permits more and we do not want to gate.
- * - `Access-Control-Expose-Headers`: `WWW-Authenticate` so browser clients
- *   can read the RFC 9728 `resource_metadata` hint on a 401.
+ * - `Access-Control-Expose-Headers` (non-preflight only): the response headers
+ *   browser clients must be able to read.
+ *   - `WWW-Authenticate` -- RFC 9728 `resource_metadata` hint on a 401.
+ *   - `Mcp-Session-Id` -- emitted by the SDK on `initialize` in stateful mode
+ *     (see `server.ts` createSession). The MCP spec requires clients to echo
+ *     this value on every subsequent request; browsers cannot read it
+ *     cross-origin without it being exposed.
+ *   - `Last-Event-ID` -- SSE resume cursor; required for browser-based SSE
+ *     reconnection.
  *
  * @internal
  */
 const ALLOW_METHODS = "GET, POST, OPTIONS";
 const ALLOW_HEADERS = "*";
-const EXPOSE_HEADERS = "WWW-Authenticate";
+const EXPOSE_HEADERS = "WWW-Authenticate, Mcp-Session-Id, Last-Event-ID";
 
 /**
  * Hostnames recognised as loopback by the default policy.
@@ -236,10 +243,14 @@ export function buildCorsHeaders(
   if (allowed === false) return headers;
 
   headers["Access-Control-Allow-Origin"] = allowed;
-  headers["Access-Control-Expose-Headers"] = EXPOSE_HEADERS;
+  // Allow-Methods/Allow-Headers belong on preflight (204) only;
+  // Expose-Headers belongs on the actual response only (browsers ignore it
+  // on a preflight per the Fetch spec). Mirror that asymmetry here.
   if (preflight) {
     headers["Access-Control-Allow-Methods"] = ALLOW_METHODS;
     headers["Access-Control-Allow-Headers"] = ALLOW_HEADERS;
+  } else {
+    headers["Access-Control-Expose-Headers"] = EXPOSE_HEADERS;
   }
   return headers;
 }

--- a/packages/ai/src/mcp/cors.ts
+++ b/packages/ai/src/mcp/cors.ts
@@ -6,7 +6,7 @@
  * without CORS headers. This module owns the policy and the header math.
  *
  * The default is **loopback-only**: a request whose `Origin` is on `localhost`,
- * `127.0.0.1`, or `[::1]` (any port, http or https) gets reflected; everything
+ * `127.0.0.1`, or `::1` (any port, http or https) gets reflected; everything
  * else gets no `Access-Control-Allow-Origin` header back and is blocked by the
  * browser. This is intentionally production-safe by construction: local
  * browser tooling works with zero config, while production deployments must
@@ -19,10 +19,17 @@
  * @experimental
  */
 
+import type { ServerResponse } from "node:http";
+
 /**
  * Resolver form of `origin`. Receives the request's `Origin` header (or
  * `undefined` when absent) and returns either the value to echo in
  * `Access-Control-Allow-Origin`, or `false` to disallow.
+ *
+ * Implementations SHOULD NOT throw. A thrown error is caught at the request
+ * boundary and treated as `false` (fail-closed), but emitting an exception
+ * also clears CORS for that request silently. Return `false` explicitly to
+ * disallow.
  *
  * Keeping this transport-agnostic (no `IncomingMessage`) lets the helper run
  * on Bun, Node, and in tests without coupling to `node:http`.
@@ -93,15 +100,24 @@ export interface ResolvedMcpCors {
 }
 
 /**
- * Hostnames recognised as loopback by the default policy. IPv6 loopback
- * appears as both `::1` and bracketed `[::1]` in `Origin` headers depending on
- * the client; both are accepted.
+ * Hostnames recognised as loopback by the default policy.
+ *
+ * IPv6: both Node and Bun's `URL.hostname` return the bracketed form
+ * `"[::1]"` for `http://[::1]:8080`, not `"::1"`. The unbracketed `"::1"`
+ * entry is kept as defence-in-depth in case a future URL parser surfaces it
+ * (the WHATWG URL spec is unsettled on this; older parsers and some
+ * synthesised inputs may produce the unbracketed form).
  */
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
 /**
- * Default origin resolver: reflect the request `Origin` iff it is loopback.
- * Returns `false` otherwise.
+ * Default origin resolver: reflect the request `Origin` iff it is loopback
+ * AND in canonical form per RFC 6454 §7.1 (`scheme://host[:port]`, no path,
+ * no userinfo, no query, no fragment). Returns `false` otherwise.
+ *
+ * Real browsers never emit anything other than a canonical Origin, so this
+ * tightening costs nothing in practice while ensuring we never echo a
+ * malformed value into `Access-Control-Allow-Origin`.
  *
  * @internal
  */
@@ -109,6 +125,7 @@ export function defaultLoopbackOriginResolver(
   requestOrigin: string | undefined,
 ): string | false {
   if (!requestOrigin) return false;
+  if (requestOrigin === "null") return false;
   let parsed: URL;
   try {
     parsed = new URL(requestOrigin);
@@ -116,6 +133,9 @@ export function defaultLoopbackOriginResolver(
     return false;
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  if (parsed.username || parsed.password) return false;
+  if (parsed.pathname !== "/" && parsed.pathname !== "") return false;
+  if (parsed.search || parsed.hash) return false;
   return LOOPBACK_HOSTS.has(parsed.hostname) ? requestOrigin : false;
 }
 
@@ -201,12 +221,35 @@ function mergeExposeHeaders(user: string[] | undefined): string {
 }
 
 /**
- * Build the response headers to add for a given request `Origin`. Returns an
- * empty object when CORS is disabled or the request `Origin` is disallowed.
+ * Run the resolver in a try/catch so a misbehaving custom origin function
+ * fails closed rather than crashing the in-flight MCP request.
+ */
+function safeResolveOrigin(
+  cors: ResolvedMcpCors,
+  requestOrigin: string | undefined,
+): string | false {
+  try {
+    return cors.resolveOrigin(requestOrigin);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the response headers to add for a given request `Origin`.
  *
- * The caller is responsible for setting these headers on the response. The
- * helper is pure to keep it testable in isolation and reusable from both the
- * raw-`node:http` (validator) and Express (OAuth-proxy) paths.
+ * Returns an empty object when CORS is disabled (`cors === null`).
+ *
+ * When the policy is origin-dependent (non-wildcard), `Vary: Origin` is
+ * **always** included -- including for rejected origins -- so a shared cache
+ * keyed by the response cannot serve a no-CORS response back to a loopback
+ * origin. Disallowed origins receive `{ Vary: "Origin" }` only, with no
+ * `Access-Control-Allow-Origin`.
+ *
+ * The caller is responsible for applying these headers. Use
+ * {@link applyCorsHeaders} on a Node `ServerResponse` to merge `Vary` with
+ * any existing value (compression middleware, etc.); spread the record into
+ * a `writeHead` call when no prior `setHeader("Vary", ...)` is in play.
  *
  * @param cors Resolved CORS options, or `null` to short-circuit.
  * @param requestOrigin Value of the request's `Origin` header.
@@ -219,16 +262,17 @@ export function buildCorsHeaders(
   preflight: boolean,
 ): Record<string, string> {
   if (!cors) return {};
-  const allowed = cors.resolveOrigin(requestOrigin);
-  if (allowed === false) return {};
 
-  const headers: Record<string, string> = {
-    "Access-Control-Allow-Origin": allowed,
-    "Access-Control-Expose-Headers": cors.exposeHeaders,
-  };
+  const headers: Record<string, string> = {};
   if (!cors.isWildcard) {
     headers["Vary"] = "Origin";
   }
+
+  const allowed = safeResolveOrigin(cors, requestOrigin);
+  if (allowed === false) return headers;
+
+  headers["Access-Control-Allow-Origin"] = allowed;
+  headers["Access-Control-Expose-Headers"] = cors.exposeHeaders;
   if (cors.credentials) {
     headers["Access-Control-Allow-Credentials"] = "true";
   }
@@ -240,4 +284,52 @@ export function buildCorsHeaders(
     }
   }
   return headers;
+}
+
+/**
+ * Apply CORS headers to a Node `ServerResponse`. Uses `setHeader` for the
+ * `Access-Control-*` family and `appendHeader` for `Vary` so any existing
+ * `Vary` value (e.g. `Vary: Accept-Encoding` from compression middleware)
+ * is preserved.
+ *
+ * A no-op when `cors === null`.
+ *
+ * @internal
+ */
+export function applyCorsHeaders(
+  res: ServerResponse,
+  cors: ResolvedMcpCors | null,
+  requestOrigin: string | undefined,
+  preflight: boolean,
+): void {
+  if (!cors) return;
+  const { Vary, ...rest } = buildCorsHeaders(cors, requestOrigin, preflight);
+  for (const [name, value] of Object.entries(rest)) {
+    res.setHeader(name, value);
+  }
+  if (Vary !== undefined) {
+    res.appendHeader("Vary", Vary);
+  }
+}
+
+/** Paths on which the MCP HTTP transport applies CORS. */
+export const PROTECTED_RESOURCE_METADATA_PATH =
+  "/.well-known/oauth-protected-resource";
+
+/**
+ * Whether a request path is one the MCP HTTP transport owns (and applies
+ * its CORS policy to). The transport listens on exactly `/mcp` (with or
+ * without trailing slash) plus the RFC 9728 metadata path. Sub-paths
+ * (`/mcp/sessions/...`) are not handled and must be added here if ever
+ * introduced; centralising the matcher prevents the validator and OAuth
+ * paths from drifting.
+ *
+ * @internal
+ */
+export function isMcpOwnedPath(url: string): boolean {
+  return (
+    url === PROTECTED_RESOURCE_METADATA_PATH ||
+    url === "/mcp" ||
+    url === "/mcp/"
+  );
 }

--- a/packages/ai/src/mcp/cors.ts
+++ b/packages/ai/src/mcp/cors.ts
@@ -1,0 +1,243 @@
+/**
+ * CORS for the MCP HTTP transport.
+ *
+ * Browser-based MCP clients (MCP Inspector UI, Claude.ai custom connectors,
+ * web-hosted Claude Desktop) cannot read responses from the MCP HTTP transport
+ * without CORS headers. This module owns the policy and the header math.
+ *
+ * The default is **loopback-only**: a request whose `Origin` is on `localhost`,
+ * `127.0.0.1`, or `[::1]` (any port, http or https) gets reflected; everything
+ * else gets no `Access-Control-Allow-Origin` header back and is blocked by the
+ * browser. This is intentionally production-safe by construction: local
+ * browser tooling works with zero config, while production deployments must
+ * opt their real origins in explicitly. See `.standards/security.md` ->
+ * "Security defaults policy" for the broader principle.
+ *
+ * Server-to-server callers (curl, `mcp-remote`, the MCP CLI) are unaffected by
+ * CORS because they do not send an `Origin` header.
+ *
+ * @experimental
+ */
+
+/**
+ * Resolver form of `origin`. Receives the request's `Origin` header (or
+ * `undefined` when absent) and returns either the value to echo in
+ * `Access-Control-Allow-Origin`, or `false` to disallow.
+ *
+ * Keeping this transport-agnostic (no `IncomingMessage`) lets the helper run
+ * on Bun, Node, and in tests without coupling to `node:http`.
+ *
+ * @experimental
+ */
+export type McpCorsOriginResolver = (
+  requestOrigin: string | undefined,
+) => string | false;
+
+/**
+ * CORS configuration for the MCP HTTP transport. Passed via
+ * `mcpPlugin({ cors: { ... } })`.
+ *
+ * Omitting `cors` entirely applies the loopback-only default. Pass `cors: false`
+ * on `McpPluginOptions` to disable CORS handling completely (useful when a
+ * reverse proxy or CDN owns CORS).
+ *
+ * @experimental
+ */
+export interface McpCorsOptions {
+  /**
+   * Allowed origin(s).
+   *
+   * - `"*"` -- permissive, no `Vary: Origin` emitted.
+   * - `string` -- exact match against the request `Origin`; non-match returns no allow header.
+   * - `string[]` -- allowlist; if the request `Origin` matches one entry, it is reflected.
+   * - {@link McpCorsOriginResolver} -- custom resolver, returns the value to echo or `false` to disallow.
+   *
+   * Omitting this property falls back to the loopback allowlist.
+   */
+  origin?: "*" | string | string[] | McpCorsOriginResolver;
+  /** Methods allowed on `/mcp` and the metadata endpoint. Default: `["GET", "POST", "OPTIONS"]`. */
+  allowMethods?: string[];
+  /** Request headers permitted on cross-origin requests. Default: `["*"]`. */
+  allowHeaders?: string[];
+  /**
+   * Response headers exposed to the browser. `WWW-Authenticate` is always
+   * exposed by default so browser clients can read the RFC 9728
+   * `resource_metadata` hint on a 401. Custom values are additive with this default.
+   */
+  exposeHeaders?: string[];
+  /**
+   * Whether to set `Access-Control-Allow-Credentials: true`. Cannot be combined
+   * with `origin: "*"` per the CORS spec; an explicit origin or allowlist is required.
+   * Default: `false`.
+   */
+  credentials?: boolean;
+  /** Preflight cache duration in seconds. Default: omitted (browser default). */
+  maxAge?: number;
+}
+
+/**
+ * Internal resolved CORS shape. Always fully populated; the consumer never has
+ * to branch on string vs array vs function.
+ *
+ * @internal
+ */
+export interface ResolvedMcpCors {
+  resolveOrigin: McpCorsOriginResolver;
+  /** `true` when `origin` was the literal `"*"`. Skips `Vary: Origin`. */
+  isWildcard: boolean;
+  allowMethods: string;
+  allowHeaders: string;
+  exposeHeaders: string;
+  credentials: boolean;
+  maxAge: number | undefined;
+}
+
+/**
+ * Hostnames recognised as loopback by the default policy. IPv6 loopback
+ * appears as both `::1` and bracketed `[::1]` in `Origin` headers depending on
+ * the client; both are accepted.
+ */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/**
+ * Default origin resolver: reflect the request `Origin` iff it is loopback.
+ * Returns `false` otherwise.
+ *
+ * @internal
+ */
+export function defaultLoopbackOriginResolver(
+  requestOrigin: string | undefined,
+): string | false {
+  if (!requestOrigin) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(requestOrigin);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  return LOOPBACK_HOSTS.has(parsed.hostname) ? requestOrigin : false;
+}
+
+const DEFAULT_ALLOW_METHODS = ["GET", "POST", "OPTIONS"];
+const DEFAULT_ALLOW_HEADERS = ["*"];
+const DEFAULT_EXPOSE_HEADERS = ["WWW-Authenticate"];
+
+/**
+ * Resolve a `cors` config slot into either a fully-populated internal shape or
+ * `null` (CORS disabled entirely). `undefined` produces the loopback default.
+ *
+ * @internal
+ */
+export function resolveCorsOptions(
+  input: false | McpCorsOptions | undefined,
+): ResolvedMcpCors | null {
+  if (input === false) return null;
+  const opts = input ?? {};
+
+  const credentials = opts.credentials === true;
+
+  let resolveOrigin: McpCorsOriginResolver;
+  let isWildcard = false;
+  if (opts.origin === undefined) {
+    resolveOrigin = defaultLoopbackOriginResolver;
+  } else if (opts.origin === "*") {
+    if (credentials) {
+      throw new TypeError(
+        "mcpPlugin: cors.credentials cannot be true when cors.origin is '*' (per the CORS spec). " +
+          "Use an explicit origin string, an allowlist, or a resolver function.",
+      );
+    }
+    resolveOrigin = () => "*";
+    isWildcard = true;
+  } else if (typeof opts.origin === "string") {
+    const allowed = opts.origin;
+    resolveOrigin = (requestOrigin) =>
+      requestOrigin === allowed ? allowed : false;
+  } else if (Array.isArray(opts.origin)) {
+    const allowed = new Set(opts.origin);
+    resolveOrigin = (requestOrigin) =>
+      requestOrigin !== undefined && allowed.has(requestOrigin)
+        ? requestOrigin
+        : false;
+  } else if (typeof opts.origin === "function") {
+    resolveOrigin = opts.origin;
+  } else {
+    throw new TypeError(
+      "mcpPlugin: cors.origin must be '*', a string, a string array, or a function",
+    );
+  }
+
+  const exposeHeaders = mergeExposeHeaders(opts.exposeHeaders);
+
+  return {
+    resolveOrigin,
+    isWildcard,
+    allowMethods: (opts.allowMethods ?? DEFAULT_ALLOW_METHODS).join(", "),
+    allowHeaders: (opts.allowHeaders ?? DEFAULT_ALLOW_HEADERS).join(", "),
+    exposeHeaders,
+    credentials,
+    maxAge: opts.maxAge,
+  };
+}
+
+/**
+ * Merge user-supplied `exposeHeaders` with the `WWW-Authenticate` default,
+ * deduplicating case-insensitively. The default exists so browser clients can
+ * read the RFC 9728 `resource_metadata` hint on a 401.
+ */
+function mergeExposeHeaders(user: string[] | undefined): string {
+  const merged = [...DEFAULT_EXPOSE_HEADERS];
+  if (user) {
+    const lower = new Set(merged.map((h) => h.toLowerCase()));
+    for (const h of user) {
+      if (!lower.has(h.toLowerCase())) {
+        merged.push(h);
+        lower.add(h.toLowerCase());
+      }
+    }
+  }
+  return merged.join(", ");
+}
+
+/**
+ * Build the response headers to add for a given request `Origin`. Returns an
+ * empty object when CORS is disabled or the request `Origin` is disallowed.
+ *
+ * The caller is responsible for setting these headers on the response. The
+ * helper is pure to keep it testable in isolation and reusable from both the
+ * raw-`node:http` (validator) and Express (OAuth-proxy) paths.
+ *
+ * @param cors Resolved CORS options, or `null` to short-circuit.
+ * @param requestOrigin Value of the request's `Origin` header.
+ * @param preflight `true` to include `Access-Control-Allow-Methods/Headers/Max-Age`.
+ * @internal
+ */
+export function buildCorsHeaders(
+  cors: ResolvedMcpCors | null,
+  requestOrigin: string | undefined,
+  preflight: boolean,
+): Record<string, string> {
+  if (!cors) return {};
+  const allowed = cors.resolveOrigin(requestOrigin);
+  if (allowed === false) return {};
+
+  const headers: Record<string, string> = {
+    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Expose-Headers": cors.exposeHeaders,
+  };
+  if (!cors.isWildcard) {
+    headers["Vary"] = "Origin";
+  }
+  if (cors.credentials) {
+    headers["Access-Control-Allow-Credentials"] = "true";
+  }
+  if (preflight) {
+    headers["Access-Control-Allow-Methods"] = cors.allowMethods;
+    headers["Access-Control-Allow-Headers"] = cors.allowHeaders;
+    if (cors.maxAge !== undefined) {
+      headers["Access-Control-Max-Age"] = String(cors.maxAge);
+    }
+  }
+  return headers;
+}

--- a/packages/ai/src/mcp/index.ts
+++ b/packages/ai/src/mcp/index.ts
@@ -12,6 +12,7 @@ export type {
   UserinfoFn,
   UserinfoOption,
 } from "./oauth.ts";
+export type { McpCorsOptions, McpCorsOriginResolver } from "./cors.ts";
 export { mcpPlugin } from "./plugin.ts";
 export { McpServer } from "./server.ts";
 export { McpToolRegistry } from "./tool-registry.ts";

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -26,7 +26,12 @@ import type {
   McpTool,
   OAuthAuthOptions,
 } from "./types.ts";
-import { buildCorsHeaders, resolveCorsOptions } from "./cors.ts";
+import {
+  applyCorsHeaders,
+  isMcpOwnedPath,
+  PROTECTED_RESOURCE_METADATA_PATH,
+  resolveCorsOptions,
+} from "./cors.ts";
 
 /**
  * MCP SDK `AuthInfo` shape. Imported as a type so nothing is required at
@@ -63,10 +68,6 @@ interface ProtectedResourceMetadata {
   scopes_supported?: string[];
   resource_documentation?: string;
 }
-
-/** Path of the RFC 9728 metadata document. Relative to the server origin. */
-const PROTECTED_RESOURCE_METADATA_PATH =
-  "/.well-known/oauth-protected-resource";
 
 /**
  * McpServer wraps the MCP SDK and bridges it to Routecraft's DirectChannel infrastructure.
@@ -507,13 +508,15 @@ export class McpServer {
    */
   private serveProtectedResourceMetadata(
     res: import("node:http").ServerResponse,
-    corsHeaders: Record<string, string> = {},
   ): void {
     const metadata = this.buildProtectedResourceMetadata();
+    // CORS headers, when applicable, are committed by the surrounding
+    // request handler via `applyCorsHeaders` before this helper runs. They
+    // survive `writeHead` because the headers object below does not name
+    // any `Access-Control-*` or `Vary` key.
     res.writeHead(200, {
       "Content-Type": "application/json",
       "Cache-Control": "public, max-age=3600",
-      ...corsHeaders,
     });
     res.end(JSON.stringify(metadata));
   }
@@ -533,42 +536,37 @@ export class McpServer {
 
     this.httpServer = createServer(async (req, res) => {
       const url = req.url?.split("?")[0] ?? "";
-      const requestOrigin = req.headers["origin"];
-      const originValue = Array.isArray(requestOrigin)
-        ? requestOrigin[0]
-        : requestOrigin;
+      const rawOrigin = req.headers["origin"];
+      const originValue = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
 
-      // Preflight: handle OPTIONS before any URL routing. The CORS spec
-      // requires preflight responses on the same path as the actual request,
-      // so we mirror the routing the real verbs use.
-      if (req.method === "OPTIONS") {
-        if (
-          url === PROTECTED_RESOURCE_METADATA_PATH ||
-          url === "/mcp" ||
-          url === "/mcp/"
-        ) {
-          const preflightHeaders = buildCorsHeaders(cors, originValue, true);
-          res.writeHead(204, preflightHeaders);
-          res.end();
-          return;
-        }
-        res.writeHead(404);
+      // OPTIONS preflight on an owned path: answer 204 with CORS headers.
+      // When `cors === null` (user opted out via `cors: false`) we DO NOT
+      // synthesize a preflight response -- the user said a fronting
+      // proxy/CDN owns CORS, so we must let the request fall through
+      // rather than swallowing OPTIONS here.
+      if (req.method === "OPTIONS" && cors !== null && isMcpOwnedPath(url)) {
+        applyCorsHeaders(res, cors, originValue, true);
+        res.writeHead(204);
         res.end();
         return;
       }
 
-      const responseCorsHeaders = buildCorsHeaders(cors, originValue, false);
+      // Commit CORS headers via setHeader/appendHeader for every owned-path
+      // request. They survive whatever writeHead() the rest of the handler
+      // (or the SDK transport) calls, except when the same key is in the
+      // writeHead headers argument -- we avoid that for `Access-Control-*`
+      // and `Vary` everywhere below.
+      if (isMcpOwnedPath(url)) {
+        applyCorsHeaders(res, cors, originValue, false);
+      }
 
       if (url === PROTECTED_RESOURCE_METADATA_PATH) {
-        this.serveProtectedResourceMetadata(res, responseCorsHeaders);
+        this.serveProtectedResourceMetadata(res);
         return;
       }
 
       if (url !== "/mcp" && url !== "/mcp/") {
-        res.writeHead(404, {
-          "Content-Type": "application/json",
-          ...responseCorsHeaders,
-        });
+        res.writeHead(404, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Not Found", path: url }));
         return;
       }
@@ -580,7 +578,6 @@ export class McpServer {
           res.writeHead(401, {
             "Content-Type": "application/json",
             "WWW-Authenticate": this.buildWwwAuthenticateHeader(),
-            ...responseCorsHeaders,
           });
           res.end(JSON.stringify({ error: "Unauthorized" }));
           return;
@@ -588,14 +585,6 @@ export class McpServer {
         principal = result;
       }
 
-      // The SDK transport owns the response from here. Commit CORS headers
-      // via setHeader() so they are merged into whatever writeHead() the SDK
-      // calls. Node merges setHeader() values with writeHead() arguments
-      // unless writeHead() explicitly overrides a header by name, and the
-      // SDK does not set `Access-Control-*` itself.
-      for (const [name, value] of Object.entries(responseCorsHeaders)) {
-        res.setHeader(name, value);
-      }
       await this.handleMcpRequest(req, res, principal, createSessionFn);
     });
 
@@ -778,33 +767,33 @@ export class McpServer {
     // design). The SDK-owned OAuth endpoints (`/register`, `/token`,
     // `/revoke`, the SDK's metadata) carry their own permissive CORS via
     // `mcpAuthRouter` -> the `cors` npm package -- we leave those alone.
-    const corsForPaths = new Set([
-      PROTECTED_RESOURCE_METADATA_PATH,
-      "/mcp",
-      "/mcp/",
-    ]);
-    app.use((req: unknown, res: unknown, next: unknown) => {
-      const nodeReq = req as IncomingMessage;
-      const nodeRes = res as import("node:http").ServerResponse;
-      const url = nodeReq.url?.split("?")[0] ?? "";
-      if (!corsForPaths.has(url)) {
+    //
+    // When `oauthCors === null` (user opted out via `cors: false`) the
+    // middleware is not registered at all: preflight requests fall through
+    // to the bearer middleware / route handler, exactly as they would if
+    // CORS support had never been built. The user told us a fronting
+    // proxy/CDN owns CORS.
+    if (oauthCors !== null) {
+      app.use((req: unknown, res: unknown, next: unknown) => {
+        const nodeReq = req as IncomingMessage;
+        const nodeRes = res as import("node:http").ServerResponse;
+        const url = nodeReq.url?.split("?")[0] ?? "";
+        if (!isMcpOwnedPath(url)) {
+          (next as () => void)();
+          return;
+        }
+        const rawOrigin = nodeReq.headers["origin"];
+        const originValue = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
+        if (nodeReq.method === "OPTIONS") {
+          applyCorsHeaders(nodeRes, oauthCors, originValue, true);
+          nodeRes.writeHead(204);
+          nodeRes.end();
+          return;
+        }
+        applyCorsHeaders(nodeRes, oauthCors, originValue, false);
         (next as () => void)();
-        return;
-      }
-      const rawOrigin = nodeReq.headers["origin"];
-      const originValue = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
-      if (nodeReq.method === "OPTIONS") {
-        const preflight = buildCorsHeaders(oauthCors, originValue, true);
-        nodeRes.writeHead(204, preflight);
-        nodeRes.end();
-        return;
-      }
-      const headers = buildCorsHeaders(oauthCors, originValue, false);
-      for (const [name, value] of Object.entries(headers)) {
-        nodeRes.setHeader(name, value);
-      }
-      (next as () => void)();
-    });
+      });
+    }
 
     // Mount our own protected-resource metadata handler BEFORE
     // `mcpAuthRouter`. The SDK's router also mounts a doc, but at a

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -26,6 +26,7 @@ import type {
   McpTool,
   OAuthAuthOptions,
 } from "./types.ts";
+import { buildCorsHeaders, resolveCorsOptions } from "./cors.ts";
 
 /**
  * MCP SDK `AuthInfo` shape. Imported as a type so nothing is required at
@@ -45,7 +46,7 @@ const principalStore = new AsyncLocalStorage<Principal | undefined>();
 type McpServerResolvedOptions = Required<
   Pick<McpPluginOptions, "name" | "version" | "transport" | "port" | "host">
 > &
-  Pick<McpPluginOptions, "tools" | "auth" | "title" | "resource">;
+  Pick<McpPluginOptions, "tools" | "auth" | "title" | "resource" | "cors">;
 
 /**
  * RFC 9728 OAuth 2.0 Protected Resource Metadata payload returned by
@@ -506,11 +507,13 @@ export class McpServer {
    */
   private serveProtectedResourceMetadata(
     res: import("node:http").ServerResponse,
+    corsHeaders: Record<string, string> = {},
   ): void {
     const metadata = this.buildProtectedResourceMetadata();
     res.writeHead(200, {
       "Content-Type": "application/json",
       "Cache-Control": "public, max-age=3600",
+      ...corsHeaders,
     });
     res.end(JSON.stringify(metadata));
   }
@@ -523,20 +526,49 @@ export class McpServer {
     const { ServerCtor, TransportClass } = await this.importSdkHttp();
     const port = this.options.port;
     const host = this.options.host;
+    const cors = resolveCorsOptions(this.options.cors);
 
     const createSessionFn = () =>
       this.createSession(ServerCtor, TransportClass);
 
     this.httpServer = createServer(async (req, res) => {
       const url = req.url?.split("?")[0] ?? "";
+      const requestOrigin = req.headers["origin"];
+      const originValue = Array.isArray(requestOrigin)
+        ? requestOrigin[0]
+        : requestOrigin;
+
+      // Preflight: handle OPTIONS before any URL routing. The CORS spec
+      // requires preflight responses on the same path as the actual request,
+      // so we mirror the routing the real verbs use.
+      if (req.method === "OPTIONS") {
+        if (
+          url === PROTECTED_RESOURCE_METADATA_PATH ||
+          url === "/mcp" ||
+          url === "/mcp/"
+        ) {
+          const preflightHeaders = buildCorsHeaders(cors, originValue, true);
+          res.writeHead(204, preflightHeaders);
+          res.end();
+          return;
+        }
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      const responseCorsHeaders = buildCorsHeaders(cors, originValue, false);
 
       if (url === PROTECTED_RESOURCE_METADATA_PATH) {
-        this.serveProtectedResourceMetadata(res);
+        this.serveProtectedResourceMetadata(res, responseCorsHeaders);
         return;
       }
 
       if (url !== "/mcp" && url !== "/mcp/") {
-        res.writeHead(404, { "Content-Type": "application/json" });
+        res.writeHead(404, {
+          "Content-Type": "application/json",
+          ...responseCorsHeaders,
+        });
         res.end(JSON.stringify({ error: "Not Found", path: url }));
         return;
       }
@@ -548,6 +580,7 @@ export class McpServer {
           res.writeHead(401, {
             "Content-Type": "application/json",
             "WWW-Authenticate": this.buildWwwAuthenticateHeader(),
+            ...responseCorsHeaders,
           });
           res.end(JSON.stringify({ error: "Unauthorized" }));
           return;
@@ -555,6 +588,14 @@ export class McpServer {
         principal = result;
       }
 
+      // The SDK transport owns the response from here. Commit CORS headers
+      // via setHeader() so they are merged into whatever writeHead() the SDK
+      // calls. Node merges setHeader() values with writeHead() arguments
+      // unless writeHead() explicitly overrides a header by name, and the
+      // SDK does not set `Access-Control-*` itself.
+      for (const [name, value] of Object.entries(responseCorsHeaders)) {
+        res.setHeader(name, value);
+      }
       await this.handleMcpRequest(req, res, principal, createSessionFn);
     });
 
@@ -729,6 +770,42 @@ export class McpServer {
 
     const app = expressFn();
 
+    const oauthCors = resolveCorsOptions(this.options.cors);
+
+    // CORS middleware for our owned routes (`/mcp` and the protected-resource
+    // metadata endpoint). Mounted FIRST so OPTIONS preflight short-circuits
+    // before bearer auth runs (a preflight has no Authorization header by
+    // design). The SDK-owned OAuth endpoints (`/register`, `/token`,
+    // `/revoke`, the SDK's metadata) carry their own permissive CORS via
+    // `mcpAuthRouter` -> the `cors` npm package -- we leave those alone.
+    const corsForPaths = new Set([
+      PROTECTED_RESOURCE_METADATA_PATH,
+      "/mcp",
+      "/mcp/",
+    ]);
+    app.use((req: unknown, res: unknown, next: unknown) => {
+      const nodeReq = req as IncomingMessage;
+      const nodeRes = res as import("node:http").ServerResponse;
+      const url = nodeReq.url?.split("?")[0] ?? "";
+      if (!corsForPaths.has(url)) {
+        (next as () => void)();
+        return;
+      }
+      const rawOrigin = nodeReq.headers["origin"];
+      const originValue = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
+      if (nodeReq.method === "OPTIONS") {
+        const preflight = buildCorsHeaders(oauthCors, originValue, true);
+        nodeRes.writeHead(204, preflight);
+        nodeRes.end();
+        return;
+      }
+      const headers = buildCorsHeaders(oauthCors, originValue, false);
+      for (const [name, value] of Object.entries(headers)) {
+        nodeRes.setHeader(name, value);
+      }
+      (next as () => void)();
+    });
+
     // Mount our own protected-resource metadata handler BEFORE
     // `mcpAuthRouter`. The SDK's router also mounts a doc, but at a
     // path-aware URL (`/.well-known/oauth-protected-resource{rsPath}`)
@@ -738,6 +815,8 @@ export class McpServer {
     // mode -- the design's "auto-mount, same shape, regardless of auth
     // mode" promise. Express matches the more specific `app.get(...)`
     // before the more general `router.use(...)` registered later.
+    // CORS headers are committed by the middleware above via `setHeader`,
+    // so the handler does not need to re-emit them in `writeHead`.
     app.get(PROTECTED_RESOURCE_METADATA_PATH, (_req: unknown, res: unknown) => {
       this.serveProtectedResourceMetadata(
         res as import("node:http").ServerResponse,

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -802,8 +802,10 @@ export class McpServer {
     // recommends. Mounting ours first means clients fetching the URL we
     // advertise in the 401 always get the same JSON shape as validator
     // mode -- the design's "auto-mount, same shape, regardless of auth
-    // mode" promise. Express matches the more specific `app.get(...)`
-    // before the more general `router.use(...)` registered later.
+    // mode" promise. Express runs middleware in registration order, so the
+    // handler registered first wins for the matching URL; do NOT move this
+    // below `app.use(mcpAuthRouter(...))` or the SDK's path-aware doc will
+    // shadow ours when the resource URL collapses to root.
     // CORS headers are committed by the middleware above via `setHeader`,
     // so the handler does not need to re-emit them in `writeHead`.
     app.get(PROTECTED_RESOURCE_METADATA_PATH, (_req: unknown, res: unknown) => {

--- a/packages/ai/src/mcp/types.ts
+++ b/packages/ai/src/mcp/types.ts
@@ -4,6 +4,7 @@ import type {
   Principal,
   ValidatorAuthOptions,
 } from "@routecraft/routecraft";
+import type { McpCorsOptions } from "./cors.ts";
 import type { McpToolRegistry } from "./tool-registry.ts";
 
 /**
@@ -386,6 +387,30 @@ export interface McpPluginOptions {
    * ```
    */
   auth?: McpHttpAuthOptions;
+
+  /**
+   * CORS configuration for the HTTP transport. Controls which browser origins
+   * can read responses from `/mcp`, `/.well-known/oauth-protected-resource`,
+   * and the 401 `WWW-Authenticate` hint. Ignored for stdio.
+   *
+   * Default (when omitted): **loopback-only**. Browser MCP clients on
+   * `localhost`, `127.0.0.1`, or `[::1]` (any port, http or https) work out of
+   * the box; non-loopback browser origins must be allowlisted explicitly. This
+   * is production-safe by construction; see `.standards/security.md` ->
+   * "Security defaults policy".
+   *
+   * - `cors: false` -- disable CORS entirely (e.g. fronted by a CDN/proxy that owns CORS).
+   * - `cors: { origin: "https://app.example.com" }` -- exact origin allowlist.
+   * - `cors: { origin: ["https://a.example", "https://b.example"] }` -- multi-origin allowlist.
+   * - `cors: { origin: "*" }` -- permissive opt-in (cannot be combined with `credentials: true`).
+   * - `cors: { origin: (req) => ... }` -- custom resolver.
+   *
+   * Server-to-server callers (curl, `mcp-remote`, the MCP CLI) are unaffected
+   * regardless of this setting because they do not send an `Origin` header.
+   *
+   * @experimental
+   */
+  cors?: false | McpCorsOptions;
 
   /**
    * Filter which tools to expose. Default: all mcp() routes.

--- a/packages/ai/src/mcp/types.ts
+++ b/packages/ai/src/mcp/types.ts
@@ -402,11 +402,15 @@ export interface McpPluginOptions {
    * - `cors: false` -- disable CORS entirely (e.g. fronted by a CDN/proxy that owns CORS).
    * - `cors: { origin: "https://app.example.com" }` -- exact origin allowlist.
    * - `cors: { origin: ["https://a.example", "https://b.example"] }` -- multi-origin allowlist.
-   * - `cors: { origin: "*" }` -- permissive opt-in (cannot be combined with `credentials: true`).
+   * - `cors: { origin: "*" }` -- permissive opt-in.
    * - `cors: { origin: (req) => ... }` -- custom resolver.
    *
    * Server-to-server callers (curl, `mcp-remote`, the MCP CLI) are unaffected
    * regardless of this setting because they do not send an `Origin` header.
+   *
+   * Method, allowed-header, exposed-header, credentials, and preflight-cache
+   * values are framework constants and not user-configurable. `WWW-Authenticate`
+   * is always exposed so browser clients can read the RFC 9728 hint on a 401.
    *
    * @experimental
    */

--- a/packages/ai/src/mcp/validate-options.ts
+++ b/packages/ai/src/mcp/validate-options.ts
@@ -33,6 +33,26 @@ export function validateMcpPluginOptions(options: McpPluginOptions): void {
 
   // Note: `cors` is silently ignored when transport is not 'http', matching
   // the `auth` posture. The stdio startup path simply does not read it.
+  // The shape of `cors.origin` is validated here so misconfiguration fails at
+  // plugin-apply time alongside `auth`, `port`, and `host`; `resolveCorsOptions`
+  // keeps the same throw as defence-in-depth for callers who bypass this gate.
+  if (
+    options.transport === "http" &&
+    options.cors !== undefined &&
+    options.cors !== false
+  ) {
+    const { origin } = options.cors;
+    const ok =
+      origin === "*" ||
+      typeof origin === "string" ||
+      Array.isArray(origin) ||
+      typeof origin === "function";
+    if (!ok) {
+      throw new TypeError(
+        "mcpPlugin: cors.origin must be '*', a string, a string array, or a function",
+      );
+    }
+  }
 
   // Validate auth options
   if (options.auth !== undefined) {

--- a/packages/ai/src/mcp/validate-options.ts
+++ b/packages/ai/src/mcp/validate-options.ts
@@ -31,6 +31,9 @@ export function validateMcpPluginOptions(options: McpPluginOptions): void {
     }
   }
 
+  // Note: `cors` is silently ignored when transport is not 'http', matching
+  // the `auth` posture. The stdio startup path simply does not read it.
+
   // Validate auth options
   if (options.auth !== undefined) {
     if ("provider" in options.auth) {

--- a/packages/ai/test/mcp-cors.bun.test.ts
+++ b/packages/ai/test/mcp-cors.bun.test.ts
@@ -105,19 +105,15 @@ describe("MCP CORS helper", () => {
     });
 
     /**
-     * @case origin: "*" produces a permissive policy and is incompatible with credentials
-     * @preconditions origin: "*", credentials true vs false
-     * @expectedResult origin:"*" works without credentials; combining with credentials throws TypeError
+     * @case origin: "*" produces a permissive policy
+     * @preconditions origin: "*"; any request Origin
+     * @expectedResult Resolved policy is wildcard; resolver returns "*" for every input
      */
-    test("origin: '*' is permissive but rejects credentials", () => {
+    test("origin: '*' is permissive", () => {
       const resolved = resolveCorsOptions({ origin: "*" });
       expect(resolved).not.toBeNull();
       expect(resolved!.isWildcard).toBe(true);
       expect(resolved!.resolveOrigin("https://anywhere.example")).toBe("*");
-
-      expect(() =>
-        resolveCorsOptions({ origin: "*", credentials: true }),
-      ).toThrow(/cors\.credentials.*cors\.origin is '\*'/i);
     });
 
     /**
@@ -180,26 +176,6 @@ describe("MCP CORS helper", () => {
         resolveCorsOptions({ origin: 42 as unknown as string }),
       ).toThrow(TypeError);
     });
-
-    /**
-     * @case Custom exposeHeaders are additive with the WWW-Authenticate default
-     * @preconditions exposeHeaders: ["X-Custom", "X-Request-Id"]
-     * @expectedResult Resolved exposeHeaders includes WWW-Authenticate plus the user values, case-insensitive dedupe
-     */
-    test("exposeHeaders is additive with the WWW-Authenticate default", () => {
-      const resolved = resolveCorsOptions({
-        exposeHeaders: ["X-Custom", "www-authenticate", "X-Request-Id"],
-      });
-      const list = resolved!.exposeHeaders.split(", ");
-      expect(list).toContain("WWW-Authenticate");
-      expect(list).toContain("X-Custom");
-      expect(list).toContain("X-Request-Id");
-      // Case-insensitive dedupe: user passed "www-authenticate" lowercase but
-      // the default WWW-Authenticate is kept and the duplicate dropped.
-      expect(
-        list.filter((h) => h.toLowerCase() === "www-authenticate").length,
-      ).toBe(1);
-    });
   });
 
   describe("buildCorsHeaders", () => {
@@ -260,18 +236,17 @@ describe("MCP CORS helper", () => {
     });
 
     /**
-     * @case Preflight responses include Access-Control-Allow-Methods/Headers and optional Max-Age
-     * @preconditions Default policy + maxAge: 600; preflight=true; loopback Origin
-     * @expectedResult Methods, Headers, and Max-Age fields present in the response
+     * @case Preflight responses include Access-Control-Allow-Methods and Allow-Headers
+     * @preconditions Default policy; preflight=true; loopback Origin
+     * @expectedResult Methods header lists GET, POST, OPTIONS; Headers is "*"
      */
-    test("preflight emits methods, headers, and max-age", () => {
-      const cors = resolveCorsOptions({ maxAge: 600 });
+    test("preflight emits methods and headers", () => {
+      const cors = resolveCorsOptions(undefined);
       const headers = buildCorsHeaders(cors, "http://localhost:6274", true);
       expect(headers["Access-Control-Allow-Methods"]).toContain("GET");
       expect(headers["Access-Control-Allow-Methods"]).toContain("POST");
       expect(headers["Access-Control-Allow-Methods"]).toContain("OPTIONS");
       expect(headers["Access-Control-Allow-Headers"]).toBe("*");
-      expect(headers["Access-Control-Max-Age"]).toBe("600");
     });
 
     /**
@@ -284,21 +259,6 @@ describe("MCP CORS helper", () => {
       const headers = buildCorsHeaders(cors, "http://localhost:6274", false);
       expect(headers["Access-Control-Allow-Methods"]).toBeUndefined();
       expect(headers["Access-Control-Allow-Headers"]).toBeUndefined();
-      expect(headers["Access-Control-Max-Age"]).toBeUndefined();
-    });
-
-    /**
-     * @case Credentials flag with explicit origin emits Allow-Credentials: true
-     * @preconditions origin: "https://app.example.com"; credentials: true
-     * @expectedResult Access-Control-Allow-Credentials: true on a matching origin
-     */
-    test("credentials flag emits Allow-Credentials with explicit origin", () => {
-      const cors = resolveCorsOptions({
-        origin: "https://app.example.com",
-        credentials: true,
-      });
-      const headers = buildCorsHeaders(cors, "https://app.example.com", false);
-      expect(headers["Access-Control-Allow-Credentials"]).toBe("true");
     });
 
     /**

--- a/packages/ai/test/mcp-cors.bun.test.ts
+++ b/packages/ai/test/mcp-cors.bun.test.ts
@@ -1,0 +1,265 @@
+import { describe, test, expect } from "bun:test";
+import {
+  buildCorsHeaders,
+  defaultLoopbackOriginResolver,
+  resolveCorsOptions,
+} from "../src/mcp/cors.ts";
+
+describe("MCP CORS helper", () => {
+  describe("defaultLoopbackOriginResolver", () => {
+    /**
+     * @case Loopback hostnames are reflected; non-loopback returns false
+     * @preconditions Origin values for localhost, 127.0.0.1, [::1], and a public host
+     * @expectedResult Loopback origins echo back; public hostnames return false
+     */
+    test("reflects loopback origins and rejects non-loopback", () => {
+      expect(defaultLoopbackOriginResolver("http://localhost:6274")).toBe(
+        "http://localhost:6274",
+      );
+      expect(defaultLoopbackOriginResolver("http://127.0.0.1:3000")).toBe(
+        "http://127.0.0.1:3000",
+      );
+      expect(defaultLoopbackOriginResolver("http://[::1]:8080")).toBe(
+        "http://[::1]:8080",
+      );
+      expect(defaultLoopbackOriginResolver("https://localhost")).toBe(
+        "https://localhost",
+      );
+      expect(defaultLoopbackOriginResolver("https://app.example.com")).toBe(
+        false,
+      );
+      expect(defaultLoopbackOriginResolver("https://evil.example")).toBe(false);
+      expect(defaultLoopbackOriginResolver(undefined)).toBe(false);
+      expect(defaultLoopbackOriginResolver("")).toBe(false);
+    });
+
+    /**
+     * @case Non-http/https protocols are rejected even on loopback
+     * @preconditions `file://`, `chrome-extension://`, and malformed Origin values
+     * @expectedResult Resolver returns false; only http(s) loopback is accepted
+     */
+    test("rejects non-http(s) protocols and malformed origins", () => {
+      expect(defaultLoopbackOriginResolver("file:///etc/passwd")).toBe(false);
+      expect(
+        defaultLoopbackOriginResolver("chrome-extension://abcdef/index.html"),
+      ).toBe(false);
+      expect(defaultLoopbackOriginResolver("not a url")).toBe(false);
+    });
+  });
+
+  describe("resolveCorsOptions", () => {
+    /**
+     * @case `false` disables CORS entirely
+     * @preconditions input is `false`
+     * @expectedResult resolveCorsOptions returns null; buildCorsHeaders is a no-op
+     */
+    test("input false returns null (CORS disabled)", () => {
+      expect(resolveCorsOptions(false)).toBeNull();
+    });
+
+    /**
+     * @case undefined input applies the secure loopback default
+     * @preconditions input is undefined
+     * @expectedResult Resolved policy uses defaultLoopbackOriginResolver; non-loopback is rejected
+     */
+    test("undefined input applies the loopback default", () => {
+      const resolved = resolveCorsOptions(undefined);
+      expect(resolved).not.toBeNull();
+      expect(resolved!.resolveOrigin("http://localhost:6274")).toBe(
+        "http://localhost:6274",
+      );
+      expect(resolved!.resolveOrigin("https://evil.example")).toBe(false);
+    });
+
+    /**
+     * @case origin: "*" produces a permissive policy and is incompatible with credentials
+     * @preconditions origin: "*", credentials true vs false
+     * @expectedResult origin:"*" works without credentials; combining with credentials throws TypeError
+     */
+    test("origin: '*' is permissive but rejects credentials", () => {
+      const resolved = resolveCorsOptions({ origin: "*" });
+      expect(resolved).not.toBeNull();
+      expect(resolved!.isWildcard).toBe(true);
+      expect(resolved!.resolveOrigin("https://anywhere.example")).toBe("*");
+
+      expect(() =>
+        resolveCorsOptions({ origin: "*", credentials: true }),
+      ).toThrow(/cors\.credentials.*cors\.origin is '\*'/i);
+    });
+
+    /**
+     * @case String origin acts as an exact-match allowlist
+     * @preconditions origin: "https://app.example.com"
+     * @expectedResult Matches the configured value, rejects others
+     */
+    test("string origin matches exactly", () => {
+      const resolved = resolveCorsOptions({
+        origin: "https://app.example.com",
+      });
+      expect(resolved!.resolveOrigin("https://app.example.com")).toBe(
+        "https://app.example.com",
+      );
+      expect(resolved!.resolveOrigin("https://evil.example")).toBe(false);
+      expect(resolved!.resolveOrigin(undefined)).toBe(false);
+    });
+
+    /**
+     * @case Array origin acts as a multi-origin allowlist
+     * @preconditions origin: ["https://a.example", "https://b.example"]
+     * @expectedResult Either match reflects; others reject
+     */
+    test("array origin matches any entry in the allowlist", () => {
+      const resolved = resolveCorsOptions({
+        origin: ["https://a.example", "https://b.example"],
+      });
+      expect(resolved!.resolveOrigin("https://a.example")).toBe(
+        "https://a.example",
+      );
+      expect(resolved!.resolveOrigin("https://b.example")).toBe(
+        "https://b.example",
+      );
+      expect(resolved!.resolveOrigin("https://c.example")).toBe(false);
+    });
+
+    /**
+     * @case Function origin is passed through as the resolver
+     * @preconditions origin: custom callback that allows only ".trusted.example"
+     * @expectedResult Resolver runs verbatim; outputs are used directly
+     */
+    test("function origin is invoked directly", () => {
+      const resolved = resolveCorsOptions({
+        origin: (req) =>
+          req !== undefined && req.endsWith(".trusted.example") ? req : false,
+      });
+      expect(resolved!.resolveOrigin("https://app.trusted.example")).toBe(
+        "https://app.trusted.example",
+      );
+      expect(resolved!.resolveOrigin("https://app.evil.example")).toBe(false);
+    });
+
+    /**
+     * @case Invalid origin shapes are rejected at construction
+     * @preconditions origin is a number, object, or null
+     * @expectedResult resolveCorsOptions throws TypeError
+     */
+    test("invalid origin shapes throw", () => {
+      expect(() =>
+        resolveCorsOptions({ origin: 42 as unknown as string }),
+      ).toThrow(TypeError);
+    });
+
+    /**
+     * @case Custom exposeHeaders are additive with the WWW-Authenticate default
+     * @preconditions exposeHeaders: ["X-Custom", "X-Request-Id"]
+     * @expectedResult Resolved exposeHeaders includes WWW-Authenticate plus the user values, case-insensitive dedupe
+     */
+    test("exposeHeaders is additive with the WWW-Authenticate default", () => {
+      const resolved = resolveCorsOptions({
+        exposeHeaders: ["X-Custom", "www-authenticate", "X-Request-Id"],
+      });
+      const list = resolved!.exposeHeaders.split(", ");
+      expect(list).toContain("WWW-Authenticate");
+      expect(list).toContain("X-Custom");
+      expect(list).toContain("X-Request-Id");
+      // Case-insensitive dedupe: user passed "www-authenticate" lowercase but
+      // the default WWW-Authenticate is kept and the duplicate dropped.
+      expect(
+        list.filter((h) => h.toLowerCase() === "www-authenticate").length,
+      ).toBe(1);
+    });
+  });
+
+  describe("buildCorsHeaders", () => {
+    /**
+     * @case Disabled CORS produces no headers
+     * @preconditions resolveCorsOptions(false)
+     * @expectedResult buildCorsHeaders returns an empty object regardless of request Origin
+     */
+    test("returns no headers when CORS is disabled", () => {
+      expect(buildCorsHeaders(null, "http://localhost:6274", false)).toEqual(
+        {},
+      );
+      expect(buildCorsHeaders(null, undefined, true)).toEqual({});
+    });
+
+    /**
+     * @case Non-allowed origins produce no Access-Control-* headers
+     * @preconditions Default (loopback-only) policy; Origin is a public domain
+     * @expectedResult Empty object; browser will block the response
+     */
+    test("rejects non-loopback origins under the default policy", () => {
+      const cors = resolveCorsOptions(undefined);
+      expect(buildCorsHeaders(cors, "https://evil.example", false)).toEqual({});
+      expect(buildCorsHeaders(cors, "https://evil.example", true)).toEqual({});
+    });
+
+    /**
+     * @case Loopback origin gets reflected with Vary: Origin
+     * @preconditions Default policy; Origin is http://localhost:6274
+     * @expectedResult Access-Control-Allow-Origin echoes the request Origin; Vary: Origin set; WWW-Authenticate exposed
+     */
+    test("reflects loopback origin with Vary: Origin and exposed WWW-Authenticate", () => {
+      const cors = resolveCorsOptions(undefined);
+      const headers = buildCorsHeaders(cors, "http://localhost:6274", false);
+      expect(headers["Access-Control-Allow-Origin"]).toBe(
+        "http://localhost:6274",
+      );
+      expect(headers["Vary"]).toBe("Origin");
+      expect(headers["Access-Control-Expose-Headers"]).toBe("WWW-Authenticate");
+    });
+
+    /**
+     * @case Wildcard origin omits Vary: Origin
+     * @preconditions origin: "*"; any request Origin
+     * @expectedResult Access-Control-Allow-Origin: *; Vary: Origin NOT set (cache-friendly)
+     */
+    test("wildcard origin does not emit Vary: Origin", () => {
+      const cors = resolveCorsOptions({ origin: "*" });
+      const headers = buildCorsHeaders(cors, "https://anywhere.example", false);
+      expect(headers["Access-Control-Allow-Origin"]).toBe("*");
+      expect(headers["Vary"]).toBeUndefined();
+    });
+
+    /**
+     * @case Preflight responses include Access-Control-Allow-Methods/Headers and optional Max-Age
+     * @preconditions Default policy + maxAge: 600; preflight=true; loopback Origin
+     * @expectedResult Methods, Headers, and Max-Age fields present in the response
+     */
+    test("preflight emits methods, headers, and max-age", () => {
+      const cors = resolveCorsOptions({ maxAge: 600 });
+      const headers = buildCorsHeaders(cors, "http://localhost:6274", true);
+      expect(headers["Access-Control-Allow-Methods"]).toContain("GET");
+      expect(headers["Access-Control-Allow-Methods"]).toContain("POST");
+      expect(headers["Access-Control-Allow-Methods"]).toContain("OPTIONS");
+      expect(headers["Access-Control-Allow-Headers"]).toBe("*");
+      expect(headers["Access-Control-Max-Age"]).toBe("600");
+    });
+
+    /**
+     * @case Non-preflight responses omit Allow-Methods/Allow-Headers
+     * @preconditions Default policy; preflight=false; loopback Origin
+     * @expectedResult Only Allow-Origin / Vary / Expose-Headers are set on the response
+     */
+    test("non-preflight responses omit preflight-specific headers", () => {
+      const cors = resolveCorsOptions(undefined);
+      const headers = buildCorsHeaders(cors, "http://localhost:6274", false);
+      expect(headers["Access-Control-Allow-Methods"]).toBeUndefined();
+      expect(headers["Access-Control-Allow-Headers"]).toBeUndefined();
+      expect(headers["Access-Control-Max-Age"]).toBeUndefined();
+    });
+
+    /**
+     * @case Credentials flag with explicit origin emits Allow-Credentials: true
+     * @preconditions origin: "https://app.example.com"; credentials: true
+     * @expectedResult Access-Control-Allow-Credentials: true on a matching origin
+     */
+    test("credentials flag emits Allow-Credentials with explicit origin", () => {
+      const cors = resolveCorsOptions({
+        origin: "https://app.example.com",
+        credentials: true,
+      });
+      const headers = buildCorsHeaders(cors, "https://app.example.com", false);
+      expect(headers["Access-Control-Allow-Credentials"]).toBe("true");
+    });
+  });
+});

--- a/packages/ai/test/mcp-cors.bun.test.ts
+++ b/packages/ai/test/mcp-cors.bun.test.ts
@@ -220,7 +220,16 @@ describe("MCP CORS helper", () => {
         "http://localhost:6274",
       );
       expect(headers["Vary"]).toBe("Origin");
-      expect(headers["Access-Control-Expose-Headers"]).toBe("WWW-Authenticate");
+      // Browser MCP clients need three response headers exposed:
+      //   - WWW-Authenticate so the RFC 9728 hint on 401 is readable
+      //   - Mcp-Session-Id because the stateful SDK transport requires it
+      //     on every request after `initialize`
+      //   - Last-Event-ID for SSE resume
+      const expose = headers["Access-Control-Expose-Headers"];
+      expect(expose).toBeDefined();
+      expect(expose).toContain("WWW-Authenticate");
+      expect(expose).toContain("Mcp-Session-Id");
+      expect(expose).toContain("Last-Event-ID");
     });
 
     /**
@@ -236,17 +245,18 @@ describe("MCP CORS helper", () => {
     });
 
     /**
-     * @case Preflight responses include Access-Control-Allow-Methods and Allow-Headers
+     * @case Preflight responses include Allow-Methods/Allow-Headers but omit Expose-Headers
      * @preconditions Default policy; preflight=true; loopback Origin
-     * @expectedResult Methods header lists GET, POST, OPTIONS; Headers is "*"
+     * @expectedResult Methods header lists GET, POST, OPTIONS; Headers is "*"; Expose-Headers is absent (browsers ignore it on preflight per the Fetch spec)
      */
-    test("preflight emits methods and headers", () => {
+    test("preflight emits methods and headers, omits expose-headers", () => {
       const cors = resolveCorsOptions(undefined);
       const headers = buildCorsHeaders(cors, "http://localhost:6274", true);
       expect(headers["Access-Control-Allow-Methods"]).toContain("GET");
       expect(headers["Access-Control-Allow-Methods"]).toContain("POST");
       expect(headers["Access-Control-Allow-Methods"]).toContain("OPTIONS");
       expect(headers["Access-Control-Allow-Headers"]).toBe("*");
+      expect(headers["Access-Control-Expose-Headers"]).toBeUndefined();
     });
 
     /**

--- a/packages/ai/test/mcp-cors.bun.test.ts
+++ b/packages/ai/test/mcp-cors.bun.test.ts
@@ -245,18 +245,30 @@ describe("MCP CORS helper", () => {
     });
 
     /**
-     * @case Preflight responses include Allow-Methods/Allow-Headers but omit Expose-Headers
+     * @case Preflight responses include Allow-Methods/Allow-Headers and PNA opt-in but omit Expose-Headers
      * @preconditions Default policy; preflight=true; loopback Origin
-     * @expectedResult Methods header lists GET, POST, OPTIONS; Headers is "*"; Expose-Headers is absent (browsers ignore it on preflight per the Fetch spec)
+     * @expectedResult Methods header lists GET, POST, OPTIONS; Headers is "*"; Allow-Private-Network is "true" so Chrome PNA preflights succeed for public->loopback crossings; Expose-Headers is absent (browsers ignore it on preflight per the Fetch spec)
      */
-    test("preflight emits methods and headers, omits expose-headers", () => {
+    test("preflight emits methods, headers, PNA opt-in; omits expose-headers", () => {
       const cors = resolveCorsOptions(undefined);
       const headers = buildCorsHeaders(cors, "http://localhost:6274", true);
       expect(headers["Access-Control-Allow-Methods"]).toContain("GET");
       expect(headers["Access-Control-Allow-Methods"]).toContain("POST");
       expect(headers["Access-Control-Allow-Methods"]).toContain("OPTIONS");
       expect(headers["Access-Control-Allow-Headers"]).toBe("*");
+      expect(headers["Access-Control-Allow-Private-Network"]).toBe("true");
       expect(headers["Access-Control-Expose-Headers"]).toBeUndefined();
+    });
+
+    /**
+     * @case Disallowed origins do not receive the PNA opt-in even on preflight
+     * @preconditions Default policy; preflight=true; non-loopback Origin
+     * @expectedResult Only Vary: Origin is set; no Allow-Origin, no PNA opt-in (browser should not see a private-network grant for an origin we are not allowing in the first place)
+     */
+    test("rejected origin preflight does not emit Allow-Private-Network", () => {
+      const cors = resolveCorsOptions(undefined);
+      const headers = buildCorsHeaders(cors, "https://evil.example", true);
+      expect(headers).toEqual({ Vary: "Origin" });
     });
 
     /**

--- a/packages/ai/test/mcp-cors.bun.test.ts
+++ b/packages/ai/test/mcp-cors.bun.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import {
+  applyCorsHeaders,
   buildCorsHeaders,
   defaultLoopbackOriginResolver,
   resolveCorsOptions,
@@ -44,6 +45,38 @@ describe("MCP CORS helper", () => {
         defaultLoopbackOriginResolver("chrome-extension://abcdef/index.html"),
       ).toBe(false);
       expect(defaultLoopbackOriginResolver("not a url")).toBe(false);
+    });
+
+    /**
+     * @case Non-canonical Origin shapes are rejected even when the host is loopback
+     * @preconditions Origin values with path, userinfo, query, or fragment components
+     * @expectedResult Resolver returns false; only canonical `scheme://host[:port]` Origins are accepted
+     */
+    test("rejects non-canonical Origin shapes (path, userinfo, query, fragment)", () => {
+      // Path appended -- RFC 6454 §7.1 says Origin has no path component
+      expect(
+        defaultLoopbackOriginResolver("http://localhost:3000/anything"),
+      ).toBe(false);
+      // Userinfo -- never present on a legitimate Origin
+      expect(
+        defaultLoopbackOriginResolver("http://user:pass@localhost:3000"),
+      ).toBe(false);
+      // Query and fragment -- never on a canonical Origin
+      expect(defaultLoopbackOriginResolver("http://localhost:3000?x=1")).toBe(
+        false,
+      );
+      expect(defaultLoopbackOriginResolver("http://localhost:3000#frag")).toBe(
+        false,
+      );
+    });
+
+    /**
+     * @case The literal string "null" Origin (sandboxed iframes, srcdoc) is rejected
+     * @preconditions Origin: "null"
+     * @expectedResult Resolver returns false; the literal "null" is treated as a sentinel, not parsed as a URL
+     */
+    test("rejects literal 'null' Origin", () => {
+      expect(defaultLoopbackOriginResolver("null")).toBe(false);
     });
   });
 
@@ -183,14 +216,20 @@ describe("MCP CORS helper", () => {
     });
 
     /**
-     * @case Non-allowed origins produce no Access-Control-* headers
+     * @case Non-allowed origins produce no Access-Control-* but still emit Vary: Origin
      * @preconditions Default (loopback-only) policy; Origin is a public domain
-     * @expectedResult Empty object; browser will block the response
+     * @expectedResult Vary: Origin present so shared caches do not serve a no-CORS variant to a loopback origin; no Access-Control-Allow-Origin
      */
-    test("rejects non-loopback origins under the default policy", () => {
+    test("rejects non-loopback origins but still emits Vary: Origin", () => {
       const cors = resolveCorsOptions(undefined);
-      expect(buildCorsHeaders(cors, "https://evil.example", false)).toEqual({});
-      expect(buildCorsHeaders(cors, "https://evil.example", true)).toEqual({});
+      const nonPreflight = buildCorsHeaders(
+        cors,
+        "https://evil.example",
+        false,
+      );
+      expect(nonPreflight).toEqual({ Vary: "Origin" });
+      const preflight = buildCorsHeaders(cors, "https://evil.example", true);
+      expect(preflight).toEqual({ Vary: "Origin" });
     });
 
     /**
@@ -260,6 +299,109 @@ describe("MCP CORS helper", () => {
       });
       const headers = buildCorsHeaders(cors, "https://app.example.com", false);
       expect(headers["Access-Control-Allow-Credentials"]).toBe("true");
+    });
+
+    /**
+     * @case A throwing user resolver fails closed rather than crashing the request
+     * @preconditions origin: () => { throw new Error("boom") }; any request Origin
+     * @expectedResult buildCorsHeaders treats the throw as "disallowed", returning only Vary: Origin -- no Allow-Origin
+     */
+    test("origin resolver that throws fails closed (returns Vary only)", () => {
+      const cors = resolveCorsOptions({
+        origin: () => {
+          throw new Error("boom");
+        },
+      });
+      const headers = buildCorsHeaders(cors, "http://localhost:6274", false);
+      expect(headers).toEqual({ Vary: "Origin" });
+    });
+  });
+
+  describe("applyCorsHeaders", () => {
+    /**
+     * Minimal fake of a Node ServerResponse that records setHeader/appendHeader calls.
+     */
+    function fakeRes(initial: Record<string, string | string[]> = {}) {
+      const single: Record<string, string> = {};
+      const lists: Record<string, string[]> = { ...initial };
+      for (const [k, v] of Object.entries(initial)) {
+        if (typeof v === "string") {
+          lists[k.toLowerCase()] = [v];
+        } else {
+          lists[k.toLowerCase()] = [...v];
+        }
+      }
+      return {
+        setHeader: (name: string, value: string) => {
+          single[name] = value;
+          lists[name.toLowerCase()] = [value];
+        },
+        appendHeader: (name: string, value: string) => {
+          const key = name.toLowerCase();
+          if (!lists[key]) lists[key] = [];
+          lists[key].push(value);
+        },
+        single,
+        lists,
+      };
+    }
+
+    /**
+     * @case applyCorsHeaders appends Vary so a pre-existing Vary value is preserved
+     * @preconditions Response already has `Vary: Accept-Encoding` from compression middleware; loopback request
+     * @expectedResult Both `Accept-Encoding` and `Origin` are present as Vary values; setHeader does not clobber the prior value
+     */
+    test("appendHeader preserves an existing Vary value", () => {
+      const cors = resolveCorsOptions(undefined);
+      const res = fakeRes({ Vary: "Accept-Encoding" });
+      applyCorsHeaders(
+        res as unknown as Parameters<typeof applyCorsHeaders>[0],
+        cors,
+        "http://localhost:6274",
+        false,
+      );
+      const vary = res.lists["vary"];
+      expect(vary).toBeDefined();
+      expect(vary).toContain("Accept-Encoding");
+      expect(vary).toContain("Origin");
+      expect(res.single["Access-Control-Allow-Origin"]).toBe(
+        "http://localhost:6274",
+      );
+    });
+
+    /**
+     * @case applyCorsHeaders is a no-op when CORS is disabled
+     * @preconditions resolveCorsOptions(false); any request Origin
+     * @expectedResult No setHeader or appendHeader calls leave traces on the response
+     */
+    test("no-op when CORS is disabled", () => {
+      const res = fakeRes();
+      applyCorsHeaders(
+        res as unknown as Parameters<typeof applyCorsHeaders>[0],
+        null,
+        "http://localhost:6274",
+        false,
+      );
+      expect(Object.keys(res.single)).toEqual([]);
+      expect(Object.keys(res.lists)).toEqual([]);
+    });
+
+    /**
+     * @case applyCorsHeaders still appends Vary when the request Origin is rejected (loopback default)
+     * @preconditions Default policy; non-loopback Origin
+     * @expectedResult Vary: Origin is appended; no Access-Control-Allow-Origin set
+     */
+    test("rejected origin still appends Vary: Origin", () => {
+      const cors = resolveCorsOptions(undefined);
+      const res = fakeRes();
+      applyCorsHeaders(
+        res as unknown as Parameters<typeof applyCorsHeaders>[0],
+        cors,
+        "https://evil.example",
+        false,
+      );
+      expect(res.lists["vary"]).toEqual(["Origin"]);
+      expect(res.single["Access-Control-Allow-Origin"]).toBeUndefined();
     });
   });
 });

--- a/packages/ai/test/mcp-plugin.bun.test.ts
+++ b/packages/ai/test/mcp-plugin.bun.test.ts
@@ -294,6 +294,50 @@ describe("MCP Plugin Integration", () => {
       });
       expect(typeof p.apply).toBe("function");
     });
+
+    /**
+     * @case Validation rejects an invalid cors.origin shape at plugin-apply time
+     * @preconditions transport: 'http', cors: { origin: 42 } cast through unknown to bypass TypeScript
+     * @expectedResult TypeError thrown by `validateMcpPluginOptions`, not deferred to server start; surfaces alongside `auth`/`port`/`host` shape errors
+     */
+    test("rejects invalid cors.origin shape at apply time", () => {
+      expect(() =>
+        mcpPlugin({
+          transport: "http",
+          cors: { origin: 42 as unknown as string },
+        }),
+      ).toThrow(/cors\.origin must be/);
+    });
+
+    /**
+     * @case `cors: false` and well-formed `cors.origin` shapes pass validation
+     * @preconditions transport: 'http' with cors: false, then cors: { origin: '*' | string | string[] | function }
+     * @expectedResult No throw for any of the four legal shapes
+     */
+    test("accepts well-formed cors shapes", () => {
+      expect(() => mcpPlugin({ transport: "http", cors: false })).not.toThrow();
+      expect(() =>
+        mcpPlugin({ transport: "http", cors: { origin: "*" } }),
+      ).not.toThrow();
+      expect(() =>
+        mcpPlugin({
+          transport: "http",
+          cors: { origin: "https://app.example.com" },
+        }),
+      ).not.toThrow();
+      expect(() =>
+        mcpPlugin({
+          transport: "http",
+          cors: { origin: ["https://a.example", "https://b.example"] },
+        }),
+      ).not.toThrow();
+      expect(() =>
+        mcpPlugin({
+          transport: "http",
+          cors: { origin: () => false },
+        }),
+      ).not.toThrow();
+    });
   });
 
   describe("stdio client config acceptance", () => {

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -221,6 +221,7 @@ describe("McpServer", () => {
         auth?: import("../src/mcp/types.ts").McpHttpAuthOptions;
         resource?: import("../src/mcp/types.ts").McpResourceOptions;
         title?: string;
+        cors?: false | import("../src/mcp/cors.ts").McpCorsOptions;
       } = {},
     ) {
       t = await testContext().routes(routes).store(MCP_STORE_KEY, true).build();
@@ -301,19 +302,24 @@ describe("McpServer", () => {
         });
       }
 
-      function get(path: string): Promise<{
+      function get(
+        path: string,
+        extraHeaders?: Record<string, string>,
+      ): Promise<{
         statusCode: number;
         body: string;
         headers: Record<string, string | string[] | undefined>;
       }> {
         return new Promise((resolve, reject) => {
+          const headers: Record<string, string> = { Connection: "close" };
+          if (extraHeaders) Object.assign(headers, extraHeaders);
           const req = http.request(
             {
               host: "127.0.0.1",
               port,
               path,
               method: "GET",
-              headers: { Connection: "close" },
+              headers,
             },
             (res) => {
               let data = "";
@@ -322,6 +328,44 @@ describe("McpServer", () => {
                 resolve({
                   statusCode: res.statusCode ?? 0,
                   body: data,
+                  headers: res.headers as Record<
+                    string,
+                    string | string[] | undefined
+                  >,
+                }),
+              );
+            },
+          );
+          req.on("error", reject);
+          req.end();
+        });
+      }
+
+      function options(
+        path: string,
+        extraHeaders?: Record<string, string>,
+      ): Promise<{
+        statusCode: number;
+        headers: Record<string, string | string[] | undefined>;
+      }> {
+        return new Promise((resolve, reject) => {
+          const headers: Record<string, string> = { Connection: "close" };
+          if (extraHeaders) Object.assign(headers, extraHeaders);
+          const req = http.request(
+            {
+              host: "127.0.0.1",
+              port,
+              path,
+              method: "OPTIONS",
+              headers,
+            },
+            (res) => {
+              res.on("data", () => {
+                /* drain */
+              });
+              res.on("end", () =>
+                resolve({
+                  statusCode: res.statusCode ?? 0,
                   headers: res.headers as Record<
                     string,
                     string | string[] | undefined
@@ -351,7 +395,7 @@ describe("McpServer", () => {
         return Array.isArray(sid) ? sid[0] : (sid as string);
       }
 
-      return { post, get, port, initSession };
+      return { post, get, options, port, initSession };
     }
 
     /**
@@ -1063,6 +1107,334 @@ describe("McpServer", () => {
         };
         expect(doc.bearer_methods_supported).toEqual(["header"]);
         expect(doc.resource).toBe("http://localhost:9999");
+      });
+    });
+
+    describe("CORS (validator mode)", () => {
+      const validPrincipal = {
+        kind: "custom" as const,
+        subject: "user-1",
+        scheme: "bearer" as const,
+      };
+      const LOOPBACK_ORIGIN = "http://localhost:6274";
+
+      /**
+       * @case OPTIONS preflight on /mcp from a loopback Origin returns 204 with allow headers
+       * @preconditions Default cors policy (loopback-only); request Origin is http://localhost:6274
+       * @expectedResult 204 status, Access-Control-Allow-Origin echoes the request Origin, Allow-Methods includes POST
+       */
+      test("OPTIONS /mcp preflight from loopback returns 204 with allow headers", async () => {
+        const { options } = await startHttpServer([]);
+        const res = await options("/mcp", { Origin: LOOPBACK_ORIGIN });
+        expect(res.statusCode).toBe(204);
+        expect(res.headers["access-control-allow-origin"]).toBe(
+          LOOPBACK_ORIGIN,
+        );
+        expect(res.headers["access-control-allow-methods"]).toContain("POST");
+        expect(res.headers["access-control-allow-methods"]).toContain(
+          "OPTIONS",
+        );
+        expect(res.headers["vary"]).toBe("Origin");
+      });
+
+      /**
+       * @case OPTIONS preflight on the metadata endpoint also returns 204 with allow headers
+       * @preconditions Default cors policy; request Origin is loopback
+       * @expectedResult 204 status with full preflight headers (mirrors /mcp)
+       */
+      test("OPTIONS /.well-known/oauth-protected-resource preflight returns 204", async () => {
+        const { options } = await startHttpServer([]);
+        const res = await options("/.well-known/oauth-protected-resource", {
+          Origin: LOOPBACK_ORIGIN,
+        });
+        expect(res.statusCode).toBe(204);
+        expect(res.headers["access-control-allow-origin"]).toBe(
+          LOOPBACK_ORIGIN,
+        );
+      });
+
+      /**
+       * @case GET metadata from a loopback Origin carries Access-Control-Allow-Origin
+       * @preconditions Default cors policy; GET /.well-known/oauth-protected-resource with loopback Origin
+       * @expectedResult 200 response; Allow-Origin reflects the request Origin; Vary: Origin present
+       */
+      test("GET metadata reflects loopback origin", async () => {
+        const { get } = await startHttpServer([]);
+        const res = await get("/.well-known/oauth-protected-resource", {
+          Origin: LOOPBACK_ORIGIN,
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.headers["access-control-allow-origin"]).toBe(
+          LOOPBACK_ORIGIN,
+        );
+        expect(res.headers["vary"]).toBe("Origin");
+      });
+
+      /**
+       * @case 401 response on /mcp carries CORS headers and exposes WWW-Authenticate
+       * @preconditions Auth validator configured; POST without Authorization from loopback Origin
+       * @expectedResult 401 status; Allow-Origin echoes Origin; Expose-Headers includes WWW-Authenticate (so browsers can read the RFC 9728 hint)
+       */
+      test("401 from /mcp carries CORS headers and exposes WWW-Authenticate", async () => {
+        const { post } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+        });
+        const res = await post(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: INIT_PARAMS,
+          }),
+          undefined,
+          { Origin: LOOPBACK_ORIGIN },
+        );
+        expect(res.statusCode).toBe(401);
+        expect(res.headers["access-control-allow-origin"]).toBe(
+          LOOPBACK_ORIGIN,
+        );
+        const expose = res.headers["access-control-expose-headers"];
+        const exposeStr = Array.isArray(expose) ? expose.join(", ") : expose;
+        expect(exposeStr).toBeDefined();
+        expect(exposeStr!.toLowerCase()).toContain("www-authenticate");
+      });
+
+      /**
+       * @case Non-loopback Origin gets no Access-Control-Allow-Origin under the default policy
+       * @preconditions Default cors policy; request Origin is https://evil.example
+       * @expectedResult Underlying response status is unchanged, but no Allow-Origin header is emitted (browser will block the response)
+       */
+      test("non-loopback origin is rejected by the default policy", async () => {
+        const { get } = await startHttpServer([]);
+        const res = await get("/.well-known/oauth-protected-resource", {
+          Origin: "https://evil.example",
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+      });
+
+      /**
+       * @case Server-to-server callers (no Origin header) are unaffected by CORS
+       * @preconditions Default cors policy; no Origin header on the request
+       * @expectedResult Response carries no Access-Control-* headers; caller is not gated by CORS
+       */
+      test("no Origin header means no CORS headers are emitted", async () => {
+        const { get } = await startHttpServer([]);
+        const res = await get("/.well-known/oauth-protected-resource");
+        expect(res.statusCode).toBe(200);
+        expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+      });
+
+      /**
+       * @case cors: false disables CORS entirely
+       * @preconditions cors: false; OPTIONS and GET requests with loopback Origin
+       * @expectedResult No Access-Control-* headers on any response; OPTIONS preflight still returns 204 but unsupported by browser
+       */
+      test("cors: false suppresses all CORS headers", async () => {
+        const { get, options } = await startHttpServer([], { cors: false });
+        const getRes = await get("/.well-known/oauth-protected-resource", {
+          Origin: LOOPBACK_ORIGIN,
+        });
+        expect(getRes.headers["access-control-allow-origin"]).toBeUndefined();
+        const optRes = await options("/mcp", { Origin: LOOPBACK_ORIGIN });
+        expect(optRes.statusCode).toBe(204);
+        expect(optRes.headers["access-control-allow-origin"]).toBeUndefined();
+      });
+
+      /**
+       * @case cors: { origin } restricts to the configured allowlist in production
+       * @preconditions cors: { origin: "https://app.example.com" }; requests with matching and non-matching Origin
+       * @expectedResult Matching Origin is reflected; non-matching Origin gets no Allow-Origin (browser blocks)
+       */
+      test("cors: { origin: '...' } restricts to the configured origin", async () => {
+        const { get } = await startHttpServer([], {
+          cors: { origin: "https://app.example.com" },
+        });
+        const matching = await get("/.well-known/oauth-protected-resource", {
+          Origin: "https://app.example.com",
+        });
+        expect(matching.headers["access-control-allow-origin"]).toBe(
+          "https://app.example.com",
+        );
+        const nonMatching = await get("/.well-known/oauth-protected-resource", {
+          Origin: "https://other.example",
+        });
+        expect(
+          nonMatching.headers["access-control-allow-origin"],
+        ).toBeUndefined();
+      });
+
+      /**
+       * @case cors: { origin: '*' } is fully permissive and skips Vary: Origin
+       * @preconditions cors: { origin: '*' }; any request Origin
+       * @expectedResult Allow-Origin: *; Vary header is NOT set (cache-friendly per CORS spec)
+       */
+      test("cors: { origin: '*' } reflects wildcard without Vary", async () => {
+        const { get } = await startHttpServer([], { cors: { origin: "*" } });
+        const res = await get("/.well-known/oauth-protected-resource", {
+          Origin: "https://anywhere.example",
+        });
+        expect(res.headers["access-control-allow-origin"]).toBe("*");
+        expect(res.headers["vary"]).toBeUndefined();
+      });
+
+      /**
+       * @case Custom exposeHeaders is additive with the WWW-Authenticate default
+       * @preconditions cors: { exposeHeaders: ['X-Request-Id'] }; 401 response from loopback Origin
+       * @expectedResult Expose-Headers includes both WWW-Authenticate and X-Request-Id
+       */
+      test("custom exposeHeaders is additive with WWW-Authenticate", async () => {
+        const { post } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+          cors: { exposeHeaders: ["X-Request-Id"] },
+        });
+        const res = await post(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: INIT_PARAMS,
+          }),
+          undefined,
+          { Origin: LOOPBACK_ORIGIN },
+        );
+        const expose = res.headers["access-control-expose-headers"];
+        const exposeStr = Array.isArray(expose) ? expose.join(", ") : expose;
+        expect(exposeStr!.toLowerCase()).toContain("www-authenticate");
+        expect(exposeStr).toContain("X-Request-Id");
+      });
+
+      /**
+       * @case Successful POST /mcp from loopback Origin carries CORS headers on the streamed response
+       * @preconditions Default cors policy; no auth; valid initialize call from loopback Origin
+       * @expectedResult Response is 200 (session established); Allow-Origin echoes Origin (set via setHeader before the SDK responds)
+       */
+      test("successful POST /mcp carries Access-Control-Allow-Origin", async () => {
+        const { post } = await startHttpServer([]);
+        const res = await post(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: INIT_PARAMS,
+          }),
+          undefined,
+          { Origin: LOOPBACK_ORIGIN },
+        );
+        expect(res.statusCode).toBe(200);
+        expect(res.headers["access-control-allow-origin"]).toBe(
+          LOOPBACK_ORIGIN,
+        );
+      });
+    });
+
+    describe("CORS (OAuth-proxy mode)", () => {
+      const LOOPBACK_ORIGIN = "http://localhost:6274";
+
+      async function buildOAuthAuth() {
+        const { oauth } = await import("../src/mcp/oauth.ts");
+        return oauth({
+          endpoints: {
+            authorizationUrl: "http://localhost:9999/authorize",
+            tokenUrl: "http://localhost:9999/token",
+          },
+          verify: async () => ({
+            kind: "oauth" as const,
+            scheme: "bearer" as const,
+            subject: "u",
+            clientId: "u",
+            expiresAt: Math.floor(Date.now() / 1000) + 60,
+          }),
+          client: async (clientId) => ({
+            client_id: clientId,
+            redirect_uris: ["http://localhost:3000/callback"],
+          }),
+        });
+      }
+
+      /**
+       * @case OAuth-proxy mode: OPTIONS preflight on /mcp returns 204 with CORS headers
+       * @preconditions oauth() auth with explicit resource.url; loopback Origin
+       * @expectedResult 204 with Allow-Origin reflecting Origin (covers the SDK-uncovered /mcp gap)
+       */
+      test("OPTIONS /mcp returns 204 with CORS headers in OAuth-proxy mode", async () => {
+        const auth = await buildOAuthAuth();
+        const { options } = await startHttpServer([], {
+          auth,
+          resource: { url: "http://localhost:9999" },
+        });
+        const res = await options("/mcp", { Origin: LOOPBACK_ORIGIN });
+        expect(res.statusCode).toBe(204);
+        expect(res.headers["access-control-allow-origin"]).toBe(
+          LOOPBACK_ORIGIN,
+        );
+      });
+
+      /**
+       * @case OAuth-proxy mode: 401 from /mcp carries Access-Control-Allow-Origin and exposes WWW-Authenticate
+       * @preconditions oauth() auth; POST /mcp with no Authorization from loopback Origin
+       * @expectedResult 401 with CORS headers so browsers can read the WWW-Authenticate hint and follow RFC 9728 discovery
+       */
+      test("401 from /mcp carries CORS headers in OAuth-proxy mode", async () => {
+        const auth = await buildOAuthAuth();
+        const { post } = await startHttpServer([], {
+          auth,
+          resource: { url: "http://localhost:9999" },
+        });
+        const res = await post(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: INIT_PARAMS,
+          }),
+          undefined,
+          { Origin: LOOPBACK_ORIGIN },
+        );
+        expect(res.statusCode).toBe(401);
+        expect(res.headers["access-control-allow-origin"]).toBe(
+          LOOPBACK_ORIGIN,
+        );
+        const expose = res.headers["access-control-expose-headers"];
+        const exposeStr = Array.isArray(expose) ? expose.join(", ") : expose;
+        expect(exposeStr).toBeDefined();
+        expect(exposeStr!.toLowerCase()).toContain("www-authenticate");
+      });
+
+      /**
+       * @case OAuth-proxy mode: GET metadata carries CORS headers
+       * @preconditions oauth() auth; GET /.well-known/oauth-protected-resource from loopback
+       * @expectedResult Allow-Origin reflects the loopback Origin
+       */
+      test("GET metadata reflects loopback Origin in OAuth-proxy mode", async () => {
+        const auth = await buildOAuthAuth();
+        const { get } = await startHttpServer([], {
+          auth,
+          resource: { url: "http://localhost:9999" },
+        });
+        const res = await get("/.well-known/oauth-protected-resource", {
+          Origin: LOOPBACK_ORIGIN,
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.headers["access-control-allow-origin"]).toBe(
+          LOOPBACK_ORIGIN,
+        );
+      });
+
+      /**
+       * @case OAuth-proxy mode: non-loopback Origin is rejected by the default policy
+       * @preconditions oauth() auth; OPTIONS on /mcp with a public Origin
+       * @expectedResult 204 returned (CORS does not 4xx), but no Allow-Origin header is emitted
+       */
+      test("non-loopback Origin gets no Allow-Origin in OAuth-proxy mode", async () => {
+        const auth = await buildOAuthAuth();
+        const { options } = await startHttpServer([], {
+          auth,
+          resource: { url: "http://localhost:9999" },
+        });
+        const res = await options("/mcp", { Origin: "https://evil.example" });
+        expect(res.statusCode).toBe(204);
+        expect(res.headers["access-control-allow-origin"]).toBeUndefined();
       });
     });
 

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -1226,18 +1226,23 @@ describe("McpServer", () => {
       });
 
       /**
-       * @case cors: false disables CORS entirely
+       * @case cors: false disables CORS entirely and does NOT hijack OPTIONS preflight
        * @preconditions cors: false; OPTIONS and GET requests with loopback Origin
-       * @expectedResult No Access-Control-* headers on any response; OPTIONS preflight still returns 204 but unsupported by browser
+       * @expectedResult GET response carries no Access-Control-* headers. OPTIONS preflight is NOT answered with 204 -- the request falls through to the route handler (the framework's contract is that a fronting proxy/CDN owns CORS, so we must let the preflight through rather than swallowing it).
        */
-      test("cors: false suppresses all CORS headers", async () => {
+      test("cors: false suppresses CORS headers and defers OPTIONS to the proxy", async () => {
         const { get, options } = await startHttpServer([], { cors: false });
         const getRes = await get("/.well-known/oauth-protected-resource", {
           Origin: LOOPBACK_ORIGIN,
         });
+        expect(getRes.statusCode).toBe(200);
         expect(getRes.headers["access-control-allow-origin"]).toBeUndefined();
+        expect(getRes.headers["vary"]).toBeUndefined();
+
         const optRes = await options("/mcp", { Origin: LOOPBACK_ORIGIN });
-        expect(optRes.statusCode).toBe(204);
+        // SDK transport rejects OPTIONS on /mcp with 405; the important
+        // contract is that we did NOT synthesize a 204 ourselves.
+        expect(optRes.statusCode).not.toBe(204);
         expect(optRes.headers["access-control-allow-origin"]).toBeUndefined();
       });
 
@@ -1325,6 +1330,58 @@ describe("McpServer", () => {
         expect(res.headers["access-control-allow-origin"]).toBe(
           LOOPBACK_ORIGIN,
         );
+        // Vary: Origin must be present so shared caches do not serve a
+        // non-loopback response back to this origin.
+        const vary = res.headers["vary"];
+        const varyStr = Array.isArray(vary) ? vary.join(", ") : vary;
+        expect(varyStr).toContain("Origin");
+      });
+
+      /**
+       * @case POST /mcp from a non-loopback Origin under the default policy gets no Access-Control-Allow-Origin
+       * @preconditions Default cors policy; valid initialize call from https://evil.example
+       * @expectedResult Response status is 200 (the JSON-RPC request itself succeeds), but the browser-readability gate (Allow-Origin) is absent; Vary: Origin is still emitted so caches stay correct
+       */
+      test("non-loopback POST /mcp gets no Allow-Origin (default policy)", async () => {
+        const { post } = await startHttpServer([]);
+        const res = await post(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: INIT_PARAMS,
+          }),
+          undefined,
+          { Origin: "https://evil.example" },
+        );
+        expect(res.statusCode).toBe(200);
+        expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+        const vary = res.headers["vary"];
+        const varyStr = Array.isArray(vary) ? vary.join(", ") : vary;
+        expect(varyStr).toContain("Origin");
+      });
+
+      /**
+       * @case 401 response from /mcp on a non-loopback Origin gets no Allow-Origin and no exposed WWW-Authenticate
+       * @preconditions Auth validator configured; POST without Authorization from https://evil.example
+       * @expectedResult 401 status; no Access-Control-Allow-Origin; the WWW-Authenticate header is present on the wire but unreadable to a cross-origin browser caller (correct behaviour: only allowlisted origins can read the RFC 9728 hint)
+       */
+      test("non-loopback 401 from /mcp gets no Allow-Origin", async () => {
+        const { post } = await startHttpServer([], {
+          auth: { validator: () => validPrincipal },
+        });
+        const res = await post(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: INIT_PARAMS,
+          }),
+          undefined,
+          { Origin: "https://evil.example" },
+        );
+        expect(res.statusCode).toBe(401);
+        expect(res.headers["access-control-allow-origin"]).toBeUndefined();
       });
     });
 

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -1284,32 +1284,6 @@ describe("McpServer", () => {
       });
 
       /**
-       * @case Custom exposeHeaders is additive with the WWW-Authenticate default
-       * @preconditions cors: { exposeHeaders: ['X-Request-Id'] }; 401 response from loopback Origin
-       * @expectedResult Expose-Headers includes both WWW-Authenticate and X-Request-Id
-       */
-      test("custom exposeHeaders is additive with WWW-Authenticate", async () => {
-        const { post } = await startHttpServer([], {
-          auth: { validator: () => validPrincipal },
-          cors: { exposeHeaders: ["X-Request-Id"] },
-        });
-        const res = await post(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1,
-            method: "initialize",
-            params: INIT_PARAMS,
-          }),
-          undefined,
-          { Origin: LOOPBACK_ORIGIN },
-        );
-        const expose = res.headers["access-control-expose-headers"];
-        const exposeStr = Array.isArray(expose) ? expose.join(", ") : expose;
-        expect(exposeStr!.toLowerCase()).toContain("www-authenticate");
-        expect(exposeStr).toContain("X-Request-Id");
-      });
-
-      /**
        * @case Successful POST /mcp from loopback Origin carries CORS headers on the streamed response
        * @preconditions Default cors policy; no auth; valid initialize call from loopback Origin
        * @expectedResult Response is 200 (session established); Allow-Origin echoes Origin (set via setHeader before the SDK responds)

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -1312,6 +1312,66 @@ describe("McpServer", () => {
       });
 
       /**
+       * @case `initialize` response exposes Mcp-Session-Id so a browser-side follow-up can echo it
+       * @preconditions Default cors policy; loopback Origin; the SDK runs in stateful mode (sessionIdGenerator set in createSession), so Mcp-Session-Id is emitted on `initialize`
+       * @expectedResult Access-Control-Expose-Headers contains "Mcp-Session-Id" (and "WWW-Authenticate", and "Last-Event-ID"). Without this, browser MCP clients read Mcp-Session-Id as undefined and the second request fails with 400 from the SDK transport.
+       */
+      test("initialize exposes Mcp-Session-Id for browser clients", async () => {
+        const { post } = await startHttpServer([]);
+        const res = await post(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: INIT_PARAMS,
+          }),
+          undefined,
+          { Origin: LOOPBACK_ORIGIN },
+        );
+        expect(res.statusCode).toBe(200);
+        // Sanity: the SDK actually emitted a session id.
+        expect(res.headers["mcp-session-id"]).toBeDefined();
+        // And the CORS exposure listing tells the browser it can read it.
+        const expose = res.headers["access-control-expose-headers"];
+        const exposeStr = Array.isArray(expose) ? expose.join(", ") : expose;
+        expect(exposeStr).toBeDefined();
+        expect(exposeStr).toContain("Mcp-Session-Id");
+        expect(exposeStr!.toLowerCase()).toContain("www-authenticate");
+        expect(exposeStr).toContain("Last-Event-ID");
+      });
+
+      /**
+       * @case Two-request flow: a follow-up tools/list with the echoed Mcp-Session-Id succeeds with CORS headers intact
+       * @preconditions Default cors policy; loopback Origin; valid initialize then a subsequent tools/list with the captured Mcp-Session-Id
+       * @expectedResult Both responses are 200; the second response also carries Access-Control-Allow-Origin -- proving the CORS contract holds across the stateful session lifecycle, not just on initialize
+       */
+      test("two-step session: tools/list after initialize keeps CORS headers", async () => {
+        const { post, initSession } = await startHttpServer([
+          craft()
+            .id("two-step-tool")
+            .description("Tool for the two-step CORS test")
+            .from(mcp())
+            .to(noop()),
+        ]);
+        const sessionId = await initSession({ Origin: LOOPBACK_ORIGIN });
+        expect(sessionId).toBeDefined();
+        const res = await post(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            method: "tools/list",
+            params: {},
+          }),
+          sessionId,
+          { Origin: LOOPBACK_ORIGIN },
+        );
+        expect(res.statusCode).toBe(200);
+        expect(res.headers["access-control-allow-origin"]).toBe(
+          LOOPBACK_ORIGIN,
+        );
+      });
+
+      /**
        * @case POST /mcp from a non-loopback Origin under the default policy gets no Access-Control-Allow-Origin
        * @preconditions Default cors policy; valid initialize call from https://evil.example
        * @expectedResult Response status is 200 (the JSON-RPC request itself succeeds), but the browser-readability gate (Allow-Origin) is absent; Vary: Origin is still emitted so caches stay correct

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -1135,6 +1135,12 @@ describe("McpServer", () => {
           "OPTIONS",
         );
         expect(res.headers["vary"]).toBe("Origin");
+        // Chrome Private Network Access opt-in so public->loopback browser
+        // clients (e.g. hosted Inspector tunnelled to a local MCP server) are
+        // not blocked at the PNA preflight gate.
+        expect(res.headers["access-control-allow-private-network"]).toBe(
+          "true",
+        );
       });
 
       /**


### PR DESCRIPTION
## Summary

Adds CORS (Cross-Origin Resource Sharing) support to the MCP HTTP transport, enabling browser-based MCP clients (MCP Inspector UI, Claude.ai custom connectors, web-hosted Claude Desktop) to read responses from the `/mcp` endpoint and RFC 9728 metadata document.

## Key Changes

- **New `cors.ts` module** (`packages/ai/src/mcp/cors.ts`): Core CORS logic with configurable origin policies
  - `defaultLoopbackOriginResolver`: Default policy that reflects loopback origins (`localhost`, `127.0.0.1`, `[::1]`) and rejects non-loopback
  - `resolveCorsOptions`: Normalizes user config (`false`, `undefined`, or `McpCorsOptions`) into an internal resolver shape
  - `buildCorsHeaders`: Generates response headers (`Access-Control-Allow-Origin`, `Vary`, `Access-Control-Expose-Headers`, etc.) based on request origin and policy
  - `applyCorsHeaders`: Applies headers to Node `ServerResponse`, preserving existing `Vary` values via `appendHeader`
  - Framework-controlled constants: `Allow-Methods` (GET, POST, OPTIONS), `Allow-Headers` (*), `Expose-Headers` (WWW-Authenticate, Mcp-Session-Id, Last-Event-ID)

- **Updated `McpPluginOptions` type** (`packages/ai/src/mcp/types.ts`):
  - New optional `cors` field: `false | McpCorsOptions | undefined`
  - Supports four origin shapes: `"*"` (wildcard), `string` (exact match), `string[]` (allowlist), or custom `McpCorsOriginResolver` function
  - Defaults to loopback-only when omitted (production-safe by construction)

- **Integration in `McpServer`** (`packages/ai/src/mcp/server.ts`):
  - Resolves CORS config at server startup via `resolveCorsOptions`
  - Handles OPTIONS preflight requests on owned paths (`/mcp`, `/.well-known/oauth-protected-resource`) with 204 response when `cors !== null`
  - Applies CORS headers to all responses via `applyCorsHeaders` before SDK processes the request
  - Defers to proxy/CDN when user sets `cors: false` (does not synthesize preflight responses)

- **Validation** (`packages/ai/src/mcp/validate-options.ts`):
  - Validates `cors.origin` shape at plugin-apply time (alongside `auth`, `port`, `host` validation)
  - Rejects invalid shapes (numbers, objects, etc.) with `TypeError`

- **Comprehensive test coverage** (`packages/ai/test/mcp-cors.bun.test.ts`):
  - Unit tests for `defaultLoopbackOriginResolver`, `resolveCorsOptions`, `buildCorsHeaders`, `applyCorsHeaders`
  - Tests for all origin shapes (wildcard, string, array, function)
  - Edge cases: malformed origins, non-canonical shapes, literal "null", throwing resolvers

- **Integration tests** (`packages/ai/test/mcp-server.bun.test.ts`):
  - New `options()` helper to send OPTIONS preflight requests
  - 15+ test cases covering preflight responses, loopback/non-loopback origins, auth 401 responses, stateful session flow, and `cors: false` behavior
  - Validates that `Mcp-Session-Id` and `WWW-Authenticate` are exposed for browser clients

- **Documentation** (`apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md`):
  - New "CORS" section explaining the default loopback-only policy, configuration options, and use cases
  - Examples for `cors: false`, `cors: { origin: "..." }`, and `cors: { origin: [...] }`

- **Type exports** (`packages/ai/src/mcp/index.ts`):
  - Exported `McpCorsOptions` and `McpCorsOri

https://claude.ai/code/session_012ZS3e165vD7pZDTMdEWSGe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CORS to the MCP HTTP transport with a loopback-only default, so browser clients can read responses from `/mcp` and the RFC 9728 metadata. Also adds Chrome PNA preflight opt‑in to avoid public→local blocks during testing.

- **New Features**
  - New CORS module and `cors` option on `mcpPlugin` (`false | { origin: "*" | string | string[] | (origin) => string | false }`); defaults to loopback-only.
  - Applies to `/mcp` and `/.well-known/oauth-protected-resource`; answers OPTIONS with 204, always adds `Vary: Origin` for non‑wildcard policies (including rejected origins), and emits `Access-Control-Allow-Private-Network: true` on preflights.
  - Exposes `WWW-Authenticate`, `Mcp-Session-Id`, and `Last-Event-ID` so browser clients can follow RFC 9728 hints, maintain sessions, and resume SSE; resolver errors fail closed.
  - `cors: false` disables framework CORS and does not synthesize preflight; OAuth-proxy mode keeps SDK CORS for its OAuth endpoints while our policy covers `/mcp` and the protected-resource metadata. Docs and security standards updated.

- **Migration**
  - For non-loopback browser clients, set `cors: { origin: "https://your-app.example" }` (or an array/function). Use `cors: { origin: "*" }` only as a last resort.
  - If a proxy/CDN owns CORS, set `cors: false`.
  - Server-to-server callers (no `Origin` header) are unaffected.

<sup>Written for commit 670359beb48c00707b3ab4cf792d997ad307ecce. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/329?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

