### PR TITLE
Agent tools: resolve MCP refs and tag-filter MCP tools

### DIFF
--- a/.standards/security.md
+++ b/.standards/security.md
@@ -94,3 +94,28 @@ Authoritative rules for authentication, authorization, principal propagation, an
 - **HTTP transport boundary** (`startHttpWithValidator` / `startHttpWithOAuth`): serves RFC 9728 metadata; emits 401 with `resource_metadata`.
 
 Each boundary is the *only* place that handles its class of error (does not re-throw). Crossing a boundary without logging duplicates entries; not logging at the boundary loses the failure entirely.
+
+## 11. Agent -> MCP auth boundary
+
+When an agent calls an MCP tool via `tools(["mcp_<client>:<tool>"])`, the
+agent runtime does NOT forward `FnHandlerContext.principal` (or the bearer it
+came from) to the MCP server. The MCP server is reached using the static
+credentials registered on `defineConfig.mcp({ clients: { name: { auth } } })`.
+
+This is intentional. Two trust boundaries:
+
+- **Principal authenticates the caller into Routecraft.** It identifies the
+  user / service that triggered the route or agent. Used by `.authorize()`,
+  guards, and downstream `directTool` dispatches that stay inside the
+  in-process trust zone.
+- **MCP `auth` authenticates the Routecraft -> MCP hop.** It identifies the
+  Routecraft instance to the remote MCP server. The MCP server has its own
+  authorisation model; mixing the routecraft principal into the MCP credential
+  conflates two policies.
+
+If an agent needs to thread user-specific data into an MCP tool call (e.g.
+"only fetch documents for tenant X"), do it as a regular tool argument: the
+agent can read `ctx.principal` in a guard or in its own handler and put a
+`tenantId` field into the MCP call's input. The MCP server then enforces
+that argument against its own policy. Never repurpose a credential field as
+a per-user parameter; never reuse a per-user bearer as an MCP credential.

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -587,7 +587,7 @@ Flat array of items. Each item is one of:
 
 - **Bare string**: name lookup. Plain ids resolve against the fn registry; `direct_*` falls back to the direct registry via `directTool`; `mcp_<client>:<tool>` resolves against `MCP_TOOL_REGISTRY` (populated by `defineConfig.mcp` / `mcpPlugin({ clients })`), and `mcp_<client>:*` expands at dispatch time to every tool the named client exposed. `agent_*` is reserved for sub-agent tools (follow-up story) and currently throws a clear "not yet supported" error.
 - **`{ name, guard?, description? }`**: same name lookup, with optional per-binding overrides. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct. The `description` override applies only to this binding for fn-style names. MCP references reject `description` (the MCP server is the source of truth for description and schema; do not override).
-- **`{ tagged, from?, guard? }`**: selects every fn / route / MCP tool whose tags overlap the requested set (single tag or array; OR semantics across the array). `from?: string` scopes the walk to a single source — today `from: "mcp_<client>"` restricts the selection to one MCP client. Optional guard applies to every match. Tag-zero-match throws RC5003 so a misconfigured selector cannot silently strip every tool from an agent.
+- **`{ tagged, from?, guard? }`**: selects every fn / route / MCP tool whose tags overlap the requested set (single tag or array; OR semantics across the array). `from?: string` scopes the walk to a single source; today `from: "mcp_<client>"` restricts the selection to one MCP client. Optional guard applies to every match. Tag-zero-match throws RC5003 so a misconfigured selector cannot silently strip every tool from an agent.
 
 MCP tools are auto-tagged at registration from each tool's MCP annotations: `readOnlyHint → "read-only"`, `destructiveHint → "destructive"`, `idempotentHint → "idempotent"`, `openWorldHint → "open-world"`. That means `{ tagged: "read-only" }` matches fns, routes, AND MCP tools out of the box.
 
@@ -629,7 +629,7 @@ Resolution rules:
 | `directTool(routeId, overrides?)` | Adapt a registered direct route as a fn. Pulls description, input schema, and tags from the route's discovery bundle by default; `overrides` can replace any of those. |
 | `defaultFns` | A small starter set (`currentTime`, `randomUuid`) tagged `read-only`/`idempotent`. Spread into your `functions:` config. |
 
-MCP tools are NOT exposed via a builder. Use the `mcp_<client>:<tool>` / `mcp_<client>:*` grammar inside `tools([...])` instead — the registry populated by `defineConfig.mcp` is the source of truth.
+MCP tools are NOT exposed via a builder. Use the `mcp_<client>:<tool>` / `mcp_<client>:*` grammar inside `tools([...])` instead; the registry populated by `defineConfig.mcp` is the source of truth.
 
 #### Tags
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -585,25 +585,51 @@ agentPlugin({
 
 Flat array of items. Each item is one of:
 
-- **Bare string**: name lookup. Plain ids resolve against the fn registry; `direct_*` falls back to the direct registry via `directTool`. `agent_*` and `mcp_*` are reserved for future stories and currently throw a clear "not yet supported" error.
-- **`{ name, guard?, description? }`**: same name lookup, with optional per-binding overrides. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct. The `description` override applies only to this binding (the registry entry stays the source of truth, so other agents binding the same fn still see the canonical description). Use it when an agent's calling context calls for a different framing of the tool than the registered description provides; descriptions affect LLM tool-selection accuracy noticeably.
-- **`{ tagged, guard? }`**: selects every fn / route whose tags overlap the requested set (single tag or array). Optional guard applies to every match. Tag-zero-match contributes nothing without throwing. No description override on the tagged form: applying a single description to N matched tools is almost always wrong.
+- **Bare string**: name lookup. Plain ids resolve against the fn registry; `direct_*` falls back to the direct registry via `directTool`; `mcp_<client>:<tool>` resolves against `MCP_TOOL_REGISTRY` (populated by `defineConfig.mcp` / `mcpPlugin({ clients })`), and `mcp_<client>:*` expands at dispatch time to every tool the named client exposed. `agent_*` is reserved for sub-agent tools (follow-up story) and currently throws a clear "not yet supported" error.
+- **`{ name, guard?, description? }`**: same name lookup, with optional per-binding overrides. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct. The `description` override applies only to this binding for fn-style names. MCP references reject `description` (the MCP server is the source of truth for description and schema; do not override).
+- **`{ tagged, from?, guard? }`**: selects every fn / route / MCP tool whose tags overlap the requested set (single tag or array; OR semantics across the array). `from?: string` scopes the walk to a single source — today `from: "mcp_<client>"` restricts the selection to one MCP client. Optional guard applies to every match. Tag-zero-match throws RC5003 so a misconfigured selector cannot silently strip every tool from an agent.
+
+MCP tools are auto-tagged at registration from each tool's MCP annotations: `readOnlyHint → "read-only"`, `destructiveHint → "destructive"`, `idempotentHint → "idempotent"`, `openWorldHint → "open-world"`. That means `{ tagged: "read-only" }` matches fns, routes, AND MCP tools out of the box.
+
+Examples:
+
+```ts
+agent({
+  tools: tools([
+    'currentTime',                                  // fn
+    'direct_orders/fetch',                          // direct route
+    'mcp_Nuclino:list_teams',                       // one MCP tool
+    'mcp_Stripe:*',                                 // all tools from one MCP client
+    { tagged: 'read-only' },                        // cross-cutting tag filter
+    { tagged: 'destructive', from: 'mcp_Nuclino' }, // tag filter scoped to one MCP client
+    {
+      name: 'mcp_Nuclino:get_item',
+      guard: (input, ctx) => {
+        if (!ctx.principal?.scopes?.includes('nuclino.read')) {
+          throw new Error('missing nuclino.read scope');
+        }
+      },
+    },
+  ]),
+});
+```
 
 Resolution rules:
 
 - Final list deduplicated by tool name.
 - Explicit refs always win over tag-selector matches, regardless of position in the list.
 - A `directTool(routeId)` fn-registry wrapper supersedes the same direct route surfaced via the prefix convention.
-- `description` is the only override permitted at the use site, and only on the explicit `{ name }` form. Input schema, tags, and any other registration-time fields are not overridable here. Register a separate fn with `directTool(routeId, { input, tags })` if you need a fundamentally different view.
+- `description` is the only override permitted at the use site, and only on the explicit `{ name }` form for fn-style names. Input schema, tags, and any other registration-time fields are not overridable here. Register a separate fn with `directTool(routeId, { input, tags })` if you need a fundamentally different view. MCP refs reject `description` outright.
+- The agent does NOT forward `FnHandlerContext.principal` to the MCP server. Principal authenticates the caller into Routecraft; MCP `auth` (configured on the client) authenticates the Routecraft → MCP hop. To thread user-specific data into an MCP call, put it in the tool's input as a regular argument and let the MCP server enforce its own policy. See `.standards/security.md` §11.
 
 #### Builders
 
 | Builder | Use |
 |---|---|
 | `directTool(routeId, overrides?)` | Adapt a registered direct route as a fn. Pulls description, input schema, and tags from the route's discovery bundle by default; `overrides` can replace any of those. |
-| `agentTool(agentId)` | Reserved for sub-agent tools (follow-up story). Currently a stub that throws a clear "not yet supported" error. |
-| `mcpTool(server, tool)` | Reserved for MCP tools (follow-up story). Currently a stub. |
 | `defaultFns` | A small starter set (`currentTime`, `randomUuid`) tagged `read-only`/`idempotent`. Spread into your `functions:` config. |
+
+MCP tools are NOT exposed via a builder. Use the `mcp_<client>:<tool>` / `mcp_<client>:*` grammar inside `tools([...])` instead — the registry populated by `defineConfig.mcp` is the source of truth.
 
 #### Tags
 

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -30,7 +30,7 @@ export interface AgentPluginOptions {
    * in follow-up stories). Keyed by the fn id; each entry is either an
    * eagerly-authored `FnOptions` (description, input, handler) or a
    * deferred descriptor emitted by a builder helper such as
-   * `directTool(routeId)` / `agentTool(agentId)` / `mcpTool(server, tool)`.
+   * `directTool(routeId)` / `agentTool(agentId)`.
    * Deferred descriptors resolve at agent dispatch time when all
    * registries are populated.
    *

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -30,7 +30,7 @@ export interface AgentPluginOptions {
    * in follow-up stories). Keyed by the fn id; each entry is either an
    * eagerly-authored `FnOptions` (description, input, handler) or a
    * deferred descriptor emitted by a builder helper such as
-   * `directTool(routeId)` / `agentTool(agentId)`.
+   * `directTool(routeId)`.
    * Deferred descriptors resolve at agent dispatch time when all
    * registries are populated.
    *

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -281,36 +281,6 @@ async function dispatchDirect<TIn>(
 }
 
 /**
- * Wrap a registered agent as a fn-shaped tool. Lands in story F (sub-
- * agents). Available now as a builder so the prefix auto-resolution
- * path in `tools(...)` can recognise `agent_*` and emit a clear "not
- * supported yet" error rather than treating the name as an unknown fn.
- *
- * @experimental
- */
-export function agentTool(
-  agentId: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- shape mirrors the future story F signature
-  _overrides?: never,
-): DeferredFn {
-  if (typeof agentId !== "string" || agentId.trim() === "") {
-    throw rcError("RC5003", undefined, {
-      message: `agentTool: agentId must be a non-empty string.`,
-    });
-  }
-  return {
-    [DEFERRED_FN_BRAND]: true,
-    kind: "agent",
-    targetId: agentId,
-    resolve(_ctx, fnId): FnOptions {
-      throw rcError("RC5003", undefined, {
-        message: `agentTool("${agentId}") (referenced as fn "${fnId}") is not yet supported. Sub-agent tools land in a follow-up story.`,
-      });
-    },
-  };
-}
-
-/**
  * Small starter set of generic, broadly useful fns. Spread into your
  * `agentPlugin({ functions: { ... } })` config to give every agent in
  * the context the basics for free.

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -311,42 +311,6 @@ export function agentTool(
 }
 
 /**
- * Wrap an MCP tool as a fn-shaped tool. Lands in story E (MCP tools).
- * Available now as a builder so the prefix auto-resolution path in
- * `tools(...)` can recognise `mcp_*` and emit a clear "not supported
- * yet" error.
- *
- * @experimental
- */
-export function mcpTool(
-  serverId: string,
-  toolName: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- shape mirrors the future story E signature
-  _overrides?: never,
-): DeferredFn {
-  if (typeof serverId !== "string" || serverId.trim() === "") {
-    throw rcError("RC5003", undefined, {
-      message: `mcpTool: serverId must be a non-empty string.`,
-    });
-  }
-  if (typeof toolName !== "string" || toolName.trim() === "") {
-    throw rcError("RC5003", undefined, {
-      message: `mcpTool: toolName must be a non-empty string.`,
-    });
-  }
-  return {
-    [DEFERRED_FN_BRAND]: true,
-    kind: "mcp",
-    targetId: `${serverId}:${toolName}`,
-    resolve(_ctx, fnId): FnOptions {
-      throw rcError("RC5003", undefined, {
-        message: `mcpTool("${serverId}", "${toolName}") (referenced as fn "${fnId}") is not yet supported. MCP tools land in a follow-up story.`,
-      });
-    },
-  };
-}
-
-/**
  * Small starter set of generic, broadly useful fns. Spread into your
  * `agentPlugin({ functions: { ... } })` config to give every agent in
  * the context the basics for free.

--- a/packages/ai/src/agent/tools/index.ts
+++ b/packages/ai/src/agent/tools/index.ts
@@ -1,5 +1,4 @@
 export {
-  agentTool,
   defaultFns,
   directTool,
   type ToolBuilderOverrides,

--- a/packages/ai/src/agent/tools/index.ts
+++ b/packages/ai/src/agent/tools/index.ts
@@ -2,7 +2,6 @@ export {
   agentTool,
   defaultFns,
   directTool,
-  mcpTool,
   type ToolBuilderOverrides,
 } from "./builders.ts";
 export {

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -174,7 +174,7 @@ export function tools(items: ToolsItem[]): ToolSelection {
       // Phase 1: explicit refs (bare strings + { name, guard }).
       for (const item of items) {
         if (typeof item === "string") {
-          if (item.startsWith("mcp_")) {
+          if (isMcpRefName(item)) {
             for (const tool of resolveMcpRefs(ctx, item, undefined)) {
               explicit.set(tool.name, tool);
             }
@@ -204,7 +204,7 @@ export function tools(items: ToolsItem[]): ToolSelection {
               message: `tools(): { name: "${item.name}", description } must be a non-empty string when present.`,
             });
           }
-          if (item.name.startsWith("mcp_")) {
+          if (isMcpRefName(item.name)) {
             if (item.description !== undefined) {
               throw rcError("RC5003", undefined, {
                 message: `tools(): { name: "${item.name}", description } is not supported for MCP tools. The MCP server is the source of truth for description and schema; do not override.`,
@@ -279,14 +279,11 @@ function resolveByName(
       message: `tools(): "${name}" looks like an agent reference. Sub-agent tools land in a follow-up story.`,
     });
   }
-  if (name.startsWith("mcp_")) {
-    // MCP refs can expand to multiple tools (wildcard) so they go
-    // through a separate path in Phase 1; reaching this branch from
-    // resolveByName means the caller forgot to special-case them.
-    throw rcError("RC5003", undefined, {
-      message: `tools(): "${name}" must be resolved via resolveMcpRefs; this is a bug in the agent tools pipeline.`,
-    });
-  }
+  // `mcp_<client>:<tool>` refs are handled by Phase 1 before this
+  // function is called (see `isMcpRefName`). A plain `mcp_*` name that
+  // arrives here is a fn id that just happens to share the prefix; let
+  // it fall through to the fn-registry / direct-registry walk above
+  // and the unknown-tool error below.
   if (name.startsWith("direct_")) {
     const routeId = name.slice("direct_".length);
     if (routeId === "") {
@@ -335,6 +332,23 @@ function toResolvedTool(
     ...(guard ? { guard } : {}),
     handler: fn.handler as FnOptions["handler"],
   };
+}
+
+/**
+ * Recognise an MCP tool reference. The grammar is
+ * `mcp_<client>:<tool>` (or `mcp_<client>:*` for a wildcard) — so a
+ * legit MCP ref always carries a `:` somewhere after the `mcp_`
+ * prefix and before the end. Without this guard, a plain fn id like
+ * `mcp_healthcheck` would be hijacked by the MCP path and throw a
+ * grammar error instead of resolving via the fn registry.
+ *
+ * @internal
+ */
+function isMcpRefName(name: string): boolean {
+  if (!name.startsWith("mcp_")) return false;
+  const rest = name.slice("mcp_".length);
+  const colon = rest.indexOf(":");
+  return colon > 0 && colon < rest.length - 1;
 }
 
 /**

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -79,8 +79,9 @@ export interface ToolSelection {
   /**
    * Resolve the selection against the live context. Throws RC5003 on
    * any unresolvable explicit reference (unknown name, deferred
-   * resolution failure). Tag selectors that match nothing contribute
-   * zero tools and never throw.
+   * resolution failure) AND on tag selectors that match zero tools,
+   * so a misconfigured selector cannot silently strip every tool from
+   * an agent.
    */
   readonly resolve: (ctx: CraftContext) => ResolvedTool[];
 }
@@ -236,12 +237,11 @@ export function tools(items: ToolsItem[]): ToolSelection {
         if (typeof item === "object" && item !== null && "tagged" in item) {
           const wanted = normalizeTags(item.tagged);
           if (wanted.length === 0) continue;
-          const from = normalizeFrom(item.from);
-          const matches = resolveByTags(ctx, wanted, item.guard, from);
+          const matches = resolveByTags(ctx, wanted, item.guard, item.from);
           if (matches.length === 0) {
             throw rcError("RC5003", undefined, {
-              message: from
-                ? `tools(): tagged selector matched no tools (tagged: ${formatTags(wanted)}, from: "${from}").`
+              message: item.from
+                ? `tools(): tagged selector matched no tools (tagged: ${formatTags(wanted)}, from: "${item.from}").`
                 : `tools(): tagged selector matched no tools (tagged: ${formatTags(wanted)}).`,
             });
           }
@@ -380,9 +380,7 @@ function resolveMcpRefs(
       message: `tools(): MCP reference "${ref}" must use the form "mcp_<client>:<tool>" or "mcp_<client>:*"; got empty client or tool segment.`,
     });
   }
-  const registry = ctx.getStore(
-    MCP_TOOL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-  ) as McpToolRegistry | undefined;
+  const registry = ctx.getStore(MCP_TOOL_REGISTRY);
   if (!registry) {
     throw rcError("RC5003", undefined, {
       message: `tools(): MCP reference "${ref}" but no MCP_TOOL_REGISTRY is present. Install mcpPlugin (defineConfig.mcp) so external clients populate the registry.`,
@@ -429,6 +427,17 @@ function resolveMcpRefs(
  * resolution time and dispatches via `dispatchMcpCall`, so a tool
  * call goes through the same stdio / HTTP plumbing as the `mcp(...)`
  * destination adapter.
+ *
+ * Auth boundary: the routecraft principal (`FnHandlerContext.principal`)
+ * authenticates the caller into routecraft and is intentionally
+ * NOT forwarded to the MCP server. The MCP client is authenticated
+ * separately via the static credentials registered on
+ * `defineConfig.mcp({ clients: { name: { auth } } })`. If the agent
+ * needs to thread user-specific data into a tool call, it must do so
+ * as a regular tool argument (e.g. include a `tenantId` field), never
+ * by piggybacking on a credential. Two trust boundaries: principal
+ * authenticates Routecraft; MCP `auth` authenticates the
+ * Routecraft -> MCP hop.
  *
  * @internal
  */
@@ -545,6 +554,9 @@ function resolveByTags(
   // double-include them. Wrappers that didn't match the wanted tag set
   // are NOT added here -- the underlying route may still match by its
   // own tags and is allowed to surface under the prefix convention.
+  // MCP entries are walked separately at the end of this function via
+  // MCP_TOOL_REGISTRY (not the fn-registry deferred path), so they
+  // sit outside this dedup set.
   const coveredRouteIds = new Set<string>();
 
   // fn registry and direct registry walks only run when scope is
@@ -618,9 +630,7 @@ function resolveByTags(
 
   // Walk the MCP registry. Under "all" scope every client is in
   // scope; under "mcp" scope only the named client contributes.
-  const mcpRegistry = ctx.getStore(
-    MCP_TOOL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-  ) as McpToolRegistry | undefined;
+  const mcpRegistry = ctx.getStore(MCP_TOOL_REGISTRY);
   if (mcpRegistry) {
     let entries: McpToolRegistryEntry[];
     if (scope.kind === "mcp") {
@@ -660,16 +670,6 @@ function formatTags(tags: Tag[]): string {
   return tags.length === 1
     ? `"${tags[0]}"`
     : `[${tags.map((t) => `"${t}"`).join(", ")}]`;
-}
-
-function normalizeFrom(from: unknown): string | undefined {
-  if (from === undefined) return undefined;
-  if (typeof from !== "string") {
-    throw rcError("RC5003", undefined, {
-      message: `tools(): "from" must be a string when present.`,
-    });
-  }
-  return from;
 }
 
 function peekDirectTags(ctx: CraftContext, routeId: string): Tag[] {

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -335,20 +335,19 @@ function toResolvedTool(
 }
 
 /**
- * Recognise an MCP tool reference. The grammar is
- * `mcp_<client>:<tool>` (or `mcp_<client>:*` for a wildcard) — so a
- * legit MCP ref always carries a `:` somewhere after the `mcp_`
- * prefix and before the end. Without this guard, a plain fn id like
- * `mcp_healthcheck` would be hijacked by the MCP path and throw a
- * grammar error instead of resolving via the fn registry.
+ * Recognise an attempted MCP tool reference. The grammar is
+ * `mcp_<client>:<tool>` (or `mcp_<client>:*` for a wildcard), so any
+ * `mcp_*` name that contains a `:` is treated as an MCP ref. Plain
+ * fn ids like `mcp_healthcheck` (no `:`) fall through to fn-registry
+ * lookup. Malformed shapes like `mcp_:foo` or `mcp_foo:` are still
+ * caught here so `resolveMcpRefs` can emit the precise grammar error
+ * instead of a generic "unknown tool" message.
  *
  * @internal
  */
 function isMcpRefName(name: string): boolean {
   if (!name.startsWith("mcp_")) return false;
-  const rest = name.slice("mcp_".length);
-  const colon = rest.indexOf(":");
-  return colon > 0 && colon < rest.length - 1;
+  return name.slice("mcp_".length).includes(":");
 }
 
 /**

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -195,15 +195,9 @@ export function tools(items: ToolsItem[]): ToolSelection {
               message: `tools(): { name } must be a non-empty string.`,
             });
           }
-          if (
-            item.description !== undefined &&
-            (typeof item.description !== "string" ||
-              item.description.trim() === "")
-          ) {
-            throw rcError("RC5003", undefined, {
-              message: `tools(): { name: "${item.name}", description } must be a non-empty string when present.`,
-            });
-          }
+          // MCP refs reject any description override (empty or not) so
+          // users see the precise "MCP server is the source of truth"
+          // message instead of the generic empty-string error.
           if (isMcpRefName(item.name)) {
             if (item.description !== undefined) {
               throw rcError("RC5003", undefined, {
@@ -214,6 +208,15 @@ export function tools(items: ToolsItem[]): ToolSelection {
               explicit.set(tool.name, tool);
             }
             continue;
+          }
+          if (
+            item.description !== undefined &&
+            (typeof item.description !== "string" ||
+              item.description.trim() === "")
+          ) {
+            throw rcError("RC5003", undefined, {
+              message: `tools(): { name: "${item.name}", description } must be a non-empty string when present.`,
+            });
           }
           const base = resolveByName(ctx, item.name, item.guard);
           // Per-binding description override. The registry entry is
@@ -466,10 +469,21 @@ function mcpEntryToResolvedTool(
       : `MCP tool "${entry.name}" on client "${entry.source}".`;
   const input = wrapJsonSchemaAsStandard(entry.inputSchema);
   const handler: FnOptions["handler"] = async (rawInput) => {
-    const args =
-      rawInput && typeof rawInput === "object"
-        ? (rawInput as Record<string, unknown>)
-        : {};
+    // MCP tools expect a JSON-object argument. Silently coercing a
+    // non-object value to `{}` would discard the LLM's args and surface
+    // an unrelated server-side error; fail loudly so the model sees a
+    // precise correction message and can retry with the right shape.
+    if (
+      rawInput === null ||
+      rawInput === undefined ||
+      typeof rawInput !== "object" ||
+      Array.isArray(rawInput)
+    ) {
+      throw rcError("RC5003", undefined, {
+        message: `mcp tool "${name}" expects an object argument; received ${rawInput === null ? "null" : Array.isArray(rawInput) ? "array" : typeof rawInput}.`,
+      });
+    }
+    const args = rawInput as Record<string, unknown>;
     return dispatchMcpCall(ctx, entry.source, entry.name, args);
   };
   const tool: ResolvedTool = {
@@ -579,10 +593,9 @@ function resolveByTags(
   if (scope.kind === "all") {
     // Walk the fn registry first so explicit fn-side tags (incl. directTool
     // wrappers) take precedence over a parallel direct-registry walk.
-    // Skip non-direct deferred entries entirely: agentTool always throws
-    // on .resolve() by design, and a misconfigured directTool would throw
-    // too -- swallowing failures here would mask real config bugs, so we
-    // don't resolve such entries unless an explicit by-name ref forces it.
+    // Skip non-direct deferred entries entirely (none exist today now that
+    // `agentTool` is gone, but the guard is kept so future deferred kinds
+    // do not silently surface here without an explicit by-name ref).
     const fnRegistry = ctx.getStore(ADAPTER_FN_REGISTRY) as
       | Map<string, FnEntry>
       | undefined;
@@ -600,7 +613,12 @@ function resolveByTags(
           const fn = entry.resolve(ctx, name);
           out.push(toResolvedTool(name, fn, guard));
           seenNames.add(name);
-          coveredRouteIds.add(entry.targetId);
+          // Direct routes register under their sanitised endpoint, but
+          // `directTool` wrappers carry the user-supplied raw id. Store the
+          // sanitised form so the direct-registry walk below (which
+          // iterates the registry by its sanitised key) dedups correctly
+          // even when the route id contains URL-special chars like "/".
+          coveredRouteIds.add(sanitizeEndpoint(entry.targetId));
           continue;
         }
         const tags = entry.tags ?? [];
@@ -612,7 +630,9 @@ function resolveByTags(
     }
 
     // Walk the direct registry for routes not already surfaced via a
-    // fn-registry wrapper. Use the prefix-convention name `direct_<id>`.
+    // fn-registry wrapper. Registry keys are the sanitised endpoint;
+    // `coveredRouteIds` is also keyed by the sanitised form so the
+    // dedup works for raw ids containing URL-special characters.
     const directRegistry = ctx.getStore(ADAPTER_DIRECT_REGISTRY) as
       | Map<string, DirectRouteMetadata>
       | undefined;

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -9,6 +9,12 @@ import {
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { ADAPTER_FN_REGISTRY } from "../../fn/store.ts";
 import type { FnHandlerContext, FnOptions } from "../../fn/types.ts";
+import { dispatchMcpCall } from "../../mcp/dispatch.ts";
+import {
+  MCP_TOOL_REGISTRY,
+  type McpToolRegistryEntry,
+} from "../../mcp/types.ts";
+import type { McpToolRegistry } from "../../mcp/tool-registry.ts";
 import { directTool } from "./builders.ts";
 import { isDeferredFn, type FnEntry } from "./types.ts";
 
@@ -28,24 +34,30 @@ export type ToolGuard = (
  * One entry in the agent's `tools([...])` list.
  *
  * - bare string: name lookup. Plain ids resolve against the fn registry;
- *   `direct_*` falls back to the direct registry via `directTool`.
+ *   `direct_*` falls back to the direct registry via `directTool`;
+ *   `mcp_<client>:<tool>` and `mcp_<client>:*` resolve against
+ *   `MCP_TOOL_REGISTRY` (populated by `defineConfig.mcp` /
+ *   `mcpPlugin({ clients })`).
  * - `{ name, guard?, description? }`: same lookup, with optional
  *   per-binding overrides. The `description` override applies only to
  *   THIS binding (the registry entry stays the source of truth, so
  *   other agents binding the same fn see the canonical description).
  *   Use this when an agent's calling context calls for a different
  *   framing of the tool than the registered description provides.
- * - `{ tagged, guard? }`: select every fn / route whose tags include any
- *   of the requested tag(s). Optional guard applies to every match.
- *   No description override here: applying one description to N
- *   matched tools is almost always wrong.
+ *   For an MCP wildcard (`{ name: "mcp_<client>:*", guard }`) the guard
+ *   is attached to every expanded tool.
+ * - `{ tagged, from?, guard? }`: select every fn / route / MCP tool
+ *   whose tags include any of the requested tag(s) (OR semantics).
+ *   `from?: string` restricts the selection to a single source:
+ *   `from: "mcp_<client>"` matches only that client's MCP tools.
+ *   Optional guard applies to every match.
  *
  * @experimental
  */
 export type ToolsItem =
   | string
   | { name: string; guard?: ToolGuard; description?: string }
-  | { tagged: Tag | Tag[]; guard?: ToolGuard };
+  | { tagged: Tag | Tag[]; from?: string; guard?: ToolGuard };
 
 /**
  * Brand for {@link ToolSelection}. Lets the agent runtime detect a
@@ -120,12 +132,15 @@ export function isToolSelection(value: unknown): value is ToolSelection {
  * - Bare names look up exact matches in the fn registry first; if
  *   missing AND the name starts with `direct_`, the suffix is treated
  *   as a direct route id and wrapped via `directTool`. Names starting
- *   with `agent_` or `mcp_` produce a "not yet supported" error
- *   (stories E and F).
- * - Tag selectors walk both the fn registry and the direct route
- *   registry, including any entry whose tags overlap with the
- *   requested set. Direct routes not already covered by a fn registry
- *   entry are surfaced under the `direct_<routeId>` name.
+ *   with `mcp_` follow the `mcp_<client>:<tool>` grammar (with `*`
+ *   wildcard for the tool slot) and resolve against
+ *   `MCP_TOOL_REGISTRY`. Names starting with `agent_` produce a "not
+ *   yet supported" error (sub-agent tools land in a follow-up story).
+ * - Tag selectors walk the fn registry, the direct route registry,
+ *   and the MCP tool registry, including any entry whose tags overlap
+ *   with the requested set. `from?: string` narrows the walk: pass
+ *   `from: "mcp_<client>"` to scope a tag selection to a single MCP
+ *   client.
  * - Final list is deduplicated by tool name. Explicit references win
  *   over tag-selector matches regardless of position in the list.
  *
@@ -158,13 +173,19 @@ export function tools(items: ToolsItem[]): ToolSelection {
       // Phase 1: explicit refs (bare strings + { name, guard }).
       for (const item of items) {
         if (typeof item === "string") {
+          if (item.startsWith("mcp_")) {
+            for (const tool of resolveMcpRefs(ctx, item, undefined)) {
+              explicit.set(tool.name, tool);
+            }
+            continue;
+          }
           const tool = resolveByName(ctx, item, undefined);
           explicit.set(tool.name, tool);
           continue;
         }
         if (item === null || typeof item !== "object") {
           throw rcError("RC5003", undefined, {
-            message: `tools(): each item must be a string, { name, guard?, description? }, or { tagged, guard? }.`,
+            message: `tools(): each item must be a string, { name, guard?, description? }, or { tagged, from?, guard? }.`,
           });
         }
         if ("name" in item) {
@@ -181,6 +202,17 @@ export function tools(items: ToolsItem[]): ToolSelection {
             throw rcError("RC5003", undefined, {
               message: `tools(): { name: "${item.name}", description } must be a non-empty string when present.`,
             });
+          }
+          if (item.name.startsWith("mcp_")) {
+            if (item.description !== undefined) {
+              throw rcError("RC5003", undefined, {
+                message: `tools(): { name: "${item.name}", description } is not supported for MCP tools. The MCP server is the source of truth for description and schema; do not override.`,
+              });
+            }
+            for (const tool of resolveMcpRefs(ctx, item.name, item.guard)) {
+              explicit.set(tool.name, tool);
+            }
+            continue;
           }
           const base = resolveByName(ctx, item.name, item.guard);
           // Per-binding description override. The registry entry is
@@ -204,7 +236,16 @@ export function tools(items: ToolsItem[]): ToolSelection {
         if (typeof item === "object" && item !== null && "tagged" in item) {
           const wanted = normalizeTags(item.tagged);
           if (wanted.length === 0) continue;
-          for (const match of resolveByTags(ctx, wanted, item.guard)) {
+          const from = normalizeFrom(item.from);
+          const matches = resolveByTags(ctx, wanted, item.guard, from);
+          if (matches.length === 0) {
+            throw rcError("RC5003", undefined, {
+              message: from
+                ? `tools(): tagged selector matched no tools (tagged: ${formatTags(wanted)}, from: "${from}").`
+                : `tools(): tagged selector matched no tools (tagged: ${formatTags(wanted)}).`,
+            });
+          }
+          for (const match of matches) {
             if (!out.has(match.name)) out.set(match.name, match);
           }
         }
@@ -239,8 +280,11 @@ function resolveByName(
     });
   }
   if (name.startsWith("mcp_")) {
+    // MCP refs can expand to multiple tools (wildcard) so they go
+    // through a separate path in Phase 1; reaching this branch from
+    // resolveByName means the caller forgot to special-case them.
     throw rcError("RC5003", undefined, {
-      message: `tools(): "${name}" looks like an MCP reference. MCP tools land in a follow-up story.`,
+      message: `tools(): "${name}" must be resolved via resolveMcpRefs; this is a bug in the agent tools pipeline.`,
     });
   }
   if (name.startsWith("direct_")) {
@@ -293,12 +337,207 @@ function toResolvedTool(
   };
 }
 
+/**
+ * Resolve an `mcp_<client>:<tool>` or `mcp_<client>:*` reference into
+ * one or more `ResolvedTool` entries. Grammar:
+ *
+ * - kind: everything before the first `_` (always `mcp` here).
+ * - client: everything after the first `_` up to the first `:`.
+ *   Client names may contain underscores
+ *   (e.g. `mcp_my_company_api:fetch_user`).
+ * - tool: everything after the first `:`. The literal `*` expands to
+ *   every tool registered under `<client>` at dispatch time. Other
+ *   colons in the tool name are tolerated and forwarded verbatim to
+ *   the MCP server.
+ *
+ * Throws RC5003 when the registry is absent, the client is unknown,
+ * the client is registered but has no tools, or the specific tool is
+ * not registered.
+ *
+ * @internal
+ */
+function resolveMcpRefs(
+  ctx: CraftContext,
+  ref: string,
+  guard: ToolGuard | undefined,
+): ResolvedTool[] {
+  if (!ref.startsWith("mcp_")) {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): MCP reference "${ref}" must start with "mcp_".`,
+    });
+  }
+  const rest = ref.slice("mcp_".length);
+  const colon = rest.indexOf(":");
+  if (colon === -1) {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): MCP reference "${ref}" must use the form "mcp_<client>:<tool>" or "mcp_<client>:*".`,
+    });
+  }
+  const clientName = rest.slice(0, colon);
+  const toolName = rest.slice(colon + 1);
+  if (clientName.trim() === "" || toolName.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): MCP reference "${ref}" must use the form "mcp_<client>:<tool>" or "mcp_<client>:*"; got empty client or tool segment.`,
+    });
+  }
+  const registry = ctx.getStore(
+    MCP_TOOL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
+  ) as McpToolRegistry | undefined;
+  if (!registry) {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): MCP reference "${ref}" but no MCP_TOOL_REGISTRY is present. Install mcpPlugin (defineConfig.mcp) so external clients populate the registry.`,
+    });
+  }
+  const clientTools = registry.getToolsByServer(clientName);
+  if (clientTools.length === 0) {
+    const known = listKnownMcpClients(registry);
+    throw rcError("RC5003", undefined, {
+      message:
+        `tools(): MCP reference "${ref}" but client "${clientName}" has no registered tools. ` +
+        (known.length > 0
+          ? `Known MCP clients: ${known.map((k) => `"${k}"`).join(", ")}.`
+          : `No MCP clients are registered in this context.`),
+    });
+  }
+  if (toolName === "*") {
+    return clientTools.map((entry) =>
+      mcpEntryToResolvedTool(ctx, entry, guard),
+    );
+  }
+  const entry = clientTools.find((t) => t.name === toolName);
+  if (!entry) {
+    const knownTools = clientTools.map((t) => t.name).sort();
+    throw rcError("RC5003", undefined, {
+      message:
+        `tools(): MCP reference "${ref}" but tool "${toolName}" is not registered under client "${clientName}". ` +
+        `Known tools on "${clientName}": ${knownTools.map((n) => `"${n}"`).join(", ")}.`,
+    });
+  }
+  return [mcpEntryToResolvedTool(ctx, entry, guard)];
+}
+
+/**
+ * Wrap an MCP registry entry as a `ResolvedTool`. The input is a
+ * Standard Schema pass-through that exposes the entry's raw JSON
+ * Schema to the Vercel AI SDK bridge (it consumes the
+ * `~standard.jsonSchema` extension) and accepts the LLM-supplied
+ * value unchanged (the MCP server is the source of truth for
+ * validation; double-validating locally adds latency and divergence
+ * risk).
+ *
+ * The handler captures the entry's `source` (client name) at
+ * resolution time and dispatches via `dispatchMcpCall`, so a tool
+ * call goes through the same stdio / HTTP plumbing as the `mcp(...)`
+ * destination adapter.
+ *
+ * @internal
+ */
+function mcpEntryToResolvedTool(
+  ctx: CraftContext,
+  entry: McpToolRegistryEntry,
+  guard: ToolGuard | undefined,
+): ResolvedTool {
+  const name = `mcp_${entry.source}:${entry.name}`;
+  const description =
+    entry.description && entry.description.trim() !== ""
+      ? entry.description
+      : `MCP tool "${entry.name}" on client "${entry.source}".`;
+  const input = wrapJsonSchemaAsStandard(entry.inputSchema);
+  const handler: FnOptions["handler"] = async (rawInput) => {
+    const args =
+      rawInput && typeof rawInput === "object"
+        ? (rawInput as Record<string, unknown>)
+        : {};
+    return dispatchMcpCall(ctx, entry.source, entry.name, args);
+  };
+  const tool: ResolvedTool = {
+    name,
+    description,
+    input,
+    handler,
+  };
+  if (entry.tags && entry.tags.length > 0) {
+    tool.tags = [...entry.tags];
+  }
+  if (guard) tool.guard = guard;
+  return tool;
+}
+
+/**
+ * Lightweight Standard Schema wrapper around a raw JSON Schema. The
+ * `~standard.validate` is a pass-through (MCP server validates); the
+ * `~standard.jsonSchema` extension hands the JSON Schema to the
+ * Vercel AI SDK bridge via `toAiInputSchema`. Follows the same shape
+ * `emptyObjectSchema` in `builders.ts` uses so the bridge code stays
+ * uniform.
+ *
+ * @internal
+ */
+function wrapJsonSchemaAsStandard(
+  schema: Record<string, unknown>,
+): StandardSchemaV1<unknown, unknown> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "routecraft",
+      validate(value) {
+        return { value };
+      },
+      jsonSchema: {
+        input: () => schema,
+        output: () => schema,
+      },
+    } as StandardSchemaV1<unknown, unknown>["~standard"],
+  };
+}
+
+function listKnownMcpClients(registry: McpToolRegistry): string[] {
+  const set = new Set<string>();
+  for (const entry of registry.getTools()) set.add(entry.source);
+  return [...set].sort();
+}
+
+/**
+ * Parsed `from` scope filter. `kind: "all"` means walk every source
+ * (default when `from` is unset). `kind: "mcp"` narrows to a single
+ * MCP client.
+ *
+ * @internal
+ */
+interface FromScope {
+  kind: "all" | "mcp";
+  mcpClient?: string;
+}
+
+function parseFromScope(from: string | undefined): FromScope {
+  if (from === undefined) return { kind: "all" };
+  if (typeof from !== "string" || from.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): "from" must be a non-empty string when present.`,
+    });
+  }
+  if (from.startsWith("mcp_")) {
+    const client = from.slice("mcp_".length);
+    if (client.trim() === "") {
+      throw rcError("RC5003", undefined, {
+        message: `tools(): from "${from}" has an empty client name; use "mcp_<client>".`,
+      });
+    }
+    return { kind: "mcp", mcpClient: client };
+  }
+  throw rcError("RC5003", undefined, {
+    message: `tools(): from "${from}" is not a supported source filter. Use "mcp_<client>".`,
+  });
+}
+
 function resolveByTags(
   ctx: CraftContext,
   wanted: Tag[],
   guard: ToolGuard | undefined,
+  from: string | undefined,
 ): ResolvedTool[] {
   const wantedSet = new Set(wanted);
+  const scope = parseFromScope(from);
   const out: ResolvedTool[] = [];
   const seenNames = new Set<string>();
   // Track route ids already surfaced via a fn-registry directTool wrapper
@@ -308,71 +547,129 @@ function resolveByTags(
   // own tags and is allowed to surface under the prefix convention.
   const coveredRouteIds = new Set<string>();
 
-  // Walk the fn registry first so explicit fn-side tags (incl. directTool
-  // wrappers) take precedence over a parallel direct-registry walk.
-  // Skip non-direct deferred entries entirely: agentTool/mcpTool always
-  // throw on .resolve() by design, and a misconfigured directTool would
-  // throw too -- swallowing failures here would mask real config bugs,
-  // so we don't resolve such entries unless an explicit by-name ref
-  // forces it.
-  const fnRegistry = ctx.getStore(ADAPTER_FN_REGISTRY) as
-    | Map<string, FnEntry>
-    | undefined;
-  if (fnRegistry) {
-    for (const [name, entry] of fnRegistry) {
-      if (isDeferredFn(entry)) {
-        if (entry.kind !== "direct") continue;
-        // Use the wrapper's explicit `overrides.tags` when present so a
-        // `directTool(routeId, { tags: [...] })` wrapper actually drives
-        // selection. Fall back to peeking the underlying route's tags
-        // when no override was supplied.
-        const candidateTags =
-          entry.overrideTags ?? peekDirectTags(ctx, entry.targetId);
-        if (!candidateTags.some((t) => wantedSet.has(t))) continue;
-        const fn = entry.resolve(ctx, name);
-        out.push(toResolvedTool(name, fn, guard));
-        seenNames.add(name);
-        coveredRouteIds.add(entry.targetId);
-        continue;
+  // fn registry and direct registry walks only run when scope is
+  // unrestricted ("all"). A scoped selector like
+  // `{ tagged: "read-only", from: "mcp_Nuclino" }` deliberately
+  // excludes fns and routes.
+  if (scope.kind === "all") {
+    // Walk the fn registry first so explicit fn-side tags (incl. directTool
+    // wrappers) take precedence over a parallel direct-registry walk.
+    // Skip non-direct deferred entries entirely: agentTool always throws
+    // on .resolve() by design, and a misconfigured directTool would throw
+    // too -- swallowing failures here would mask real config bugs, so we
+    // don't resolve such entries unless an explicit by-name ref forces it.
+    const fnRegistry = ctx.getStore(ADAPTER_FN_REGISTRY) as
+      | Map<string, FnEntry>
+      | undefined;
+    if (fnRegistry) {
+      for (const [name, entry] of fnRegistry) {
+        if (isDeferredFn(entry)) {
+          if (entry.kind !== "direct") continue;
+          // Use the wrapper's explicit `overrides.tags` when present so a
+          // `directTool(routeId, { tags: [...] })` wrapper actually drives
+          // selection. Fall back to peeking the underlying route's tags
+          // when no override was supplied.
+          const candidateTags =
+            entry.overrideTags ?? peekDirectTags(ctx, entry.targetId);
+          if (!candidateTags.some((t) => wantedSet.has(t))) continue;
+          const fn = entry.resolve(ctx, name);
+          out.push(toResolvedTool(name, fn, guard));
+          seenNames.add(name);
+          coveredRouteIds.add(entry.targetId);
+          continue;
+        }
+        const tags = entry.tags ?? [];
+        if (tags.some((t) => wantedSet.has(t))) {
+          out.push(toResolvedTool(name, entry, guard));
+          seenNames.add(name);
+        }
       }
-      const tags = entry.tags ?? [];
-      if (tags.some((t) => wantedSet.has(t))) {
-        out.push(toResolvedTool(name, entry, guard));
-        seenNames.add(name);
+    }
+
+    // Walk the direct registry for routes not already surfaced via a
+    // fn-registry wrapper. Use the prefix-convention name `direct_<id>`.
+    const directRegistry = ctx.getStore(ADAPTER_DIRECT_REGISTRY) as
+      | Map<string, DirectRouteMetadata>
+      | undefined;
+    if (directRegistry) {
+      for (const [routeId, meta] of directRegistry) {
+        if (coveredRouteIds.has(routeId)) continue;
+        const tags = meta.tags ?? [];
+        if (!tags.some((t) => wantedSet.has(t))) continue;
+        const conventionName = `direct_${routeId}`;
+        if (seenNames.has(conventionName)) continue;
+        // Only include if the route is fully tool-shaped (has description
+        // and input schema). Routes that are missing those silently skip
+        // tag-selector inclusion -- explicit refs would still throw.
+        if (
+          typeof meta.description !== "string" ||
+          meta.description.trim() === ""
+        ) {
+          continue;
+        }
+        if (!meta.input?.body) continue;
+        const wrapper = directTool(routeId);
+        const fn = wrapper.resolve(ctx, conventionName);
+        out.push(toResolvedTool(conventionName, fn, guard));
+        seenNames.add(conventionName);
       }
     }
   }
 
-  // Walk the direct registry for routes not already surfaced via a
-  // fn-registry wrapper. Use the prefix-convention name `direct_<id>`.
-  const directRegistry = ctx.getStore(ADAPTER_DIRECT_REGISTRY) as
-    | Map<string, DirectRouteMetadata>
-    | undefined;
-  if (directRegistry) {
-    for (const [routeId, meta] of directRegistry) {
-      if (coveredRouteIds.has(routeId)) continue;
-      const tags = meta.tags ?? [];
-      if (!tags.some((t) => wantedSet.has(t))) continue;
-      const conventionName = `direct_${routeId}`;
-      if (seenNames.has(conventionName)) continue;
-      // Only include if the route is fully tool-shaped (has description
-      // and input schema). Routes that are missing those silently skip
-      // tag-selector inclusion -- explicit refs would still throw.
-      if (
-        typeof meta.description !== "string" ||
-        meta.description.trim() === ""
-      ) {
-        continue;
+  // Walk the MCP registry. Under "all" scope every client is in
+  // scope; under "mcp" scope only the named client contributes.
+  const mcpRegistry = ctx.getStore(
+    MCP_TOOL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
+  ) as McpToolRegistry | undefined;
+  if (mcpRegistry) {
+    let entries: McpToolRegistryEntry[];
+    if (scope.kind === "mcp") {
+      entries = mcpRegistry.getToolsByServer(scope.mcpClient as string);
+      if (entries.length === 0) {
+        const known = listKnownMcpClients(mcpRegistry);
+        throw rcError("RC5003", undefined, {
+          message:
+            `tools(): from "mcp_${scope.mcpClient}" has no registered tools. ` +
+            (known.length > 0
+              ? `Known MCP clients: ${known.map((k) => `"${k}"`).join(", ")}.`
+              : `No MCP clients are registered in this context.`),
+        });
       }
-      if (!meta.input?.body) continue;
-      const wrapper = directTool(routeId);
-      const fn = wrapper.resolve(ctx, conventionName);
-      out.push(toResolvedTool(conventionName, fn, guard));
-      seenNames.add(conventionName);
+    } else {
+      entries = mcpRegistry.getTools();
     }
+    for (const entry of entries) {
+      const tags = entry.tags ?? [];
+      if (!tags.some((t) => wantedSet.has(t))) continue;
+      const tool = mcpEntryToResolvedTool(ctx, entry, guard);
+      if (seenNames.has(tool.name)) continue;
+      out.push(tool);
+      seenNames.add(tool.name);
+    }
+  } else if (scope.kind === "mcp") {
+    // Asked for a specific MCP client but the registry isn't installed.
+    throw rcError("RC5003", undefined, {
+      message: `tools(): from "mcp_${scope.mcpClient}" but no MCP_TOOL_REGISTRY is present. Install mcpPlugin (defineConfig.mcp).`,
+    });
   }
 
   return out;
+}
+
+function formatTags(tags: Tag[]): string {
+  return tags.length === 1
+    ? `"${tags[0]}"`
+    : `[${tags.map((t) => `"${t}"`).join(", ")}]`;
+}
+
+function normalizeFrom(from: unknown): string | undefined {
+  if (from === undefined) return undefined;
+  if (typeof from !== "string") {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): "from" must be a string when present.`,
+    });
+  }
+  return from;
 }
 
 function peekDirectTags(ctx: CraftContext, routeId: string): Tag[] {

--- a/packages/ai/src/agent/tools/types.ts
+++ b/packages/ai/src/agent/tools/types.ts
@@ -12,13 +12,15 @@ export const DEFERRED_FN_BRAND = Symbol.for("routecraft.ai.fn.deferred");
 
 /**
  * The kinds of underlying things `tools(...)` can wrap as a fn. Each
- * builder helper (`directTool`, `agentTool`, `mcpTool`) emits one of
- * these kinds; the kind is purely informational at runtime (used for
+ * builder helper (`directTool`, `agentTool`) emits one of these
+ * kinds; the kind is purely informational at runtime (used for
  * error messages and the prefix-auto-resolution path in `tools()`).
+ * MCP tools are resolved directly from `MCP_TOOL_REGISTRY` at
+ * selection time and do not go through a deferred-fn descriptor.
  *
  * @experimental
  */
-export type DeferredFnKind = "direct" | "agent" | "mcp";
+export type DeferredFnKind = "direct" | "agent";
 
 /**
  * A fn that cannot be fully constructed at config-write time because it
@@ -66,7 +68,7 @@ export interface DeferredFn {
 
 /**
  * Type guard. Returns true when the value is a deferred fn descriptor
- * emitted by `directTool` / `agentTool` / `mcpTool`.
+ * emitted by `directTool` / `agentTool`.
  *
  * @internal
  */
@@ -81,8 +83,8 @@ export function isDeferredFn(value: unknown): value is DeferredFn {
 
 /**
  * What the fn registry actually holds. Eagerly authored fns are stored
- * as `FnOptions`; entries from `directTool` / `agentTool` / `mcpTool`
- * are stored as `DeferredFn` and resolved on first agent dispatch.
+ * as `FnOptions`; entries from `directTool` / `agentTool` are stored
+ * as `DeferredFn` and resolved on first agent dispatch.
  *
  * @experimental
  */

--- a/packages/ai/src/agent/tools/types.ts
+++ b/packages/ai/src/agent/tools/types.ts
@@ -11,16 +11,16 @@ import type { FnOptions } from "../../fn/types.ts";
 export const DEFERRED_FN_BRAND = Symbol.for("routecraft.ai.fn.deferred");
 
 /**
- * The kinds of underlying things `tools(...)` can wrap as a fn. Each
- * builder helper (`directTool`, `agentTool`) emits one of these
- * kinds; the kind is purely informational at runtime (used for
- * error messages and the prefix-auto-resolution path in `tools()`).
+ * The kinds of underlying things `tools(...)` can wrap as a deferred
+ * fn. Today only `directTool(routeId)` produces a deferred entry;
  * MCP tools are resolved directly from `MCP_TOOL_REGISTRY` at
- * selection time and do not go through a deferred-fn descriptor.
+ * selection time, and sub-agent tools are not yet supported. The
+ * kind is purely informational at runtime (used for error messages
+ * and the prefix-auto-resolution path in `tools()`).
  *
  * @experimental
  */
-export type DeferredFnKind = "direct" | "agent";
+export type DeferredFnKind = "direct";
 
 /**
  * A fn that cannot be fully constructed at config-write time because it
@@ -68,7 +68,7 @@ export interface DeferredFn {
 
 /**
  * Type guard. Returns true when the value is a deferred fn descriptor
- * emitted by `directTool` / `agentTool`.
+ * emitted by `directTool`.
  *
  * @internal
  */
@@ -83,8 +83,8 @@ export function isDeferredFn(value: unknown): value is DeferredFn {
 
 /**
  * What the fn registry actually holds. Eagerly authored fns are stored
- * as `FnOptions`; entries from `directTool` / `agentTool` are stored
- * as `DeferredFn` and resolved on first agent dispatch.
+ * as `FnOptions`; entries from `directTool` are stored as `DeferredFn`
+ * and resolved on first agent dispatch.
  *
  * @experimental
  */

--- a/packages/ai/src/fn/store.ts
+++ b/packages/ai/src/fn/store.ts
@@ -5,9 +5,8 @@ import type { FnEntry } from "../agent/tools/types.ts";
  * the agent tool loop at dispatch time (follow-up story).
  *
  * Entries are either eagerly authored `FnOptions` or deferred
- * descriptors emitted by `directTool` / `agentTool`. The agent
- * runtime resolves deferred entries on first dispatch when all
- * registries are live.
+ * descriptors emitted by `directTool`. The agent runtime resolves
+ * deferred entries on first dispatch when all registries are live.
  *
  * @experimental
  */

--- a/packages/ai/src/fn/store.ts
+++ b/packages/ai/src/fn/store.ts
@@ -5,8 +5,8 @@ import type { FnEntry } from "../agent/tools/types.ts";
  * the agent tool loop at dispatch time (follow-up story).
  *
  * Entries are either eagerly authored `FnOptions` or deferred
- * descriptors emitted by `directTool` / `agentTool` / `mcpTool`. The
- * agent runtime resolves deferred entries on first dispatch when all
+ * descriptors emitted by `directTool` / `agentTool`. The agent
+ * runtime resolves deferred entries on first dispatch when all
  * registries are live.
  *
  * @experimental

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -159,11 +159,12 @@ export type {
   RegisteredFnId,
 } from "./fn/index.ts";
 
-// Tool builders: wrap registered routes / agents / MCP tools as
-// fn-shaped entries usable from `agentPlugin({ functions: { ... } })`,
-// plus the `tools([...])` selector consumed by the agent runtime.
+// Tool builders: wrap registered routes as fn-shaped entries usable
+// from `agentPlugin({ functions: { ... } })`, plus the `tools([...])`
+// selector consumed by the agent runtime. MCP tools are resolved
+// directly via the `mcp_<client>:<tool>` grammar inside `tools(...)`;
+// sub-agent tools land in a follow-up story.
 export {
-  agentTool,
   defaultFns,
   directTool,
   isDeferredFn,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -166,7 +166,6 @@ export {
   agentTool,
   defaultFns,
   directTool,
-  mcpTool,
   isDeferredFn,
   isToolSelection,
   tools,

--- a/packages/ai/src/mcp/adapters/mcp/destination.ts
+++ b/packages/ai/src/mcp/adapters/mcp/destination.ts
@@ -1,17 +1,16 @@
 import type { Exchange, Destination } from "@routecraft/routecraft";
-import { getExchangeContext, loadOptionalPeer } from "@routecraft/routecraft";
+import { getExchangeContext } from "@routecraft/routecraft";
 import type {
   McpClientOptions,
   McpArgsExtractor,
   McpClientAuthOptions,
   McpClientHttpConfig,
 } from "../../types.ts";
-import { ADAPTER_MCP_CLIENT_SERVERS, MCP_STDIO_MANAGERS } from "../../types.ts";
+import { ADAPTER_MCP_CLIENT_SERVERS } from "../../types.ts";
 import { BRAND_MCP_ADAPTER } from "./shared.ts";
-import { extractContent } from "../../extract-content.ts";
-import { buildAuthHeaders } from "../../build-auth-headers.ts";
+import { callRemoteTool, dispatchMcpCall } from "../../dispatch.ts";
 
-/** Ensure inline url is HTTP(S) only. Stdio clients are resolved via MCP_STDIO_MANAGERS store. */
+/** Ensure inline url is HTTP(S) only. Stdio clients are reached via dispatchMcpCall. */
 function assertHttpUrl(url: string): void {
   const trimmed = url.trim().toLowerCase();
   if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) {
@@ -31,10 +30,14 @@ function resolveServerConfig(
   context: ReturnType<typeof getExchangeContext>,
 ): McpClientHttpConfig | string | undefined {
   if (!options.serverId || !context) return undefined;
-  const servers = context.getStore(
-    ADAPTER_MCP_CLIENT_SERVERS as keyof import("@routecraft/routecraft").StoreRegistry,
-  ) as Map<string, McpClientHttpConfig | string> | undefined;
-  return servers?.get(options.serverId);
+  const servers = context.getStore(ADAPTER_MCP_CLIENT_SERVERS);
+  const cfg = servers?.get(options.serverId);
+  if (cfg && typeof cfg === "object" && "transport" in cfg) {
+    // stdio configs surface through dispatchMcpCall; resolveConnection only
+    // needs the http variant for the inline-URL or http-serverId fall-through.
+    return undefined;
+  }
+  return cfg as McpClientHttpConfig | string | undefined;
 }
 
 /**
@@ -131,67 +134,47 @@ export class McpDestinationAdapter implements Destination<unknown, unknown> {
     const argsExtractor = this.options.args ?? defaultArgs;
     const args = argsExtractor(exchange);
 
-    // Check for stdio manager first (registered via mcpPlugin)
-    if (this.options.serverId && context) {
-      const stdioManagers = context.getStore(
-        MCP_STDIO_MANAGERS as keyof import("@routecraft/routecraft").StoreRegistry,
-      ) as
-        | Map<
-            string,
-            {
-              callTool(
-                name: string,
-                args: Record<string, unknown>,
-              ): Promise<unknown>;
-            }
-          >
-        | undefined;
-      const manager = stdioManagers?.get(this.options.serverId);
-      if (manager) {
-        const result = await manager.callTool(toolName, args);
-        if (result && typeof result === "object") {
-          (result as Record<string, unknown>)["metadata"] = {
-            toolName,
-            transport: "stdio",
-            serverId: this.options.serverId,
-          };
-        }
-        return result;
-      }
-
-      // Guard: if the registered config is stdio-type but the manager is missing,
-      // throw a clear error instead of falling through to HTTP (which would fail
-      // confusingly since stdio configs have no url property).
-      const servers = context.getStore(
-        ADAPTER_MCP_CLIENT_SERVERS as keyof import("@routecraft/routecraft").StoreRegistry,
-      ) as Map<string, unknown> | undefined;
-      const serverConfig = servers?.get(this.options.serverId);
-      if (
-        serverConfig &&
-        typeof serverConfig === "object" &&
-        "transport" in serverConfig &&
-        (serverConfig as { transport: string }).transport === "stdio"
-      ) {
+    // serverId path -> registered MCP client (stdio or http). Delegates
+    // to `dispatchMcpCall` so transport selection (stdio manager vs
+    // one-shot HTTP client), missing-client diagnostics, and resource
+    // cleanup all live in one place shared with the agent
+    // `tools([...])` resolver.
+    if (this.options.serverId) {
+      if (!context) {
         throw new Error(
-          `MCP client: stdio server "${this.options.serverId}" is not running. Ensure mcpPlugin is applied and the stdio client started successfully.`,
+          `MCP client: serverId "${this.options.serverId}" requires a context to resolve. Ensure the exchange has context (e.g. from a route).`,
         );
       }
+      const transport = resolveServerTransport(context, this.options.serverId);
+      const result = await dispatchMcpCall(
+        context,
+        this.options.serverId,
+        toolName,
+        args,
+      );
+      if (result && typeof result === "object") {
+        (result as Record<string, unknown>)["metadata"] = {
+          toolName,
+          transport,
+          serverId: this.options.serverId,
+        };
+      }
+      return result;
     }
 
-    // Fall through to HTTP
+    // Inline-URL path -> direct HTTP call without going through the
+    // registry. Uses the shared `callRemoteTool` helper so transport
+    // setup, auth-header building, and cleanup stay aligned with
+    // `dispatchMcpCall`.
     const { url, auth } = resolveConnection(this.options, context);
-    const result = await this.callRemoteTool(url, toolName, args, auth);
-
-    // Attach metadata to result for getMetadata() to read (eliminates race condition)
+    const result = await callRemoteTool(url, toolName, args, auth);
     if (result && typeof result === "object") {
       (result as Record<string, unknown>)["metadata"] = {
         toolName,
         url,
         transport: "http",
-        ...(this.options.serverId ? { serverId: this.options.serverId } : {}),
       };
     }
-
     return result;
   }
 
@@ -208,100 +191,28 @@ export class McpDestinationAdapter implements Destination<unknown, unknown> {
       transport: "unknown",
     };
   }
+}
 
-  private async callRemoteTool(
-    serverUrl: string,
-    toolName: string,
-    args: Record<string, unknown>,
-    auth?: McpClientAuthOptions,
-  ): Promise<unknown> {
-    const clientModule = (await loadOptionalPeer(
-      () => import("@modelcontextprotocol/sdk/client/index.js"),
-      {
-        adapterName: "mcp (http client)",
-        packageName: "@modelcontextprotocol/sdk",
-      },
-    )) as unknown as {
-      Client: new (
-        info: { name: string; version: string },
-        options?: { capabilities?: Record<string, unknown> },
-      ) => unknown;
-    };
-    const transportModule = (await loadOptionalPeer(
-      () => import("@modelcontextprotocol/sdk/client/streamableHttp.js"),
-      {
-        adapterName: "mcp (http client)",
-        packageName: "@modelcontextprotocol/sdk",
-      },
-    )) as unknown as {
-      StreamableHTTPClientTransport: new (
-        url: URL,
-        options?: {
-          sessionId?: string;
-          requestInit?: { headers?: Record<string, string> };
-        },
-      ) => unknown;
-    };
-    const Client = clientModule.Client;
-    const StreamableHTTPClientTransport =
-      transportModule.StreamableHTTPClientTransport;
-
-    const url = new URL(serverUrl);
-    const headers = await buildAuthHeaders(auth);
-    const transportOptions = headers ? { requestInit: { headers } } : undefined;
-    const transport = new StreamableHTTPClientTransport(url, transportOptions);
-    const clientInfo = { name: "routecraft-mcp-client", version: "1.0.0" };
-    const client = new (Client as new (
-      info: { name: string; version: string },
-      options?: { capabilities?: Record<string, unknown> },
-    ) => InstanceType<typeof clientModule.Client>)(clientInfo, {
-      capabilities: {},
-    });
-    try {
-      const connect = (
-        client as unknown as { connect(transport: unknown): Promise<void> }
-      ).connect;
-      await connect.call(client, transport);
-
-      const callTool = (
-        client as unknown as {
-          callTool(params: {
-            name: string;
-            arguments?: Record<string, unknown>;
-          }): Promise<{ content?: Array<{ type: string; text?: string }> }>;
-        }
-      ).callTool;
-      const response = await callTool.call(client, {
-        name: toolName,
-        arguments: args,
-      });
-
-      return extractContent(response);
-    } finally {
-      const clientCleanup = client as unknown as {
-        close?: () => void | Promise<void>;
-        disconnect?: () => void | Promise<void>;
-      };
-      const closeOrDisconnect = clientCleanup.close ?? clientCleanup.disconnect;
-      if (typeof closeOrDisconnect === "function") {
-        try {
-          await Promise.resolve(closeOrDisconnect.call(client));
-        } catch {
-          // Ignore cleanup errors so original error propagates
-        }
-      }
-      const transportCleanup = transport as unknown as {
-        close?: () => void | Promise<void>;
-        destroy?: () => void;
-      };
-      const closeOrDestroy = transportCleanup.close ?? transportCleanup.destroy;
-      if (typeof closeOrDestroy === "function") {
-        try {
-          await Promise.resolve(closeOrDestroy.call(transport));
-        } catch {
-          // Ignore cleanup errors so original error propagates
-        }
-      }
-    }
+/**
+ * Look up the transport label for a registered MCP server so the
+ * destination's metadata reflects what `dispatchMcpCall` actually
+ * used. Falls back to `"http"` because that's the default for
+ * registered clients without an explicit transport tag (stdio configs
+ * carry `transport: "stdio"` explicitly).
+ */
+function resolveServerTransport(
+  context: NonNullable<ReturnType<typeof getExchangeContext>>,
+  serverId: string,
+): "stdio" | "http" {
+  const servers = context.getStore(ADAPTER_MCP_CLIENT_SERVERS);
+  const cfg = servers?.get(serverId);
+  if (
+    cfg &&
+    typeof cfg === "object" &&
+    "transport" in cfg &&
+    (cfg as { transport: string }).transport === "stdio"
+  ) {
+    return "stdio";
   }
+  return "http";
 }

--- a/packages/ai/src/mcp/dispatch.ts
+++ b/packages/ai/src/mcp/dispatch.ts
@@ -1,0 +1,178 @@
+import {
+  loadOptionalPeer,
+  rcError,
+  type CraftContext,
+} from "@routecraft/routecraft";
+import { buildAuthHeaders } from "./build-auth-headers.ts";
+import { extractContent } from "./extract-content.ts";
+import {
+  ADAPTER_MCP_CLIENT_SERVERS,
+  MCP_STDIO_MANAGERS,
+  type McpClientAuthOptions,
+  type McpClientHttpConfig,
+  type McpClientStdioConfig,
+} from "./types.ts";
+
+/**
+ * Stdio-call shape stored in `MCP_STDIO_MANAGERS`. Kept narrow so this
+ * module does not depend on `StdioClientManager` directly.
+ *
+ * @internal
+ */
+interface StdioCallable {
+  callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
+}
+
+/**
+ * Dispatch an MCP tool call against a server registered via
+ * `mcpPlugin({ clients })`. Used by both the `mcp(...)` destination
+ * adapter and the agent `tools([...])` resolver so the same transport
+ * logic backs both call sites.
+ *
+ * - For stdio clients (`MCP_STDIO_MANAGERS.get(serverId)`), delegates
+ *   to the long-lived `StdioClientManager.callTool`.
+ * - For HTTP clients (`ADAPTER_MCP_CLIENT_SERVERS.get(serverId).url`),
+ *   opens a single MCP SDK client connection per call, dispatches,
+ *   and closes. The agent path is per-tool-call so latency dominates
+ *   over connection setup; if that becomes a problem the http
+ *   client cache in `mcpPlugin` can be promoted to a context store
+ *   in a follow-up.
+ *
+ * Throws `RC5003` when the server is not registered, when a stdio
+ * server is registered but its manager is absent (mcpPlugin
+ * teardown raced ahead, etc.), or when an HTTP call fails.
+ *
+ * @internal
+ */
+export async function dispatchMcpCall(
+  ctx: CraftContext,
+  serverId: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const stdioManagers = ctx.getStore(
+    MCP_STDIO_MANAGERS as keyof import("@routecraft/routecraft").StoreRegistry,
+  ) as Map<string, StdioCallable> | undefined;
+  const manager = stdioManagers?.get(serverId);
+  if (manager) {
+    return manager.callTool(toolName, args);
+  }
+
+  const servers = ctx.getStore(
+    ADAPTER_MCP_CLIENT_SERVERS as keyof import("@routecraft/routecraft").StoreRegistry,
+  ) as
+    | Map<string, McpClientHttpConfig | McpClientStdioConfig | string>
+    | undefined;
+  const config = servers?.get(serverId);
+  if (!config) {
+    throw rcError("RC5003", undefined, {
+      message: `mcp dispatch: server "${serverId}" is not registered. Register it via defineConfig.mcp / mcpPlugin({ clients }).`,
+    });
+  }
+  if (typeof config !== "object" || config === null) {
+    throw rcError("RC5003", undefined, {
+      message: `mcp dispatch: server "${serverId}" config is a string shorthand and cannot be called directly. Use a full HTTP config with a url.`,
+    });
+  }
+  if (
+    "transport" in config &&
+    (config as { transport: string }).transport === "stdio"
+  ) {
+    throw rcError("RC5003", undefined, {
+      message: `mcp dispatch: stdio server "${serverId}" is registered but its client is not running. Ensure mcpPlugin started successfully.`,
+    });
+  }
+  const http = config as McpClientHttpConfig;
+  if (typeof http.url !== "string" || http.url.trim() === "") {
+    throw rcError("RC5003", undefined, {
+      message: `mcp dispatch: server "${serverId}" has no url. Cannot dispatch over HTTP.`,
+    });
+  }
+  return callRemoteTool(http.url, toolName, args, http.auth);
+}
+
+/**
+ * Open a one-shot MCP SDK client over Streamable HTTP, dispatch the
+ * tool, then close. Mirrors the implementation in
+ * `mcp/adapters/mcp/destination.ts` so both call sites agree on
+ * transport setup, auth-header building, and content extraction.
+ *
+ * @internal
+ */
+async function callRemoteTool(
+  serverUrl: string,
+  toolName: string,
+  args: Record<string, unknown>,
+  auth?: McpClientAuthOptions,
+): Promise<unknown> {
+  const clientModule = (await loadOptionalPeer(
+    () => import("@modelcontextprotocol/sdk/client/index.js"),
+    {
+      adapterName: "mcp (http client)",
+      packageName: "@modelcontextprotocol/sdk",
+    },
+  )) as unknown as {
+    Client: new (
+      info: { name: string; version: string },
+      options?: { capabilities?: Record<string, unknown> },
+    ) => unknown;
+  };
+  const transportModule = (await loadOptionalPeer(
+    () => import("@modelcontextprotocol/sdk/client/streamableHttp.js"),
+    {
+      adapterName: "mcp (http client)",
+      packageName: "@modelcontextprotocol/sdk",
+    },
+  )) as unknown as {
+    StreamableHTTPClientTransport: new (
+      url: URL,
+      options?: {
+        sessionId?: string;
+        requestInit?: { headers?: Record<string, string> };
+      },
+    ) => unknown;
+  };
+
+  const url = new URL(serverUrl);
+  const headers = await buildAuthHeaders(auth);
+  const transportOptions = headers ? { requestInit: { headers } } : undefined;
+  const transport = new transportModule.StreamableHTTPClientTransport(
+    url,
+    transportOptions,
+  );
+  const client = new clientModule.Client(
+    { name: "routecraft-mcp-client", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  try {
+    await (client as unknown as { connect(t: unknown): Promise<void> }).connect(
+      transport,
+    );
+    const callTool = (
+      client as unknown as {
+        callTool(params: {
+          name: string;
+          arguments?: Record<string, unknown>;
+        }): Promise<{ content?: Array<{ type: string; text?: string }> }>;
+      }
+    ).callTool;
+    const response = await callTool.call(client, {
+      name: toolName,
+      arguments: args,
+    });
+    return extractContent(response);
+  } finally {
+    const cleanup = client as unknown as {
+      close?: () => void | Promise<void>;
+      disconnect?: () => void | Promise<void>;
+    };
+    const closeOrDisconnect = cleanup.close ?? cleanup.disconnect;
+    if (typeof closeOrDisconnect === "function") {
+      try {
+        await Promise.resolve(closeOrDisconnect.call(client));
+      } catch {
+        /* swallow cleanup errors */
+      }
+    }
+  }
+}

--- a/packages/ai/src/mcp/dispatch.ts
+++ b/packages/ai/src/mcp/dispatch.ts
@@ -10,18 +10,7 @@ import {
   MCP_STDIO_MANAGERS,
   type McpClientAuthOptions,
   type McpClientHttpConfig,
-  type McpClientStdioConfig,
 } from "./types.ts";
-
-/**
- * Stdio-call shape stored in `MCP_STDIO_MANAGERS`. Kept narrow so this
- * module does not depend on `StdioClientManager` directly.
- *
- * @internal
- */
-interface StdioCallable {
-  callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
-}
 
 /**
  * Dispatch an MCP tool call against a server registered via
@@ -50,19 +39,13 @@ export async function dispatchMcpCall(
   toolName: string,
   args: Record<string, unknown>,
 ): Promise<unknown> {
-  const stdioManagers = ctx.getStore(
-    MCP_STDIO_MANAGERS as keyof import("@routecraft/routecraft").StoreRegistry,
-  ) as Map<string, StdioCallable> | undefined;
+  const stdioManagers = ctx.getStore(MCP_STDIO_MANAGERS);
   const manager = stdioManagers?.get(serverId);
   if (manager) {
     return manager.callTool(toolName, args);
   }
 
-  const servers = ctx.getStore(
-    ADAPTER_MCP_CLIENT_SERVERS as keyof import("@routecraft/routecraft").StoreRegistry,
-  ) as
-    | Map<string, McpClientHttpConfig | McpClientStdioConfig | string>
-    | undefined;
+  const servers = ctx.getStore(ADAPTER_MCP_CLIENT_SERVERS);
   const config = servers?.get(serverId);
   if (!config) {
     throw rcError("RC5003", undefined, {
@@ -93,13 +76,14 @@ export async function dispatchMcpCall(
 
 /**
  * Open a one-shot MCP SDK client over Streamable HTTP, dispatch the
- * tool, then close. Mirrors the implementation in
- * `mcp/adapters/mcp/destination.ts` so both call sites agree on
- * transport setup, auth-header building, and content extraction.
+ * tool, then close. Used by `dispatchMcpCall` for the HTTP path and
+ * by `McpDestinationAdapter` for inline-URL routes that bypass the
+ * registry. Centralised here so transport setup, auth-header
+ * building, and content extraction stay in one place.
  *
  * @internal
  */
-async function callRemoteTool(
+export async function callRemoteTool(
   serverUrl: string,
   toolName: string,
   args: Record<string, unknown>,
@@ -162,16 +146,28 @@ async function callRemoteTool(
     });
     return extractContent(response);
   } finally {
-    const cleanup = client as unknown as {
+    const clientCleanup = client as unknown as {
       close?: () => void | Promise<void>;
       disconnect?: () => void | Promise<void>;
     };
-    const closeOrDisconnect = cleanup.close ?? cleanup.disconnect;
+    const closeOrDisconnect = clientCleanup.close ?? clientCleanup.disconnect;
     if (typeof closeOrDisconnect === "function") {
       try {
         await Promise.resolve(closeOrDisconnect.call(client));
       } catch {
-        /* swallow cleanup errors */
+        // Ignore cleanup errors so original error propagates
+      }
+    }
+    const transportCleanup = transport as unknown as {
+      close?: () => void | Promise<void>;
+      destroy?: () => void;
+    };
+    const closeOrDestroy = transportCleanup.close ?? transportCleanup.destroy;
+    if (typeof closeOrDestroy === "function") {
+      try {
+        await Promise.resolve(closeOrDestroy.call(transport));
+      } catch {
+        // Ignore cleanup errors so original error propagates
       }
     }
   }

--- a/packages/ai/src/mcp/dispatch.ts
+++ b/packages/ai/src/mcp/dispatch.ts
@@ -125,18 +125,20 @@ export async function callRemoteTool(
     ) => unknown;
   };
 
-  const url = new URL(serverUrl);
-  const headers = await buildAuthHeaders(auth);
-  const transportOptions = headers ? { requestInit: { headers } } : undefined;
-  const transport = new transportModule.StreamableHTTPClientTransport(
-    url,
-    transportOptions,
-  );
-  const client = new clientModule.Client(
-    { name: "routecraft-mcp-client", version: "1.0.0" },
-    { capabilities: {} },
-  );
+  let transport: unknown;
+  let client: unknown;
   try {
+    const url = new URL(serverUrl);
+    const headers = await buildAuthHeaders(auth);
+    const transportOptions = headers ? { requestInit: { headers } } : undefined;
+    transport = new transportModule.StreamableHTTPClientTransport(
+      url,
+      transportOptions,
+    );
+    client = new clientModule.Client(
+      { name: "routecraft-mcp-client", version: "1.0.0" },
+      { capabilities: {} },
+    );
     await (client as unknown as { connect(t: unknown): Promise<void> }).connect(
       transport,
     );
@@ -166,28 +168,36 @@ export async function callRemoteTool(
       message: `mcp dispatch: failed to call tool "${toolName}" at "${serverUrl}".`,
     });
   } finally {
-    const clientCleanup = client as unknown as {
-      close?: () => void | Promise<void>;
-      disconnect?: () => void | Promise<void>;
-    };
-    const closeOrDisconnect = clientCleanup.close ?? clientCleanup.disconnect;
-    if (typeof closeOrDisconnect === "function") {
-      try {
-        await Promise.resolve(closeOrDisconnect.call(client));
-      } catch {
-        // Ignore cleanup errors so original error propagates
+    // `client` and `transport` may be undefined when an early step
+    // inside the try block (URL parsing, auth header building,
+    // transport / client construction) threw before they were
+    // assigned. Guard each cleanup with a truthy check.
+    if (client) {
+      const clientCleanup = client as {
+        close?: () => void | Promise<void>;
+        disconnect?: () => void | Promise<void>;
+      };
+      const closeOrDisconnect = clientCleanup.close ?? clientCleanup.disconnect;
+      if (typeof closeOrDisconnect === "function") {
+        try {
+          await Promise.resolve(closeOrDisconnect.call(client));
+        } catch {
+          // Ignore cleanup errors so original error propagates
+        }
       }
     }
-    const transportCleanup = transport as unknown as {
-      close?: () => void | Promise<void>;
-      destroy?: () => void;
-    };
-    const closeOrDestroy = transportCleanup.close ?? transportCleanup.destroy;
-    if (typeof closeOrDestroy === "function") {
-      try {
-        await Promise.resolve(closeOrDestroy.call(transport));
-      } catch {
-        // Ignore cleanup errors so original error propagates
+    if (transport) {
+      const transportCleanup = transport as {
+        close?: () => void | Promise<void>;
+        destroy?: () => void;
+      };
+      const closeOrDestroy = transportCleanup.close ?? transportCleanup.destroy;
+      if (typeof closeOrDestroy === "function") {
+        try {
+          await Promise.resolve(closeOrDestroy.call(transport));
+        } catch {
+          // Ignore cleanup errors so original error propagates
+        }
       }
     }
   }

--- a/packages/ai/src/mcp/dispatch.ts
+++ b/packages/ai/src/mcp/dispatch.ts
@@ -1,4 +1,5 @@
 import {
+  isRoutecraftError,
   loadOptionalPeer,
   rcError,
   type CraftContext,
@@ -42,7 +43,14 @@ export async function dispatchMcpCall(
   const stdioManagers = ctx.getStore(MCP_STDIO_MANAGERS);
   const manager = stdioManagers?.get(serverId);
   if (manager) {
-    return manager.callTool(toolName, args);
+    try {
+      return await manager.callTool(toolName, args);
+    } catch (cause) {
+      if (isRoutecraftError(cause)) throw cause;
+      throw rcError("RC5003", cause, {
+        message: `mcp dispatch: stdio call to "${serverId}:${toolName}" failed.`,
+      });
+    }
   }
 
   const servers = ctx.getStore(ADAPTER_MCP_CLIENT_SERVERS);
@@ -145,6 +153,18 @@ export async function callRemoteTool(
       arguments: args,
     });
     return extractContent(response);
+  } catch (cause) {
+    // Wrap SDK / transport / network errors as RC5003 with the original
+    // attached as `cause`, matching the Error and Logging Policy
+    // (`level 1`: throw rcError with the right framework code so the
+    // dispatch boundary always surfaces an MCP-tagged error rather than
+    // a bare TypeError or SDK-specific class). `RoutecraftError`s
+    // thrown by called helpers pass through unchanged so caller-facing
+    // error codes are preserved.
+    if (isRoutecraftError(cause)) throw cause;
+    throw rcError("RC5003", cause, {
+      message: `mcp dispatch: failed to call tool "${toolName}" at "${serverUrl}".`,
+    });
   } finally {
     const clientCleanup = client as unknown as {
       close?: () => void | Promise<void>;

--- a/packages/ai/src/mcp/tool-registry.ts
+++ b/packages/ai/src/mcp/tool-registry.ts
@@ -1,4 +1,33 @@
-import type { McpTool, McpToolRegistryEntry } from "./types.ts";
+import type { Tag } from "@routecraft/routecraft";
+import type {
+  McpTool,
+  McpToolAnnotations,
+  McpToolRegistryEntry,
+} from "./types.ts";
+
+/**
+ * Derive capability tags from MCP `annotations` hints so MCP tools
+ * surface alongside fns and direct routes under the same `Tag`
+ * selectors (`tools([{ tagged: "read-only" }])`).
+ *
+ * Mapping: `readOnlyHint -> "read-only"`,
+ * `destructiveHint -> "destructive"`, `idempotentHint -> "idempotent"`,
+ * `openWorldHint -> "open-world"`. Returns an empty array (omitted
+ * from the entry) when no hints apply.
+ *
+ * @internal
+ */
+function deriveTagsFromAnnotations(
+  annotations: McpToolAnnotations | undefined,
+): Tag[] {
+  if (!annotations) return [];
+  const tags: Tag[] = [];
+  if (annotations.readOnlyHint) tags.push("read-only");
+  if (annotations.destructiveHint) tags.push("destructive");
+  if (annotations.idempotentHint) tags.push("idempotent");
+  if (annotations.openWorldHint) tags.push("open-world");
+  return tags;
+}
 
 /**
  * Central registry of MCP tools discovered from remote MCP servers.
@@ -47,6 +76,10 @@ export class McpToolRegistry {
       }
       if (tool.annotations !== undefined) {
         entry.annotations = tool.annotations;
+      }
+      const derivedTags = deriveTagsFromAnnotations(tool.annotations);
+      if (derivedTags.length > 0) {
+        entry.tags = derivedTags;
       }
       sourceMap.set(tool.name, entry);
     }

--- a/packages/ai/src/mcp/types.ts
+++ b/packages/ai/src/mcp/types.ts
@@ -1,4 +1,4 @@
-import type { Exchange } from "@routecraft/routecraft";
+import type { Exchange, Tag } from "@routecraft/routecraft";
 import type {
   OAuthPrincipal,
   Principal,
@@ -576,6 +576,19 @@ export interface McpToolRegistryEntry {
   transport: "stdio" | "http" | "local";
   /** MCP tool annotations (behavior hints). */
   annotations?: McpToolAnnotations;
+  /**
+   * Capability tags derived from the MCP `annotations` field at
+   * registration time. Mirrors the `Tag` namespace fns and direct
+   * routes use, so the agent `tools([{ tagged: "read-only" }])`
+   * selector matches MCP tools alongside fn/route entries.
+   *
+   * Mapping: `readOnlyHint -> "read-only"`,
+   * `destructiveHint -> "destructive"`, `idempotentHint -> "idempotent"`,
+   * `openWorldHint -> "open-world"`.
+   *
+   * @experimental
+   */
+  tags?: readonly Tag[];
 }
 
 /**

--- a/packages/ai/test/mcp.bun.test.ts
+++ b/packages/ai/test/mcp.bun.test.ts
@@ -576,4 +576,45 @@ describe("dispatchMcpCall: RC5003 error wrapping", () => {
       await t.stop();
     }
   });
+
+  /**
+   * @case Malformed HTTP server URL surfaces as RC5003, not a raw TypeError
+   * @preconditions Server registered with `url: "not a url"`; dispatchMcpCall invoked
+   * @expectedResult Caught error is a RoutecraftError with rc "RC5003"; the underlying TypeError travels on `cause`
+   */
+  test("malformed serverUrl throws RC5003 (URL construction is inside the try)", async () => {
+    const { dispatchMcpCall } = await import("../src/mcp/dispatch.ts");
+    const { ADAPTER_MCP_CLIENT_SERVERS } = await import("../src/index.ts");
+    const { isRoutecraftError } = await import("@routecraft/routecraft");
+    const t = await testContext()
+      .with({
+        plugins: [
+          {
+            apply(ctx) {
+              const servers = new Map<
+                string,
+                { url: string; auth?: undefined }
+              >();
+              servers.set("bad", { url: "not a url" });
+              ctx.setStore(ADAPTER_MCP_CLIENT_SERVERS, servers);
+            },
+          },
+        ],
+      })
+      .build();
+    try {
+      let caught: unknown;
+      try {
+        await dispatchMcpCall(t.ctx, "bad", "anything", {});
+      } catch (err) {
+        caught = err;
+      }
+      expect(isRoutecraftError(caught)).toBe(true);
+      const rcerr = caught as { rc: string; cause?: unknown };
+      expect(rcerr.rc).toBe("RC5003");
+      expect(rcerr.cause).toBeInstanceOf(TypeError);
+    } finally {
+      await t.stop();
+    }
+  });
 });

--- a/packages/ai/test/mcp.bun.test.ts
+++ b/packages/ai/test/mcp.bun.test.ts
@@ -474,3 +474,106 @@ describe("mcp() DSL function", () => {
     await ctx.stop();
   });
 });
+
+describe("dispatchMcpCall: RC5003 error wrapping", () => {
+  /**
+   * @case Stdio dispatch errors surface as RC5003 with the original error preserved on `cause`
+   * @preconditions Context with a stdio manager whose callTool rejects with a raw TypeError
+   * @expectedResult dispatchMcpCall rejects with a RoutecraftError; rc === "RC5003"; cause === original TypeError
+   */
+  test("wraps stdio dispatch errors as RC5003 with cause", async () => {
+    const { dispatchMcpCall } = await import("../src/mcp/dispatch.ts");
+    const { MCP_STDIO_MANAGERS } = await import("../src/index.ts");
+    const { isRoutecraftError } = await import("@routecraft/routecraft");
+    const original = new TypeError("simulated SDK fault");
+    const t = await testContext()
+      .with({
+        plugins: [
+          {
+            apply(ctx) {
+              const managers = new Map<
+                string,
+                {
+                  callTool(
+                    name: string,
+                    args: Record<string, unknown>,
+                  ): Promise<unknown>;
+                }
+              >();
+              managers.set("Nuclino", {
+                async callTool() {
+                  throw original;
+                },
+              });
+              ctx.setStore(MCP_STDIO_MANAGERS, managers);
+            },
+          },
+        ],
+      })
+      .build();
+    try {
+      let caught: unknown;
+      try {
+        await dispatchMcpCall(t.ctx, "Nuclino", "list_teams", {});
+      } catch (err) {
+        caught = err;
+      }
+      expect(isRoutecraftError(caught)).toBe(true);
+      const rcerr = caught as { rc: string; cause?: unknown };
+      expect(rcerr.rc).toBe("RC5003");
+      expect(rcerr.cause).toBe(original);
+    } finally {
+      await t.stop();
+    }
+  });
+
+  /**
+   * @case A RoutecraftError thrown from inside the stdio manager passes through unchanged
+   * @preconditions Manager's callTool rejects with a pre-tagged RC5021
+   * @expectedResult dispatchMcpCall rethrows the same error; rc remains "RC5021"; no double-wrap
+   */
+  test("does not double-wrap an inner RoutecraftError", async () => {
+    const { dispatchMcpCall } = await import("../src/mcp/dispatch.ts");
+    const { MCP_STDIO_MANAGERS } = await import("../src/index.ts");
+    const { rcError } = await import("@routecraft/routecraft");
+    const original = rcError("RC5021", undefined, {
+      message: "userinfo enrichment failed",
+    });
+    const t = await testContext()
+      .with({
+        plugins: [
+          {
+            apply(ctx) {
+              const managers = new Map<
+                string,
+                {
+                  callTool(
+                    name: string,
+                    args: Record<string, unknown>,
+                  ): Promise<unknown>;
+                }
+              >();
+              managers.set("Nuclino", {
+                async callTool() {
+                  throw original;
+                },
+              });
+              ctx.setStore(MCP_STDIO_MANAGERS, managers);
+            },
+          },
+        ],
+      })
+      .build();
+    try {
+      let caught: unknown;
+      try {
+        await dispatchMcpCall(t.ctx, "Nuclino", "list_teams", {});
+      } catch (err) {
+        caught = err;
+      }
+      expect((caught as { rc: string }).rc).toBe("RC5021");
+    } finally {
+      await t.stop();
+    }
+  });
+});

--- a/packages/ai/test/tool-registry.bun.test.ts
+++ b/packages/ai/test/tool-registry.bun.test.ts
@@ -242,4 +242,66 @@ describe("McpToolRegistry", () => {
     const tool = registry.getTool("plain");
     expect(tool?.annotations).toBeUndefined();
   });
+
+  /**
+   * @case Annotations are derived into `tags` so the `{ tagged }` selector picks up MCP tools
+   * @preconditions Four tools each carrying a different annotation hint
+   * @expectedResult Each entry's `tags` matches the documented mapping (readOnlyHint -> "read-only", destructiveHint -> "destructive", idempotentHint -> "idempotent", openWorldHint -> "open-world")
+   */
+  test("derives tags from annotations at registration time", () => {
+    registry.setToolsForSource("server-a", "http", [
+      {
+        name: "read",
+        inputSchema: { type: "object" },
+        annotations: { readOnlyHint: true },
+      },
+      {
+        name: "write",
+        inputSchema: { type: "object" },
+        annotations: { destructiveHint: true },
+      },
+      {
+        name: "idem",
+        inputSchema: { type: "object" },
+        annotations: { idempotentHint: true },
+      },
+      {
+        name: "world",
+        inputSchema: { type: "object" },
+        annotations: { openWorldHint: true },
+      },
+    ]);
+    expect(registry.getTool("read")?.tags).toEqual(["read-only"]);
+    expect(registry.getTool("write")?.tags).toEqual(["destructive"]);
+    expect(registry.getTool("idem")?.tags).toEqual(["idempotent"]);
+    expect(registry.getTool("world")?.tags).toEqual(["open-world"]);
+  });
+
+  /**
+   * @case Multiple annotation hints combine into multiple tags
+   * @preconditions readOnlyHint and idempotentHint both true
+   * @expectedResult tags include both "read-only" and "idempotent" in mapping order
+   */
+  test("combines multiple annotation hints into multiple tags", () => {
+    registry.setToolsForSource("server-a", "http", [
+      {
+        name: "safe",
+        inputSchema: { type: "object" },
+        annotations: { readOnlyHint: true, idempotentHint: true },
+      },
+    ]);
+    expect(registry.getTool("safe")?.tags).toEqual(["read-only", "idempotent"]);
+  });
+
+  /**
+   * @case Tools without active hints carry no tags
+   * @preconditions Tool with an annotations object whose hints are all false / undefined
+   * @expectedResult tags field is omitted from the registry entry
+   */
+  test("omits tags field when no hints apply", () => {
+    registry.setToolsForSource("server-a", "http", [
+      { name: "plain", inputSchema: { type: "object" }, annotations: {} },
+    ]);
+    expect(registry.getTool("plain")?.tags).toBeUndefined();
+  });
 });

--- a/packages/ai/test/tools-builders.bun.test.ts
+++ b/packages/ai/test/tools-builders.bun.test.ts
@@ -8,7 +8,6 @@ import {
   defaultFns,
   directTool,
   isDeferredFn,
-  mcpTool,
   ADAPTER_FN_REGISTRY,
   type FnEntry,
   type FnOptions,
@@ -362,31 +361,6 @@ describe("tool builders - agentTool stub", () => {
    */
   test("agentTool throws on empty agentId", () => {
     expect(() => agentTool("")).toThrow(/agentId/i);
-  });
-});
-
-describe("tool builders - mcpTool stub", () => {
-  /**
-   * @case mcpTool returns a deferred descriptor whose resolve throws
-   * @preconditions mcpTool("brave", "search")
-   * @expectedResult deferred kind === "mcp"; resolve throws RC5003 mentioning the story
-   */
-  test("mcpTool returns a deferred descriptor that resolves to a not-yet-supported error", () => {
-    const desc = mcpTool("brave", "search");
-    expect(desc.kind).toBe("mcp");
-    expect(() => desc.resolve(undefined as never, "searchWeb")).toThrow(
-      /not yet supported/i,
-    );
-  });
-
-  /**
-   * @case mcpTool throws on empty serverId or toolName
-   * @preconditions mcpTool with blank inputs
-   * @expectedResult RC5003 thrown synchronously
-   */
-  test("mcpTool throws on empty serverId / toolName", () => {
-    expect(() => mcpTool("", "search")).toThrow(/serverId/i);
-    expect(() => mcpTool("brave", "")).toThrow(/toolName/i);
   });
 });
 

--- a/packages/ai/test/tools-builders.bun.test.ts
+++ b/packages/ai/test/tools-builders.bun.test.ts
@@ -4,7 +4,6 @@ import { craft, direct, isRoutecraftError, log } from "@routecraft/routecraft";
 import { testContext, type TestContext } from "@routecraft/testing";
 import {
   agentPlugin,
-  agentTool,
   defaultFns,
   directTool,
   isDeferredFn,
@@ -337,30 +336,6 @@ describe("tool builders - directTool dispatch", () => {
       },
     );
     expect(downstreamPrincipal).toEqual(principal);
-  });
-});
-
-describe("tool builders - agentTool stub", () => {
-  /**
-   * @case agentTool returns a deferred descriptor whose resolve throws
-   * @preconditions agentTool("researcher")
-   * @expectedResult deferred kind === "agent"; resolve throws RC5003 mentioning the story
-   */
-  test("agentTool returns a deferred descriptor that resolves to a not-yet-supported error", () => {
-    const desc = agentTool("researcher");
-    expect(desc.kind).toBe("agent");
-    expect(() => desc.resolve(undefined as never, "research")).toThrow(
-      /not yet supported/i,
-    );
-  });
-
-  /**
-   * @case agentTool throws on empty agentId at build time
-   * @preconditions agentTool("")
-   * @expectedResult RC5003 thrown synchronously
-   */
-  test("agentTool throws on empty agentId", () => {
-    expect(() => agentTool("")).toThrow(/agentId/i);
   });
 });
 

--- a/packages/ai/test/tools-selection-mcp.bun.test.ts
+++ b/packages/ai/test/tools-selection-mcp.bun.test.ts
@@ -1,0 +1,395 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { testContext, type TestContext } from "@routecraft/testing";
+import {
+  agentPlugin,
+  defaultFns,
+  MCP_TOOL_REGISTRY,
+  tools,
+  type FnHandlerContext,
+} from "../src/index.ts";
+import { McpToolRegistry } from "../src/mcp/tool-registry.ts";
+
+// Mock the MCP dispatch path so handlers can be exercised without
+// real stdio / HTTP clients. Each test captures the recorded calls
+// and asserts against them.
+const recordedDispatches: Array<{
+  serverId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+}> = [];
+
+const dispatchMock = mock(
+  async (
+    _ctx: unknown,
+    serverId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<unknown> => {
+    recordedDispatches.push({ serverId, toolName, args });
+    return { ok: true, serverId, toolName };
+  },
+);
+
+mock.module("../src/mcp/dispatch.ts", () => ({
+  dispatchMcpCall: dispatchMock,
+}));
+
+async function buildCtxWithMcp(
+  entries: Array<{
+    source: string;
+    transport: "stdio" | "http" | "local";
+    tools: Array<{
+      name: string;
+      description?: string;
+      inputSchema?: Record<string, unknown>;
+      annotations?: {
+        readOnlyHint?: boolean;
+        destructiveHint?: boolean;
+        idempotentHint?: boolean;
+        openWorldHint?: boolean;
+      };
+    }>;
+  }>,
+  options: {
+    functions?: NonNullable<Parameters<typeof agentPlugin>[0]>["functions"];
+  } = {},
+): Promise<TestContext> {
+  const t = await testContext()
+    .with({
+      plugins: [
+        agentPlugin({ functions: options.functions ?? {} }),
+        {
+          apply(ctx) {
+            const registry = new McpToolRegistry();
+            for (const e of entries) {
+              registry.setToolsForSource(
+                e.source,
+                e.transport,
+                e.tools.map((tt) => ({
+                  name: tt.name,
+                  ...(tt.description ? { description: tt.description } : {}),
+                  inputSchema: tt.inputSchema ?? { type: "object" as const },
+                  ...(tt.annotations ? { annotations: tt.annotations } : {}),
+                })),
+              );
+            }
+            ctx.setStore(
+              MCP_TOOL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
+              registry,
+            );
+          },
+        },
+      ],
+    })
+    .build();
+  return t;
+}
+
+describe("tools() resolver - MCP refs", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    recordedDispatches.length = 0;
+    dispatchMock.mockClear();
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case mcp_<client>:<tool> resolves to a single ResolvedTool
+   * @preconditions Registry has Nuclino:list_teams with description and JSON Schema
+   * @expectedResult Resolution yields one tool named mcp_Nuclino:list_teams whose handler dispatches through dispatchMcpCall
+   */
+  test("mcp_<client>:<tool> resolves to one ResolvedTool", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [
+          {
+            name: "list_teams",
+            description: "List teams.",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      },
+    ]);
+    const resolved = tools(["mcp_Nuclino:list_teams"]).resolve(t.ctx);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.name).toBe("mcp_Nuclino:list_teams");
+    expect(resolved[0]!.description).toBe("List teams.");
+    await resolved[0]!.handler(
+      { foo: "bar" } as unknown,
+      {} as FnHandlerContext,
+    );
+    expect(recordedDispatches).toEqual([
+      { serverId: "Nuclino", toolName: "list_teams", args: { foo: "bar" } },
+    ]);
+  });
+
+  /**
+   * @case mcp_<client>:* expands to every tool registered under the client
+   * @preconditions Registry has three Nuclino tools
+   * @expectedResult Resolution yields three ResolvedTools, one per registered tool, names follow mcp_Nuclino:<tool>
+   */
+  test("mcp_<client>:* expands to every tool on the client", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [
+          { name: "list_teams" },
+          { name: "list_workspaces" },
+          { name: "search_items" },
+        ],
+      },
+    ]);
+    const resolved = tools(["mcp_Nuclino:*"]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name).sort();
+    expect(names).toEqual([
+      "mcp_Nuclino:list_teams",
+      "mcp_Nuclino:list_workspaces",
+      "mcp_Nuclino:search_items",
+    ]);
+  });
+
+  /**
+   * @case Wildcard with a guard attaches the guard to every expanded tool
+   * @preconditions Client with two tools; { name: "mcp_X:*", guard }
+   * @expectedResult Every resolved tool carries the same guard reference
+   */
+  test("mcp_<client>:* with a guard attaches the guard to every expanded tool", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [{ name: "a" }, { name: "b" }],
+      },
+    ]);
+    const guard = mock(async () => undefined);
+    const resolved = tools([{ name: "mcp_Nuclino:*", guard }]).resolve(t.ctx);
+    expect(resolved).toHaveLength(2);
+    for (const r of resolved) expect(r.guard).toBe(guard);
+  });
+
+  /**
+   * @case Unknown MCP client throws RC5003 listing known clients
+   * @preconditions Registry has client "Nuclino"; user references "Foo"
+   * @expectedResult Throw mentioning client "Foo" and listing "Nuclino"
+   */
+  test("unknown MCP client throws RC5003 with known clients", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [{ name: "list_teams" }],
+      },
+    ]);
+    expect(() => tools(["mcp_Foo:bar"]).resolve(t!.ctx)).toThrow(
+      /client "Foo" has no registered tools.*Nuclino/s,
+    );
+  });
+
+  /**
+   * @case Known client with unknown tool throws and lists registered tools
+   * @preconditions Registry has Nuclino:list_teams; user asks for Nuclino:nope
+   * @expectedResult Throw mentions "nope" and lists "list_teams"
+   */
+  test("known client + unknown tool throws RC5003 listing available tools", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [{ name: "list_teams" }, { name: "search_items" }],
+      },
+    ]);
+    expect(() => tools(["mcp_Nuclino:nope"]).resolve(t!.ctx)).toThrow(
+      /"nope".*list_teams.*search_items/s,
+    );
+  });
+
+  /**
+   * @case Client names containing underscores resolve correctly
+   * @preconditions Registry has client "my_company_api"
+   * @expectedResult mcp_my_company_api:get_user resolves to the right tool
+   */
+  test("client names with underscores resolve correctly", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "my_company_api",
+        transport: "http",
+        tools: [{ name: "get_user", description: "Get a user." }],
+      },
+    ]);
+    const resolved = tools(["mcp_my_company_api:get_user"]).resolve(t.ctx);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.name).toBe("mcp_my_company_api:get_user");
+  });
+
+  /**
+   * @case MCP_TOOL_REGISTRY missing throws a helpful "install mcpPlugin" error
+   * @preconditions Context built without mcpPlugin; user references an MCP tool
+   * @expectedResult Throw mentions install hint
+   */
+  test("missing MCP_TOOL_REGISTRY throws install hint", async () => {
+    t = await testContext()
+      .with({ plugins: [agentPlugin({})] })
+      .build();
+    expect(() => tools(["mcp_Foo:bar"]).resolve(t!.ctx)).toThrow(
+      /no MCP_TOOL_REGISTRY is present/,
+    );
+  });
+
+  /**
+   * @case mcp_<client>:<tool> with description override on { name } shape throws
+   * @preconditions { name: "mcp_X:y", description: "x" } in tools()
+   * @expectedResult RC5003 explaining MCP descriptions are server-owned
+   */
+  test("description override on an MCP { name } item throws", async () => {
+    t = await buildCtxWithMcp([
+      { source: "X", transport: "http", tools: [{ name: "y" }] },
+    ]);
+    expect(() =>
+      tools([{ name: "mcp_X:y", description: "override" }]).resolve(t!.ctx),
+    ).toThrow(/description.*MCP server is the source of truth/);
+  });
+});
+
+describe("tools() resolver - { tagged, from? } over MCP", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    recordedDispatches.length = 0;
+    dispatchMock.mockClear();
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case `{ tagged: "read-only" }` walks fns AND MCP tools in one selection
+   * @preconditions defaultFns provides currentTime ("read-only"); registry has Nuclino:get_item with readOnlyHint
+   * @expectedResult Both tools appear in the resolved list
+   */
+  test("{ tagged } walks fns and MCP tools together", async () => {
+    t = await buildCtxWithMcp(
+      [
+        {
+          source: "Nuclino",
+          transport: "http",
+          tools: [{ name: "get_item", annotations: { readOnlyHint: true } }],
+        },
+      ],
+      { functions: { ...defaultFns } },
+    );
+    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name).sort();
+    expect(names).toContain("currentTime");
+    expect(names).toContain("mcp_Nuclino:get_item");
+  });
+
+  /**
+   * @case `from: "mcp_<client>"` scopes the tag selector to one MCP client
+   * @preconditions defaultFns ships read-only fns; registry has Nuclino read-only tool and Stripe read-only tool
+   * @expectedResult Only Nuclino's read-only tool appears; defaultFns and Stripe are excluded
+   */
+  test("{ tagged, from } scopes to a single MCP client", async () => {
+    t = await buildCtxWithMcp(
+      [
+        {
+          source: "Nuclino",
+          transport: "http",
+          tools: [{ name: "get_item", annotations: { readOnlyHint: true } }],
+        },
+        {
+          source: "Stripe",
+          transport: "http",
+          tools: [
+            { name: "list_charges", annotations: { readOnlyHint: true } },
+          ],
+        },
+      ],
+      { functions: { ...defaultFns } },
+    );
+    const resolved = tools([
+      { tagged: "read-only", from: "mcp_Nuclino" },
+    ]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name).sort();
+    expect(names).toEqual(["mcp_Nuclino:get_item"]);
+  });
+
+  /**
+   * @case `from: "mcp_<unknown>"` throws RC5003 listing registered clients
+   * @preconditions Registry has Nuclino only; user scopes from "mcp_Foo"
+   * @expectedResult Throw mentions "mcp_Foo" and lists "Nuclino"
+   */
+  test("{ tagged, from } against an unknown MCP client throws", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [{ name: "get_item", annotations: { readOnlyHint: true } }],
+      },
+    ]);
+    expect(() =>
+      tools([{ tagged: "read-only", from: "mcp_Foo" }]).resolve(t!.ctx),
+    ).toThrow(/mcp_Foo.*Nuclino/s);
+  });
+
+  /**
+   * @case Zero-match `{ tagged, from }` throws so a misconfig never silently no-ops
+   * @preconditions Nuclino has a destructive tool only; user filters for "read-only"
+   * @expectedResult RC5003 thrown
+   */
+  test("{ tagged, from } that matches zero tools throws RC5003", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [
+          { name: "delete_team", annotations: { destructiveHint: true } },
+        ],
+      },
+    ]);
+    expect(() =>
+      tools([{ tagged: "read-only", from: "mcp_Nuclino" }]).resolve(t!.ctx),
+    ).toThrow(/matched no tools/);
+  });
+
+  /**
+   * @case Mixed selection of MCP wildcard, MCP scoped tag, fn, and direct in one array
+   * @preconditions Two MCP tools (one read-only, one destructive); two defaultFns
+   * @expectedResult Resolved list contains the wildcard expansion + the tag-filtered subset + the explicit fn, deduped
+   */
+  test("mixes MCP refs, tag filters, and fn names in one selection", async () => {
+    t = await buildCtxWithMcp(
+      [
+        {
+          source: "Nuclino",
+          transport: "http",
+          tools: [
+            { name: "get_item", annotations: { readOnlyHint: true } },
+            { name: "delete_item", annotations: { destructiveHint: true } },
+          ],
+        },
+      ],
+      { functions: { ...defaultFns } },
+    );
+    const resolved = tools([
+      "mcp_Nuclino:*",
+      { tagged: "destructive", from: "mcp_Nuclino" },
+      "currentTime",
+    ]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name).sort();
+    expect(names).toEqual([
+      "currentTime",
+      "mcp_Nuclino:delete_item",
+      "mcp_Nuclino:get_item",
+    ]);
+  });
+});

--- a/packages/ai/test/tools-selection-mcp.bun.test.ts
+++ b/packages/ai/test/tools-selection-mcp.bun.test.ts
@@ -230,6 +230,32 @@ describe("tools() resolver - MCP refs", () => {
   });
 
   /**
+   * @case A plain fn id that happens to start with "mcp_" resolves via the fn registry, not the MCP path
+   * @preconditions agentPlugin registers a fn named "mcp_healthcheck"; tools(["mcp_healthcheck"])
+   * @expectedResult Resolution returns the fn-registry tool; no MCP grammar error
+   */
+  test("mcp_-prefixed fn id without ':' resolves via fn registry", async () => {
+    t = await buildCtxWithMcp([], {
+      functions: {
+        mcp_healthcheck: {
+          description: "Ping the local mcp infra.",
+          input: {
+            "~standard": {
+              version: 1,
+              vendor: "routecraft",
+              validate: (value: unknown) => ({ value }),
+            },
+          } as never,
+          handler: async () => ({ ok: true }),
+        },
+      },
+    });
+    const resolved = tools(["mcp_healthcheck"]).resolve(t.ctx);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.name).toBe("mcp_healthcheck");
+  });
+
+  /**
    * @case MCP_TOOL_REGISTRY missing throws a helpful "install mcpPlugin" error
    * @preconditions Context built without mcpPlugin; user references an MCP tool
    * @expectedResult Throw mentions install hint

--- a/packages/ai/test/tools-selection-mcp.bun.test.ts
+++ b/packages/ai/test/tools-selection-mcp.bun.test.ts
@@ -256,6 +256,23 @@ describe("tools() resolver - MCP refs", () => {
   });
 
   /**
+   * @case Malformed MCP refs with an empty client or tool segment surface as MCP grammar errors, not generic "unknown tool"
+   * @preconditions Registry populated with one valid Nuclino tool; user writes `mcp_:foo` or `mcp_foo:`
+   * @expectedResult Each throws RC5003 mentioning the MCP grammar (form "mcp_<client>:<tool>"), not "unknown tool"
+   */
+  test("malformed mcp_ refs (empty client / empty tool) emit MCP-specific errors", async () => {
+    t = await buildCtxWithMcp([
+      { source: "Nuclino", transport: "http", tools: [{ name: "real_tool" }] },
+    ]);
+    expect(() => tools(["mcp_:foo"]).resolve(t!.ctx)).toThrow(
+      /MCP reference.*form "mcp_<client>:<tool>".*empty client or tool/,
+    );
+    expect(() => tools(["mcp_foo:"]).resolve(t!.ctx)).toThrow(
+      /MCP reference.*form "mcp_<client>:<tool>".*empty client or tool/,
+    );
+  });
+
+  /**
    * @case MCP_TOOL_REGISTRY missing throws a helpful "install mcpPlugin" error
    * @preconditions Context built without mcpPlugin; user references an MCP tool
    * @expectedResult Throw mentions install hint

--- a/packages/ai/test/tools-selection-mcp.bun.test.ts
+++ b/packages/ai/test/tools-selection-mcp.bun.test.ts
@@ -299,6 +299,69 @@ describe("tools() resolver - MCP refs", () => {
       tools([{ name: "mcp_X:y", description: "override" }]).resolve(t!.ctx),
     ).toThrow(/description.*MCP server is the source of truth/);
   });
+
+  /**
+   * @case Empty-string description on an MCP { name } item throws the MCP-specific error, not the generic empty-string error
+   * @preconditions { name: "mcp_X:y", description: "" } in tools()
+   * @expectedResult RC5003 mentioning "MCP server is the source of truth", not "must be a non-empty string"
+   */
+  test("empty-string description on an MCP { name } item throws the MCP-specific error", async () => {
+    t = await buildCtxWithMcp([
+      { source: "X", transport: "http", tools: [{ name: "y" }] },
+    ]);
+    expect(() =>
+      tools([{ name: "mcp_X:y", description: "" }]).resolve(t!.ctx),
+    ).toThrow(/MCP server is the source of truth/);
+  });
+
+  /**
+   * @case description override on an MCP wildcard { name } item throws the MCP-specific error
+   * @preconditions { name: "mcp_X:*", description: "x" } in tools()
+   * @expectedResult RC5003 mentioning MCP server is the source of truth
+   */
+  test("description override on an MCP wildcard { name } item throws", async () => {
+    t = await buildCtxWithMcp([
+      { source: "X", transport: "http", tools: [{ name: "y" }] },
+    ]);
+    expect(() =>
+      tools([{ name: "mcp_X:*", description: "override" }]).resolve(t!.ctx),
+    ).toThrow(/MCP server is the source of truth/);
+  });
+
+  /**
+   * @case MCP tool handler rejects non-object input instead of silently coercing to {}
+   * @preconditions Resolved MCP tool's handler called with null / array / number
+   * @expectedResult RC5003 thrown synchronously naming the tool and the received type; dispatch never runs
+   */
+  test("MCP tool handler throws RC5003 on non-object input", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [
+          {
+            name: "search_items",
+            description: "search",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      },
+    ]);
+    const resolved = tools(["mcp_Nuclino:search_items"]).resolve(t!.ctx);
+    expect(resolved).toHaveLength(1);
+    const tool = resolved[0]!;
+    await expect(
+      tool.handler(null as unknown, {} as FnHandlerContext),
+    ).rejects.toThrow(/mcp tool.*expects an object argument.*null/);
+    await expect(
+      tool.handler([1, 2] as unknown, {} as FnHandlerContext),
+    ).rejects.toThrow(/mcp tool.*expects an object argument.*array/);
+    await expect(
+      tool.handler(42 as unknown, {} as FnHandlerContext),
+    ).rejects.toThrow(/mcp tool.*expects an object argument.*number/);
+    // Sanity: a real object argument still dispatches through.
+    expect(recordedDispatches).toHaveLength(0);
+  });
 });
 
 describe("tools() resolver - { tagged, from? } over MCP", () => {

--- a/packages/ai/test/tools-selection.bun.test.ts
+++ b/packages/ai/test/tools-selection.bun.test.ts
@@ -156,18 +156,6 @@ describe("tools() resolver - bare references", () => {
       /sub-agent|follow-up/i,
     );
   });
-
-  /**
-   * @case mcp_<server>_<tool> reference surfaces a clear "story E" error
-   * @preconditions resolve tools(["mcp_brave_search"])
-   * @expectedResult RC5003 thrown mentioning MCP / follow-up story
-   */
-  test("mcp_<...> bare ref throws not-yet-supported", async () => {
-    t = await buildCtx({});
-    expect(() => tools(["mcp_brave_search"]).resolve(t!.ctx)).toThrow(
-      /MCP|follow-up/i,
-    );
-  });
 });
 
 describe("tools() resolver - { name, guard }", () => {

--- a/packages/ai/test/tools-selection.bun.test.ts
+++ b/packages/ai/test/tools-selection.bun.test.ts
@@ -365,31 +365,6 @@ describe("tools() resolver - regression", () => {
   });
 
   /**
-   * @case Tag selectors must NOT resolve agentTool stubs even when those stubs are present in the registry
-   * @preconditions agentPlugin functions has an `agentTool("x")` deferred stub plus eager fns; query an unrelated tag that only the eager fns carry
-   * @expectedResult Resolution returns matching eager fns; the stub is silently skipped (not thrown)
-   */
-  test("tag walk silently skips non-direct deferred stubs", async () => {
-    const { agentTool } = await import("../src/index.ts");
-    t = await testContext()
-      .with({
-        plugins: [
-          agentPlugin({
-            functions: {
-              ...defaultFns,
-              futureAgent: agentTool("researcher"),
-            },
-          }),
-        ],
-      })
-      .build();
-
-    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
-    const names = resolved.map((r) => r.name).sort();
-    expect(names).toEqual(["currentTime", "randomUuid"]);
-  });
-
-  /**
    * @case Tag selectors must NOT throw when a misconfigured directTool wrapper is in the registry; only explicit refs throw
    * @preconditions functions: { broken: directTool("does-not-exist") }; tag selector that matches eager fns
    * @expectedResult Selector returns the eager match; broken wrapper is silently skipped because its underlying route has no matching tag
@@ -574,5 +549,40 @@ describe("tools() resolver - dedup and prefix-convention coverage", () => {
     const names = resolved.map((r) => r.name);
     expect(names).toContain("fetchOrder");
     expect(names).not.toContain("direct_fetch-order");
+  });
+
+  /**
+   * @case Same dedup holds for route ids that include URL-special characters (the direct registry stores them sanitised, but the wrapper carries the raw id)
+   * @preconditions Route "orders/fetch" tagged "read-only"; functions: { ordersFetch: directTool("orders/fetch") }; tag selector { tagged: "read-only" }
+   * @expectedResult Only the fn-registry wrapper "ordersFetch" surfaces; the sanitised `direct_orders%2Ffetch` form is suppressed (dedup compares sanitised on both sides)
+   */
+  test("directTool fn registry wrapper supersedes the same direct route even when the route id contains URL-special characters", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: {
+              ordersFetch: directTool("orders/fetch"),
+            },
+          }),
+        ],
+      })
+      .routes([
+        craft()
+          .id("orders/fetch")
+          .description("Fetch an order.")
+          .input(z.object({ orderId: z.string() }))
+          .tag("read-only")
+          .from(direct())
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
+    const names = resolved.map((r) => r.name);
+    expect(names).toContain("ordersFetch");
+    expect(names).not.toContain("direct_orders/fetch");
+    expect(names).not.toContain("direct_orders%2Ffetch");
   });
 });

--- a/packages/ai/test/tools-selection.bun.test.ts
+++ b/packages/ai/test/tools-selection.bun.test.ts
@@ -327,14 +327,15 @@ describe("tools() resolver - tag selectors", () => {
   });
 
   /**
-   * @case Tag-zero-match returns nothing and does not throw
+   * @case Tag-zero-match throws RC5003 so a misconfigured tag never silently no-ops
    * @preconditions No registered entry has tag "ghost"
-   * @expectedResult tools([{ tagged: "ghost" }]).resolve() returns []
+   * @expectedResult tools([{ tagged: "ghost" }]).resolve() throws RC5003 naming the tag
    */
-  test("tag-zero-match returns nothing without throwing", async () => {
+  test("tag-zero-match throws RC5003", async () => {
     t = await buildCtx({ functions: { ...defaultFns } });
-    const resolved = tools([{ tagged: "ghost" }]).resolve(t.ctx);
-    expect(resolved).toEqual([]);
+    expect(() => tools([{ tagged: "ghost" }]).resolve(t!.ctx)).toThrow(
+      /matched no tools/,
+    );
   });
 
   /**
@@ -376,12 +377,12 @@ describe("tools() resolver - regression", () => {
   });
 
   /**
-   * @case Tag selectors must NOT resolve agentTool/mcpTool stubs even when those stubs are present in the registry
-   * @preconditions agentPlugin functions has both an `agentTool("x")` and an `mcpTool("a","b")` deferred entry, plus eager fns; query unrelated tag
-   * @expectedResult Resolution returns matching eager fns; the stubs are silently skipped (not thrown)
+   * @case Tag selectors must NOT resolve agentTool stubs even when those stubs are present in the registry
+   * @preconditions agentPlugin functions has an `agentTool("x")` deferred stub plus eager fns; query an unrelated tag that only the eager fns carry
+   * @expectedResult Resolution returns matching eager fns; the stub is silently skipped (not thrown)
    */
   test("tag walk silently skips non-direct deferred stubs", async () => {
-    const { agentTool, mcpTool } = await import("../src/index.ts");
+    const { agentTool } = await import("../src/index.ts");
     t = await testContext()
       .with({
         plugins: [
@@ -389,7 +390,6 @@ describe("tools() resolver - regression", () => {
             functions: {
               ...defaultFns,
               futureAgent: agentTool("researcher"),
-              futureMcp: mcpTool("brave", "search"),
             },
           }),
         ],


### PR DESCRIPTION
## Summary

Implement MCP tool resolution in the agent `tools([...])` selector, enabling agents to bind MCP tools via explicit references (`mcp_<client>:<tool>`, `mcp_<client>:*`) and tag-based selection (`{ tagged, from? }`). Consolidate MCP dispatch logic into a shared `dispatchMcpCall` helper used by both the agent resolver and the `mcp(...)` destination adapter.

## Key Changes

- **MCP reference resolution**: `tools(["mcp_Nuclino:list_teams"])` and `tools(["mcp_Nuclino:*"])` now resolve against `MCP_TOOL_REGISTRY`, expanding wildcards to all tools on a client and validating client/tool existence with helpful error messages listing known alternatives.

- **Tag-based MCP selection**: `tools([{ tagged: "read-only" }])` now walks the MCP tool registry alongside fn and direct route registries. MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) are derived into capability tags at registration time so MCP tools surface under the same selectors as fns.

- **Scoped tag selection**: `{ tagged: "read-only", from: "mcp_Nuclino" }` narrows a tag selector to a single MCP client, enabling fine-grained tool binding.

- **Zero-match tag validation**: Tag selectors that match zero tools now throw `RC5003` instead of silently returning an empty list, preventing misconfigured selectors from stripping every tool from an agent.

- **Shared MCP dispatch**: Extract `dispatchMcpCall` and `callRemoteTool` into `packages/ai/src/mcp/dispatch.ts` so both the agent resolver and `McpDestinationAdapter` use the same transport logic (stdio manager lookup, HTTP client setup, auth headers, content extraction, cleanup).

- **MCP tool wrapping**: `mcpEntryToResolvedTool` wraps MCP registry entries as `ResolvedTool` with a Standard Schema pass-through (MCP server validates; bridge consumes raw JSON Schema via `~standard.jsonSchema`). Handlers dispatch via `dispatchMcpCall` and capture the client name at resolution time.

- **Description override restriction**: `{ name: "mcp_X:y", description: "..." }` now throws `RC5003` because the MCP server is the source of truth for tool descriptions; per-binding overrides are not supported for MCP tools.

- **Removed `mcpTool` stub**: Delete the placeholder `mcpTool` builder and its "not yet supported" error; MCP tools are now fully integrated into the resolver.

- **Test coverage**: Add `tools-selection-mcp.bun.test.ts` with 11 test cases covering explicit refs, wildcards, guards, tag selection, scoping, error cases, and mixed selections.

## Implementation Details

- MCP refs follow the grammar `mcp_<client>:<tool>` where client names may contain underscores (e.g. `mcp_my_company_api:fetch_user`). The tool slot accepts `*` for wildcard expansion or any string (colons tolerated) for specific tools.

- `McpToolRegistry.setToolsForSource` now derives tags from annotations via `deriveTagsFromAnnotations`, mapping hints to the standard tag set used by fns and direct routes.

- `resolveByTags` gains a `from?: string` parameter to filter by source; `parseFromScope` validates and normalizes the scope.

- Auth boundary: `FnHandlerContext.principal` is intentionally NOT forwarded to the MCP server. The MCP client authenticates via static credentials registered on `defineConfig.mcp({ clients: { name: { auth } } })`. Two trust boundaries: principal authenticates Routecraft; MCP `auth` authenticates the Routecraft -> MCP hop. Documented in `.standards/security.md` § 11.

- `resolveServerTransport` helper in `McpDestinationAdapter` determines whether a registered config is stdio or HTTP so metadata can be attached to results.

https://claude.ai/code/session_016gV6bA4AXo4SjNWrPibKpS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class MCP tool selection in agent `tools([...])` via explicit `mcp_<client>:<tool>`, wildcards, and tag filters with optional client scoping. Dispatch is unified across agents and the `mcp(...)` destination, with RC5003-wrapped errors, transport metadata, and proper cleanup.

- **New Features**
  - Resolve `mcp_<client>:<tool>` and `mcp_<client>:*` via `MCP_TOOL_REGISTRY`; wildcards expand and guards propagate. Plain `mcp_*` without a colon remain fn ids.
  - `{ tagged, from? }` walks fns, direct routes, and MCP tools; use `from: "mcp_<client>"` to scope. MCP annotations map to standard tags so `{ tagged }` finds them.
  - Shared `dispatchMcpCall` powers agent tools and `mcp(...)` (stdio/HTTP, auth headers, content extraction, cleanup). Errors wrap as `RC5003`; results include transport metadata. MCP tools pass through JSON Schema and reject non-object inputs with clear `RC5003` errors.

- **Migration**
  - `{ tagged }` selectors that match zero tools now throw `RC5003`.
  - Removed `mcpTool(...)` and `agentTool(...)`; use string refs (`"mcp_<client>:<tool>"`, `"mcp_<client>:*"`) or `{ tagged, from }`.
  - Disallow `description` overrides for MCP refs; the MCP server owns description and schema. The agent principal is not forwarded to MCP; set MCP auth on the client (`defineConfig.mcp({ clients })`).

<sup>Written for commit 695a273293873eac2547ab12e933459542987236. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/331?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

