### PR TITLE
Add server identity, branding, and icon inheritance for MCP

### DIFF
--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -223,22 +223,6 @@ craft()
 
 Icons resolve with the same rule at both levels: omit `icons` to inherit (a tool with no icon of its own shows the server's icon, including the Routecraft default), set `icons: [...]` for a custom icon, or set `icons: []` to show none.
 
-### Migrating from `McpToolIcon`
-
-The icon type was renamed from `McpToolIcon` to the shared `McpIcon` and reshaped to match the MCP `Icon` spec. If you set per-tool icons before, update the field shape:
-
-```ts
-// Before
-icons: [{ src: '/icon.svg', sizes: '48x48', type: 'image/svg+xml' }]
-
-// After
-icons: [{ src: '/icon.svg', sizes: ['48x48'], mimeType: 'image/svg+xml' }]
-```
-
-- `type` is renamed to `mimeType`.
-- `sizes` changes from a space-separated string to a string array (`'48x48 96x96'` becomes `['48x48', '96x96']`).
-- A new optional `theme: 'light' | 'dark'` field is available.
-
 ## Authentication
 
 When using HTTP transport, secure the endpoint with the `auth` option.

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -168,6 +168,60 @@ Start the server with `craft run`, then point your AI client at it.
 }
 ```
 
+## Server identity and branding
+
+When a client like Claude adds your server, it renders the server's identity from the MCP `initialize` handshake. Configure it on `mcpPlugin` (or the `mcp` key of `defineConfig`):
+
+```ts
+// craft.config.ts
+import { mcpPlugin } from '@routecraft/ai'
+
+export default {
+  plugins: [
+    mcpPlugin({
+      name: 'acme-bot',                          // serverInfo.name (machine id)
+      title: 'Acme Bot',                         // serverInfo.title (display name)
+      version: '2.1.0',                          // serverInfo.version
+      description: 'Acme operations over MCP.',  // serverInfo.description
+      websiteUrl: 'https://acme.example.com',    // serverInfo.websiteUrl
+      instructions: 'Call orders.search before orders.refund.', // initialize.instructions
+      icons: [
+        { src: 'https://acme.example.com/icon.svg', mimeType: 'image/svg+xml' },
+        { src: 'data:image/png;base64,...', mimeType: 'image/png', sizes: ['48x48'], theme: 'light' },
+      ],
+    }),
+  ],
+}
+```
+
+`instructions` is server-wide guidance the client may add to the model's context (advisory per the spec). It complements each tool's own `.description()`, which is the per-tool equivalent.
+
+### Defaults and how to opt out
+
+When you do not set them, Routecraft fills in a "powered by Routecraft" identity. Each default is overridable with your own value or suppressible with an empty value:
+
+| Field | Default when unset | Suppress with |
+| --- | --- | --- |
+| `icons` | Routecraft logo (light and dark variants) | `icons: []` |
+| `description` | `"Powered by Routecraft.dev"` | `description: ""` |
+| `websiteUrl` | `"https://routecraft.dev"` | `websiteUrl: ""` |
+
+### Per-tool icons and inheritance
+
+A capability can carry its own icon via the `mcp()` source. The icon shape follows the MCP `Icon` spec (`src`, optional `mimeType`, `sizes` as a string array, and an optional `theme`):
+
+```ts
+craft()
+  .id('orders.search')
+  .description('Search orders')
+  .from(mcp({
+    annotations: { readOnlyHint: true },
+    icons: [{ src: 'https://acme.example.com/search.svg', mimeType: 'image/svg+xml', sizes: ['48x48'] }],
+  }))
+```
+
+Icons resolve with the same rule at both levels: omit `icons` to inherit (a tool with no icon of its own shows the server's icon, including the Routecraft default), set `icons: [...]` for a custom icon, or set `icons: []` to show none.
+
 ## Authentication
 
 When using HTTP transport, secure the endpoint with the `auth` option.

--- a/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/expose-as-mcp/page.md
@@ -205,6 +205,7 @@ When you do not set them, Routecraft fills in a "powered by Routecraft" identity
 | `icons` | Routecraft logo (light and dark variants) | `icons: []` |
 | `description` | `"Powered by Routecraft.dev"` | `description: ""` |
 | `websiteUrl` | `"https://routecraft.dev"` | `websiteUrl: ""` |
+| `instructions` | none (omitted) | `instructions: ""` |
 
 ### Per-tool icons and inheritance
 
@@ -221,6 +222,22 @@ craft()
 ```
 
 Icons resolve with the same rule at both levels: omit `icons` to inherit (a tool with no icon of its own shows the server's icon, including the Routecraft default), set `icons: [...]` for a custom icon, or set `icons: []` to show none.
+
+### Migrating from `McpToolIcon`
+
+The icon type was renamed from `McpToolIcon` to the shared `McpIcon` and reshaped to match the MCP `Icon` spec. If you set per-tool icons before, update the field shape:
+
+```ts
+// Before
+icons: [{ src: '/icon.svg', sizes: '48x48', type: 'image/svg+xml' }]
+
+// After
+icons: [{ src: '/icon.svg', sizes: ['48x48'], mimeType: 'image/svg+xml' }]
+```
+
+- `type` is renamed to `mimeType`.
+- `sizes` changes from a space-separated string to a string array (`'48x48 96x96'` becomes `['48x48', '96x96']`).
+- A new optional `theme: 'light' | 'dark'` field is available.
 
 ## Authentication
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -179,8 +179,13 @@ export default config
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `name` | `string` | `'routecraft'` | Server name exposed in MCP metadata |
+| `name` | `string` | `'routecraft'` | Server name exposed in MCP metadata (`serverInfo.name`) |
+| `title` | `string` | -- | Human-readable display title (`serverInfo.title`) |
 | `version` | `string` | `'1.0.0'` | Server version |
+| `description` | `string` | `'Powered by Routecraft.dev'` | `serverInfo.description`; pass `''` to omit |
+| `websiteUrl` | `string` | `'https://routecraft.dev'` | `serverInfo.websiteUrl`; pass `''` to omit |
+| `instructions` | `string` | -- | Server-wide usage guidance on the `initialize` result; pass `''` (or omit) to send none |
+| `icons` | `McpIcon[]` | Routecraft logo | `serverInfo.icons`, inherited by tools that set none of their own; pass `[]` to omit. See [Server identity and branding](/docs/advanced/expose-as-mcp#server-identity-and-branding). |
 | `transport` | `'http' \| 'stdio'` | `'stdio'` | Transport protocol for the MCP server |
 | `port` | `number` | `3001` | HTTP port (http transport only) |
 | `host` | `string` | `'localhost'` | HTTP host (http transport only) |

--- a/examples/src/craft.config.ts
+++ b/examples/src/craft.config.ts
@@ -29,7 +29,9 @@ export const craftConfig = defineConfig({
   },
   mcp: {
     name: "routecraft",
+    title: "Routecraft Examples",
     version,
+    description: "Example capabilities exposed over MCP.",
     transport: "http",
     auth: jwt({
       secret: env.JWT_SECRET,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -92,7 +92,7 @@ export {
   type McpToolAnnotations,
   type McpInput,
   type McpOutput,
-  type McpToolIcon,
+  type McpIcon,
   type McpToolRegistryEntry,
   type McpToolResult,
   type OAuthAuthOptions,

--- a/packages/ai/src/mcp/default-icon.ts
+++ b/packages/ai/src/mcp/default-icon.ts
@@ -16,15 +16,18 @@ const toDataUri = (svg: string): string =>
  * set their own. Two variants so the mark stays legible on either client theme:
  * a white logo for dark UIs and a black logo for light UIs.
  */
-export const ROUTECRAFT_DEFAULT_ICONS: McpIcon[] = [
-  {
+// Frozen because this single array is handed out by reference to every server's
+// serverInfo and every inheriting tool; freezing prevents an accidental in-place
+// mutation from leaking process-wide into the shared default.
+export const ROUTECRAFT_DEFAULT_ICONS: McpIcon[] = Object.freeze([
+  Object.freeze({
     src: toDataUri(logoSvg("#ffffff")),
     mimeType: "image/svg+xml",
     theme: "dark",
-  },
-  {
+  }),
+  Object.freeze({
     src: toDataUri(logoSvg("#000000")),
     mimeType: "image/svg+xml",
     theme: "light",
-  },
-];
+  }),
+]) as McpIcon[];

--- a/packages/ai/src/mcp/default-icon.ts
+++ b/packages/ai/src/mcp/default-icon.ts
@@ -18,12 +18,12 @@ const toDataUri = (svg: string): string =>
  */
 export const ROUTECRAFT_DEFAULT_ICONS: McpIcon[] = [
   {
-    src: toDataUri(logoSvg("white")),
+    src: toDataUri(logoSvg("#ffffff")),
     mimeType: "image/svg+xml",
     theme: "dark",
   },
   {
-    src: toDataUri(logoSvg("black")),
+    src: toDataUri(logoSvg("#000000")),
     mimeType: "image/svg+xml",
     theme: "light",
   },

--- a/packages/ai/src/mcp/default-icon.ts
+++ b/packages/ai/src/mcp/default-icon.ts
@@ -1,0 +1,30 @@
+import type { McpIcon } from "./types.ts";
+
+/**
+ * The Routecraft logo as an inline SVG, parameterised by fill colour so we can
+ * emit a light-theme (dark logo) and dark-theme (light logo) variant from one
+ * source. Geometry is taken from `routecraft.svg` at the repo root.
+ */
+const logoSvg = (fill: string): string =>
+  `<svg width="162" height="153" viewBox="0 0 162 153" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M141.881 62.9617C141.881 44.2319 126.65 29.0002 107.92 29.0002H30.1636L52.4304 52.2797L71.8879 52.3014L62.5672 42.4107H107.92C119.252 42.4107 128.471 51.6298 128.471 62.9617C128.471 74.293 119.252 83.5128 107.92 83.5128H101.193H88.5983H54.5814C50.8822 83.5128 47.8762 86.5187 47.8762 90.2173C47.8762 93.9278 50.8822 96.9225 54.5814 96.9225H95.4038L120.815 123.997H139.227L113.374 96.4753C129.522 93.8717 141.881 79.8359 141.881 62.9617Z" fill="${fill}"/><path d="M54.8718 110.59C43.5966 110.59 34.4105 101.403 34.4105 90.1282C34.4105 78.8411 43.5966 69.6662 54.8718 69.6662H107.115C110.814 69.6662 113.82 66.6714 113.82 62.9617C113.82 59.2624 110.814 56.2564 107.115 56.2564H54.8718C36.1988 56.2564 21 71.4545 21 90.1282C21 108.802 36.1988 124 54.8718 124H113.597L101.014 110.59H54.8718Z" fill="${fill}"/></svg>`;
+
+const toDataUri = (svg: string): string =>
+  `data:image/svg+xml;base64,${Buffer.from(svg, "utf8").toString("base64")}`;
+
+/**
+ * Default Routecraft branding for `serverInfo.icons` when a consumer does not
+ * set their own. Two variants so the mark stays legible on either client theme:
+ * a white logo for dark UIs and a black logo for light UIs.
+ */
+export const ROUTECRAFT_DEFAULT_ICONS: McpIcon[] = [
+  {
+    src: toDataUri(logoSvg("white")),
+    mimeType: "image/svg+xml",
+    theme: "dark",
+  },
+  {
+    src: toDataUri(logoSvg("black")),
+    mimeType: "image/svg+xml",
+    theme: "light",
+  },
+];

--- a/packages/ai/src/mcp/index.ts
+++ b/packages/ai/src/mcp/index.ts
@@ -33,7 +33,7 @@ export {
   type McpToolAnnotations,
   type McpInput,
   type McpOutput,
-  type McpToolIcon,
+  type McpIcon,
   type McpToolRegistryEntry,
   type McpToolResult,
   type OAuthAuthOptions,

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -21,6 +21,7 @@ import {
   isOAuthAuth,
 } from "./types.ts";
 import type {
+  McpIcon,
   McpLocalToolEntry,
   McpPluginOptions,
   McpTool,
@@ -32,6 +33,7 @@ import {
   PROTECTED_RESOURCE_METADATA_PATH,
   resolveCorsOptions,
 } from "./cors.ts";
+import { ROUTECRAFT_DEFAULT_ICONS } from "./default-icon.ts";
 
 /**
  * MCP SDK `AuthInfo` shape. Imported as a type so nothing is required at
@@ -51,7 +53,40 @@ const principalStore = new AsyncLocalStorage<Principal | undefined>();
 type McpServerResolvedOptions = Required<
   Pick<McpPluginOptions, "name" | "version" | "transport" | "port" | "host">
 > &
-  Pick<McpPluginOptions, "tools" | "auth" | "title" | "resource" | "cors">;
+  Pick<
+    McpPluginOptions,
+    | "tools"
+    | "auth"
+    | "title"
+    | "resource"
+    | "cors"
+    | "description"
+    | "websiteUrl"
+    | "instructions"
+    | "icons"
+  >;
+
+/** The MCP SDK `Server` constructor info arg (the fields we populate). */
+type SdkServerInfo = {
+  name: string;
+  version: string;
+  title?: string;
+  description?: string;
+  websiteUrl?: string;
+  icons?: McpIcon[];
+};
+
+/** The MCP SDK `Server` constructor options arg (the fields we populate). */
+type SdkServerOptions = {
+  capabilities: { tools: Record<string, unknown> };
+  instructions?: string;
+};
+
+/** The MCP SDK `Server` constructor as we consume it via dynamic import. */
+type SdkServerCtor = new (
+  info: SdkServerInfo,
+  options: SdkServerOptions,
+) => unknown;
 
 /**
  * RFC 9728 OAuth 2.0 Protected Resource Metadata payload returned by
@@ -107,6 +142,56 @@ export class McpServer {
       ...options,
     };
     this.validateResourceConfig();
+  }
+
+  /**
+   * Resolve the server-level icons: the Routecraft default when unset, the
+   * consumer's icons otherwise (an explicit empty array means "no icon").
+   */
+  private resolveServerIcons(): McpIcon[] {
+    return this.options.icons === undefined
+      ? ROUTECRAFT_DEFAULT_ICONS
+      : this.options.icons;
+  }
+
+  /**
+   * Build the MCP `serverInfo` (`Implementation`) object shared by both
+   * transports. Applies the Routecraft "powered by" defaults for description,
+   * websiteUrl, and icons; an empty string/array opts out of a given field.
+   */
+  private buildServerInfo(): SdkServerInfo {
+    const info: SdkServerInfo = {
+      name: this.options.name,
+      version: this.options.version,
+    };
+    if (this.options.title !== undefined) {
+      info.title = this.options.title;
+    }
+
+    const description = this.options.description ?? "Powered by Routecraft.dev";
+    if (description !== "") {
+      info.description = description;
+    }
+
+    const websiteUrl = this.options.websiteUrl ?? "https://routecraft.dev";
+    if (websiteUrl !== "") {
+      info.websiteUrl = websiteUrl;
+    }
+
+    const icons = this.resolveServerIcons();
+    if (icons.length > 0) {
+      info.icons = icons;
+    }
+    return info;
+  }
+
+  /** Build the MCP `Server` options arg (capabilities plus optional instructions). */
+  private buildServerOptions(): SdkServerOptions {
+    const options: SdkServerOptions = { capabilities: { tools: {} } };
+    if (this.options.instructions !== undefined) {
+      options.instructions = this.options.instructions;
+    }
+    return options;
   }
 
   /**
@@ -177,10 +262,7 @@ export class McpServer {
       () => import("@modelcontextprotocol/sdk/server/index.js"),
       { adapterName: "mcp (stdio)", packageName: "@modelcontextprotocol/sdk" },
     );
-    const Server = serverMod.Server as new (
-      info: { name: string; version: string; title?: string },
-      options: { capabilities: { tools: Record<string, unknown> } },
-    ) => unknown;
+    const Server = serverMod.Server as SdkServerCtor;
     const stdioMod = await loadOptionalPeer(
       () => import("@modelcontextprotocol/sdk/server/stdio.js"),
       { adapterName: "mcp (stdio)", packageName: "@modelcontextprotocol/sdk" },
@@ -188,13 +270,7 @@ export class McpServer {
     const StdioServerTransport =
       stdioMod.StdioServerTransport as new () => unknown;
 
-    this.server = new Server(
-      {
-        name: this.options.name,
-        version: this.options.version,
-      },
-      { capabilities: { tools: {} } },
-    );
+    this.server = new Server(this.buildServerInfo(), this.buildServerOptions());
 
     await this.setupRequestHandlers();
 
@@ -223,10 +299,7 @@ export class McpServer {
    * Shared by both HTTP startup paths.
    */
   private async importSdkHttp(): Promise<{
-    ServerCtor: new (
-      info: { name: string; version: string; title?: string },
-      options: { capabilities: { tools: Record<string, unknown> } },
-    ) => unknown;
+    ServerCtor: SdkServerCtor;
     TransportClass: new (options?: {
       sessionIdGenerator?: () => string;
       onsessioninitialized?: (sessionId: string) => void;
@@ -237,10 +310,7 @@ export class McpServer {
       () => import("@modelcontextprotocol/sdk/server/index.js"),
       { adapterName: "mcp (http)", packageName: "@modelcontextprotocol/sdk" },
     );
-    const ServerCtor = serverModule.Server as new (
-      info: { name: string; version: string; title?: string },
-      options: { capabilities: { tools: Record<string, unknown> } },
-    ) => unknown;
+    const ServerCtor = serverModule.Server as SdkServerCtor;
 
     // streamableHttp is a sub-export that may not exist on older SDK
     // versions; the `.catch(() => null)` lets the OAuth-aware fallback
@@ -275,10 +345,7 @@ export class McpServer {
    * Called on every initialization request (no session ID header).
    */
   private async createSession(
-    ServerCtor: new (
-      info: { name: string; version: string; title?: string },
-      options: { capabilities: { tools: Record<string, unknown> } },
-    ) => unknown,
+    ServerCtor: SdkServerCtor,
     TransportClass: new (options?: {
       sessionIdGenerator?: () => string;
       onsessioninitialized?: (sessionId: string) => void;
@@ -293,12 +360,8 @@ export class McpServer {
     ) => Promise<void>;
   }> {
     const server = new ServerCtor(
-      {
-        name: this.options.name,
-        version: this.options.version,
-        ...(this.options.title !== undefined && { title: this.options.title }),
-      },
-      { capabilities: { tools: {} } },
+      this.buildServerInfo(),
+      this.buildServerOptions(),
     );
 
     await this.setupRequestHandlersOn(server);
@@ -1219,8 +1282,9 @@ export class McpServer {
     if (entry.annotations !== undefined) {
       tool.annotations = entry.annotations;
     }
-    if (entry.icons !== undefined) {
-      tool.icons = entry.icons;
+    const icons = entry.icons ?? this.resolveServerIcons();
+    if (icons.length > 0) {
+      tool.icons = icons;
     }
     return tool;
   }

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -155,6 +155,20 @@ export class McpServer {
   }
 
   /**
+   * Apply a default when the value is unset, then treat an empty string as an
+   * explicit opt-out (returns `undefined` so the caller omits the field). This
+   * is the uniform "default unless empty" contract used by every optional
+   * string field of the server identity.
+   */
+  private defaultUnlessEmpty(
+    value: string | undefined,
+    fallback: string,
+  ): string | undefined {
+    const resolved = value ?? fallback;
+    return resolved === "" ? undefined : resolved;
+  }
+
+  /**
    * Build the MCP `serverInfo` (`Implementation`) object shared by both
    * transports. Applies the Routecraft "powered by" defaults for description,
    * websiteUrl, and icons; an empty string/array opts out of a given field.
@@ -168,13 +182,19 @@ export class McpServer {
       info.title = this.options.title;
     }
 
-    const description = this.options.description ?? "Powered by Routecraft.dev";
-    if (description !== "") {
+    const description = this.defaultUnlessEmpty(
+      this.options.description,
+      "Powered by Routecraft.dev",
+    );
+    if (description !== undefined) {
       info.description = description;
     }
 
-    const websiteUrl = this.options.websiteUrl ?? "https://routecraft.dev";
-    if (websiteUrl !== "") {
+    const websiteUrl = this.defaultUnlessEmpty(
+      this.options.websiteUrl,
+      "https://routecraft.dev",
+    );
+    if (websiteUrl !== undefined) {
       info.websiteUrl = websiteUrl;
     }
 
@@ -185,11 +205,16 @@ export class McpServer {
     return info;
   }
 
-  /** Build the MCP `Server` options arg (capabilities plus optional instructions). */
+  /**
+   * Build the MCP `Server` options arg (capabilities plus optional
+   * instructions). `instructions` has no default; an empty string opts out,
+   * matching the empty-value contract of the serverInfo string fields.
+   */
   private buildServerOptions(): SdkServerOptions {
     const options: SdkServerOptions = { capabilities: { tools: {} } };
-    if (this.options.instructions !== undefined) {
-      options.instructions = this.options.instructions;
+    const instructions = this.defaultUnlessEmpty(this.options.instructions, "");
+    if (instructions !== undefined) {
+      options.instructions = instructions;
     }
     return options;
   }

--- a/packages/ai/src/mcp/types.ts
+++ b/packages/ai/src/mcp/types.ts
@@ -509,6 +509,8 @@ export interface McpToolAnnotations {
  * Icon reference for an MCP server or tool. Mirrors the MCP specification's
  * `Icon` shape, which is reused by `serverInfo.icons`, `Tool.icons`, and the
  * resource/prompt primitives.
+ *
+ * @experimental
  */
 export interface McpIcon {
   /** URL or data URI of the icon. */

--- a/packages/ai/src/mcp/types.ts
+++ b/packages/ai/src/mcp/types.ts
@@ -88,7 +88,7 @@ export interface McpLocalToolEntry {
   /** MCP tool annotations (read-only hints, destructive hints, etc.). */
   annotations?: McpToolAnnotations;
   /** Icons forwarded to `tools/list` per the MCP spec. */
-  icons?: McpToolIcon[];
+  icons?: McpIcon[];
   /**
    * Invocation handler. Receives an exchange pre-built by the MCP server
    * (with tool/session/auth headers and the request body) and returns the
@@ -355,6 +355,35 @@ export interface McpPluginOptions {
   /** Server version. Default: "1.0.0" */
   version?: string;
 
+  /**
+   * Human-readable server description, forwarded as MCP `serverInfo.description`.
+   * Defaults to `"Powered by Routecraft.dev"` when unset; pass an empty string
+   * (`""`) to omit it entirely.
+   */
+  description?: string;
+
+  /**
+   * Server website, forwarded as MCP `serverInfo.websiteUrl`. Defaults to
+   * `"https://routecraft.dev"` when unset; pass an empty string (`""`) to omit it.
+   */
+  websiteUrl?: string;
+
+  /**
+   * Server-wide usage guidance, forwarded as the MCP `initialize` result's
+   * `instructions`. Clients may inject it into the model's context as a hint
+   * (advisory per the spec, not guaranteed). Use it for cross-tool guidance the
+   * model cannot infer from individual tool schemas.
+   */
+  instructions?: string;
+
+  /**
+   * Icons identifying this server, forwarded as MCP `serverInfo.icons` and
+   * inherited by tools that do not set their own icons. Defaults to the
+   * Routecraft logo (light and dark variants) when unset; pass an empty array
+   * (`[]`) to serve no icon.
+   */
+  icons?: McpIcon[];
+
   /** Transport mode for MCP server. Default: "stdio" */
   transport?: "stdio" | "http";
 
@@ -477,16 +506,19 @@ export interface McpToolAnnotations {
 }
 
 /**
- * Icon reference for an MCP tool.
- * Mirrors the MCP specification's `Tool.icons[]` entry (web app manifest shape).
+ * Icon reference for an MCP server or tool. Mirrors the MCP specification's
+ * `Icon` shape, which is reused by `serverInfo.icons`, `Tool.icons`, and the
+ * resource/prompt primitives.
  */
-export interface McpToolIcon {
+export interface McpIcon {
   /** URL or data URI of the icon. */
   src: string;
-  /** One or more icon sizes, e.g. `"48x48"` or `"48x48 96x96"`. */
-  sizes?: string;
-  /** MIME type of the icon. */
-  type?: string;
+  /** MIME type of the icon, e.g. `"image/svg+xml"` or `"image/png"`. */
+  mimeType?: string;
+  /** One or more icon sizes, e.g. `["48x48"]` or `["48x48", "96x96"]`. */
+  sizes?: string[];
+  /** The client UI theme this icon is designed for. */
+  theme?: "light" | "dark";
 }
 
 /**
@@ -515,7 +547,7 @@ export interface McpServerOptions {
   annotations?: McpToolAnnotations;
 
   /** Icons forwarded on `tools/list` per the MCP spec. */
-  icons?: McpToolIcon[];
+  icons?: McpIcon[];
 }
 
 export type McpOptions = McpServerOptions;
@@ -582,7 +614,7 @@ export interface McpTool {
   /** MCP tool annotations (behavior hints) reported by the server. */
   annotations?: McpToolAnnotations;
   /** Icons forwarded to clients per the MCP spec. */
-  icons?: McpToolIcon[];
+  icons?: McpIcon[];
 }
 
 /**

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -9,6 +9,7 @@ import {
   type Principal,
 } from "@routecraft/routecraft";
 import { mcp, MCP_PLUGIN_REGISTERED } from "../src/index.ts";
+import { ROUTECRAFT_DEFAULT_ICONS } from "../src/mcp/default-icon.ts";
 import { buildAuthHeaders } from "../src/mcp/build-auth-headers.ts";
 import { z } from "zod";
 import http from "node:http";
@@ -211,6 +212,112 @@ describe("McpServer", () => {
     expect(tools[0]).not.toHaveProperty("annotations");
   });
 
+  /**
+   * @case A tool without its own icons inherits the default Routecraft server icons
+   * @preconditions Default server options; route uses mcp() without icons
+   * @expectedResult getAvailableTools() reports the tool carrying ROUTECRAFT_DEFAULT_ICONS
+   */
+  test("tools inherit the default server icons", async () => {
+    t = await testContext()
+      .routes([
+        craft().id("plain").description("No icons").from(mcp()).to(noop()),
+      ])
+      .store(MCP_STORE_KEY, true)
+      .build();
+    server = new McpServer(t.ctx);
+    await t.startAndWaitReady();
+    const tools = server.getAvailableTools();
+    expect(tools[0].icons).toEqual(ROUTECRAFT_DEFAULT_ICONS);
+  });
+
+  /**
+   * @case A tool inherits custom server-level icons when it declares none of its own
+   * @preconditions Server configured with custom icons; route uses mcp() without icons
+   * @expectedResult The tool carries the custom server icons
+   */
+  test("tools inherit custom server icons", async () => {
+    const serverIcons = [
+      { src: "https://acme.example.com/logo.svg", mimeType: "image/svg+xml" },
+    ];
+    t = await testContext()
+      .routes([
+        craft().id("plain").description("No icons").from(mcp()).to(noop()),
+      ])
+      .store(MCP_STORE_KEY, true)
+      .build();
+    server = new McpServer(t.ctx, { icons: serverIcons });
+    await t.startAndWaitReady();
+    const tools = server.getAvailableTools();
+    expect(tools[0].icons).toEqual(serverIcons);
+  });
+
+  /**
+   * @case A tool's own icons take precedence over inherited server icons
+   * @preconditions Server with custom icons; route uses mcp({ icons })
+   * @expectedResult The tool keeps its own icons, not the server's
+   */
+  test("tool icons override inherited server icons", async () => {
+    const toolIcons = [
+      { src: "https://acme.example.com/tool.svg", mimeType: "image/svg+xml" },
+    ];
+    t = await testContext()
+      .routes([
+        craft()
+          .id("custom")
+          .description("Has icons")
+          .from(mcp({ icons: toolIcons }))
+          .to(noop()),
+      ])
+      .store(MCP_STORE_KEY, true)
+      .build();
+    server = new McpServer(t.ctx, {
+      icons: [{ src: "https://acme.example.com/server.svg" }],
+    });
+    await t.startAndWaitReady();
+    const tools = server.getAvailableTools();
+    expect(tools[0].icons).toEqual(toolIcons);
+  });
+
+  /**
+   * @case An empty per-tool icons array opts the tool out of inheriting any icon
+   * @preconditions Default server icons; route uses mcp({ icons: [] })
+   * @expectedResult The tool omits the icons field
+   */
+  test("empty tool icons suppress inheritance", async () => {
+    t = await testContext()
+      .routes([
+        craft()
+          .id("bare")
+          .description("Suppressed")
+          .from(mcp({ icons: [] }))
+          .to(noop()),
+      ])
+      .store(MCP_STORE_KEY, true)
+      .build();
+    server = new McpServer(t.ctx);
+    await t.startAndWaitReady();
+    const tools = server.getAvailableTools();
+    expect(tools[0]).not.toHaveProperty("icons");
+  });
+
+  /**
+   * @case Suppressing server icons removes branding from inheriting tools too
+   * @preconditions Server with icons: []; route uses mcp() without icons
+   * @expectedResult The tool omits the icons field
+   */
+  test("server icons: [] disables default branding for tools", async () => {
+    t = await testContext()
+      .routes([
+        craft().id("plain").description("No icons").from(mcp()).to(noop()),
+      ])
+      .store(MCP_STORE_KEY, true)
+      .build();
+    server = new McpServer(t.ctx, { icons: [] });
+    await t.startAndWaitReady();
+    const tools = server.getAvailableTools();
+    expect(tools[0]).not.toHaveProperty("icons");
+  });
+
   describe("HTTP transport", () => {
     /** Start HTTP server with given route builders; returns post helper and port. Call initSession() to get session id. */
     async function startHttpServer(
@@ -221,6 +328,10 @@ describe("McpServer", () => {
         auth?: import("../src/mcp/types.ts").McpHttpAuthOptions;
         resource?: import("../src/mcp/types.ts").McpResourceOptions;
         title?: string;
+        description?: string;
+        websiteUrl?: string;
+        instructions?: string;
+        icons?: import("../src/mcp/types.ts").McpIcon[];
         cors?: false | import("../src/mcp/cors.ts").McpCorsOptions;
       } = {},
     ) {
@@ -428,6 +539,88 @@ describe("McpServer", () => {
         (t) => t.name,
       );
       expect(toolNames).toContain("http-tool");
+    });
+
+    /**
+     * @case initialize returns the default Routecraft server identity
+     * @preconditions HTTP server with default options; send initialize
+     * @expectedResult serverInfo carries the default description, websiteUrl, and icons; no instructions
+     */
+    test("initialize returns the default server identity", async () => {
+      const { post } = await startHttpServer([
+        craft().id("id-tool").description("Tool").from(mcp()).to(noop()),
+      ]);
+      const res = await post(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: INIT_PARAMS,
+        }),
+      );
+      expect(res.statusCode).toBe(200);
+      const result = JSON.parse(res.body).result;
+      expect(result.serverInfo.description).toBe("Powered by Routecraft.dev");
+      expect(result.serverInfo.websiteUrl).toBe("https://routecraft.dev");
+      expect(result.serverInfo.icons).toEqual(ROUTECRAFT_DEFAULT_ICONS);
+      expect(result.instructions).toBeUndefined();
+    });
+
+    /**
+     * @case initialize reflects custom server identity and instructions
+     * @preconditions HTTP server with custom description/websiteUrl/instructions/icons
+     * @expectedResult serverInfo and instructions carry the configured values
+     */
+    test("initialize reflects custom server identity", async () => {
+      const icons = [
+        { src: "https://acme.example.com/logo.svg", mimeType: "image/svg+xml" },
+      ];
+      const { post } = await startHttpServer(
+        [craft().id("id-tool").description("Tool").from(mcp()).to(noop())],
+        {
+          description: "Acme over MCP",
+          websiteUrl: "https://acme.example.com",
+          instructions: "Call id-tool first.",
+          icons,
+        },
+      );
+      const res = await post(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: INIT_PARAMS,
+        }),
+      );
+      const result = JSON.parse(res.body).result;
+      expect(result.serverInfo.description).toBe("Acme over MCP");
+      expect(result.serverInfo.websiteUrl).toBe("https://acme.example.com");
+      expect(result.serverInfo.icons).toEqual(icons);
+      expect(result.instructions).toBe("Call id-tool first.");
+    });
+
+    /**
+     * @case Empty-string identity fields and an empty icons array are omitted from serverInfo
+     * @preconditions HTTP server with description:"", websiteUrl:"", icons:[]
+     * @expectedResult serverInfo omits description, websiteUrl, and icons
+     */
+    test("initialize omits suppressed identity fields", async () => {
+      const { post } = await startHttpServer(
+        [craft().id("id-tool").description("Tool").from(mcp()).to(noop())],
+        { description: "", websiteUrl: "", icons: [] },
+      );
+      const res = await post(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: INIT_PARAMS,
+        }),
+      );
+      const info = JSON.parse(res.body).result.serverInfo;
+      expect(info).not.toHaveProperty("description");
+      expect(info).not.toHaveProperty("websiteUrl");
+      expect(info).not.toHaveProperty("icons");
     });
 
     /**

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -600,14 +600,14 @@ describe("McpServer", () => {
     });
 
     /**
-     * @case Empty-string identity fields and an empty icons array are omitted from serverInfo
-     * @preconditions HTTP server with description:"", websiteUrl:"", icons:[]
-     * @expectedResult serverInfo omits description, websiteUrl, and icons
+     * @case Empty-string identity fields, empty icons, and empty instructions are omitted
+     * @preconditions HTTP server with description:"", websiteUrl:"", icons:[], instructions:""
+     * @expectedResult serverInfo omits description, websiteUrl, and icons; result omits instructions
      */
     test("initialize omits suppressed identity fields", async () => {
       const { post } = await startHttpServer(
         [craft().id("id-tool").description("Tool").from(mcp()).to(noop())],
-        { description: "", websiteUrl: "", icons: [] },
+        { description: "", websiteUrl: "", icons: [], instructions: "" },
       );
       const res = await post(
         JSON.stringify({
@@ -617,10 +617,11 @@ describe("McpServer", () => {
           params: INIT_PARAMS,
         }),
       );
-      const info = JSON.parse(res.body).result.serverInfo;
-      expect(info).not.toHaveProperty("description");
-      expect(info).not.toHaveProperty("websiteUrl");
-      expect(info).not.toHaveProperty("icons");
+      const result = JSON.parse(res.body).result;
+      expect(result.serverInfo).not.toHaveProperty("description");
+      expect(result.serverInfo).not.toHaveProperty("websiteUrl");
+      expect(result.serverInfo).not.toHaveProperty("icons");
+      expect(result.instructions).toBeUndefined();
     });
 
     /**

--- a/packages/ai/test/mcp.bun.test.ts
+++ b/packages/ai/test/mcp.bun.test.ts
@@ -170,7 +170,13 @@ describe("mcp() DSL function", () => {
    * @expectedResult Registry contains entry with every tool-shape field
    */
   test("mcp() registers in local tool registry", async () => {
-    const icons = [{ src: "https://example.com/icon.svg", sizes: "48x48" }];
+    const icons = [
+      {
+        src: "https://example.com/icon.svg",
+        mimeType: "image/svg+xml",
+        sizes: ["48x48"],
+      },
+    ];
 
     t = await testContext()
       .routes([


### PR DESCRIPTION
## Summary

Adds comprehensive server identity and branding support to the MCP plugin, including configurable description, website URL, instructions, and icons. Tools now inherit server-level icons when they don't define their own, with sensible defaults ("Powered by Routecraft") and opt-out support via empty values.

## Key Changes

- **Server identity fields** (`McpPluginOptions`): Added `description`, `websiteUrl`, `instructions`, and `icons` options that flow into the MCP `initialize` handshake's `serverInfo` and `instructions` fields.

- **Icon inheritance model**: Tools without their own icons now inherit from the server level. The server defaults to `ROUTECRAFT_DEFAULT_ICONS` (Routecraft logo in light and dark variants) unless explicitly set or suppressed with an empty array.

- **Default-unless-empty contract**: String fields (`description`, `websiteUrl`, `instructions`) apply Routecraft defaults when unset but allow opt-out via empty string (`""`). Icons follow the same pattern with arrays.

- **Icon type migration**: Renamed `McpToolIcon` to `McpIcon` and reshaped it to match the MCP spec:
  - `type` → `mimeType`
  - `sizes` from space-separated string to string array
  - Added optional `theme: 'light' | 'dark'` field

- **Default icon asset** (`default-icon.ts`): Routecraft logo as inline SVG data URIs with theme variants for legibility on both light and dark UIs.

- **Server info builder**: New `buildServerInfo()` and `buildServerOptions()` methods centralize identity construction for both stdio and HTTP transports, ensuring consistent defaults and opt-out behavior.

- **Tool icon resolution**: Updated `buildToolEntry()` to apply server icons to tools that don't declare their own, respecting empty-array opt-outs.

- **HTTP transport support**: Extended `startHttpServer()` test helper to accept `description`, `websiteUrl`, `instructions`, and `icons` options.

- **Documentation**: Added "Server identity and branding" section to the MCP guide with examples, defaults table, per-tool icon inheritance rules, and migration notes for the icon type change.

## Notable Implementation Details

- Icon inheritance is resolved at tool-list time, not at registration time, allowing dynamic server configuration.
- The `resolveServerIcons()` method centralizes the default-or-custom logic for reuse across both tool and server contexts.
- All five new test cases cover the inheritance hierarchy: default icons, custom server icons, tool override, empty-array suppression at both levels, and server-level suppression disabling defaults for inheriting tools.
- The Routecraft logo SVG is parameterized by fill color to emit both light-theme (dark logo) and dark-theme (light logo) variants from a single source.

https://claude.ai/code/session_011myfdcManw31xL3yomYCDp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable MCP server identity (description, website, instructions, icons) and tool icon inheritance with sensible defaults. Defaults to Routecraft branding with opt-out; ensures consistent `serverInfo` over stdio/HTTP (fixes stdio dropping `title`) and freezes default icons to prevent mutation leaks.

- **New Features**
  - Configure `description`, `websiteUrl`, `instructions`, and `icons` via `mcpPlugin`/`defineConfig` in `@routecraft/ai`; emitted in `initialize` as `serverInfo` and `instructions`.
  - Tools inherit server `icons` when unset; set `icons: []` to show none. Server fields default to Routecraft branding; empty string/array omits the field.
  - Default SVG icons (light/dark) included and frozen; centralized builders ensure the same identity on stdio and HTTP.

- **Migration**
  - Rename `McpToolIcon` to `McpIcon`.
  - Field changes: `type` -> `mimeType`, `sizes` (string) -> `sizes` (string[]), optional `theme: 'light' | 'dark'` added.
  - Update any per-tool `icons` to the new shape.

<sup>Written for commit 60a06c2ad2ac6f925aab11ad3cc5796c0e126df6. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/335?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

