### PR TITLE
feat(ai): Claude-compatible agent tool grammar + fn factories

### DIFF
--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -445,7 +445,7 @@ ESLint rules continue to enforce route-only positioning. Wrapper positioning is 
 - `tools()` helper for declarative tool authorisation (explicit names, tag selectors, per-binding guards and overrides).
 - `fn()` primitive for ad-hoc in-process functions registered via `agentPlugin({ functions })`.
 - Streaming agents: opt in via `stream: true` to receive an `AgentStream` body. The HTTP server bridges to SSE automatically.
-- `defaultFns`: built-in read-only fns (`currentTime`, `randomUuid`).
+- Built-in fn factories: `currentTime()`, `randomUuid()` (read-only).
 - Forward-compat hooks landed for durable agents (0.6.0): `SuspendError` (`@experimental`), `FnHandlerContext.checkpointId`, `AgentSession`.
 
 ### Choice operation

--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -221,7 +221,7 @@ agent({
   model: "anthropic:claude-opus-4-7",
   system: "You are a summariser.",
   user: (ex) => `Summarise: ${ex.body}`,
-  tools: tools(["fetch-order", "cancel-order", "mcp_docs-server:search"]),
+  tools: tools(["fetch-order", "cancel-order", "MCP(docs-server:search)"]),
 })
 ```
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -575,7 +575,7 @@ agentPlugin({
       tools: tools([
         'CurrentTime',                              // bare ref
         'fetchOrder',
-        'direct_cancel-order',                      // prefix convention
+        'Direct(cancel-order)',                     // direct route
         { name: 'sendSlack', guard: requireApproval },
         { tagged: 'read-only' },                    // single tag
         { tagged: ['read-only', 'idempotent'] },    // OR-of-tags
@@ -593,9 +593,9 @@ agentPlugin({
 
 Flat array of items. Each item is one of:
 
-- **Bare string**: name lookup. Plain ids resolve against the fn registry; `direct_*` falls back to the direct registry via `directTool`; `mcp_<client>:<tool>` resolves against `MCP_TOOL_REGISTRY` (populated by `defineConfig.mcp` / `mcpPlugin({ clients })`), and `mcp_<client>:*` expands at dispatch time to every tool the named client exposed. `agent_*` is reserved for sub-agent tools (follow-up story) and currently throws a clear "not yet supported" error.
+- **Bare string**: name lookup. Plain ids resolve against the fn registry; `Direct(<routeId>)` wraps a direct route via `directTool` (the LLM-facing tool name stays `direct_<routeId>`); `MCP(server:tool)` resolves against `MCP_TOOL_REGISTRY` (populated by `defineConfig.mcp` / `mcpPlugin({ clients })`), and `MCP(server)` (or the raw `mcp__server__tool` / `mcp__server` / `mcp__server__*` forms) expands at dispatch time to every tool the named server exposed. The raw `mcp__server__tool` form is the string Claude Code agent files carry, so they resolve unchanged.
 - **`{ name, guard?, description? }`**: same name lookup, with optional per-binding overrides. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct. The `description` override applies only to this binding for fn-style names. MCP references reject `description` (the MCP server is the source of truth for description and schema; do not override).
-- **`{ tagged, from?, guard? }`**: selects every fn / route / MCP tool whose tags overlap the requested set (single tag or array; OR semantics across the array). `from?: string` scopes the walk to a single source; today `from: "mcp_<client>"` restricts the selection to one MCP client. Optional guard applies to every match. Tag-zero-match throws RC5003 so a misconfigured selector cannot silently strip every tool from an agent.
+- **`{ tagged, from?, guard? }`**: selects every fn / route / MCP tool whose tags overlap the requested set (single tag or array; OR semantics across the array). `from?: string` scopes the walk to a single source; today `from: "mcp__<server>"` restricts the selection to one MCP server. Optional guard applies to every match. Tag-zero-match throws RC5003 so a misconfigured selector cannot silently strip every tool from an agent.
 
 MCP tools are auto-tagged at registration from each tool's MCP annotations: `readOnlyHint → "read-only"`, `destructiveHint → "destructive"`, `idempotentHint → "idempotent"`, `openWorldHint → "open-world"`. That means `{ tagged: "read-only" }` matches fns, routes, AND MCP tools out of the box.
 
@@ -605,13 +605,13 @@ Examples:
 agent({
   tools: tools([
     'CurrentTime',                                  // fn
-    'direct_orders/fetch',                          // direct route
-    'mcp_Nuclino:list_teams',                       // one MCP tool
-    'mcp_Stripe:*',                                 // all tools from one MCP client
+    'Direct(orders/fetch)',                         // direct route
+    'MCP(Nuclino:list_teams)',                      // one MCP tool
+    'MCP(Stripe)',                                  // all tools from one MCP server
     { tagged: 'read-only' },                        // cross-cutting tag filter
-    { tagged: 'destructive', from: 'mcp_Nuclino' }, // tag filter scoped to one MCP client
+    { tagged: 'destructive', from: 'mcp__Nuclino' }, // tag filter scoped to one MCP server
     {
-      name: 'mcp_Nuclino:get_item',
+      name: 'MCP(Nuclino:get_item)',
       guard: (input, ctx) => {
         if (!ctx.principal?.scopes?.includes('nuclino.read')) {
           throw new Error('missing nuclino.read scope');
@@ -637,7 +637,7 @@ Resolution rules:
 | `directTool(routeId, overrides?)` | Adapt a registered direct route as a fn. Pulls description, input schema, and tags from the route's discovery bundle by default; `overrides` can replace any of those. |
 | `currentTime()` / `randomUuid()` | Built-in fn factories (read-only / idempotent). Assign each a tool name in your `functions:` config, the same way as `directTool`. |
 
-MCP tools are NOT exposed via a builder. Use the `mcp_<client>:<tool>` / `mcp_<client>:*` grammar inside `tools([...])` instead; the registry populated by `defineConfig.mcp` is the source of truth.
+MCP tools are NOT exposed via a builder. Use the `MCP(server:tool)` / `MCP(server)` grammar (or the raw `mcp__server__tool` form) inside `tools([...])` instead; the registry populated by `defineConfig.mcp` is the source of truth.
 
 #### Tags
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -556,14 +556,16 @@ Tags, the `tools([...])` selector, the builder helpers, and the context-level `d
 import {
   agentPlugin,
   agent,
-  defaultFns,
+  currentTime,
   directTool,
+  randomUuid,
   tools,
 } from '@routecraft/ai'
 
 agentPlugin({
   functions: {
-    ...defaultFns,                                  // currentTime, randomUuid (read-only, idempotent)
+    CurrentTime: currentTime(),                     // built-in (read-only, idempotent)
+    RandomUuid: randomUuid(),                        // built-in (read-only)
     sendSlack: { description, input, handler, tags: ['destructive', 'messaging'] },
     fetchOrder: directTool('fetch-order'),          // wraps a direct route as a fn
   },
@@ -571,7 +573,7 @@ agentPlugin({
     researcher: {
       description, system,                          // model + tools inherit from defaultOptions
       tools: tools([
-        'currentTime',                              // bare ref
+        'CurrentTime',                              // bare ref
         'fetchOrder',
         'direct_cancel-order',                      // prefix convention
         { name: 'sendSlack', guard: requireApproval },
@@ -582,7 +584,7 @@ agentPlugin({
   },
   defaultOptions: {
     model: 'anthropic:claude-opus-4-7',             // applies to agents that omit `model`
-    tools: tools(['currentTime', { tagged: 'read-only' }]),
+    tools: tools(['CurrentTime', { tagged: 'read-only' }]),
   },
 })
 ```
@@ -602,7 +604,7 @@ Examples:
 ```ts
 agent({
   tools: tools([
-    'currentTime',                                  // fn
+    'CurrentTime',                                  // fn
     'direct_orders/fetch',                          // direct route
     'mcp_Nuclino:list_teams',                       // one MCP tool
     'mcp_Stripe:*',                                 // all tools from one MCP client
@@ -633,7 +635,7 @@ Resolution rules:
 | Builder | Use |
 |---|---|
 | `directTool(routeId, overrides?)` | Adapt a registered direct route as a fn. Pulls description, input schema, and tags from the route's discovery bundle by default; `overrides` can replace any of those. |
-| `defaultFns` | A small starter set (`currentTime`, `randomUuid`) tagged `read-only`/`idempotent`. Spread into your `functions:` config. |
+| `currentTime()` / `randomUuid()` | Built-in fn factories (read-only / idempotent). Assign each a tool name in your `functions:` config, the same way as `directTool`. |
 
 MCP tools are NOT exposed via a builder. Use the `mcp_<client>:<tool>` / `mcp_<client>:*` grammar inside `tools([...])` instead; the registry populated by `defineConfig.mcp` is the source of truth.
 
@@ -668,7 +670,7 @@ Two `agentPlugin` installs that each set the same field throw at context init. T
 agentPlugin({
   defaultOptions: {
     model: 'anthropic:claude-opus-4-7',
-    tools: tools(['currentTime', { tagged: 'read-only' }]),
+    tools: tools(['CurrentTime', { tagged: 'read-only' }]),
   },
   agents: {
     researcher: { description, system },                            // inherits both

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -115,7 +115,7 @@ function validateRegisteredAgent(
  *     },
  *   },
  *   functions: {
- *     currentTime: {
+ *     CurrentTime: {
  *       description: "Current UTC timestamp in ISO 8601",
  *       input: z.object({}),
  *       handler: async () => new Date().toISOString(),

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -57,7 +57,7 @@ const EMPTY_OBJECT_JSON_SCHEMA = {
 
 /**
  * Standard Schema implementation of an empty input object. Used by the
- * `defaultFns` so this module stays free of a Zod runtime dependency
+ * built-in fn factories so this module stays free of a Zod runtime dependency
  * (per CLAUDE.md "Use Standard Schema, not Zod/Valibot directly in
  * shared code").
  *
@@ -281,9 +281,10 @@ async function dispatchDirect<TIn>(
 }
 
 /**
- * Small starter set of generic, broadly useful fns. Spread into your
- * `agentPlugin({ functions: { ... } })` config to give every agent in
- * the context the basics for free.
+ * Built-in fn factory: returns the current UTC timestamp in ISO 8601
+ * format. Takes no configuration. Assign it a tool name in your
+ * `agentPlugin({ functions: { ... } })` config, the same way you use
+ * `directTool(...)`.
  *
  * @experimental
  *
@@ -291,23 +292,38 @@ async function dispatchDirect<TIn>(
  * ```ts
  * agentPlugin({
  *   functions: {
- *     ...defaultFns,
+ *     CurrentTime: currentTime(),
  *     fetchOrder: directTool("fetch-order"),
  *   },
  * });
  * ```
  */
-export const defaultFns = {
-  CurrentTime: {
+export function currentTime(): FnOptions<Record<string, never>, string> {
+  return {
     description: "Returns the current UTC timestamp in ISO 8601 format.",
     input: emptyObjectSchema,
     handler: () => new Date().toISOString(),
     tags: ["read-only", "idempotent"] satisfies KnownTag[],
-  } satisfies FnOptions<Record<string, never>, string>,
-  RandomUuid: {
+  };
+}
+
+/**
+ * Built-in fn factory: generates a fresh random UUID v4. Takes no
+ * configuration. Assign it a tool name in your
+ * `agentPlugin({ functions: { ... } })` config.
+ *
+ * @experimental
+ *
+ * @example
+ * ```ts
+ * agentPlugin({ functions: { RandomUuid: randomUuid() } });
+ * ```
+ */
+export function randomUuid(): FnOptions<Record<string, never>, string> {
+  return {
     description: "Generates a fresh random UUID v4.",
     input: emptyObjectSchema,
     handler: () => randomUUID(),
     tags: ["read-only"] satisfies KnownTag[],
-  } satisfies FnOptions<Record<string, never>, string>,
-};
+  };
+}

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -298,13 +298,13 @@ async function dispatchDirect<TIn>(
  * ```
  */
 export const defaultFns = {
-  currentTime: {
+  CurrentTime: {
     description: "Returns the current UTC timestamp in ISO 8601 format.",
     input: emptyObjectSchema,
     handler: () => new Date().toISOString(),
     tags: ["read-only", "idempotent"] satisfies KnownTag[],
   } satisfies FnOptions<Record<string, never>, string>,
-  randomUuid: {
+  RandomUuid: {
     description: "Generates a fresh random UUID v4.",
     input: emptyObjectSchema,
     handler: () => randomUUID(),

--- a/packages/ai/src/agent/tools/index.ts
+++ b/packages/ai/src/agent/tools/index.ts
@@ -1,6 +1,7 @@
 export {
-  defaultFns,
+  currentTime,
   directTool,
+  randomUuid,
   type ToolBuilderOverrides,
 } from "./builders.ts";
 export {

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -34,8 +34,9 @@ export type ToolGuard = (
  * One entry in the agent's `tools([...])` list.
  *
  * - bare string: name lookup. Plain ids resolve against the fn registry;
- *   `direct_*` falls back to the direct registry via `directTool`;
- *   `mcp_<client>:<tool>` and `mcp_<client>:*` resolve against
+ *   `Direct(<routeId>)` wraps a direct route via `directTool`;
+ *   `MCP(server:tool)` / `MCP(server)` and the raw `mcp__server__tool`
+ *   / `mcp__server` / `mcp__server__*` forms resolve against
  *   `MCP_TOOL_REGISTRY` (populated by `defineConfig.mcp` /
  *   `mcpPlugin({ clients })`).
  * - `{ name, guard?, description? }`: same lookup, with optional
@@ -44,12 +45,12 @@ export type ToolGuard = (
  *   other agents binding the same fn see the canonical description).
  *   Use this when an agent's calling context calls for a different
  *   framing of the tool than the registered description provides.
- *   For an MCP wildcard (`{ name: "mcp_<client>:*", guard }`) the guard
- *   is attached to every expanded tool.
+ *   For an MCP whole-server ref (`{ name: "MCP(server)", guard }`) the
+ *   guard is attached to every expanded tool.
  * - `{ tagged, from?, guard? }`: select every fn / route / MCP tool
  *   whose tags include any of the requested tag(s) (OR semantics).
  *   `from?: string` restricts the selection to a single source:
- *   `from: "mcp_<client>"` matches only that client's MCP tools.
+ *   `from: "mcp__<server>"` matches only that server's MCP tools.
  *   Optional guard applies to every match.
  *
  * @experimental
@@ -93,7 +94,7 @@ export interface ToolSelection {
  * @experimental
  */
 export interface ResolvedTool {
-  /** Tool name presented to the LLM (matches the registered fn id or, for routes referenced by convention, `direct_<routeId>`). */
+  /** Tool name presented to the LLM: the registered fn id, `direct_<routeId>` for routes, or `mcp__<server>__<tool>` for MCP tools. */
   name: string;
   /** Description shown to the LLM. */
   description: string;
@@ -130,18 +131,16 @@ export function isToolSelection(value: unknown): value is ToolSelection {
  * Resolution happens lazily at agent dispatch time.
  *
  * Resolution rules:
- * - Bare names look up exact matches in the fn registry first; if
- *   missing AND the name starts with `direct_`, the suffix is treated
- *   as a direct route id and wrapped via `directTool`. Names starting
- *   with `mcp_` follow the `mcp_<client>:<tool>` grammar (with `*`
- *   wildcard for the tool slot) and resolve against
- *   `MCP_TOOL_REGISTRY`. Names starting with `agent_` produce a "not
- *   yet supported" error (sub-agent tools land in a follow-up story).
+ * - Bare names look up exact matches in the fn registry first.
+ *   `Direct(<routeId>)` wraps a direct route via `directTool` (the
+ *   LLM-facing tool name stays `direct_<routeId>`). `MCP(server:tool)`
+ *   / `MCP(server)` and the raw `mcp__server__tool` / `mcp__server` /
+ *   `mcp__server__*` forms resolve against `MCP_TOOL_REGISTRY`.
  * - Tag selectors walk the fn registry, the direct route registry,
  *   and the MCP tool registry, including any entry whose tags overlap
  *   with the requested set. `from?: string` narrows the walk: pass
- *   `from: "mcp_<client>"` to scope a tag selection to a single MCP
- *   client.
+ *   `from: "mcp__<server>"` to scope a tag selection to a single MCP
+ *   server.
  * - Final list is deduplicated by tool name. Explicit references win
  *   over tag-selector matches regardless of position in the list.
  *
@@ -153,7 +152,8 @@ export function isToolSelection(value: unknown): value is ToolSelection {
  *   tools: tools([
  *     "CurrentTime",
  *     "fetchOrder",
- *     "direct_cancel-order",
+ *     "Direct(cancel-order)",
+ *     "MCP(github:create_issue)",
  *     { name: "sendSlack", guard: confirmGuard },
  *     { tagged: "read-only" },
  *   ]),
@@ -277,26 +277,22 @@ function resolveByName(
     return resolveFnEntry(ctx, name, fnEntry, guard);
   }
 
-  if (name.startsWith("agent_")) {
-    throw rcError("RC5003", undefined, {
-      message: `tools(): "${name}" looks like an agent reference. Sub-agent tools land in a follow-up story.`,
-    });
-  }
-  // `mcp_<client>:<tool>` refs are handled by Phase 1 before this
-  // function is called (see `isMcpRefName`). A plain `mcp_*` name that
-  // arrives here is a fn id that just happens to share the prefix; let
-  // it fall through to the fn-registry / direct-registry walk above
-  // and the unknown-tool error below.
-  if (name.startsWith("direct_")) {
-    const routeId = name.slice("direct_".length);
+  // `Direct(<routeId>)` wraps a registered direct route as a tool. The
+  // LLM-facing tool name stays the valid `direct_<routeId>` form (tool
+  // names cannot contain parentheses); `Direct(...)` is only the
+  // reference grammar a developer writes in `tools([...])`.
+  const directMatch = /^Direct\((.*)\)$/.exec(name);
+  if (directMatch) {
+    const routeId = directMatch[1]!.trim();
     if (routeId === "") {
       throw rcError("RC5003", undefined, {
-        message: `tools(): "${name}" has an empty direct route id.`,
+        message: `tools(): "${name}" has an empty route id; use "Direct(<routeId>)".`,
       });
     }
+    const toolName = `direct_${routeId}`;
     const wrapper = directTool(routeId);
-    const fn = wrapper.resolve(ctx, name);
-    return toResolvedTool(name, fn, guard);
+    const fn = wrapper.resolve(ctx, toolName);
+    return toResolvedTool(toolName, fn, guard);
   }
 
   const known = listKnownNames(ctx);
@@ -338,36 +334,71 @@ function toResolvedTool(
 }
 
 /**
- * Recognise an attempted MCP tool reference. The grammar is
- * `mcp_<client>:<tool>` (or `mcp_<client>:*` for a wildcard), so any
- * `mcp_*` name that contains a `:` is treated as an MCP ref. Plain
- * fn ids like `mcp_healthcheck` (no `:`) fall through to fn-registry
- * lookup. Malformed shapes like `mcp_:foo` or `mcp_foo:` are still
- * caught here so `resolveMcpRefs` can emit the precise grammar error
- * instead of a generic "unknown tool" message.
+ * Recognise an attempted MCP tool reference. Two accepted forms: the
+ * raw flat identity `mcp__<server>__<tool>` (also `mcp__<server>` and
+ * `mcp__<server>__*` for a whole server), which is what Claude Code
+ * agent files carry, and the `MCP(server:tool)` / `MCP(server)` sugar.
  *
  * @internal
  */
 function isMcpRefName(name: string): boolean {
-  if (!name.startsWith("mcp_")) return false;
-  return name.slice("mcp_".length).includes(":");
+  if (name.startsWith("mcp__")) return true;
+  return name.startsWith("MCP(") && name.endsWith(")");
 }
 
 /**
- * Resolve an `mcp_<client>:<tool>` or `mcp_<client>:*` reference into
- * one or more `ResolvedTool` entries. Grammar:
+ * Parse an MCP reference into its server (client) and tool parts.
+ * Accepts two forms:
  *
- * - kind: everything before the first `_` (always `mcp` here).
- * - client: everything after the first `_` up to the first `:`.
- *   Client names may contain underscores
- *   (e.g. `mcp_my_company_api:fetch_user`).
- * - tool: everything after the first `:`. The literal `*` expands to
- *   every tool registered under `<client>` at dispatch time. Other
- *   colons in the tool name are tolerated and forwarded verbatim to
- *   the MCP server.
+ * - Raw identity `mcp__<server>__<tool>`. Server and tool split on the
+ *   first `__` after the `mcp__` prefix (so single-underscore server
+ *   names like `my_company_api` are preserved). `mcp__<server>` and
+ *   `mcp__<server>__*` select every tool on the server. This is the
+ *   string Claude Code agent files carry, so they resolve unchanged.
+ * - Sugar `MCP(server:tool)`. Colon-separated; `MCP(server)` and
+ *   `MCP(server:*)` select every tool on the server.
  *
- * Throws RC5003 when the registry is absent, the client is unknown,
- * the client is registered but has no tools, or the specific tool is
+ * A `toolName` of `*` means "every tool on the server".
+ *
+ * @internal
+ */
+function parseMcpRef(ref: string): { clientName: string; toolName: string } {
+  if (ref.startsWith("MCP(") && ref.endsWith(")")) {
+    const inner = ref.slice(4, -1).trim();
+    const colon = inner.indexOf(":");
+    const clientName = colon === -1 ? inner : inner.slice(0, colon).trim();
+    const toolName = colon === -1 ? "*" : inner.slice(colon + 1).trim();
+    if (clientName === "" || toolName === "") {
+      throw rcError("RC5003", undefined, {
+        message: `tools(): MCP reference "${ref}" must use "MCP(server:tool)" or "MCP(server)"; got an empty server or tool segment.`,
+      });
+    }
+    return { clientName, toolName };
+  }
+  if (ref.startsWith("mcp__")) {
+    const rest = ref.slice("mcp__".length);
+    const sep = rest.indexOf("__");
+    const clientName = sep === -1 ? rest : rest.slice(0, sep);
+    const toolName = sep === -1 ? "*" : rest.slice(sep + 2);
+    if (clientName.trim() === "" || toolName.trim() === "") {
+      throw rcError("RC5003", undefined, {
+        message: `tools(): MCP reference "${ref}" must use "mcp__server__tool" or "mcp__server"; got an empty server or tool segment.`,
+      });
+    }
+    return { clientName, toolName };
+  }
+  throw rcError("RC5003", undefined, {
+    message: `tools(): MCP reference "${ref}" must use "MCP(server:tool)", "MCP(server)", or the raw "mcp__server__tool" form.`,
+  });
+}
+
+/**
+ * Resolve an MCP reference into one or more `ResolvedTool` entries.
+ * The whole-server forms expand to every tool registered under the
+ * server at dispatch time.
+ *
+ * Throws RC5003 when the registry is absent, the server is unknown,
+ * the server is registered but has no tools, or the specific tool is
  * not registered.
  *
  * @internal
@@ -377,25 +408,7 @@ function resolveMcpRefs(
   ref: string,
   guard: ToolGuard | undefined,
 ): ResolvedTool[] {
-  if (!ref.startsWith("mcp_")) {
-    throw rcError("RC5003", undefined, {
-      message: `tools(): MCP reference "${ref}" must start with "mcp_".`,
-    });
-  }
-  const rest = ref.slice("mcp_".length);
-  const colon = rest.indexOf(":");
-  if (colon === -1) {
-    throw rcError("RC5003", undefined, {
-      message: `tools(): MCP reference "${ref}" must use the form "mcp_<client>:<tool>" or "mcp_<client>:*".`,
-    });
-  }
-  const clientName = rest.slice(0, colon);
-  const toolName = rest.slice(colon + 1);
-  if (clientName.trim() === "" || toolName.trim() === "") {
-    throw rcError("RC5003", undefined, {
-      message: `tools(): MCP reference "${ref}" must use the form "mcp_<client>:<tool>" or "mcp_<client>:*"; got empty client or tool segment.`,
-    });
-  }
+  const { clientName, toolName } = parseMcpRef(ref);
   const registry = ctx.getStore(MCP_TOOL_REGISTRY);
   if (!registry) {
     throw rcError("RC5003", undefined, {
@@ -462,7 +475,7 @@ function mcpEntryToResolvedTool(
   entry: McpToolRegistryEntry,
   guard: ToolGuard | undefined,
 ): ResolvedTool {
-  const name = `mcp_${entry.source}:${entry.name}`;
+  const name = `mcp__${entry.source}__${entry.name}`;
   const description =
     entry.description && entry.description.trim() !== ""
       ? entry.description
@@ -552,17 +565,17 @@ function parseFromScope(from: string | undefined): FromScope {
       message: `tools(): "from" must be a non-empty string when present.`,
     });
   }
-  if (from.startsWith("mcp_")) {
-    const client = from.slice("mcp_".length);
+  if (from.startsWith("mcp__")) {
+    const client = from.slice("mcp__".length);
     if (client.trim() === "") {
       throw rcError("RC5003", undefined, {
-        message: `tools(): from "${from}" has an empty client name; use "mcp_<client>".`,
+        message: `tools(): from "${from}" has an empty server name; use "mcp__<server>".`,
       });
     }
     return { kind: "mcp", mcpClient: client };
   }
   throw rcError("RC5003", undefined, {
-    message: `tools(): from "${from}" is not a supported source filter. Use "mcp_<client>".`,
+    message: `tools(): from "${from}" is not a supported source filter. Use "mcp__<server>".`,
   });
 }
 
@@ -588,7 +601,7 @@ function resolveByTags(
 
   // fn registry and direct registry walks only run when scope is
   // unrestricted ("all"). A scoped selector like
-  // `{ tagged: "read-only", from: "mcp_Nuclino" }` deliberately
+  // `{ tagged: "read-only", from: "mcp__Nuclino" }` deliberately
   // excludes fns and routes.
   if (scope.kind === "all") {
     // Walk the fn registry first so explicit fn-side tags (incl. directTool
@@ -672,7 +685,7 @@ function resolveByTags(
         const known = listKnownMcpClients(mcpRegistry);
         throw rcError("RC5003", undefined, {
           message:
-            `tools(): from "mcp_${scope.mcpClient}" has no registered tools. ` +
+            `tools(): from "mcp__${scope.mcpClient}" has no registered tools. ` +
             (known.length > 0
               ? `Known MCP clients: ${known.map((k) => `"${k}"`).join(", ")}.`
               : `No MCP clients are registered in this context.`),
@@ -692,7 +705,7 @@ function resolveByTags(
   } else if (scope.kind === "mcp") {
     // Asked for a specific MCP client but the registry isn't installed.
     throw rcError("RC5003", undefined, {
-      message: `tools(): from "mcp_${scope.mcpClient}" but no MCP_TOOL_REGISTRY is present. Install mcpPlugin (defineConfig.mcp).`,
+      message: `tools(): from "mcp__${scope.mcpClient}" but no MCP_TOOL_REGISTRY is present. Install mcpPlugin (defineConfig.mcp).`,
     });
   }
 
@@ -732,6 +745,6 @@ function listKnownNames(ctx: CraftContext): string[] {
         | Map<string, DirectRouteMetadata>
         | undefined) ?? new Map()
     ).keys(),
-  ].map((id) => `direct_${id}`);
+  ].map((id) => `Direct(${id})`);
   return [...fnNames, ...routeNames].sort();
 }

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -151,7 +151,7 @@ export function isToolSelection(value: unknown): value is ToolSelection {
  * ```ts
  * agent({
  *   tools: tools([
- *     "currentTime",
+ *     "CurrentTime",
  *     "fetchOrder",
  *     "direct_cancel-order",
  *     { name: "sendSlack", guard: confirmGuard },

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -174,7 +174,9 @@ export function tools(items: ToolsItem[]): ToolSelection {
       // Phase 1: explicit refs (bare strings + { name, guard }).
       for (const item of items) {
         if (typeof item === "string") {
-          if (isMcpRefName(item)) {
+          // An exact fn id always wins over the MCP-ref grammar, so a fn
+          // whose id happens to start with `mcp__` stays reachable.
+          if (isMcpRefName(item) && !fnRegistryHas(ctx, item)) {
             for (const tool of resolveMcpRefs(ctx, item, undefined)) {
               explicit.set(tool.name, tool);
             }
@@ -198,7 +200,7 @@ export function tools(items: ToolsItem[]): ToolSelection {
           // MCP refs reject any description override (empty or not) so
           // users see the precise "MCP server is the source of truth"
           // message instead of the generic empty-string error.
-          if (isMcpRefName(item.name)) {
+          if (isMcpRefName(item.name) && !fnRegistryHas(ctx, item.name)) {
             if (item.description !== undefined) {
               throw rcError("RC5003", undefined, {
                 message: `tools(): { name: "${item.name}", description } is not supported for MCP tools. The MCP server is the source of truth for description and schema; do not override.`,
@@ -257,6 +259,20 @@ export function tools(items: ToolsItem[]): ToolSelection {
       return [...out.values()];
     },
   };
+}
+
+/**
+ * True when the fn registry holds an exact entry for `name`. Used to let
+ * an explicitly registered fn win over the MCP-ref grammar for bare
+ * strings (so a fn id starting with `mcp__` stays reachable).
+ *
+ * @internal
+ */
+function fnRegistryHas(ctx: CraftContext, name: string): boolean {
+  const fnRegistry = ctx.getStore(ADAPTER_FN_REGISTRY) as
+    | Map<string, FnEntry>
+    | undefined;
+  return fnRegistry?.has(name) ?? false;
 }
 
 function resolveByName(
@@ -339,6 +355,9 @@ function toResolvedTool(
  * `mcp__<server>__*` for a whole server), which is what Claude Code
  * agent files carry, and the `MCP(server:tool)` / `MCP(server)` sugar.
  *
+ * Callers consult the fn registry first, so an exact fn id (even one
+ * starting with `mcp__`) takes precedence over this grammar.
+ *
  * @internal
  */
 function isMcpRefName(name: string): boolean {
@@ -358,7 +377,10 @@ function isMcpRefName(name: string): boolean {
  * - Sugar `MCP(server:tool)`. Colon-separated; `MCP(server)` and
  *   `MCP(server:*)` select every tool on the server.
  *
- * A `toolName` of `*` means "every tool on the server".
+ * A `toolName` of `*` means "every tool on the server". Separators
+ * beyond the first split (extra `__` in the raw form, extra `:` in the
+ * sugar) stay in the tool segment and are forwarded to the MCP server
+ * verbatim.
  *
  * @internal
  */
@@ -593,7 +615,7 @@ function resolveByTags(
   // **that actually contributed** so the direct-registry walk doesn't
   // double-include them. Wrappers that didn't match the wanted tag set
   // are NOT added here -- the underlying route may still match by its
-  // own tags and is allowed to surface under the prefix convention.
+  // own tags and is allowed to surface under its direct_<routeId> name.
   // MCP entries are walked separately at the end of this function via
   // MCP_TOOL_REGISTRY (not the fn-registry deferred path), so they
   // sit outside this dedup set.

--- a/packages/ai/src/fn/types.ts
+++ b/packages/ai/src/fn/types.ts
@@ -148,7 +148,7 @@ export interface FnOptions<TIn = unknown, TOut = unknown> {
  * ```typescript
  * declare module "@routecraft/ai" {
  *   interface FnRegistry {
- *     currentTime: true;
+ *     CurrentTime: true;
  *     sendSlackMessage: true;
  *   }
  * }

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -162,9 +162,9 @@ export type {
 
 // Tool builders: wrap registered routes as fn-shaped entries usable
 // from `agentPlugin({ functions: { ... } })`, plus the `tools([...])`
-// selector consumed by the agent runtime. MCP tools are resolved
-// directly via the `mcp_<client>:<tool>` grammar inside `tools(...)`;
-// sub-agent tools land in a follow-up story.
+// selector consumed by the agent runtime. MCP tools are referenced via
+// the `MCP(server:tool)` / `mcp__server__tool` grammar inside
+// `tools(...)`.
 export {
   currentTime,
   directTool,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -166,10 +166,11 @@ export type {
 // directly via the `mcp_<client>:<tool>` grammar inside `tools(...)`;
 // sub-agent tools land in a follow-up story.
 export {
-  defaultFns,
+  currentTime,
   directTool,
   isDeferredFn,
   isToolSelection,
+  randomUuid,
   tools,
   type DeferredFn,
   type DeferredFnKind,

--- a/packages/ai/test/agent-bus-events.bun.test.ts
+++ b/packages/ai/test/agent-bus-events.bun.test.ts
@@ -5,7 +5,8 @@ import { z } from "zod";
 import {
   agent,
   agentPlugin,
-  defaultFns,
+  currentTime,
+  randomUuid,
   llmPlugin,
   tools,
   type AgentDelta,
@@ -95,7 +96,9 @@ describe("agent context-bus events", () => {
       .with({
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
-          agentPlugin({ functions: { ...defaultFns } }),
+          agentPlugin({
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+          }),
         ],
       })
       .routes(

--- a/packages/ai/test/agent-bus-events.bun.test.ts
+++ b/packages/ai/test/agent-bus-events.bun.test.ts
@@ -106,7 +106,7 @@ describe("agent context-bus events", () => {
             agent({
               system: "Be helpful.",
               model: "anthropic:claude-opus-4-7",
-              tools: tools(["currentTime"]),
+              tools: tools(["CurrentTime"]),
             }),
           ),
       )
@@ -131,10 +131,10 @@ describe("agent context-bus events", () => {
     expect(events.map((e) => e.name)).toEqual(["invoked", "result"]);
     const invoked = events[0]!.details as Record<string, unknown>;
     expect(invoked["routeId"]).toBe("with-tool");
-    expect(invoked["toolName"]).toBe("currentTime");
-    expect(invoked["toolCallId"]).toBe("call-currentTime-1");
+    expect(invoked["toolName"]).toBe("CurrentTime");
+    expect(invoked["toolCallId"]).toBe("call-CurrentTime-1");
     const result = events[1]!.details as Record<string, unknown>;
-    expect(result["toolName"]).toBe("currentTime");
+    expect(result["toolName"]).toBe("CurrentTime");
     expect(result["duration"]).toBeTypeOf("number");
   });
 

--- a/packages/ai/test/agent-runtime.bun.test.ts
+++ b/packages/ai/test/agent-runtime.bun.test.ts
@@ -5,7 +5,8 @@ import { z } from "zod";
 import {
   agent,
   agentPlugin,
-  defaultFns,
+  currentTime,
+  randomUuid,
   llmPlugin,
   tools,
   type AgentResult,
@@ -87,7 +88,9 @@ describe("agent runtime: tool wiring through callLlm", () => {
       .with({
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
-          agentPlugin({ functions: { ...defaultFns } }),
+          agentPlugin({
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+          }),
         ],
       })
       .routes(
@@ -124,7 +127,9 @@ describe("agent runtime: tool wiring through callLlm", () => {
       .with({
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
-          agentPlugin({ functions: { ...defaultFns } }),
+          agentPlugin({
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+          }),
         ],
       })
       .routes(
@@ -258,7 +263,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
           agentPlugin({
-            functions: { ...defaultFns },
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
             defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
@@ -289,7 +294,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
           agentPlugin({
-            functions: { ...defaultFns },
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
             defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],

--- a/packages/ai/test/agent-runtime.bun.test.ts
+++ b/packages/ai/test/agent-runtime.bun.test.ts
@@ -79,8 +79,8 @@ describe("agent runtime: tool wiring through callLlm", () => {
 
   /**
    * @case Agent with one fn tool passes a single Vercel tool to callLlm with stopWhen
-   * @preconditions agentPlugin functions: { currentTime }; agent.tools = tools(["currentTime"])
-   * @expectedResult callLlm receives tools.currentTime (Vercel tool object) and a stopWhen
+   * @preconditions agentPlugin functions: { CurrentTime }; agent.tools = tools(["CurrentTime"])
+   * @expectedResult callLlm receives tools.CurrentTime (Vercel tool object) and a stopWhen
    */
   test("agent with one fn tool passes the tool map to callLlm", async () => {
     t = await testContext()
@@ -98,7 +98,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
             agent({
               system: "Be helpful.",
               model: "anthropic:claude-opus-4-7",
-              tools: tools(["currentTime"]),
+              tools: tools(["CurrentTime"]),
             }),
           ),
       )
@@ -109,7 +109,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
     const args = callLlmMock.mock.calls[0][0];
     expect(args.tools).toBeDefined();
     expect(Object.keys(args.tools as Record<string, unknown>)).toEqual([
-      "currentTime",
+      "CurrentTime",
     ]);
     expect(args.stopWhen).toBeDefined();
   });
@@ -135,7 +135,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
             agent({
               system: "x",
               model: "anthropic:claude-opus-4-7",
-              tools: tools(["currentTime"]),
+              tools: tools(["CurrentTime"]),
               maxTurns: 3,
             }),
           ),
@@ -249,7 +249,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
 
   /**
    * @case Agent inherits defaultOptions.tools when tools field is omitted
-   * @preconditions agentPlugin.defaultOptions.tools = tools(["currentTime"]); agent omits tools
+   * @preconditions agentPlugin.defaultOptions.tools = tools(["CurrentTime"]); agent omits tools
    * @expectedResult callLlm receives the inherited tool map
    */
   test("agent inherits defaultOptions.tools when its own tools is omitted", async () => {
@@ -259,7 +259,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
           agentPlugin({
             functions: { ...defaultFns },
-            defaultOptions: { tools: tools(["currentTime"]) },
+            defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
       })
@@ -274,14 +274,14 @@ describe("agent runtime: tool wiring through callLlm", () => {
     await t.test();
     const args = callLlmMock.mock.calls[0][0];
     expect(Object.keys(args.tools as Record<string, unknown>)).toEqual([
-      "currentTime",
+      "CurrentTime",
     ]);
   });
 
   /**
    * @case Explicit tools on the agent override defaultOptions.tools entirely
-   * @preconditions defaultOptions.tools includes only "currentTime"; agent.tools includes only "randomUuid"
-   * @expectedResult callLlm receives only "randomUuid"
+   * @preconditions defaultOptions.tools includes only "CurrentTime"; agent.tools includes only "RandomUuid"
+   * @expectedResult callLlm receives only "RandomUuid"
    */
   test("per-agent tools overrides defaultOptions.tools", async () => {
     t = await testContext()
@@ -290,7 +290,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
           agentPlugin({
             functions: { ...defaultFns },
-            defaultOptions: { tools: tools(["currentTime"]) },
+            defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
       })
@@ -302,7 +302,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
             agent({
               system: "x",
               model: "anthropic:claude-opus-4-7",
-              tools: tools(["randomUuid"]),
+              tools: tools(["RandomUuid"]),
             }),
           ),
       )
@@ -311,7 +311,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
     await t.test();
     const args = callLlmMock.mock.calls[0][0];
     expect(Object.keys(args.tools as Record<string, unknown>)).toEqual([
-      "randomUuid",
+      "RandomUuid",
     ]);
   });
 });

--- a/packages/ai/test/fn.bun.test.ts
+++ b/packages/ai/test/fn.bun.test.ts
@@ -18,7 +18,7 @@ describe("fn registration via agentPlugin", () => {
 
   /**
    * @case agentPlugin populates ADAPTER_FN_REGISTRY from the functions record
-   * @preconditions agentPlugin({ functions: { currentTime: {...} } })
+   * @preconditions agentPlugin({ functions: { CurrentTime: {...} } })
    * @expectedResult ADAPTER_FN_REGISTRY store contains the registered entry keyed by id
    */
   test("agentPlugin populates ADAPTER_FN_REGISTRY from the functions record", async () => {
@@ -27,7 +27,7 @@ describe("fn registration via agentPlugin", () => {
         plugins: [
           agentPlugin({
             functions: {
-              currentTime: {
+              CurrentTime: {
                 description: "Current UTC timestamp in ISO 8601",
                 input: z.object({}),
                 handler: async () => new Date().toISOString(),
@@ -40,8 +40,8 @@ describe("fn registration via agentPlugin", () => {
 
     const registry = t.ctx.getStore(ADAPTER_FN_REGISTRY);
     expect(registry).toBeInstanceOf(Map);
-    expect(registry?.has("currentTime")).toBe(true);
-    expect((registry?.get("currentTime") as FnOptions).description).toBe(
+    expect(registry?.has("CurrentTime")).toBe(true);
+    expect((registry?.get("CurrentTime") as FnOptions).description).toBe(
       "Current UTC timestamp in ISO 8601",
     );
   });
@@ -167,7 +167,7 @@ describe("fn registration via agentPlugin", () => {
         plugins: [
           agentPlugin({
             functions: {
-              currentTime: {
+              CurrentTime: {
                 description: "Current UTC ISO 8601 timestamp.",
                 input: z.object({}),
                 handler: async () => new Date().toISOString(),
@@ -179,7 +179,7 @@ describe("fn registration via agentPlugin", () => {
       })
       .build();
 
-    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("currentTime") as
+    const entry = t.ctx.getStore(ADAPTER_FN_REGISTRY)?.get("CurrentTime") as
       | FnOptions
       | undefined;
     expect(entry?.tags).toEqual(["read-only", "idempotent"]);

--- a/packages/ai/test/tools-builders.bun.test.ts
+++ b/packages/ai/test/tools-builders.bun.test.ts
@@ -341,31 +341,31 @@ describe("tool builders - directTool dispatch", () => {
 
 describe("tool builders - defaultFns", () => {
   /**
-   * @case defaultFns ships currentTime and randomUuid as eager FnOptions
+   * @case defaultFns ships CurrentTime and RandomUuid as eager FnOptions
    * @preconditions Spread defaultFns into agentPlugin.functions
    * @expectedResult Both registered, both have description / schema / handler / tags
    */
-  test("defaultFns provides currentTime and randomUuid as eager fns", () => {
-    expect(defaultFns.currentTime).toBeDefined();
-    expect(isDeferredFn(defaultFns.currentTime!)).toBe(false);
-    const ct = defaultFns.currentTime as FnOptions;
+  test("defaultFns provides CurrentTime and RandomUuid as eager fns", () => {
+    expect(defaultFns.CurrentTime).toBeDefined();
+    expect(isDeferredFn(defaultFns.CurrentTime!)).toBe(false);
+    const ct = defaultFns.CurrentTime as FnOptions;
     expect(typeof ct.description).toBe("string");
     expect(typeof ct.handler).toBe("function");
     expect(ct.tags).toContain("read-only");
 
-    expect(defaultFns.randomUuid).toBeDefined();
-    const ru = defaultFns.randomUuid as FnOptions;
+    expect(defaultFns.RandomUuid).toBeDefined();
+    const ru = defaultFns.RandomUuid as FnOptions;
     expect(typeof ru.description).toBe("string");
     expect(typeof ru.handler).toBe("function");
   });
 
   /**
-   * @case currentTime handler returns an ISO 8601 timestamp string
-   * @preconditions Call defaultFns.currentTime.handler({}, ctx)
+   * @case CurrentTime handler returns an ISO 8601 timestamp string
+   * @preconditions Call defaultFns.CurrentTime.handler({}, ctx)
    * @expectedResult Returns a parseable ISO string within a second of now
    */
-  test("currentTime handler returns a fresh ISO timestamp", async () => {
-    const ct = defaultFns.currentTime as FnOptions<
+  test("CurrentTime handler returns a fresh ISO timestamp", async () => {
+    const ct = defaultFns.CurrentTime as FnOptions<
       Record<string, never>,
       string
     >;

--- a/packages/ai/test/tools-builders.bun.test.ts
+++ b/packages/ai/test/tools-builders.bun.test.ts
@@ -4,7 +4,8 @@ import { craft, direct, isRoutecraftError, log } from "@routecraft/routecraft";
 import { testContext, type TestContext } from "@routecraft/testing";
 import {
   agentPlugin,
-  defaultFns,
+  currentTime,
+  randomUuid,
   directTool,
   isDeferredFn,
   ADAPTER_FN_REGISTRY,
@@ -339,36 +340,33 @@ describe("tool builders - directTool dispatch", () => {
   });
 });
 
-describe("tool builders - defaultFns", () => {
+describe("tool builders - built-in fn factories", () => {
   /**
-   * @case defaultFns ships CurrentTime and RandomUuid as eager FnOptions
-   * @preconditions Spread defaultFns into agentPlugin.functions
-   * @expectedResult Both registered, both have description / schema / handler / tags
+   * @case currentTime() and randomUuid() factories return eager FnOptions
+   * @preconditions Call the factories directly
+   * @expectedResult Both return objects with description / schema / handler / tags
    */
-  test("defaultFns provides CurrentTime and RandomUuid as eager fns", () => {
-    expect(defaultFns.CurrentTime).toBeDefined();
-    expect(isDeferredFn(defaultFns.CurrentTime!)).toBe(false);
-    const ct = defaultFns.CurrentTime as FnOptions;
+  test("currentTime() and randomUuid() return eager fns", () => {
+    expect(currentTime()).toBeDefined();
+    expect(isDeferredFn(currentTime())).toBe(false);
+    const ct = currentTime() as FnOptions;
     expect(typeof ct.description).toBe("string");
     expect(typeof ct.handler).toBe("function");
     expect(ct.tags).toContain("read-only");
 
-    expect(defaultFns.RandomUuid).toBeDefined();
-    const ru = defaultFns.RandomUuid as FnOptions;
+    expect(randomUuid()).toBeDefined();
+    const ru = randomUuid() as FnOptions;
     expect(typeof ru.description).toBe("string");
     expect(typeof ru.handler).toBe("function");
   });
 
   /**
    * @case CurrentTime handler returns an ISO 8601 timestamp string
-   * @preconditions Call defaultFns.CurrentTime.handler({}, ctx)
+   * @preconditions Call currentTime().handler({}, ctx)
    * @expectedResult Returns a parseable ISO string within a second of now
    */
   test("CurrentTime handler returns a fresh ISO timestamp", async () => {
-    const ct = defaultFns.CurrentTime as FnOptions<
-      Record<string, never>,
-      string
-    >;
+    const ct = currentTime() as FnOptions<Record<string, never>, string>;
     const before = Date.now();
     const out = await ct.handler(
       {},

--- a/packages/ai/test/tools-default.bun.test.ts
+++ b/packages/ai/test/tools-default.bun.test.ts
@@ -21,7 +21,7 @@ describe("agentPlugin defaultOptions storage", () => {
 
   /**
    * @case defaultOptions.tools is stored under ADAPTER_AGENT_DEFAULT_OPTIONS
-   * @preconditions agentPlugin({ defaultOptions: { tools: tools(["currentTime"]) } })
+   * @preconditions agentPlugin({ defaultOptions: { tools: tools(["CurrentTime"]) } })
    * @expectedResult Store entry has a `tools` ToolSelection
    */
   test("agentPlugin stores defaultOptions.tools under the new symbol", async () => {
@@ -30,7 +30,7 @@ describe("agentPlugin defaultOptions storage", () => {
         plugins: [
           agentPlugin({
             functions: { ...defaultFns },
-            defaultOptions: { tools: tools(["currentTime"]) },
+            defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
       })
@@ -86,10 +86,10 @@ describe("agentPlugin defaultOptions storage", () => {
           plugins: [
             agentPlugin({
               functions: { ...defaultFns },
-              defaultOptions: { tools: tools(["currentTime"]) },
+              defaultOptions: { tools: tools(["CurrentTime"]) },
             }),
             agentPlugin({
-              defaultOptions: { tools: tools(["randomUuid"]) },
+              defaultOptions: { tools: tools(["RandomUuid"]) },
             }),
           ],
         })
@@ -133,7 +133,7 @@ describe("agentPlugin defaultOptions storage", () => {
           }),
           agentPlugin({
             functions: { ...defaultFns },
-            defaultOptions: { tools: tools(["currentTime"]) },
+            defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
       })
@@ -197,7 +197,7 @@ describe("agentPlugin per-agent tools field", () => {
    * @expectedResult Registered options contain the same ToolSelection
    */
   test("per-agent tools selection is preserved on AgentRegisteredOptions", async () => {
-    const sel = tools(["currentTime"]);
+    const sel = tools(["CurrentTime"]);
     t = await testContext()
       .with({
         plugins: [
@@ -252,7 +252,7 @@ describe("agentPlugin per-agent tools field", () => {
 
   /**
    * @case agentPlugin throws when an agent's tools is not a ToolSelection
-   * @preconditions agents entry with tools: ["currentTime"] cast to never
+   * @preconditions agents entry with tools: ["CurrentTime"] cast to never
    * @expectedResult RC5003 thrown at context init naming the agent
    */
   test("agentPlugin throws when agent tools is not a ToolSelection", async () => {
@@ -266,7 +266,7 @@ describe("agentPlugin per-agent tools field", () => {
                   description: "x",
                   model: "anthropic:claude-opus-4-7",
                   system: "y",
-                  tools: ["currentTime"] as never,
+                  tools: ["CurrentTime"] as never,
                 },
               },
             }),
@@ -280,7 +280,7 @@ describe("agentPlugin per-agent tools field", () => {
 describe("agent() inline tools validation", () => {
   /**
    * @case Inline agent({ tools }) rejects a non-ToolSelection synchronously
-   * @preconditions agent({ ..., tools: ["currentTime"] as never })
+   * @preconditions agent({ ..., tools: ["CurrentTime"] as never })
    * @expectedResult RC5003 thrown synchronously by validateAgentOptions
    */
   test("inline agent({ tools }) rejects a non-ToolSelection", () => {
@@ -288,21 +288,21 @@ describe("agent() inline tools validation", () => {
       agent({
         model: "anthropic:claude-opus-4-7",
         system: "Be helpful.",
-        tools: ["currentTime"] as never,
+        tools: ["CurrentTime"] as never,
       }),
     ).toThrow(/tools\(/);
   });
 
   /**
    * @case Inline agent({ tools: tools([...]) }) accepts a ToolSelection
-   * @preconditions agent with tools: tools(["currentTime"])
+   * @preconditions agent with tools: tools(["CurrentTime"])
    * @expectedResult agent() returns a destination without throwing
    */
   test("inline agent({ tools: tools(...) }) accepts a ToolSelection", () => {
     const dest = agent({
       model: "anthropic:claude-opus-4-7",
       system: "Be helpful.",
-      tools: tools(["currentTime"]),
+      tools: tools(["CurrentTime"]),
     });
     expect(dest).toBeDefined();
   });

--- a/packages/ai/test/tools-default.bun.test.ts
+++ b/packages/ai/test/tools-default.bun.test.ts
@@ -6,7 +6,8 @@ import {
   ADAPTER_AGENT_REGISTRY,
   agent,
   agentPlugin,
-  defaultFns,
+  currentTime,
+  randomUuid,
   isToolSelection,
   tools,
   type AgentRegisteredOptions,
@@ -29,7 +30,7 @@ describe("agentPlugin defaultOptions storage", () => {
       .with({
         plugins: [
           agentPlugin({
-            functions: { ...defaultFns },
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
             defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
@@ -68,7 +69,13 @@ describe("agentPlugin defaultOptions storage", () => {
    */
   test("agentPlugin without defaultOptions does not set the store", async () => {
     t = await testContext()
-      .with({ plugins: [agentPlugin({ functions: { ...defaultFns } })] })
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+          }),
+        ],
+      })
       .build();
 
     expect(t.ctx.getStore(ADAPTER_AGENT_DEFAULT_OPTIONS)).toBeUndefined();
@@ -85,7 +92,10 @@ describe("agentPlugin defaultOptions storage", () => {
         .with({
           plugins: [
             agentPlugin({
-              functions: { ...defaultFns },
+              functions: {
+                CurrentTime: currentTime(),
+                RandomUuid: randomUuid(),
+              },
               defaultOptions: { tools: tools(["CurrentTime"]) },
             }),
             agentPlugin({
@@ -132,7 +142,7 @@ describe("agentPlugin defaultOptions storage", () => {
             defaultOptions: { model: "anthropic:claude-opus-4-7" },
           }),
           agentPlugin({
-            functions: { ...defaultFns },
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
             defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
@@ -202,7 +212,7 @@ describe("agentPlugin per-agent tools field", () => {
       .with({
         plugins: [
           agentPlugin({
-            functions: { ...defaultFns },
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
             agents: {
               researcher: {
                 description: "Research workflow coordinator.",

--- a/packages/ai/test/tools-selection-mcp.bun.test.ts
+++ b/packages/ai/test/tools-selection-mcp.bun.test.ts
@@ -177,6 +177,115 @@ describe("tools() resolver - MCP refs", () => {
   });
 
   /**
+   * @case MCP(server:tool) sugar resolves identically to the raw mcp__server__tool form
+   * @preconditions Registry has Nuclino:list_teams
+   * @expectedResult One ResolvedTool named mcp__Nuclino__list_teams whose handler dispatches through dispatchMcpCall
+   */
+  test("MCP(server:tool) sugar resolves to one ResolvedTool", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [{ name: "list_teams", description: "List teams." }],
+      },
+    ]);
+    const resolved = tools(["MCP(Nuclino:list_teams)"]).resolve(t.ctx);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.name).toBe("mcp__Nuclino__list_teams");
+    expect(resolved[0]!.description).toBe("List teams.");
+    await resolved[0]!.handler(
+      { foo: "bar" } as unknown,
+      {} as FnHandlerContext,
+    );
+    expect(recordedDispatches).toEqual([
+      { serverId: "Nuclino", toolName: "list_teams", args: { foo: "bar" } },
+    ]);
+  });
+
+  /**
+   * @case MCP(server) and raw mcp__server both expand to every tool on the server
+   * @preconditions Registry has two Nuclino tools
+   * @expectedResult Both forms yield the same set of mcp__Nuclino__<tool> names
+   */
+  test("MCP(server) and raw mcp__server expand to all server tools", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [{ name: "list_teams" }, { name: "search_items" }],
+      },
+    ]);
+    const viaSugar = tools(["MCP(Nuclino)"])
+      .resolve(t.ctx)
+      .map((r) => r.name)
+      .sort();
+    const viaRaw = tools(["mcp__Nuclino"])
+      .resolve(t.ctx)
+      .map((r) => r.name)
+      .sort();
+    expect(viaSugar).toEqual([
+      "mcp__Nuclino__list_teams",
+      "mcp__Nuclino__search_items",
+    ]);
+    expect(viaRaw).toEqual(viaSugar);
+  });
+
+  /**
+   * @case MCP(server) with a guard attaches the guard to every expanded tool
+   * @preconditions Server with two tools; { name: "MCP(Nuclino)", guard }
+   * @expectedResult Every resolved tool carries the same guard reference
+   */
+  test("MCP(server) with a guard attaches the guard to every expanded tool", async () => {
+    t = await buildCtxWithMcp([
+      {
+        source: "Nuclino",
+        transport: "http",
+        tools: [{ name: "a" }, { name: "b" }],
+      },
+    ]);
+    const guard = mock(async () => undefined);
+    const resolved = tools([{ name: "MCP(Nuclino)", guard }]).resolve(t.ctx);
+    expect(resolved).toHaveLength(2);
+    for (const r of resolved) expect(r.guard).toBe(guard);
+  });
+
+  /**
+   * @case A fn id starting with mcp__ wins over the MCP-ref grammar (exact fn id is authoritative)
+   * @preconditions agentPlugin registers a fn named "mcp__health"; an MCP server is also registered
+   * @expectedResult tools(["mcp__health"]) resolves the fn, not a whole-server MCP ref
+   */
+  test("fn id starting with mcp__ resolves via fn registry, not MCP grammar", async () => {
+    t = await buildCtxWithMcp(
+      [
+        {
+          source: "Nuclino",
+          transport: "http",
+          tools: [{ name: "list_teams" }],
+        },
+      ],
+      {
+        functions: {
+          mcp__health: {
+            description: "Ping the local mcp infra.",
+            input: {
+              "~standard": {
+                version: 1,
+                vendor: "routecraft",
+                validate: (value: unknown) => ({ value }),
+              },
+            } as never,
+            handler: async () => ({ ok: true }),
+          },
+        },
+      },
+    );
+    const resolved = tools(["mcp__health"]).resolve(t.ctx);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.name).toBe("mcp__health");
+    expect(resolved[0]!.description).toBe("Ping the local mcp infra.");
+  });
+
+  /**
    * @case Unknown MCP client throws RC5003 listing known clients
    * @preconditions Registry has client "Nuclino"; user references "Foo"
    * @expectedResult Throw mentioning client "Foo" and listing "Nuclino"

--- a/packages/ai/test/tools-selection-mcp.bun.test.ts
+++ b/packages/ai/test/tools-selection-mcp.bun.test.ts
@@ -379,7 +379,7 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
 
   /**
    * @case `{ tagged: "read-only" }` walks fns AND MCP tools in one selection
-   * @preconditions defaultFns provides currentTime ("read-only"); registry has Nuclino:get_item with readOnlyHint
+   * @preconditions defaultFns provides CurrentTime ("read-only"); registry has Nuclino:get_item with readOnlyHint
    * @expectedResult Both tools appear in the resolved list
    */
   test("{ tagged } walks fns and MCP tools together", async () => {
@@ -395,7 +395,7 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
     );
     const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
-    expect(names).toContain("currentTime");
+    expect(names).toContain("CurrentTime");
     expect(names).toContain("mcp_Nuclino:get_item");
   });
 
@@ -489,11 +489,11 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
     const resolved = tools([
       "mcp_Nuclino:*",
       { tagged: "destructive", from: "mcp_Nuclino" },
-      "currentTime",
+      "CurrentTime",
     ]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
     expect(names).toEqual([
-      "currentTime",
+      "CurrentTime",
       "mcp_Nuclino:delete_item",
       "mcp_Nuclino:get_item",
     ]);

--- a/packages/ai/test/tools-selection-mcp.bun.test.ts
+++ b/packages/ai/test/tools-selection-mcp.bun.test.ts
@@ -100,11 +100,11 @@ describe("tools() resolver - MCP refs", () => {
   });
 
   /**
-   * @case mcp_<client>:<tool> resolves to a single ResolvedTool
+   * @case mcp__server__tool resolves to a single ResolvedTool
    * @preconditions Registry has Nuclino:list_teams with description and JSON Schema
-   * @expectedResult Resolution yields one tool named mcp_Nuclino:list_teams whose handler dispatches through dispatchMcpCall
+   * @expectedResult Resolution yields one tool named mcp__Nuclino__list_teams whose handler dispatches through dispatchMcpCall
    */
-  test("mcp_<client>:<tool> resolves to one ResolvedTool", async () => {
+  test("mcp__server__tool resolves to one ResolvedTool", async () => {
     t = await buildCtxWithMcp([
       {
         source: "Nuclino",
@@ -118,9 +118,9 @@ describe("tools() resolver - MCP refs", () => {
         ],
       },
     ]);
-    const resolved = tools(["mcp_Nuclino:list_teams"]).resolve(t.ctx);
+    const resolved = tools(["mcp__Nuclino__list_teams"]).resolve(t.ctx);
     expect(resolved).toHaveLength(1);
-    expect(resolved[0]!.name).toBe("mcp_Nuclino:list_teams");
+    expect(resolved[0]!.name).toBe("mcp__Nuclino__list_teams");
     expect(resolved[0]!.description).toBe("List teams.");
     await resolved[0]!.handler(
       { foo: "bar" } as unknown,
@@ -132,11 +132,11 @@ describe("tools() resolver - MCP refs", () => {
   });
 
   /**
-   * @case mcp_<client>:* expands to every tool registered under the client
+   * @case mcp__server__* expands to every tool registered under the client
    * @preconditions Registry has three Nuclino tools
-   * @expectedResult Resolution yields three ResolvedTools, one per registered tool, names follow mcp_Nuclino:<tool>
+   * @expectedResult Resolution yields three ResolvedTools, one per registered tool, names follow mcp__Nuclino__<tool>
    */
-  test("mcp_<client>:* expands to every tool on the client", async () => {
+  test("mcp__server__* expands to every tool on the client", async () => {
     t = await buildCtxWithMcp([
       {
         source: "Nuclino",
@@ -148,21 +148,21 @@ describe("tools() resolver - MCP refs", () => {
         ],
       },
     ]);
-    const resolved = tools(["mcp_Nuclino:*"]).resolve(t.ctx);
+    const resolved = tools(["mcp__Nuclino__*"]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
     expect(names).toEqual([
-      "mcp_Nuclino:list_teams",
-      "mcp_Nuclino:list_workspaces",
-      "mcp_Nuclino:search_items",
+      "mcp__Nuclino__list_teams",
+      "mcp__Nuclino__list_workspaces",
+      "mcp__Nuclino__search_items",
     ]);
   });
 
   /**
    * @case Wildcard with a guard attaches the guard to every expanded tool
-   * @preconditions Client with two tools; { name: "mcp_X:*", guard }
+   * @preconditions Client with two tools; { name: "mcp__X__*", guard }
    * @expectedResult Every resolved tool carries the same guard reference
    */
-  test("mcp_<client>:* with a guard attaches the guard to every expanded tool", async () => {
+  test("mcp__server__* with a guard attaches the guard to every expanded tool", async () => {
     t = await buildCtxWithMcp([
       {
         source: "Nuclino",
@@ -171,7 +171,7 @@ describe("tools() resolver - MCP refs", () => {
       },
     ]);
     const guard = mock(async () => undefined);
-    const resolved = tools([{ name: "mcp_Nuclino:*", guard }]).resolve(t.ctx);
+    const resolved = tools([{ name: "mcp__Nuclino__*", guard }]).resolve(t.ctx);
     expect(resolved).toHaveLength(2);
     for (const r of resolved) expect(r.guard).toBe(guard);
   });
@@ -189,7 +189,7 @@ describe("tools() resolver - MCP refs", () => {
         tools: [{ name: "list_teams" }],
       },
     ]);
-    expect(() => tools(["mcp_Foo:bar"]).resolve(t!.ctx)).toThrow(
+    expect(() => tools(["mcp__Foo__bar"]).resolve(t!.ctx)).toThrow(
       /client "Foo" has no registered tools.*Nuclino/s,
     );
   });
@@ -207,7 +207,7 @@ describe("tools() resolver - MCP refs", () => {
         tools: [{ name: "list_teams" }, { name: "search_items" }],
       },
     ]);
-    expect(() => tools(["mcp_Nuclino:nope"]).resolve(t!.ctx)).toThrow(
+    expect(() => tools(["mcp__Nuclino__nope"]).resolve(t!.ctx)).toThrow(
       /"nope".*list_teams.*search_items/s,
     );
   });
@@ -215,7 +215,7 @@ describe("tools() resolver - MCP refs", () => {
   /**
    * @case Client names containing underscores resolve correctly
    * @preconditions Registry has client "my_company_api"
-   * @expectedResult mcp_my_company_api:get_user resolves to the right tool
+   * @expectedResult mcp__my_company_api__get_user resolves to the right tool
    */
   test("client names with underscores resolve correctly", async () => {
     t = await buildCtxWithMcp([
@@ -225,9 +225,9 @@ describe("tools() resolver - MCP refs", () => {
         tools: [{ name: "get_user", description: "Get a user." }],
       },
     ]);
-    const resolved = tools(["mcp_my_company_api:get_user"]).resolve(t.ctx);
+    const resolved = tools(["mcp__my_company_api__get_user"]).resolve(t.ctx);
     expect(resolved).toHaveLength(1);
-    expect(resolved[0]!.name).toBe("mcp_my_company_api:get_user");
+    expect(resolved[0]!.name).toBe("mcp__my_company_api__get_user");
   });
 
   /**
@@ -257,19 +257,19 @@ describe("tools() resolver - MCP refs", () => {
   });
 
   /**
-   * @case Malformed MCP refs with an empty client or tool segment surface as MCP grammar errors, not generic "unknown tool"
-   * @preconditions Registry populated with one valid Nuclino tool; user writes `mcp_:foo` or `mcp_foo:`
-   * @expectedResult Each throws RC5003 mentioning the MCP grammar (form "mcp_<client>:<tool>"), not "unknown tool"
+   * @case Malformed MCP refs with an empty server or tool segment surface as MCP grammar errors, not generic "unknown tool"
+   * @preconditions Registry populated with one valid Nuclino tool; user writes `MCP(:foo)` or `MCP(foo:)`
+   * @expectedResult Each throws RC5003 mentioning the MCP grammar, not "unknown tool"
    */
-  test("malformed mcp_ refs (empty client / empty tool) emit MCP-specific errors", async () => {
+  test("malformed MCP refs (empty server / empty tool) emit MCP-specific errors", async () => {
     t = await buildCtxWithMcp([
       { source: "Nuclino", transport: "http", tools: [{ name: "real_tool" }] },
     ]);
-    expect(() => tools(["mcp_:foo"]).resolve(t!.ctx)).toThrow(
-      /MCP reference.*form "mcp_<client>:<tool>".*empty client or tool/,
+    expect(() => tools(["MCP(:foo)"]).resolve(t!.ctx)).toThrow(
+      /MCP reference.*empty server or tool/,
     );
-    expect(() => tools(["mcp_foo:"]).resolve(t!.ctx)).toThrow(
-      /MCP reference.*form "mcp_<client>:<tool>".*empty client or tool/,
+    expect(() => tools(["MCP(foo:)"]).resolve(t!.ctx)).toThrow(
+      /MCP reference.*empty server or tool/,
     );
   });
 
@@ -282,14 +282,14 @@ describe("tools() resolver - MCP refs", () => {
     t = await testContext()
       .with({ plugins: [agentPlugin({})] })
       .build();
-    expect(() => tools(["mcp_Foo:bar"]).resolve(t!.ctx)).toThrow(
+    expect(() => tools(["mcp__Foo__bar"]).resolve(t!.ctx)).toThrow(
       /no MCP_TOOL_REGISTRY is present/,
     );
   });
 
   /**
-   * @case mcp_<client>:<tool> with description override on { name } shape throws
-   * @preconditions { name: "mcp_X:y", description: "x" } in tools()
+   * @case mcp__server__tool with description override on { name } shape throws
+   * @preconditions { name: "mcp__X__y", description: "x" } in tools()
    * @expectedResult RC5003 explaining MCP descriptions are server-owned
    */
   test("description override on an MCP { name } item throws", async () => {
@@ -297,13 +297,13 @@ describe("tools() resolver - MCP refs", () => {
       { source: "X", transport: "http", tools: [{ name: "y" }] },
     ]);
     expect(() =>
-      tools([{ name: "mcp_X:y", description: "override" }]).resolve(t!.ctx),
+      tools([{ name: "mcp__X__y", description: "override" }]).resolve(t!.ctx),
     ).toThrow(/description.*MCP server is the source of truth/);
   });
 
   /**
    * @case Empty-string description on an MCP { name } item throws the MCP-specific error, not the generic empty-string error
-   * @preconditions { name: "mcp_X:y", description: "" } in tools()
+   * @preconditions { name: "mcp__X__y", description: "" } in tools()
    * @expectedResult RC5003 mentioning "MCP server is the source of truth", not "must be a non-empty string"
    */
   test("empty-string description on an MCP { name } item throws the MCP-specific error", async () => {
@@ -311,13 +311,13 @@ describe("tools() resolver - MCP refs", () => {
       { source: "X", transport: "http", tools: [{ name: "y" }] },
     ]);
     expect(() =>
-      tools([{ name: "mcp_X:y", description: "" }]).resolve(t!.ctx),
+      tools([{ name: "mcp__X__y", description: "" }]).resolve(t!.ctx),
     ).toThrow(/MCP server is the source of truth/);
   });
 
   /**
    * @case description override on an MCP wildcard { name } item throws the MCP-specific error
-   * @preconditions { name: "mcp_X:*", description: "x" } in tools()
+   * @preconditions { name: "mcp__X__*", description: "x" } in tools()
    * @expectedResult RC5003 mentioning MCP server is the source of truth
    */
   test("description override on an MCP wildcard { name } item throws", async () => {
@@ -325,7 +325,7 @@ describe("tools() resolver - MCP refs", () => {
       { source: "X", transport: "http", tools: [{ name: "y" }] },
     ]);
     expect(() =>
-      tools([{ name: "mcp_X:*", description: "override" }]).resolve(t!.ctx),
+      tools([{ name: "mcp__X__*", description: "override" }]).resolve(t!.ctx),
     ).toThrow(/MCP server is the source of truth/);
   });
 
@@ -348,7 +348,7 @@ describe("tools() resolver - MCP refs", () => {
         ],
       },
     ]);
-    const resolved = tools(["mcp_Nuclino:search_items"]).resolve(t!.ctx);
+    const resolved = tools(["mcp__Nuclino__search_items"]).resolve(t!.ctx);
     expect(resolved).toHaveLength(1);
     const tool = resolved[0]!;
     await expect(
@@ -397,11 +397,11 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
     const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
     expect(names).toContain("CurrentTime");
-    expect(names).toContain("mcp_Nuclino:get_item");
+    expect(names).toContain("mcp__Nuclino__get_item");
   });
 
   /**
-   * @case `from: "mcp_<client>"` scopes the tag selector to one MCP client
+   * @case `from: "mcp__<server>"` scopes the tag selector to one MCP client
    * @preconditions Built-in read-only fns registered; registry has Nuclino read-only tool and Stripe read-only tool
    * @expectedResult Only Nuclino's read-only tool appears; the local fns and Stripe are excluded
    */
@@ -424,16 +424,16 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
       { functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() } },
     );
     const resolved = tools([
-      { tagged: "read-only", from: "mcp_Nuclino" },
+      { tagged: "read-only", from: "mcp__Nuclino" },
     ]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
-    expect(names).toEqual(["mcp_Nuclino:get_item"]);
+    expect(names).toEqual(["mcp__Nuclino__get_item"]);
   });
 
   /**
    * @case `from: "mcp_<unknown>"` throws RC5003 listing registered clients
-   * @preconditions Registry has Nuclino only; user scopes from "mcp_Foo"
-   * @expectedResult Throw mentions "mcp_Foo" and lists "Nuclino"
+   * @preconditions Registry has Nuclino only; user scopes from "mcp__Foo"
+   * @expectedResult Throw mentions "mcp__Foo" and lists "Nuclino"
    */
   test("{ tagged, from } against an unknown MCP client throws", async () => {
     t = await buildCtxWithMcp([
@@ -444,8 +444,8 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
       },
     ]);
     expect(() =>
-      tools([{ tagged: "read-only", from: "mcp_Foo" }]).resolve(t!.ctx),
-    ).toThrow(/mcp_Foo.*Nuclino/s);
+      tools([{ tagged: "read-only", from: "mcp__Foo" }]).resolve(t!.ctx),
+    ).toThrow(/mcp__Foo.*Nuclino/s);
   });
 
   /**
@@ -464,7 +464,7 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
       },
     ]);
     expect(() =>
-      tools([{ tagged: "read-only", from: "mcp_Nuclino" }]).resolve(t!.ctx),
+      tools([{ tagged: "read-only", from: "mcp__Nuclino" }]).resolve(t!.ctx),
     ).toThrow(/matched no tools/);
   });
 
@@ -488,15 +488,15 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
       { functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() } },
     );
     const resolved = tools([
-      "mcp_Nuclino:*",
-      { tagged: "destructive", from: "mcp_Nuclino" },
+      "mcp__Nuclino__*",
+      { tagged: "destructive", from: "mcp__Nuclino" },
       "CurrentTime",
     ]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
     expect(names).toEqual([
       "CurrentTime",
-      "mcp_Nuclino:delete_item",
-      "mcp_Nuclino:get_item",
+      "mcp__Nuclino__delete_item",
+      "mcp__Nuclino__get_item",
     ]);
   });
 });

--- a/packages/ai/test/tools-selection-mcp.bun.test.ts
+++ b/packages/ai/test/tools-selection-mcp.bun.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { testContext, type TestContext } from "@routecraft/testing";
 import {
   agentPlugin,
-  defaultFns,
+  currentTime,
+  randomUuid,
   MCP_TOOL_REGISTRY,
   tools,
   type FnHandlerContext,
@@ -379,7 +380,7 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
 
   /**
    * @case `{ tagged: "read-only" }` walks fns AND MCP tools in one selection
-   * @preconditions defaultFns provides CurrentTime ("read-only"); registry has Nuclino:get_item with readOnlyHint
+   * @preconditions currentTime() registered ("read-only"); registry has Nuclino:get_item with readOnlyHint
    * @expectedResult Both tools appear in the resolved list
    */
   test("{ tagged } walks fns and MCP tools together", async () => {
@@ -391,7 +392,7 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
           tools: [{ name: "get_item", annotations: { readOnlyHint: true } }],
         },
       ],
-      { functions: { ...defaultFns } },
+      { functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() } },
     );
     const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
@@ -401,8 +402,8 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
 
   /**
    * @case `from: "mcp_<client>"` scopes the tag selector to one MCP client
-   * @preconditions defaultFns ships read-only fns; registry has Nuclino read-only tool and Stripe read-only tool
-   * @expectedResult Only Nuclino's read-only tool appears; defaultFns and Stripe are excluded
+   * @preconditions Built-in read-only fns registered; registry has Nuclino read-only tool and Stripe read-only tool
+   * @expectedResult Only Nuclino's read-only tool appears; the local fns and Stripe are excluded
    */
   test("{ tagged, from } scopes to a single MCP client", async () => {
     t = await buildCtxWithMcp(
@@ -420,7 +421,7 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
           ],
         },
       ],
-      { functions: { ...defaultFns } },
+      { functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() } },
     );
     const resolved = tools([
       { tagged: "read-only", from: "mcp_Nuclino" },
@@ -469,7 +470,7 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
 
   /**
    * @case Mixed selection of MCP wildcard, MCP scoped tag, fn, and direct in one array
-   * @preconditions Two MCP tools (one read-only, one destructive); two defaultFns
+   * @preconditions Two MCP tools (one read-only, one destructive); two built-in fns
    * @expectedResult Resolved list contains the wildcard expansion + the tag-filtered subset + the explicit fn, deduped
    */
   test("mixes MCP refs, tag filters, and fn names in one selection", async () => {
@@ -484,7 +485,7 @@ describe("tools() resolver - { tagged, from? } over MCP", () => {
           ],
         },
       ],
-      { functions: { ...defaultFns } },
+      { functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() } },
     );
     const resolved = tools([
       "mcp_Nuclino:*",

--- a/packages/ai/test/tools-selection.bun.test.ts
+++ b/packages/ai/test/tools-selection.bun.test.ts
@@ -23,22 +23,22 @@ async function buildCtx(opts: {
 describe("tools() resolver - shape", () => {
   /**
    * @case tools(items) returns a branded selection descriptor
-   * @preconditions tools(["currentTime"])
+   * @preconditions tools(["CurrentTime"])
    * @expectedResult isToolSelection returns true; resolve is callable
    */
   test("tools() returns a branded selection descriptor", () => {
-    const sel = tools(["currentTime"]);
+    const sel = tools(["CurrentTime"]);
     expect(isToolSelection(sel)).toBe(true);
     expect(typeof sel.resolve).toBe("function");
   });
 
   /**
    * @case tools(items) rejects non-array input
-   * @preconditions tools("currentTime" as never)
+   * @preconditions tools("CurrentTime" as never)
    * @expectedResult RC5003 thrown synchronously
    */
   test("tools() rejects non-array input", () => {
-    expect(() => tools("currentTime" as never)).toThrow(/array/i);
+    expect(() => tools("CurrentTime" as never)).toThrow(/array/i);
   });
 });
 
@@ -51,14 +51,14 @@ describe("tools() resolver - bare references", () => {
 
   /**
    * @case Bare fn name resolves against the fn registry
-   * @preconditions agentPlugin functions includes currentTime; resolve tools(["currentTime"])
-   * @expectedResult Single ResolvedTool named "currentTime" with description and handler from defaultFns
+   * @preconditions agentPlugin functions includes CurrentTime; resolve tools(["CurrentTime"])
+   * @expectedResult Single ResolvedTool named "CurrentTime" with description and handler from defaultFns
    */
   test("bare fn name resolves to a registered fn", async () => {
     t = await buildCtx({ functions: { ...defaultFns } });
-    const resolved = tools(["currentTime"]).resolve(t.ctx);
+    const resolved = tools(["CurrentTime"]).resolve(t.ctx);
     expect(resolved).toHaveLength(1);
-    expect(resolved[0].name).toBe("currentTime");
+    expect(resolved[0].name).toBe("CurrentTime");
     expect(resolved[0].description).toMatch(/timestamp/i);
     expect(typeof resolved[0].handler).toBe("function");
     expect(resolved[0].tags).toContain("read-only");
@@ -142,7 +142,7 @@ describe("tools() resolver - bare references", () => {
     expect(isRoutecraftError(caught)).toBe(true);
     expect((caught as { rc?: string }).rc).toBe("RC5003");
     expect((caught as Error).message).toMatch(/missing/);
-    expect((caught as Error).message).toMatch(/currentTime|randomUuid/);
+    expect((caught as Error).message).toMatch(/CurrentTime|RandomUuid/);
   });
 
   /**
@@ -167,14 +167,14 @@ describe("tools() resolver - { name, guard }", () => {
 
   /**
    * @case { name, guard } attaches the guard to the resolved tool
-   * @preconditions tools([{ name: "currentTime", guard: g }]) with currentTime registered
+   * @preconditions tools([{ name: "CurrentTime", guard: g }]) with CurrentTime registered
    * @expectedResult ResolvedTool.guard is the supplied function
    */
   test("{ name, guard } attaches the guard", async () => {
     t = await buildCtx({ functions: { ...defaultFns } });
     const guard = mock();
-    const [resolved] = tools([{ name: "currentTime", guard }]).resolve(t.ctx);
-    expect(resolved.name).toBe("currentTime");
+    const [resolved] = tools([{ name: "CurrentTime", guard }]).resolve(t.ctx);
+    expect(resolved.name).toBe("CurrentTime");
     expect(resolved.guard).toBe(guard);
   });
 
@@ -190,14 +190,14 @@ describe("tools() resolver - { name, guard }", () => {
 
   /**
    * @case { name, description } overrides description for THIS binding
-   * @preconditions tools([{ name: "currentTime", description: "Per-agent framing" }]) with currentTime registered
+   * @preconditions tools([{ name: "CurrentTime", description: "Per-agent framing" }]) with CurrentTime registered
    * @expectedResult ResolvedTool.description is the override; the registry entry's description is unchanged
    */
   test("{ name, description } overrides description per binding", async () => {
     t = await buildCtx({ functions: { ...defaultFns } });
     const [resolved] = tools([
       {
-        name: "currentTime",
+        name: "CurrentTime",
         description: "Per-agent framing of the time tool.",
       },
     ]).resolve(t.ctx);
@@ -205,20 +205,20 @@ describe("tools() resolver - { name, guard }", () => {
 
     // Registry entry stays canonical: a second binding without the
     // override sees the original description.
-    const [resolved2] = tools(["currentTime"]).resolve(t.ctx);
-    expect(resolved2.description).toBe(defaultFns.currentTime.description);
+    const [resolved2] = tools(["CurrentTime"]).resolve(t.ctx);
+    expect(resolved2.description).toBe(defaultFns.CurrentTime.description);
     expect(resolved2.description).not.toBe(resolved.description);
   });
 
   /**
    * @case { name, description } rejects empty/blank string
-   * @preconditions tools([{ name: "currentTime", description: "" }])
+   * @preconditions tools([{ name: "CurrentTime", description: "" }])
    * @expectedResult RC5003 with a message naming the field
    */
   test("{ name, description } rejects empty string", async () => {
     t = await buildCtx({ functions: { ...defaultFns } });
     expect(() =>
-      tools([{ name: "currentTime", description: "" }]).resolve(t!.ctx),
+      tools([{ name: "CurrentTime", description: "" }]).resolve(t!.ctx),
     ).toThrow(/description.*non-empty/i);
   });
 
@@ -232,7 +232,7 @@ describe("tools() resolver - { name, guard }", () => {
     const guard = mock();
     const [resolved] = tools([
       {
-        name: "currentTime",
+        name: "CurrentTime",
         guard,
         description: "Reframed for this agent.",
       },
@@ -251,14 +251,14 @@ describe("tools() resolver - tag selectors", () => {
 
   /**
    * @case Single-tag selector matches eager fn registry entries
-   * @preconditions defaultFns spread (currentTime + randomUuid both tagged "read-only")
+   * @preconditions defaultFns spread (CurrentTime + RandomUuid both tagged "read-only")
    * @expectedResult { tagged: "read-only" } resolves to both fns
    */
   test("{ tagged } matches eager fn registry entries", async () => {
     t = await buildCtx({ functions: { ...defaultFns } });
     const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
-    expect(names).toEqual(["currentTime", "randomUuid"]);
+    expect(names).toEqual(["CurrentTime", "RandomUuid"]);
   });
 
   /**
@@ -292,8 +292,8 @@ describe("tools() resolver - tag selectors", () => {
 
   /**
    * @case OR-of-tags: matches entries with ANY of the requested tags
-   * @preconditions defaultFns (read-only, idempotent for currentTime; read-only for randomUuid) + a fn tagged only "destructive"
-   * @expectedResult { tagged: ["idempotent", "destructive"] } returns currentTime and the destructive fn but not randomUuid
+   * @preconditions defaultFns (read-only, idempotent for CurrentTime; read-only for RandomUuid) + a fn tagged only "destructive"
+   * @expectedResult { tagged: ["idempotent", "destructive"] } returns CurrentTime and the destructive fn but not RandomUuid
    */
   test("{ tagged: [...] } is an OR over the listed tags", async () => {
     t = await buildCtx({
@@ -311,7 +311,7 @@ describe("tools() resolver - tag selectors", () => {
       t.ctx,
     );
     const names = resolved.map((r) => r.name).sort();
-    expect(names).toEqual(["currentTime", "wipe"]);
+    expect(names).toEqual(["CurrentTime", "wipe"]);
   });
 
   /**
@@ -341,8 +341,8 @@ describe("tools() resolver - tag selectors", () => {
 
   /**
    * @case Explicit refs win over tag-selector matches regardless of order
-   * @preconditions Tag selector matches "currentTime"; later (or earlier) explicit ref overrides with a different guard
-   * @expectedResult Final list contains "currentTime" with the explicit guard
+   * @preconditions Tag selector matches "CurrentTime"; later (or earlier) explicit ref overrides with a different guard
+   * @expectedResult Final list contains "CurrentTime" with the explicit guard
    */
   test("explicit refs win over tag-selector matches", async () => {
     t = await buildCtx({ functions: { ...defaultFns } });
@@ -350,9 +350,9 @@ describe("tools() resolver - tag selectors", () => {
     const tagGuard = mock();
     const resolved = tools([
       { tagged: "read-only", guard: tagGuard },
-      { name: "currentTime", guard: explicitGuard },
+      { name: "CurrentTime", guard: explicitGuard },
     ]).resolve(t.ctx);
-    const ct = resolved.find((r) => r.name === "currentTime");
+    const ct = resolved.find((r) => r.name === "CurrentTime");
     expect(ct?.guard).toBe(explicitGuard);
   });
 });
@@ -385,7 +385,7 @@ describe("tools() resolver - regression", () => {
 
     const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
-    expect(names).toEqual(["currentTime", "randomUuid"]);
+    expect(names).toEqual(["CurrentTime", "RandomUuid"]);
   });
 
   /**
@@ -484,7 +484,7 @@ describe("tools() resolver - regression", () => {
             functions: {
               padded: {
                 description: "x",
-                input: defaultFns.currentTime.input,
+                input: defaultFns.CurrentTime.input,
                 handler: () => "ok",
                 tags: ["  read-only  "],
               },
@@ -508,12 +508,12 @@ describe("tools() resolver - dedup and prefix-convention coverage", () => {
 
   /**
    * @case Same tool referenced twice surfaces only once
-   * @preconditions tools(["currentTime", "currentTime"])
+   * @preconditions tools(["CurrentTime", "CurrentTime"])
    * @expectedResult Single ResolvedTool
    */
   test("duplicate explicit refs are deduplicated", async () => {
     t = await buildCtx({ functions: { ...defaultFns } });
-    const resolved = tools(["currentTime", "currentTime"]).resolve(t.ctx);
+    const resolved = tools(["CurrentTime", "CurrentTime"]).resolve(t.ctx);
     expect(resolved).toHaveLength(1);
   });
 

--- a/packages/ai/test/tools-selection.bun.test.ts
+++ b/packages/ai/test/tools-selection.bun.test.ts
@@ -4,7 +4,8 @@ import { craft, direct, isRoutecraftError, log } from "@routecraft/routecraft";
 import { testContext, type TestContext } from "@routecraft/testing";
 import {
   agentPlugin,
-  defaultFns,
+  currentTime,
+  randomUuid,
   directTool,
   isToolSelection,
   tools,
@@ -52,10 +53,12 @@ describe("tools() resolver - bare references", () => {
   /**
    * @case Bare fn name resolves against the fn registry
    * @preconditions agentPlugin functions includes CurrentTime; resolve tools(["CurrentTime"])
-   * @expectedResult Single ResolvedTool named "CurrentTime" with description and handler from defaultFns
+   * @expectedResult Single ResolvedTool named "CurrentTime" with description and handler from currentTime()
    */
   test("bare fn name resolves to a registered fn", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     const resolved = tools(["CurrentTime"]).resolve(t.ctx);
     expect(resolved).toHaveLength(1);
     expect(resolved[0].name).toBe("CurrentTime");
@@ -132,7 +135,9 @@ describe("tools() resolver - bare references", () => {
    * @expectedResult RC5003 thrown listing available names
    */
   test("unknown bare name throws RC5003", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     let caught: unknown;
     try {
       tools(["missing"]).resolve(t.ctx);
@@ -171,7 +176,9 @@ describe("tools() resolver - { name, guard }", () => {
    * @expectedResult ResolvedTool.guard is the supplied function
    */
   test("{ name, guard } attaches the guard", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     const guard = mock();
     const [resolved] = tools([{ name: "CurrentTime", guard }]).resolve(t.ctx);
     expect(resolved.name).toBe("CurrentTime");
@@ -184,7 +191,9 @@ describe("tools() resolver - { name, guard }", () => {
    * @expectedResult RC5003 thrown synchronously at resolve
    */
   test("{ name } rejects empty string", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     expect(() => tools([{ name: "" }]).resolve(t!.ctx)).toThrow(/non-empty/i);
   });
 
@@ -194,7 +203,9 @@ describe("tools() resolver - { name, guard }", () => {
    * @expectedResult ResolvedTool.description is the override; the registry entry's description is unchanged
    */
   test("{ name, description } overrides description per binding", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     const [resolved] = tools([
       {
         name: "CurrentTime",
@@ -206,7 +217,7 @@ describe("tools() resolver - { name, guard }", () => {
     // Registry entry stays canonical: a second binding without the
     // override sees the original description.
     const [resolved2] = tools(["CurrentTime"]).resolve(t.ctx);
-    expect(resolved2.description).toBe(defaultFns.CurrentTime.description);
+    expect(resolved2.description).toBe(currentTime().description);
     expect(resolved2.description).not.toBe(resolved.description);
   });
 
@@ -216,7 +227,9 @@ describe("tools() resolver - { name, guard }", () => {
    * @expectedResult RC5003 with a message naming the field
    */
   test("{ name, description } rejects empty string", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     expect(() =>
       tools([{ name: "CurrentTime", description: "" }]).resolve(t!.ctx),
     ).toThrow(/description.*non-empty/i);
@@ -228,7 +241,9 @@ describe("tools() resolver - { name, guard }", () => {
    * @expectedResult Resolved tool has both the override description and the guard
    */
   test("{ name, guard, description } applies both overrides", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     const guard = mock();
     const [resolved] = tools([
       {
@@ -251,11 +266,13 @@ describe("tools() resolver - tag selectors", () => {
 
   /**
    * @case Single-tag selector matches eager fn registry entries
-   * @preconditions defaultFns spread (CurrentTime + RandomUuid both tagged "read-only")
+   * @preconditions currentTime() + randomUuid() registered (both tagged "read-only")
    * @expectedResult { tagged: "read-only" } resolves to both fns
    */
   test("{ tagged } matches eager fn registry entries", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     const resolved = tools([{ tagged: "read-only" }]).resolve(t.ctx);
     const names = resolved.map((r) => r.name).sort();
     expect(names).toEqual(["CurrentTime", "RandomUuid"]);
@@ -292,13 +309,14 @@ describe("tools() resolver - tag selectors", () => {
 
   /**
    * @case OR-of-tags: matches entries with ANY of the requested tags
-   * @preconditions defaultFns (read-only, idempotent for CurrentTime; read-only for RandomUuid) + a fn tagged only "destructive"
+   * @preconditions currentTime() (read-only, idempotent) + randomUuid() (read-only) + a fn tagged only "destructive"
    * @expectedResult { tagged: ["idempotent", "destructive"] } returns CurrentTime and the destructive fn but not RandomUuid
    */
   test("{ tagged: [...] } is an OR over the listed tags", async () => {
     t = await buildCtx({
       functions: {
-        ...defaultFns,
+        CurrentTime: currentTime(),
+        RandomUuid: randomUuid(),
         wipe: {
           description: "Wipe data.",
           input: z.object({}),
@@ -320,7 +338,9 @@ describe("tools() resolver - tag selectors", () => {
    * @expectedResult tools([{ tagged: "ghost" }]).resolve() throws RC5003 naming the tag
    */
   test("tag-zero-match throws RC5003", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     expect(() => tools([{ tagged: "ghost" }]).resolve(t!.ctx)).toThrow(
       /matched no tools/,
     );
@@ -332,7 +352,9 @@ describe("tools() resolver - tag selectors", () => {
    * @expectedResult Both ResolvedTools have ResolvedTool.guard === g
    */
   test("tag selector guard applies to every matched tool", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     const guard = mock();
     const resolved = tools([{ tagged: "read-only", guard }]).resolve(t.ctx);
     expect(resolved.length).toBeGreaterThanOrEqual(1);
@@ -345,7 +367,9 @@ describe("tools() resolver - tag selectors", () => {
    * @expectedResult Final list contains "CurrentTime" with the explicit guard
    */
   test("explicit refs win over tag-selector matches", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     const explicitGuard = mock();
     const tagGuard = mock();
     const resolved = tools([
@@ -375,7 +399,8 @@ describe("tools() resolver - regression", () => {
         plugins: [
           agentPlugin({
             functions: {
-              ...defaultFns,
+              CurrentTime: currentTime(),
+              RandomUuid: randomUuid(),
               broken: directTool("does-not-exist"),
             },
           }),
@@ -396,7 +421,11 @@ describe("tools() resolver - regression", () => {
   test("tools() throws on object items lacking both name and tagged", async () => {
     t = await testContext()
       .with({
-        plugins: [agentPlugin({ functions: { ...defaultFns } })],
+        plugins: [
+          agentPlugin({
+            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+          }),
+        ],
       })
       .build();
 
@@ -484,7 +513,7 @@ describe("tools() resolver - regression", () => {
             functions: {
               padded: {
                 description: "x",
-                input: defaultFns.CurrentTime.input,
+                input: currentTime().input,
                 handler: () => "ok",
                 tags: ["  read-only  "],
               },
@@ -512,7 +541,9 @@ describe("tools() resolver - dedup and prefix-convention coverage", () => {
    * @expectedResult Single ResolvedTool
    */
   test("duplicate explicit refs are deduplicated", async () => {
-    t = await buildCtx({ functions: { ...defaultFns } });
+    t = await buildCtx({
+      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+    });
     const resolved = tools(["CurrentTime", "CurrentTime"]).resolve(t.ctx);
     expect(resolved).toHaveLength(1);
   });

--- a/packages/ai/test/tools-selection.bun.test.ts
+++ b/packages/ai/test/tools-selection.bun.test.ts
@@ -532,7 +532,7 @@ describe("tools() resolver - regression", () => {
   });
 });
 
-describe("tools() resolver - dedup and prefix-convention coverage", () => {
+describe("tools() resolver - dedup and direct-route surfacing coverage", () => {
   let t: TestContext | undefined;
   afterEach(async () => {
     if (t) await t.stop();

--- a/packages/ai/test/tools-selection.bun.test.ts
+++ b/packages/ai/test/tools-selection.bun.test.ts
@@ -68,11 +68,11 @@ describe("tools() resolver - bare references", () => {
   });
 
   /**
-   * @case direct_<routeId> bare ref resolves via the direct registry
+   * @case Direct(routeId) ref resolves via the direct registry
    * @preconditions Direct route "fetch-order" registered with description + input
-   * @expectedResult Single ResolvedTool named "direct_fetch-order"
+   * @expectedResult Single ResolvedTool whose LLM-facing name is "direct_fetch-order"
    */
-  test("direct_<routeId> bare ref resolves via the direct registry", async () => {
+  test("Direct(routeId) ref resolves via the direct registry", async () => {
     const inputSchema = z.object({ orderId: z.string() });
     t = await testContext()
       .routes([
@@ -86,7 +86,7 @@ describe("tools() resolver - bare references", () => {
       .build();
     await t.startAndWaitReady();
 
-    const resolved = tools(["direct_fetch-order"]).resolve(t.ctx);
+    const resolved = tools(["Direct(fetch-order)"]).resolve(t.ctx);
     expect(resolved).toHaveLength(1);
     expect(resolved[0].name).toBe("direct_fetch-order");
     expect(resolved[0].description).toBe("Fetch an order by id.");
@@ -94,11 +94,11 @@ describe("tools() resolver - bare references", () => {
   });
 
   /**
-   * @case Fn registry entry with id "direct_x" wins over the prefix convention
-   * @preconditions Route "x" registered AND fn registry entry named "direct_x" with explicit description
-   * @expectedResult Resolution returns the fn registry entry (not the route-derived one)
+   * @case A bare "direct_x" is a plain fn id; the route form is "Direct(x)"
+   * @preconditions Route "x" registered AND a fn registry entry literally named "direct_x"
+   * @expectedResult tools(["direct_x"]) resolves the fn; tools(["Direct(x)"]) resolves the route
    */
-  test("explicit fn registry entry wins over the prefix convention", async () => {
+  test("bare direct_ name is a plain fn id; Direct(id) is the route", async () => {
     t = await testContext()
       .with({
         plugins: [
@@ -125,8 +125,12 @@ describe("tools() resolver - bare references", () => {
       .build();
     await t.startAndWaitReady();
 
-    const [resolved] = tools(["direct_x"]).resolve(t.ctx);
-    expect(resolved.description).toBe("Explicit fn registry entry.");
+    const [asFn] = tools(["direct_x"]).resolve(t.ctx);
+    expect(asFn.description).toBe("Explicit fn registry entry.");
+
+    const [asRoute] = tools(["Direct(x)"]).resolve(t.ctx);
+    expect(asRoute.name).toBe("direct_x");
+    expect(asRoute.description).toBe("Route description.");
   });
 
   /**
@@ -151,14 +155,14 @@ describe("tools() resolver - bare references", () => {
   });
 
   /**
-   * @case agent_<id> reference surfaces a clear "story F" error
-   * @preconditions resolve tools(["agent_researcher"])
-   * @expectedResult RC5003 thrown mentioning sub-agent / follow-up story
+   * @case Agent(...) references are not supported and surface as unknown tools
+   * @preconditions resolve tools(["Agent(researcher)"]) with no such fn registered
+   * @expectedResult RC5003 unknown-tool error (sub-agent tools are not implemented)
    */
-  test("agent_<id> bare ref throws not-yet-supported", async () => {
+  test("Agent(...) ref throws unknown-tool", async () => {
     t = await buildCtx({});
-    expect(() => tools(["agent_researcher"]).resolve(t!.ctx)).toThrow(
-      /sub-agent|follow-up/i,
+    expect(() => tools(["Agent(researcher)"]).resolve(t!.ctx)).toThrow(
+      /unknown tool/i,
     );
   });
 });


### PR DESCRIPTION
## Summary

Foundational story (#339) of the Claude-compatible agent tools epic (#338): aligns the agent tool-reference grammar with the Claude Code convention and reworks the built-in fns into individual factories. This unblocks the web-tool stories (#341/#342, which just need bare PascalCase names) and the agent-file drop-in work (#340).

Three commits:

1. **`feat(ai)!`: rename default fns to PascalCase** — `CurrentTime` / `RandomUuid`. House style: first-party tool fns are PascalCase tool names (shown to a model), matching Claude Code's built-in tool casing.
2. **`refactor(ai)!`: replace `defaultFns` bundle with individual factories** — `currentTime()` / `randomUuid()`, used like `directTool()`. The bundle stopped making sense once most useful tools (web search/fetch, etc.) need configuration, so a "spread them all" wrapper does not fit. Each tool is now a factory: simple ones take no params, configurable ones will take options.
3. **`feat(ai)!`: align the tool-reference grammar with Claude Code**:
   - direct routes: `Direct(routeId)` replaces the `direct_<routeId>` prefix (the LLM-facing wire name stays the valid `direct_<routeId>`).
   - MCP tools: `MCP(server:tool)` / `MCP(server)` sugar, plus the raw `mcp__server__tool` / `mcp__server` / `mcp__server__*` forms that Claude Code agent files carry, so they resolve unchanged.
   - MCP wire name changes from `mcp_<server>:<tool>` to `mcp__<server>__<tool>` (a valid tool name; the old colon form is rejected by real providers).
   - tag-selector scope filter: `from: "mcp__<server>"` replaces `from: "mcp_<client>"`.

## Scope notes (deliberate)

- **No `Agent()` / `Bash()` constructors or `Tool(specifier)` use-site guards.** Their targets (sub-agents-as-tools, the shell adapter, `WebFetch`) do not exist yet, so per a "no placeholders" decision these refs resolve to a plain unknown-tool error rather than a stub. They land with their owning stories.
- **No reserved-keyword validation.** It proved unnecessary: constructors require parentheses, so a bare fn named `Direct` or `MCP` cannot collide with `Direct(...)` / `MCP(...)`. The `mcp__` prefix is reserved-by-convention for the MCP namespace (same as Claude). Easy to add later if we want to be defensive.

## Breaking changes

- `defaultFns` is removed (no deprecation). Replace `functions: { ...defaultFns }` with `functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() }`.
- Default fn names: `currentTime` -> `CurrentTime`, `randomUuid` -> `RandomUuid`.
- Tool-reference grammar: `direct_<routeId>` -> `Direct(routeId)`; `mcp_<client>:<tool>` -> `MCP(server:tool)` or the raw `mcp__server__tool`; `from: "mcp_<client>"` -> `from: "mcp__<server>"`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run format` clean
- [x] `bun test packages/ai/test` — all agent-tool tests pass (grammar resolution, factories, MCP refs, tag selectors, docs migrated)
- [ ] Reviewer: confirm the grammar reads well in `packages/ai/src/agent/tools/selection.ts`

## Note on a pre-existing failure

`bun test packages/ai/test` shows 3 failures in `mcp.bun.test.ts` (`dispatchMcpCall` RC5003 error-wrapping). These are a pre-existing test-pollution bug (the file passes when run alone, fails in the full-suite run) present on `main` independent of this PR, and unrelated to the grammar change. Happy to file a separate issue / fix it in a follow-up.

Closes #339. Part of #338.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCGdWE8Uxqab82Pp2efYuQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns agent tool-reference grammar and built‑in tool naming with Claude Code, adds fn‑first precedence for `mcp__` ids, and replaces `defaultFns` with individual factories. This standardizes tool IDs, prevents MCP refs from shadowing exact fn ids, and unblocks upcoming web tools and MCP agent-file support.

- New Features
  - New tool-reference grammar: `Direct(<routeId>)` for routes; `MCP(server:tool)` or raw `mcp__server__tool` (also `MCP(server)` / `mcp__server` / `mcp__server__*`).
  - MCP tool wire names now use `mcp__<server>__<tool>`; tag scoping uses `from: "mcp__<server>"`.
  - Built-in fn factories: `currentTime()` and `randomUuid()`; assign names in `agentPlugin({ functions })`.
  - First-party tool names are PascalCase: `CurrentTime`, `RandomUuid`.
  - Resolution precedence: exact fn ids (including those starting with `mcp__`) win over the MCP grammar.

- Migration
  - Replace `functions: { ...defaultFns }` with `functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() }`.
  - Rename tool IDs in `tools([...])`: `currentTime` → `CurrentTime`, `randomUuid` → `RandomUuid`.
  - Update references:
    - `direct_<routeId>` → `Direct(<routeId>)` (LLM-facing name remains `direct_<routeId>`).
    - `mcp_<client>:<tool>` → `MCP(server:tool)` or `mcp__server__tool`; `mcp_<client>:*` → `MCP(server)` or `mcp__server__*`.
    - `from: "mcp_<client>"` → `from: "mcp__<server>"`.

<sup>Written for commit fe3f1545a5010d1100f2a6fdd752b0bdceb9ab93. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

