### PR TITLE
fix(ai): widen built-in fn factory return types to FnOptions

### DIFF
--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -298,7 +298,7 @@ async function dispatchDirect<TIn>(
  * });
  * ```
  */
-export function currentTime(): FnOptions<Record<string, never>, string> {
+export function currentTime(): FnOptions {
   return {
     description: "Returns the current UTC timestamp in ISO 8601 format.",
     input: emptyObjectSchema,
@@ -319,7 +319,7 @@ export function currentTime(): FnOptions<Record<string, never>, string> {
  * agentPlugin({ functions: { RandomUuid: randomUuid() } });
  * ```
  */
-export function randomUuid(): FnOptions<Record<string, never>, string> {
+export function randomUuid(): FnOptions {
   return {
     description: "Generates a fresh random UUID v4.",
     input: emptyObjectSchema,


### PR DESCRIPTION
## Summary

- `currentTime()` / `randomUuid()` declared a precise `FnOptions<Record<string, never>, string>` return type, which is **not assignable** to the `functions` map's `FnEntry` (`FnOptions<unknown, unknown> | DeferredFn`). `FnOptions` is invariant in `TIn` (covariant in `input: StandardSchemaV1<unknown, TIn>`, contravariant in `handler: (input: TIn) => ...`), so the documented usage `functions: { CurrentTime: currentTime() }` failed to typecheck with `TS2322`.
- Widen both factories to return `FnOptions`. Their handlers take no input (`() => string`), so the implementation stays assignable, and the precise generics gave consumers nothing (the map erases them anyway). `directTool()` already sidesteps this by returning `DeferredFn`.

## Why it wasn't caught

`**/*.bun.test.ts` is excluded from `tsc`, so `packages/ai/test/tools-default.bun.test.ts` -- which uses this exact pattern -- was never type-checked. Tracked in #348.

## Test plan

- [x] `bun run typecheck` clean (confirmed the error reproduces in a type-checked path before the fix, clears after)
- [x] `bun run lint` and Prettier clean
- [x] `packages/ai/test/tools-default.bun.test.ts` 16/16 pass

Closes nothing; relates to #348.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCGdWE8Uxqab82Pp2efYuQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened return types of `currentTime()` and `randomUuid()` to `FnOptions` so they work in `functions` maps without TS2322 errors. No runtime behavior change; relates to #348.

<sup>Written for commit 37b999cefb3699aa43b581b87779723f78df1a99. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/349?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

