### PR TITLE
Add principal option to agent markdown loader

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/page.md
@@ -470,7 +470,12 @@ craft()
 | `system` | `string \| (exchange) => string` | Yes | System prompt. Static string or a function that derives it from the exchange (mirrors `llm({ system })`) |
 | `user` | `string \| (exchange) => string` | No | User prompt override. Static string or a function that derives it from the exchange. Defaults to `exchange.body` (string as-is, JSON for objects) when omitted |
 | `tools` | `ToolSelection` | No | Tool whitelist built via `tools([...])`. Inherits `defaultOptions.tools` when omitted; an explicit value replaces the default entirely |
+| `maxTurns` | `number` | No | Cap on tool-calling turns. Inherits `defaultOptions.maxTurns` when omitted |
+| `skills` | `string[]` | No | Skill names whose content is appended to the system prompt. Resolved against `agentPlugin({ skills })` |
+| `principal` | `boolean \| (principal, exchange) => string` | No | Append a `## Caller` section describing `exchange.principal`. `true` for the built-in block, a function to render it yourself. Inherits `defaultOptions.principal` when omitted; a per-agent value (including `false`) overrides it. See [Telling the agent who the caller is](/docs/reference/adapters#telling-the-agent-who-the-caller-is) |
 | `output` | `StandardSchemaV1` | No | Schema for structured output. Validated and parsed onto `AgentResult.output` after dispatch (runtime ships in a follow-up release) |
+
+Agents loaded from markdown via [`agents("./dir")`](/docs/reference/adapters#agent) accept the same fields as frontmatter. `principal` is supported there as a boolean (`principal: true`); the function-renderer form is a closure YAML cannot express, so set it via the per-agent override map (`agents("./dir", { zoe: { principal: (p) => ... } })`) or `agentPlugin({ defaultOptions })`.
 
 **Resolution semantics:**
 

--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -1,5 +1,6 @@
 import { rcError } from "@routecraft/routecraft";
 import {
+  optionalBoolean,
   optionalPositiveInt,
   optionalStringArray,
   readMarkdownDir,
@@ -26,6 +27,7 @@ const SUPPORTED_AGENT_KEYS = new Set([
   "maxTurns",
   "tools",
   "skills",
+  "principal",
 ]);
 
 /**
@@ -35,12 +37,18 @@ const SUPPORTED_AGENT_KEYS = new Set([
  * (markdown frontmatter cannot express closures) so set those on the
  * agent at the call site or via `agentPlugin({ defaultOptions })`.
  *
+ * `principal` accepts the full {@link AgentRegisteredOptions.principal}
+ * shape here (`boolean | AgentPrincipalRenderer`). Frontmatter can only
+ * carry the boolean form; reach for the override (or
+ * `agentPlugin({ defaultOptions })`) when an agent needs the
+ * function-renderer form that YAML cannot express.
+ *
  * @experimental
  */
 export interface AgentMarkdownOverride extends Partial<
   Pick<
     AgentRegisteredOptions,
-    "description" | "model" | "maxTurns" | "tools" | "skills"
+    "description" | "model" | "maxTurns" | "tools" | "skills" | "principal"
   >
 > {
   /**
@@ -111,6 +119,14 @@ function toAgent(
     "skills",
     source,
   );
+  // Frontmatter carries only the boolean form; the function-renderer
+  // form is a closure YAML cannot express and is supplied via the
+  // override map or agentPlugin({ defaultOptions }).
+  const principal = optionalBoolean(
+    frontmatter["principal"],
+    "principal",
+    source,
+  );
   const agent: AgentRegisteredOptions = {
     description,
     system: body,
@@ -119,6 +135,7 @@ function toAgent(
   if (maxTurns !== undefined) agent.maxTurns = maxTurns;
   if (toolNames !== undefined) agent.tools = tools(toolNames);
   if (skillNames !== undefined) agent.skills = skillNames;
+  if (principal !== undefined) agent.principal = principal;
   return { name, agent };
 }
 
@@ -142,6 +159,7 @@ function applyOverride(
   if (override.maxTurns !== undefined) out.maxTurns = override.maxTurns;
   if (override.tools !== undefined) out.tools = override.tools;
   if (override.skills !== undefined) out.skills = override.skills;
+  if (override.principal !== undefined) out.principal = override.principal;
   if (override.system !== undefined) out.system = override.system;
   return out;
 }
@@ -167,6 +185,8 @@ function applyOverride(
  * | `maxTurns`    | no       | `AgentRegisteredOptions.maxTurns`      |
  * | `tools`       | no       | `tools(stringArray)`                   |
  * | `skills`      | no       | `AgentRegisteredOptions.skills`        |
+ * | `principal`   | no       | `AgentRegisteredOptions.principal`     |
+ * |               |          | (boolean only; renderer via override)  |
  *
  * Body of the file becomes `system`. Other Claude subagent fields
  * (`disallowedTools`, `permissionMode`, `mcpServers`, `hooks`,

--- a/packages/ai/src/skill/markdown.ts
+++ b/packages/ai/src/skill/markdown.ts
@@ -263,6 +263,28 @@ export function optionalStringArray(
 }
 
 /**
+ * Validate that `value` is a boolean (or undefined) and return it;
+ * otherwise throw RC5003. Use for frontmatter flags that map to a
+ * boolean option; the function-form variant of an option (a closure)
+ * cannot be expressed in YAML and must be set in code instead.
+ *
+ * @internal
+ */
+export function optionalBoolean(
+  value: unknown,
+  field: string,
+  source: string,
+): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter field "${field}" must be a boolean (true or false).`,
+    });
+  }
+  return value;
+}
+
+/**
  * Validate that `value` is a finite positive integer (or undefined)
  * and return it; otherwise throw RC5003.
  *

--- a/packages/ai/test/agent-loader.bun.test.ts
+++ b/packages/ai/test/agent-loader.bun.test.ts
@@ -61,6 +61,62 @@ describe("agents() markdown loader", () => {
   });
 
   /**
+   * @case principal: true frontmatter passes through as a boolean
+   * @preconditions Agent with principal: true
+   * @expectedResult AgentRegisteredOptions.principal is the boolean true
+   */
+  test("principal: true frontmatter passes through", async () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\nprincipal: true\n---\nsystem",
+    });
+    const result = await agents(dir);
+    expect(result["x"]?.principal).toBe(true);
+  });
+
+  /**
+   * @case principal: false frontmatter passes through (opt-out of a default)
+   * @preconditions Agent with principal: false
+   * @expectedResult AgentRegisteredOptions.principal is the boolean false so it
+   *   overrides any agentPlugin({ defaultOptions: { principal } }) at dispatch
+   */
+  test("principal: false frontmatter passes through", async () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\nprincipal: false\n---\nsystem",
+    });
+    const result = await agents(dir);
+    expect(result["x"]?.principal).toBe(false);
+  });
+
+  /**
+   * @case Non-boolean principal frontmatter is rejected
+   * @preconditions principal set to a string (a renderer cannot be expressed in YAML)
+   * @expectedResult Throws RC5003 telling the user principal must be a boolean
+   */
+  test("rejects non-boolean principal frontmatter", async () => {
+    const dir = makeDir({
+      "x.md":
+        "---\nname: x\ndescription: d\nprincipal: yes-please\n---\nsystem",
+    });
+    await expect(agents(dir)).rejects.toThrow(
+      /frontmatter field "principal" must be a boolean/,
+    );
+  });
+
+  /**
+   * @case Override supplies the principal renderer that YAML cannot express
+   * @preconditions Markdown omits principal; override sets a renderer function
+   * @expectedResult Loaded agent.principal is the override function
+   */
+  test("override can set the principal renderer", async () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\n---\nsystem",
+    });
+    const renderer = (): string => "## Caller\n\ncustom";
+    const result = await agents(dir, { x: { principal: renderer } });
+    expect(result["x"]?.principal).toBe(renderer);
+  });
+
+  /**
    * @case tools string array becomes a tools([...]) selection
    * @preconditions Agent with tools: [fetchOrder, "tagged:read-only"]
    * @expectedResult agent.tools is a ToolSelection (brand check via isToolSelection)


### PR DESCRIPTION
Extends the agent markdown loader to support the `principal` option, allowing agents to declare whether they should include a "Caller" section describing the exchange principal.

## Summary

The `principal` option controls whether an agent appends a `## Caller` section to its system prompt. This change adds support for declaring `principal` as a boolean in agent markdown frontmatter, with the ability to override it programmatically for function-renderer forms that YAML cannot express.

## Key Changes

- **Markdown frontmatter support**: Agents can now declare `principal: true` or `principal: false` in frontmatter; boolean validation rejects non-boolean values with RC5003
- **Override map support**: The `agents(dir, overrides)` call accepts `principal` in per-agent overrides, supporting both boolean and function-renderer forms
- **Validation**: Added `optionalBoolean()` helper in `skill/markdown.ts` to validate and parse boolean frontmatter fields
- **Documentation**: Updated reference docs to explain `principal` semantics, frontmatter limitations (boolean only), and override patterns

## Implementation Details

- `principal` is added to `SUPPORTED_AGENT_KEYS` and `AgentMarkdownOverride` interface
- Frontmatter carries only the boolean form; function-renderer closures must be supplied via override map or `agentPlugin({ defaultOptions })`
- Override application respects the same conditional-set pattern as other optional fields (`maxTurns`, `tools`, `skills`)
- All four new test cases follow the JSDoc convention with `@case`, `@preconditions`, and `@expectedResult`

https://claude.ai/code/session_01VVKwjXYBRRPUkkun7sRRy9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `principal` support to the named agent markdown loader so agents can include a "Caller" section in their system prompt. Frontmatter accepts a boolean; overrides and `agentPlugin({ defaultOptions })` can supply a renderer function.

- **New Features**
  - Frontmatter `principal: true|false`; non-boolean values throw RC5003.
  - Loader recognizes and forwards `principal`; `agents(dir, overrides)` and `agentPlugin({ defaultOptions })` accept boolean or a renderer function.
  - Added `optionalBoolean()` for validation; tests cover boolean pass-through, rejection, and override renderer. Docs updated to document `principal` (boolean-only in frontmatter) and how to set a renderer via overrides.

<sup>Written for commit 7be097995b1c4c397da124cb4488a7de55a8e9c1. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/351?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

