### PR TITLE
0.5.0 stabilization: telemetry docs, version drift fix, flush durability

### DIFF
--- a/apps/routecraft.dev/src/app/docs/changelog/page.md
+++ b/apps/routecraft.dev/src/app/docs/changelog/page.md
@@ -12,7 +12,7 @@ Routecraft is in active development -- APIs may change between minor versions.
 
 *May 2026*
 
-Several breaking changes across the core, AI, mail, logger, and CLI surfaces. See the [0.4.x to 0.5.0 migration guide](/docs/migrating/0.4-to-0.5) for the full public-API diff and step-by-step upgrade notes.
+Several breaking changes across the core, AI, mail, telemetry, logger, and CLI surfaces. See the [0.4.x to 0.5.0 migration guide](/docs/migrating/0.4-to-0.5) for the full public-API diff and step-by-step upgrade notes.
 
 ### Core
 
@@ -36,7 +36,7 @@ Several breaking changes across the core, AI, mail, logger, and CLI surfaces. Se
 - **Adapter mocking** -- `mockAdapter` swaps any tagged adapter in tests; `file`, `csv`, `json`, `jsonl`, and `html` factories are tagged out of the box.
 - **Mail (IMAP)** -- the IMAP source is reliable across poll and re-evaluation workloads, with reconnect on transient fetch failures. `MailMessage` body is reshaped and a verify-sender option is available.
 
-### Telemetry {% badge color="red" %}Breaking{% /badge %}
+### Telemetry
 
 - **Bun-only SQLite sink** -- the embedded telemetry SQLite sink now uses Bun's built-in `bun:sqlite`. `better-sqlite3` has been removed from the runtime, including from peer dependencies. Deployments that use the built-in sink must run under Bun (`engines.bun >= 1.1.0`); Node deployments that previously relied on `better-sqlite3` need to bring their own sink.
 

--- a/apps/routecraft.dev/src/app/docs/changelog/page.md
+++ b/apps/routecraft.dev/src/app/docs/changelog/page.md
@@ -36,6 +36,10 @@ Several breaking changes across the core, AI, mail, logger, and CLI surfaces. Se
 - **Adapter mocking** -- `mockAdapter` swaps any tagged adapter in tests; `file`, `csv`, `json`, `jsonl`, and `html` factories are tagged out of the box.
 - **Mail (IMAP)** -- the IMAP source is reliable across poll and re-evaluation workloads, with reconnect on transient fetch failures. `MailMessage` body is reshaped and a verify-sender option is available.
 
+### Telemetry {% badge color="red" %}Breaking{% /badge %}
+
+- **Bun-only SQLite sink** -- the embedded telemetry SQLite sink now uses Bun's built-in `bun:sqlite`. `better-sqlite3` has been removed from the runtime, including from peer dependencies. Deployments that use the built-in sink must run under Bun (`engines.bun >= 1.1.0`); Node deployments that previously relied on `better-sqlite3` need to bring their own sink.
+
 ### Logger
 
 - **stdout default** -- the logger writes to stdout instead of stderr.

--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -10,7 +10,7 @@ This guide covers every breaking change extracted from a direct diff of the publ
 2. **Experimental-API changes** that only affect you if you opted into the AI, MCP, mail, or auth surfaces flagged `@experimental` at 0.4.0.
 3. **What is new in 0.5.0** — for context, no migration required.
 
-If you stayed on the stable surface (route DSL, `http()`, `cron()`, `timer()`, `simple()`, `direct()`, `telemetry`, `logger`, `eslint-plugin`), the only changes that touch you are sections 1.1, 1.2, and 1.3.
+If you stayed on the stable surface (route DSL, `http()`, `cron()`, `timer()`, `simple()`, `direct()`, `telemetry`, `logger`, `eslint-plugin`), the only changes that touch you are sections 1.1, 1.2, and 1.3 -- plus section 1.7 if you use the built-in telemetry SQLite sink.
 
 ---
 
@@ -171,6 +171,17 @@ Two related framework signals moved off headers (which would now fail because th
 - `exchange.headers["routecraft.startedAt"]` is gone. Child exchange start timestamps used by `aggregate` for duration emission live on the exchange's internals via framework-internal helpers; survives `rewrap`.
 
 For deeper details, see `.standards/type-safety-and-schemas.md` § Exchange Immutability.
+
+### 1.7 Telemetry SQLite sink is now Bun-only
+
+The built-in telemetry sink behind `telemetry({ sqlite: ... })` now persists through Bun's native `bun:sqlite`. `better-sqlite3` has been removed from the runtime and from the package's peer dependencies.
+
+If you run your context under Bun (`engines.bun >= 1.1.0`), there is nothing to do: the sink uses `bun:sqlite` automatically and you can drop `better-sqlite3` from your own dependencies.
+
+If you run under Node, the built-in SQLite sink no longer works. You have two options:
+
+- **Run the telemetry-emitting context under Bun.** This is the supported path for the embedded sink and matches the CLI, which is already Bun-only.
+- **Bring your own exporter under Node.** Pass `telemetry({ tracerProvider, disableSqlite: true })` with your own OpenTelemetry `TracerProvider`, then export spans wherever you like (OTLP, etc.). With `disableSqlite: true` the `bun:sqlite` backend is never loaded, so this path runs on Node.
 
 ---
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 import { checkBunRuntime } from "./runtime-gate.js";
+import { version } from "../package.json";
 
 // ── 1. Bun runtime gate ─────────────────────────────────────────────
 const gate = checkBunRuntime();
@@ -28,7 +29,7 @@ const program = new Command();
 program
   .name("craft")
   .description("A modern routing framework for TypeScript")
-  .version("0.5.0")
+  .version(version)
   .enablePositionalOptions()
   .option(
     "--log-level <level>",

--- a/packages/cli/src/tui/app.tsx
+++ b/packages/cli/src/tui/app.tsx
@@ -22,6 +22,7 @@ import { EventsView } from "./components/events-view.js";
 import { EventDetail } from "./components/event-detail.js";
 import { ExchangeDeepView } from "./components/exchange-deep-view.js";
 import { CapabilityList } from "./components/capability-list.js";
+import { version } from "../../package.json";
 
 /**
  * Focus tracks which panel owns the cursor.
@@ -461,7 +462,7 @@ function App({ db }: { db: TelemetryDb }) {
           ROUTECRAFT TUI
         </Text>
         <Text> </Text>
-        <Text dimColor>v0.4.0</Text>
+        <Text dimColor>v{version}</Text>
       </Box>
 
       {/* 3-column body */}

--- a/packages/os/package.json
+++ b/packages/os/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@routecraft/os",
   "version": "0.5.0",
+  "private": true,
   "description": "System-native adapters for Routecraft: shell execution and browser automation",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/routecraft/src/telemetry/plugin.ts
+++ b/packages/routecraft/src/telemetry/plugin.ts
@@ -10,11 +10,7 @@ import type { TelemetryOptions, TelemetryEvent } from "./types.ts";
 import { SqliteConnection } from "./sqlite-connection.ts";
 import { SqliteSpanProcessor, ATTR, SPAN_KIND } from "./sqlite-processor.ts";
 import { SqliteEventWriter } from "./sqlite-event-writer.ts";
-
-/**
- * Tracer instrumentation version. Update when releasing a new version.
- */
-const TRACER_VERSION = "0.4.0";
+import { version as TRACER_VERSION } from "../../package.json";
 
 /**
  * Default batch size for the event writer.

--- a/packages/routecraft/src/telemetry/sqlite-event-writer.ts
+++ b/packages/routecraft/src/telemetry/sqlite-event-writer.ts
@@ -2,6 +2,13 @@ import type { SqliteConnection } from "./sqlite-connection.ts";
 import type { TelemetryEvent, TelemetryLogger } from "./types.ts";
 
 /**
+ * Upper bound on events retained in memory while flushes keep failing. A
+ * transient fault is retried without loss; a sustained outage drops the
+ * oldest events past this cap so the sink can never OOM the host process.
+ */
+const MAX_BUFFERED_EVENTS = 10_000;
+
+/**
  * Buffered batch writer for the SQLite `events` table.
  *
  * Accumulates events in memory and flushes them in batches
@@ -69,16 +76,35 @@ export class SqliteEventWriter {
 
   flush(): void {
     if (this.buffer.length === 0) return;
-    const batch = this.buffer.splice(0, this.buffer.length);
+    // Snapshot without removing: a failed transaction must leave the events
+    // buffered so a transient fault (locked DB, brief I/O error) is retried on
+    // the next flush instead of silently dropping telemetry.
+    const batch = this.buffer.slice();
     try {
       this.insertManyTxn(batch);
     } catch (err) {
       // Non-blocking: SQLite errors must not destabilize event processing.
+      // Keep the batch buffered for retry, but bound the buffer so a sustained
+      // outage cannot grow it without limit and OOM the host process. Past the
+      // cap, drop the oldest overflow (the freshest events are most useful).
       this.logger?.warn(
         { err, batchSize: batch.length },
-        "Failed to flush telemetry event batch",
+        "Failed to flush telemetry event batch; retaining for retry",
       );
+      if (this.buffer.length > MAX_BUFFERED_EVENTS) {
+        const dropped = this.buffer.length - MAX_BUFFERED_EVENTS;
+        this.buffer.splice(0, dropped);
+        this.logger?.warn(
+          { dropped },
+          "Telemetry buffer exceeded cap during sustained sink failure; dropped oldest events",
+        );
+      }
+      return;
     }
+    // Commit succeeded: drop exactly the events we persisted. flush() is
+    // synchronous (bun:sqlite transactions run sync), so no write() interleaved
+    // and the first batch.length entries are exactly the committed ones.
+    this.buffer.splice(0, batch.length);
   }
 
   close(): void {

--- a/packages/routecraft/test/telemetry.bun.test.ts
+++ b/packages/routecraft/test/telemetry.bun.test.ts
@@ -12,6 +12,8 @@ import {
   telemetry,
   SqliteConnection,
 } from "@routecraft/routecraft";
+import { SqliteEventWriter } from "../src/telemetry/sqlite-event-writer.ts";
+import type { TelemetryEvent } from "../src/telemetry/types.ts";
 
 /**
  * Helper: create a telemetry() plugin wired to a specific SQLite database.
@@ -346,5 +348,115 @@ describe("TelemetryPlugin", () => {
     } finally {
       SqliteConnection.loadDriver = original;
     }
+  });
+});
+
+describe("SqliteEventWriter flush durability", () => {
+  function makeEvent(i: number): TelemetryEvent {
+    return {
+      timestamp: new Date().toISOString(),
+      contextId: "ctx",
+      eventName: `event-${i}`,
+      details: "{}",
+    };
+  }
+
+  /**
+   * Build a fake SqliteConnection whose transaction fails for the first
+   * `failCount` invocations, then succeeds. `persisted` records every event
+   * that reaches the prepared statement's run() inside a committed transaction.
+   */
+  function fakeConnection(failCount: number) {
+    const persisted: TelemetryEvent[] = [];
+    const warnings: string[] = [];
+    let calls = 0;
+    const connection = {
+      logger: {
+        warn: (_b: Record<string, unknown>, message: string) =>
+          warnings.push(message),
+      },
+      db: {
+        prepare: () => ({
+          run: (...args: unknown[]) => {
+            persisted.push({
+              timestamp: args[0] as string,
+              contextId: args[1] as string,
+              eventName: args[2] as string,
+              details: args[3] as string,
+            });
+          },
+        }),
+        transaction:
+          (fn: (events: TelemetryEvent[]) => void) =>
+          (events: TelemetryEvent[]) => {
+            calls += 1;
+            if (calls <= failCount) {
+              throw new Error("database is locked");
+            }
+            fn(events);
+          },
+      },
+    };
+    return { connection, persisted, warnings };
+  }
+
+  /**
+   * @case A failed flush retains its batch and a later flush persists it
+   * @preconditions Writer over a connection whose first transaction throws, the second succeeds
+   * @expectedResult Nothing persists on the failing flush; the retained batch persists on the next flush with no loss
+   */
+  test("retains events on a failed flush and persists them on retry", () => {
+    const { connection, persisted } = fakeConnection(1);
+    // Large interval so the internal timer never fires during the test.
+    const writer = new SqliteEventWriter(
+      connection as unknown as SqliteConnection,
+      50,
+      60_000,
+    );
+
+    writer.write(makeEvent(1));
+    writer.write(makeEvent(2));
+
+    writer.flush(); // transaction #1 throws -> batch must be retained
+    expect(persisted.length).toBe(0);
+
+    writer.flush(); // transaction #2 succeeds -> retained batch is persisted
+    expect(persisted.map((e) => e.eventName)).toEqual(["event-1", "event-2"]);
+
+    writer.flush(); // nothing left to flush
+    expect(persisted.length).toBe(2);
+
+    writer.close();
+  });
+
+  /**
+   * @case A sustained sink outage bounds the in-memory buffer
+   * @preconditions Writer over a connection whose transaction always throws, fed more than the retention cap
+   * @expectedResult The buffer never exceeds the 10k cap and the oldest events are dropped with a warning
+   */
+  test("bounds the buffer during a sustained outage", () => {
+    const { connection, persisted, warnings } = fakeConnection(
+      Number.POSITIVE_INFINITY,
+    );
+    // batchSize 1 makes every write() trigger a (failing) flush.
+    const writer = new SqliteEventWriter(
+      connection as unknown as SqliteConnection,
+      1,
+      60_000,
+    );
+
+    for (let i = 0; i < 10_050; i++) {
+      writer.write(makeEvent(i));
+    }
+
+    expect(persisted.length).toBe(0);
+    const buffered = (writer as unknown as { buffer: TelemetryEvent[] }).buffer
+      .length;
+    expect(buffered).toBeLessThanOrEqual(10_000);
+    expect(warnings.some((m) => m.includes("dropped oldest events"))).toBe(
+      true,
+    );
+
+    writer.close();
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 
     // Bundler mode
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

Pre-release stabilization for 0.5.0, found while auditing `main` for the release. All changes target `main`.

- **docs(telemetry):** the embedded telemetry sink dropped `better-sqlite3` for `bun:sqlite` (#304), but it was undocumented. The changelog had no Telemetry section and the migration guide listed `telemetry` as *unaffected stable surface*. Adds a `Telemetry {Breaking}` changelog entry and a new migration section *1.7 Telemetry SQLite sink is now Bun-only*, including the Node escape hatch `telemetry({ tracerProvider, disableSqlite: true })`.
- **fix(version drift):** the TUI title bar (`v0.4.0`), the OTel tracer instrumentation version (`"0.4.0"`), and `craft --version` were each hardcoded, so a release left the first two stale. All three now derive `version` from their `package.json` (enabled `resolveJsonModule`), so they track the released version and can't drift again. Verified `craft --version` now prints `0.5.0`.
- **fix(telemetry):** `flush()` spliced the batch out of the buffer *before* the transaction ran, so a transient write failure silently dropped up to a full batch. Now the batch is only removed after a successful commit and retried otherwise, with the retained buffer bounded (10k) so a sustained outage drops oldest events rather than growing unbounded. Adds two unit tests.
- **chore:** marks the empty placeholder `@routecraft/os` (`src/index.ts` is `export {}`) as `"private": true` so a workspace-wide publish can't ship an empty package. Revert when the shell adapter lands.

## Verification (run on this branch)

- `typecheck` ✓ · `lint` ✓ · `build` ✓ · `size-limit` ✓ (routecraft 53/100 kB)
- Full test suite: **1119 pass / 0 fail** (100 files)
- `craft --version` → `0.5.0`

## Notes for the release (not addressed here)

- The `adapter-cross-runtime` CI jobs run `test:cross-runtime`, but no `cross-runtime/` test dirs exist, so they pass with zero tests; the "Node 22+ and Bun" dual-runtime claim is not actually exercised by CI.
- The TUI opens a second writable connection that runs redundant DDL on the live telemetry DB (`cli/src/tui/db.ts`); it degrades gracefully but is worth a follow-up.
- `@routecraft/ai` is at 145.6/150 kB, near its size ceiling.

https://claude.ai/code/session_016BG8iVEDt2LVxL5e5VAh6L

---
_Generated by [Claude Code](https://claude.ai/code/session_016BG8iVEDt2LVxL5e5VAh6L)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the 0.5.0 release by preventing telemetry data loss, eliminating version drift, and documenting the Bun‑only telemetry sink; also updates changelog wording and marks `@routecraft/os` as private to avoid publishing an empty package.

- **Bug Fixes**
  - Telemetry SQLite flush durability: keep batches until a successful commit, retry on failures, and cap the in‑memory buffer at 10k; adds unit tests.
  - Version drift: TUI title, tracer instrumentation, and `craft --version` now read from `package.json` (via `resolveJsonModule`).

- **Migration**
  - Changelog and migration guide document the Bun-only SQLite sink (`bun:sqlite`) and the Node escape hatch `telemetry({ tracerProvider, disableSqlite: true })`; the changelog intro now lists telemetry among breaking surfaces.

<sup>Written for commit 7548c52c4a8ba2739354e5a4b79baa9c0eb9a850. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/354?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

