### PR TITLE
docs: fill 0.5.0 reference gaps and fix changelog/migration errors

### DIFF
--- a/apps/routecraft.dev/src/app/docs/changelog/page.md
+++ b/apps/routecraft.dev/src/app/docs/changelog/page.md
@@ -49,10 +49,6 @@ Several breaking changes across the core, AI, mail, telemetry, logger, and CLI s
 
 ### Telemetry {% badge color="red" %}Breaking{% /badge %}
 
-- **Bun-only SQLite sink** -- the embedded telemetry SQLite sink now uses Bun's built-in `bun:sqlite`. `better-sqlite3` has been removed from the runtime, including from peer dependencies. Deployments must run under Bun (`engines.bun >= 1.1.0`); Node deployments that previously relied on `better-sqlite3` need to bring their own sink.
-
-### Telemetry
-
 - **Bun-only SQLite sink** -- the embedded telemetry SQLite sink now uses Bun's built-in `bun:sqlite`. `better-sqlite3` has been removed from the runtime, including from peer dependencies. Deployments that use the built-in sink must run under Bun (`engines.bun >= 1.1.0`); Node deployments that previously relied on `better-sqlite3` need to bring their own sink.
 
 ### Logger

--- a/apps/routecraft.dev/src/app/docs/introduction/exchange/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/exchange/page.md
@@ -142,7 +142,8 @@ Operations that change the exchange return a new one by copy-on-write (spread) r
   headers: { ...exchange.headers, 'x-stage': 'processed' },
 }))
 
-// Wrong: mutating a frozen exchange is a compile error (readonly) and throws at runtime
+// Wrong: body is not deep-frozen, so this compiles and runs without throwing, but mutating
+// in place bypasses copy-on-write, so the framework never re-wraps or tracks the change
 .process((exchange) => {
   exchange.body.stage = 'processed'
   return exchange

--- a/apps/routecraft.dev/src/app/docs/introduction/exchange/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/exchange/page.md
@@ -128,6 +128,29 @@ Most operations give you a choice: work with just the body, or the full exchange
 
 Use `.transform()` when you only need the data. Use `.process()` or `.filter()` when you need headers, correlation IDs, or the context.
 
+## Immutability
+
+The exchange is immutable. `DefaultExchange` shallow-freezes the wrapper, its headers, and (when present) the principal at construction, and every field on `Exchange<T>` is `readonly`. The body is intentionally not deep-frozen so adapters can attach arbitrary payloads, but the framework never mutates it and your code should not either.
+
+Operations that change the exchange return a new one by copy-on-write (spread) rather than mutating in place. The framework re-wraps the returned plain object back into a proper instance, preserving the context binding, route binding, and `id`.
+
+```ts
+// Correct: copy-on-write
+.process((exchange) => ({
+  ...exchange,
+  body: { ...exchange.body, stage: 'processed' },
+  headers: { ...exchange.headers, 'x-stage': 'processed' },
+}))
+
+// Wrong: mutating a frozen exchange is a compile error (readonly) and throws at runtime
+.process((exchange) => {
+  exchange.body.stage = 'processed'
+  return exchange
+})
+```
+
+Returning the same `exchange` unchanged is still a valid no-op pass-through. For the full rationale and the drop-signalling helpers that moved off headers (`markDropped` / `isDropped`), see the [0.4 to 0.5 migration guide](/docs/migrating/0.4-to-0.5).
+
 ## Exchange in taps
 
 When you `.tap()`, the tap receives a **deep copy** of the exchange with a new ID. The correlation ID is preserved so you can trace the tap back to its parent exchange. The main pipeline continues immediately without waiting for the tap.

--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -26,7 +26,7 @@ If you stayed on the stable surface (route DSL, `http()`, `cron()`, `timer()`, `
 - `.description(value: string)` — discoverable description
 - `.input(schema | { body, headers })` — body and header validation, framework-enforced before the pipeline runs
 - `.output(schema | { body, headers })` — output validation against the primary destination
-- `.tag(value)` / `.tags(values)` — tags drive selectors like `tools({ tagged: "read-only" })` on the agent side; literals `"read-only" | "destructive" | "idempotent"` autocomplete and any string is accepted
+- `.tag(value | values)` — accepts a single tag or an array, and calls before `.from()` accumulate (deduplicated); tags drive selectors like `tools({ tagged: "read-only" })` on the agent side; literals `"read-only" | "destructive" | "idempotent"` autocomplete and any string is accepted
 
 `.input()` failures emit `exchange:dropped`; `.output()` failures route through the route's error handler or emit `exchange:failed`.
 

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -237,6 +237,30 @@ Options:
 
 **Headers added:** Cron metadata including expression, fired time, counter, next run, timezone, and name (via `routecraft.cron.*` headers)
 
+### event
+
+```ts
+import { event } from '@routecraft/routecraft'
+```
+
+Produce exchanges from framework events. Use as the source with `.from(event(filter))`; the exchange body is the event payload.
+
+```ts
+// Single event
+craft().from(event('route:started')).to(log())
+
+// Multiple events
+craft().from(event(['route:started', 'route:stopped'])).to(log())
+```
+
+**Filter (`EventFilter`):** an event name, an array of names, or a wildcard pattern.
+
+- `*` (single-level) matches exactly one colon-separated segment: `route:*` matches `route:started` but not `route:pay:exchange:started`.
+- `**` (globstar) matches zero or more segments at any depth: `route:**` matches every route event; `route:*:operation:**` matches operations at any adapter depth.
+- `*` on its own matches all events.
+
+Static subscriptions (`context:started`, `route:started`, ...) expand wildcards at startup against known event names; hierarchical events (`route:<id>:exchange:<phase>`) need explicit patterns or `**` to match runtime route ids. See the [Events reference](/docs/reference/events) for the full taxonomy.
+
 ### direct
 
 ```ts
@@ -1942,6 +1966,59 @@ Model ID format: `"provider:model-name"` (e.g., `"huggingface:all-MiniLM-L6-v2"`
 | `embedding` | `number[]` | Vector representation of the input text |
 
 Provider credentials are configured once in `embeddingPlugin()` and shared across all `embedding()` calls. See [Plugins reference](/docs/reference/plugins).
+
+---
+
+## Clustering adapters
+
+### group
+
+```ts
+import { group } from '@routecraft/routecraft'
+```
+
+Transformer that groups an array into clusters using a comparator. Use with `.transform(group(options))`. By default it reads the body as the array and replaces the body with the array of clusters; use `from` / `to` to read and write sub-fields, and `map` to shape each cluster.
+
+```ts
+.transform(group({
+  comparator: cosine({ field: 'embedding', threshold: 0.82 }),
+  from: (body) => body.items,
+  map: (cluster) => ({ size: cluster.length, first: cluster[0] }),
+}))
+```
+
+**Options (`GroupOptions`):**
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `comparator` | `Comparator<T>` | Yes | Decides whether two items belong in the same cluster (e.g. from `cosine()`) |
+| `from` | `(body) => T[]` | No | Read the array to cluster (default: the body itself) |
+| `map` | `(cluster: T[]) => R` | No | Shape each resulting cluster (default: the raw cluster) |
+| `to` | `(body, result: R[]) => unknown` | No | Write the clusters back (default: replace the body) |
+
+### cosine
+
+```ts
+import { cosine } from '@routecraft/routecraft'
+```
+
+Comparator that groups items by cosine similarity of a numeric vector field. Pass it to `group({ comparator: cosine(options) })`.
+
+```ts
+.transform(group({
+  comparator: cosine({ field: 'embedding', threshold: 0.85 }),
+  from: (body) => body.items,
+}))
+```
+
+**Options (`CosineOptions`):**
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `field` | `string` | Yes | Property on each item holding the embedding vector (`number[]`) |
+| `threshold` | `number` | No | Items cluster when their cosine similarity is strictly greater than this value (default: `0.82`) |
+
+Items whose `field` is not an array never match.
 
 ---
 

--- a/apps/routecraft.dev/src/app/docs/reference/operations/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/page.md
@@ -53,7 +53,7 @@ DSL operators with signatures and examples. {% .lead %}
 
 ## Route operations
 
-Route operations configure the capability itself. `id`, `batch`, and route-scope `error` go before `from()`; if called after an existing route, they are staged for the next `from()`. `from()` defines the source and creates the capability. `error` is dual-mode: when chained AFTER `from()` it becomes a step-scope wrapper around the next step (see the [`error`](#error) section below).
+Route operations configure the capability itself. `id`, `title`, `description`, `input`, `output`, `tag`, `batch`, and route-scope `error` go before `from()`; if called after an existing route, they are staged for the next `from()`. `from()` defines the source and creates the capability. `error` is dual-mode: when chained AFTER `from()` it becomes a step-scope wrapper around the next step (see the [`error`](#error) section below).
 
 ### id
 
@@ -79,6 +79,109 @@ craft()
 ```
 
 If no ID is specified, a random UUID will be generated automatically.
+
+### title
+
+```ts
+title(value: string): RouteBuilder<Current>
+```
+
+Set a human-readable title for the next route. Mirrored into the `direct` / `mcp` registries so discovery consumers (agents, MCP clients, docs) can display it alongside the id. Place before `from()`.
+
+```ts
+craft()
+  .id('ingest')
+  .title('Ingest orders')
+  .from(direct())
+  .to(saveOrder)
+```
+
+### description
+
+```ts
+description(value: string): RouteBuilder<Current>
+```
+
+Set a human-readable description for the next route. Used by discovery-aware adapters when exposing the route to external consumers such as agents and MCP clients.
+
+```ts
+craft()
+  .id('ingest')
+  .description('Validate and persist an inbound order')
+  .from(direct())
+  .to(saveOrder)
+```
+
+### input
+
+```ts
+input(
+  schema: StandardSchemaV1 | { body?: StandardSchemaV1; headers?: StandardSchemaV1 },
+): RouteBuilder<Current>
+```
+
+Declare input validation for the next route. The engine validates the incoming body and headers against these schemas **before any pipeline step runs**; a validation failure emits `exchange:dropped` and the pipeline never sees the message. Accepts either a bundle (`{ body, headers }`) or a bare Standard Schema as a body-only shorthand.
+
+To flow the validated body type through the chain, pass it as a generic on `.from<T>(source)` after the `.input()` call.
+
+```ts
+craft()
+  .id('ingest')
+  .input({ body: OrderSchema, headers: AuthHeaders })
+  .from(direct())
+  .to(saveOrder)
+
+// Body-only shorthand
+craft()
+  .id('ingest')
+  .input(OrderSchema)
+  .from(direct())
+  .to(saveOrder)
+```
+
+### output
+
+```ts
+output(
+  schema: StandardSchemaV1 | { body?: StandardSchemaV1; headers?: StandardSchemaV1 },
+): RouteBuilder<Current>
+```
+
+Declare output validation for the next route. The engine validates the final exchange against these schemas **before the primary destination fires**; a validation failure is routed to the route's error handler (or emits `exchange:failed` when no handler is set). Accepts a bundle (`{ body, headers }`) or a bare Standard Schema as a body-only shorthand.
+
+```ts
+craft()
+  .id('ingest')
+  .input(OrderSchema)
+  .output(SavedOrderSchema)
+  .from(direct())
+  .to(saveOrder)
+```
+
+### tag
+
+```ts
+tag(value: Tag | Tag[]): RouteBuilder<Current>
+```
+
+Tag the next route. Accepts a single tag or an array; multiple `.tag()` calls before `from()` accumulate (deduplicated, insertion order preserved). Empty strings are rejected with `RC2001`.
+
+Tags drive selectors like `tools({ tagged: "read-only" })` in `@routecraft/ai`. The `KnownTag` literals `"read-only"`, `"destructive"`, and `"idempotent"` autocomplete; any other string is also accepted.
+
+```ts
+craft()
+  .id('list-orders')
+  .tag('read-only')
+  .from(direct())
+  .to(listOrders)
+
+// Multiple tags
+craft()
+  .id('delete-order')
+  .tag(['destructive', 'orders'])
+  .from(direct())
+  .to(deleteOrder)
+```
 
 ### batch
 
@@ -675,7 +778,20 @@ Enrich the exchange with additional data from a destination adapter. Uses the sa
 .enrich(http({ url: 'https://api.example.com/user' }), only((r) => r.body?.name, "userName"))
 ```
 
-**`only(getValue, into?)`**: Returns an aggregator that merges one value from the enrichment result. Omit `into` to spread a plain object onto the body, or use fallbacks: string → `body.text`, array → `body.array`. Provide `into` to set `body[into]`. Values that are `null` or `undefined` are never merged (exchange unchanged).
+**`only(getValue, into?)`**: Returns an aggregator that merges one value from the enrichment result. Omit `into` to spread a plain object onto the body, or use fallbacks: primitive → `body.stdout`, array → `body.array`. Provide `into` to set `body[into]`. Values that are `null` or `undefined` are never merged (exchange unchanged).
+
+**`none()`**: Returns a no-op aggregator that leaves the exchange unchanged, so the enrichment result is ignored. Use it when you only need the destination's side effect (logging, firing an API call) and do not want to merge its return value.
+
+```ts
+.enrich(http({ url: "https://api.example.com/ping" }), none())
+```
+
+**`replace()`** (experimental): Returns an aggregator that replaces the body with the enrichment result instead of merging it. Use it when the enrichment returns the value you want as the new body.
+
+```ts
+.enrich(mail({ folder: "INBOX", unseen: true }), replace())
+// body becomes MailMessage[] (the raw enrichment result)
+```
 
 **Key difference from `.to()`:**
 


### PR DESCRIPTION
## Summary

Closes documentation gaps for public 0.5.0 surfaces found in a coverage audit, and fixes two errors introduced when the 0.5.0 stabilization PR (#354) merged alongside concurrently-landed auth/OAuth PRs.

### Fixes (live on `main`)
- **Changelog:** the #354 merge left a **duplicate `### Telemetry` section** (one badged, one not). Removed the unbadged duplicate; kept the badged entry with the more precise "Deployments that use the built-in sink..." wording.
- **Migration guide:** corrected `.tag(value)` / `.tags(values)` → `.tag()` only. Verified in `builder.ts:442` (`tag(value: Tag | Tag[])`); there is **no `.tags()` method**.
- **`only()` aggregator docs:** said primitives fall back to `body.text`; the code (`enrich.ts`) uses `body.stdout`.

### New reference coverage
- **Operations:** dedicated sections for the route-metadata builder methods `.title` / `.description` / `.input` / `.output` / `.tag` (previously only name-dropped inside `authorize`), including validation timing (`.input` drops pre-pipeline; `.output` routes to the error handler) and the `{ body, headers }` vs bare-schema shorthand. Documented the `none()` and `replace()` enrich aggregators.
- **Adapters:** documented the `event` source and the `group` / `cosine` clustering adapters — all exported from `@routecraft/routecraft` but undocumented.
- **Exchange concept page:** added an Immutability section (frozen wrapper, copy-on-write, the framework re-wraps returned plain objects).

All option tables and signatures were taken directly from source (`builder.ts`, `enrich.ts`, `adapters/group`, `adapters/cosine`, `adapters/sources/event`).

## Test plan
- [x] `prettier --check` on all changed docs — clean
- [x] `bun run --filter routecraft.dev build` — compiles, 45 static pages generated, Markdoc valid
- [ ] Visual spot-check of the new reference sections on the rendered site

## Notes
- A separate, larger follow-up will add explicit API-stability tags (`@beta` / `@experimental`) across the public surface per the 0.5.x "nothing is stable yet" policy.
- Pre-existing unrelated build warning: `MODULE_TYPELESS_PACKAGE_JSON` for `apps/routecraft.dev` — not touched here.

https://claude.ai/code/session_016BG8iVEDt2LVxL5e5VAh6L

---
_Generated by [Claude Code](https://claude.ai/code/session_016BG8iVEDt2LVxL5e5VAh6L)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fills 0.5.0 docs gaps and fixes two merge errors, plus corrects an Exchange immutability example. Adds reference coverage for route metadata, enrich aggregators, the `event` source, clustering adapters, and an Exchange immutability section.

- **New Features**
  - Route operations: docs for `.title`, `.description`, `.input` (pre-pipeline), `.output` (validated before destination), and `.tag` (single or array; accumulates before `.from()`).
  - Enrich aggregators: added `none()` and `replace()` with usage examples.
  - Adapters: documented `event` source and `group`/`cosine` clustering adapters exported by `@routecraft/routecraft`.
  - Exchange: new “Immutability” section (frozen wrapper, copy‑on‑write, framework re-wraps returned objects).

- **Bug Fixes**
  - Changelog: removed a duplicate “Telemetry” section and kept the badged, precise entry.
  - Migration guide: corrected `.tags()` to `.tag(value | values)` and noted accumulation semantics.
  - Operations reference: fixed `only()` fallback (primitives map to `body.stdout`, not `body.text`).
  - Exchange: corrected the immutability counter-example; the body isn’t deep-frozen, so mutating it compiles and runs but bypasses copy‑on‑write.

<sup>Written for commit 87b9753848be5a29ca6428c07e62b286e52cdd4a. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/356?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

