### PR TITLE
fix(ai): stop laundering non-authentic principals through the agent tool-bridge

### DIFF
--- a/packages/ai/src/agent/tool-bridge.ts
+++ b/packages/ai/src/agent/tool-bridge.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import {
   logger as frameworkLogger,
+  isAuthentic,
+  markAuthentic,
   type CraftContext,
   type EventName,
   type Principal,
@@ -190,12 +192,23 @@ function makeFnHandlerContext(
  * @internal
  */
 function freezePrincipal(principal: Principal): Principal {
+  // Capture the trusted-origin signal before cloning: the spread below
+  // produces a fresh object that is not a member of the authenticity
+  // WeakSet, so authenticity must be re-derived from the live principal.
+  const wasAuthentic = isAuthentic(principal);
   const snapshot: Principal = { ...principal };
   if (snapshot.audience) snapshot.audience = [...snapshot.audience];
   if (snapshot.scopes) snapshot.scopes = [...snapshot.scopes];
   if (snapshot.roles) snapshot.roles = [...snapshot.roles];
   if (snapshot.claims) snapshot.claims = structuredClone(snapshot.claims);
-  return deepFreeze(snapshot);
+  deepFreeze(snapshot);
+  // Preserve authenticity across the snapshot: a snapshot of an authentic
+  // principal is exactly as authentic as its source, and a snapshot of a
+  // self-asserted (plain-object) principal must stay non-authentic so a
+  // downstream authorize() still rejects it with RC5023. markAuthentic
+  // returns a frozen member whose nested claims/arrays are the already
+  // deep-frozen references from above.
+  return wasAuthentic ? markAuthentic(snapshot) : snapshot;
 }
 
 /**

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -3,6 +3,7 @@ import {
   DefaultExchange,
   HeadersKeys,
   getDirectChannel,
+  isAuthentic,
   markAuthentic,
   rcError,
   sanitizeEndpoint,
@@ -31,13 +32,16 @@ import { DEFERRED_FN_BRAND, type DeferredFn } from "./types.ts";
  * `structuredClone` so the downstream principal shares no references
  * with the agent's frozen snapshot.
  *
- * The clone is re-branded with `markAuthentic` before forwarding: the
- * agent layer only ever forwards the identity it was handed (it cannot
- * mint or escalate, the snapshot is deeply frozen), so the forwarded
- * principal is exactly as authentic as the one that triggered the
- * agent. Without re-branding, the spread would strip the authenticity
- * brand and the downstream route's `authorize()` would reject the
- * agent's own caller identity (RC5023).
+ * Authenticity is forwarded only when the principal that triggered the
+ * agent was itself authentic: `isAuthentic(rp)` is true for a JWT /
+ * `authenticate()` identity (the tool-bridge preserves the trusted-origin
+ * signal on the frozen snapshot) and false for a self-asserted plain-object
+ * principal. Re-branding restores the brand the spread strips for the
+ * legitimate case; leaving it unbranded for the self-asserted case lets the
+ * downstream route's `authorize()` correctly reject it with RC5023, instead
+ * of laundering an unverified caller into a trusted one across the
+ * agent -> tool boundary. The agent layer never mints or escalates: it only
+ * forwards the identity it was handed.
  */
 function cloneFrozenPrincipal(rp: ReadonlyPrincipal): Principal {
   const out: Principal = { ...rp } as Principal;
@@ -46,7 +50,7 @@ function cloneFrozenPrincipal(rp: ReadonlyPrincipal): Principal {
   if (rp.roles) out.roles = [...rp.roles];
   if (rp.claims)
     out.claims = structuredClone(rp.claims) as Record<string, unknown>;
-  return markAuthentic(out);
+  return isAuthentic(rp) ? markAuthentic(out) : out;
 }
 
 /**

--- a/packages/ai/test/tool-bridge.bun.test.ts
+++ b/packages/ai/test/tool-bridge.bun.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { z } from "zod";
+import { isAuthentic, markAuthentic } from "@routecraft/routecraft";
 import { buildVercelTools } from "../src/agent/tool-bridge.ts";
 import type { ResolvedTool } from "../src/agent/tools/selection.ts";
 
@@ -133,6 +134,65 @@ describe("buildVercelTools: execute path", () => {
       ctx: { principal?: typeof principal },
     ];
     expect(callArgs[1].principal).toEqual(principal);
+  });
+
+  /**
+   * @case freezePrincipal preserves the trusted-origin (authentic) signal across the snapshot
+   * @preconditions buildVercelTools called once with an authentic principal and once with a self-asserted plain object
+   * @expectedResult The handler's ctx.principal is authentic only when the dispatching principal was authentic (the spread inside the snapshot must not strip the brand, nor confer it)
+   */
+  test("freezePrincipal preserves authenticity on the handler ctx", async () => {
+    const captured: Array<boolean> = [];
+    const handler = mock(
+      async (_input: unknown, ctx: { principal?: object }) => {
+        captured.push(isAuthentic(ctx.principal));
+        return "done";
+      },
+    );
+    const resolved: ResolvedTool = {
+      name: "auth-probe",
+      description: "Auth probe.",
+      input: z.object({}),
+      handler: handler as ResolvedTool["handler"],
+    };
+
+    const authentic = markAuthentic({
+      kind: "jwt" as const,
+      scheme: "bearer" as const,
+      subject: "verified",
+      roles: ["admin"],
+    });
+    const authenticMap = await buildVercelTools(
+      [resolved],
+      undefined,
+      new AbortController().signal,
+      undefined,
+      authentic,
+    );
+    await (
+      authenticMap["auth-probe"] as {
+        execute: (i: unknown) => Promise<unknown>;
+      }
+    ).execute({});
+
+    const selfAsserted = {
+      kind: "jwt" as const,
+      scheme: "bearer" as const,
+      subject: "forged",
+      roles: ["admin"],
+    };
+    const plainMap = await buildVercelTools(
+      [resolved],
+      undefined,
+      new AbortController().signal,
+      undefined,
+      selfAsserted,
+    );
+    await (
+      plainMap["auth-probe"] as { execute: (i: unknown) => Promise<unknown> }
+    ).execute({});
+
+    expect(captured).toEqual([true, false]);
   });
 
   /**

--- a/packages/ai/test/tools-builders.bun.test.ts
+++ b/packages/ai/test/tools-builders.bun.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { z } from "zod";
-import { craft, direct, isRoutecraftError, log } from "@routecraft/routecraft";
+import {
+  craft,
+  direct,
+  isAuthentic,
+  isRoutecraftError,
+  markAuthentic,
+  log,
+} from "@routecraft/routecraft";
 import { testContext, type TestContext } from "@routecraft/testing";
 import {
   agentPlugin,
@@ -337,6 +344,132 @@ describe("tool builders - directTool dispatch", () => {
       },
     );
     expect(downstreamPrincipal).toEqual(principal);
+  });
+
+  /**
+   * @case directTool forwards authenticity only when the calling principal is authentic
+   * @preconditions Downstream route records isAuthentic(ex.principal); handler invoked once with an authentic principal and once with a self-asserted plain object carrying the same fields
+   * @expectedResult Authentic in -> authentic downstream; self-asserted in -> non-authentic downstream (no laundering across the agent -> tool boundary)
+   */
+  test("dispatchDirect forwards authenticity only for authentic principals", async () => {
+    let downstreamAuthentic: boolean | undefined;
+    t = await testContext()
+      .routes([
+        craft()
+          .id("guarded/echo")
+          .description("Echo with auth capture.")
+          .input(z.object({}))
+          .from(direct())
+          .process((ex) => {
+            downstreamAuthentic = isAuthentic(ex.principal);
+            return { ...ex, body: { ok: true } };
+          })
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const desc = directTool("guarded/echo");
+    const fn = desc.resolve(t.ctx, "guardedEcho");
+    const base = {
+      logger: undefined as unknown as Parameters<
+        typeof fn.handler
+      >[1]["logger"],
+      abortSignal: new AbortController().signal,
+    };
+
+    await fn.handler(
+      {},
+      {
+        ...base,
+        principal: markAuthentic({
+          kind: "jwt" as const,
+          scheme: "bearer" as const,
+          subject: "verified",
+          roles: ["admin"],
+        }),
+      },
+    );
+    expect(downstreamAuthentic).toBe(true);
+
+    downstreamAuthentic = undefined;
+    await fn.handler(
+      {},
+      {
+        ...base,
+        principal: {
+          kind: "jwt" as const,
+          scheme: "bearer" as const,
+          subject: "forged",
+          roles: ["admin"],
+        },
+      },
+    );
+    expect(downstreamAuthentic).toBe(false);
+  });
+
+  /**
+   * @case A self-asserted principal reaching a guarded route through directTool is rejected with RC5023
+   * @preconditions Route guarded by .authorize({ roles: ["admin"] }); directTool invoked once with an authentic admin principal and once with a self-asserted (plain-object) admin principal
+   * @expectedResult Authentic admin passes; self-asserted admin is rejected with RC5023 instead of being laundered into a trusted identity
+   */
+  test("guarded route reached through directTool rejects a self-asserted principal (RC5023)", async () => {
+    t = await testContext()
+      .routes([
+        craft()
+          .id("guarded-admin")
+          .description("Admin-only guarded tool.")
+          .input(z.object({}))
+          .authorize({ roles: ["admin"] })
+          .from(direct())
+          .process((ex) => ({ ...ex, body: { ok: true } }))
+          .to(log()),
+      ])
+      .build();
+    await t.startAndWaitReady();
+
+    const desc = directTool("guarded-admin");
+    const fn = desc.resolve(t.ctx, "guardedAdmin");
+    const base = {
+      logger: undefined as unknown as Parameters<
+        typeof fn.handler
+      >[1]["logger"],
+      abortSignal: new AbortController().signal,
+    };
+
+    const authResult = await fn.handler(
+      {},
+      {
+        ...base,
+        principal: markAuthentic({
+          kind: "jwt" as const,
+          scheme: "bearer" as const,
+          subject: "verified-admin",
+          roles: ["admin"],
+        }),
+      },
+    );
+    expect(authResult).toMatchObject({ ok: true });
+
+    let caught: unknown;
+    try {
+      await fn.handler(
+        {},
+        {
+          ...base,
+          principal: {
+            kind: "jwt" as const,
+            scheme: "bearer" as const,
+            subject: "forged-admin",
+            roles: ["admin"],
+          },
+        },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(isRoutecraftError(caught)).toBe(true);
+    expect((caught as { rc?: string }).rc).toBe("RC5023");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #355. The agent tool-bridge re-branded **every** principal it forwarded to a `Direct(...)` tool as authentic, regardless of whether the principal that triggered the agent was authentic. A self-asserted (plain-object) principal that reached an agent was laundered into a trusted one for all of that agent's tool calls, so a downstream route's `.authorize()` never raised **RC5023** ("principal was not established by a trusted origin").

### Root cause
- `tool-bridge.ts` `freezePrincipal()` spreads the principal into a fresh snapshot, which strips its authenticity `WeakSet` membership.
- `builders.ts` `cloneFrozenPrincipal()` then called `markAuthentic()` **unconditionally** to restore the brand for the legitimate (JWT / `authenticate()`) case — silently upgrading the illegitimate (plain-object) case too.

### Fix (gate authenticity on the source principal)
- `freezePrincipal()` captures `isAuthentic()` before cloning and re-marks the frozen snapshot authentic **only when the source was authentic**, so the trusted-origin signal is neither stripped nor conferred.
- `cloneFrozenPrincipal()` re-brands **only when** the forwarded principal is authentic; a self-asserted principal stays unbranded, so `authorize()` rejects it with RC5023.

The legitimate path (JWT / `authenticate()` identities) stays authentic across the `agent -> tool` boundary.

### Approach note
I carry the authenticity signal via the existing `WeakSet` (preserving it through `freezePrincipal`) rather than threading a new boolean field on the public `FnHandlerContext`. This keeps the fix to the auth primitive, adds no public surface, and also corrects a latent inconsistency where `ctx.principal` on a tool handler always reported non-authentic.

## Tests
- `freezePrincipal preserves authenticity on the handler ctx` (authentic in -> authentic; plain in -> non-authentic).
- `dispatchDirect forwards authenticity only for authentic principals` (downstream `isAuthentic(ex.principal)` capture).
- `guarded route reached through directTool rejects a self-asserted principal (RC5023)` (end-to-end; authentic admin passes).

## Verification
- `typecheck` ✓ · `lint` ✓ · new tests pass. The only AI-suite failures are the pre-existing local-only `RC5003` `mock.module` flake (green in CI), unrelated to this change.

https://claude.ai/code/session_016BG8iVEDt2LVxL5e5VAh6L

---
_Generated by [Claude Code](https://claude.ai/code/session_016BG8iVEDt2LVxL5e5VAh6L)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops laundering self-asserted principals through the agent tool-bridge. Authenticity now forwards only when the caller is authentic, so guarded routes correctly reject with RC5023. Closes Linear #355.

- **Bug Fixes**
  - Gate authenticity on the source principal: preserve the brand on the frozen snapshot only if `isAuthentic` was true, and conditionally `markAuthentic` when cloning for tool calls.
  - Add regression tests for authentic-in/authentic-out, non-authentic-in/non-authentic-out, and RC5023 on guarded routes.

<sup>Written for commit 1f6b7ea40cabb750438fa8539bca826f6f316d1a. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/358?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

