### PR TITLE
Add service.name log binding from CraftConfig

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
@@ -27,6 +27,7 @@ export const craftConfig = defineConfig({
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
+| `name` | `string` | No | -- | Service / application name. Emitted on every log line as `service.name` ([details](#service-name)) |
 | `store` | `Map<keyof StoreRegistry, StoreRegistry[keyof StoreRegistry]>` | No | -- | Initial values for the context store |
 | `on` | `Partial<Record<EventName, EventHandler \| EventHandler[]>>` | No | -- | Event handlers to register on context creation |
 | `once` | `Partial<Record<EventName, EventHandler \| EventHandler[]>>` | No | -- | One-time event handlers that fire once then auto-unsubscribe |
@@ -130,6 +131,26 @@ export default {
 ```
 
 When using the CLI, pass `--log-level` or `--log-file` to set the corresponding env var before the logger initializes, so CLI flags override any config file.
+
+### Service name
+
+Set `name` on the context to tag every log line with a `service.name` field (the OpenTelemetry semantic convention). This identifies the originating application when shipping logs to an aggregator, and lines up with OTel resource mappings such as BetterStack's `resources.service.name`.
+
+```ts
+import { defineConfig } from "@routecraft/routecraft";
+
+export const craftConfig = defineConfig({
+  name: "eywa",
+});
+```
+
+Every log emitted through the context, its routes, and their exchanges then carries the field:
+
+```json
+{ "level": "info", "service.name": "eywa", "route": "zoe-mail", "msg": "..." }
+```
+
+When `name` is omitted, no `service.name` field is added. The value is a per-context log binding; it does not configure OpenTelemetry trace resources. If you also export traces via `telemetry({ tracerProvider })`, set the matching `service.name` on that provider's `Resource` so logs and spans agree.
 
 ## Environment variables
 

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -101,6 +101,14 @@ export interface CraftPlugin {
  * ```
  */
 export interface CraftConfig {
+  /**
+   * Service / application name for this context. Emitted on every log line as
+   * `service.name` (the OpenTelemetry semantic convention), so log aggregators
+   * that map OTel resource attributes (e.g. BetterStack `resources.service.name`)
+   * can identify the originating app. When omitted, no `service.name` field is
+   * added to logs.
+   */
+  name?: string;
   /** Initial values for the context store */
   store?: Map<keyof StoreRegistry, StoreRegistry[keyof StoreRegistry]>;
   /** Event handlers to register on context creation */
@@ -161,6 +169,9 @@ export class CraftContext {
   /** Unique identifier for this context instance */
   public readonly contextId: string = randomUUID();
 
+  /** Service / application name, surfaced on logs as `service.name`. */
+  public readonly name?: string;
+
   /** Routes registered with this context */
   private routes: Route[] = [];
 
@@ -200,6 +211,7 @@ export class CraftContext {
    */
   constructor(config?: CraftConfig) {
     setBrand(this, BRAND.CraftContext);
+    if (config?.name !== undefined) this.name = config.name;
     this.logger = logger.child(childBindings(this));
     if (config) {
       // Initialize store from config

--- a/packages/routecraft/src/logger.ts
+++ b/packages/routecraft/src/logger.ts
@@ -171,14 +171,19 @@ export function childBindings(
 ): Record<string, unknown> {
   if (isCraftContext(context)) {
     const ctx = context as CraftContext;
-    return { contextId: ctx.contextId };
+    const bindings: Record<string, unknown> = { contextId: ctx.contextId };
+    if (ctx.name !== undefined) bindings["service.name"] = ctx.name;
+    return bindings;
   }
   if (isRoute(context)) {
     const route = context as Route;
-    return {
+    const bindings: Record<string, unknown> = {
       contextId: route.context.contextId,
       route: route.definition.id,
     };
+    if (route.context.name !== undefined)
+      bindings["service.name"] = route.context.name;
+    return bindings;
   }
   if (isExchange(context)) {
     const ex = context as Exchange;
@@ -190,6 +195,8 @@ export function childBindings(
         correlationId: ex.headers[HeadersKeys.CORRELATION_ID],
         exchangeId: ex.id,
       };
+
+      if (ctx.name !== undefined) bindings["service.name"] = ctx.name;
 
       // Include non-PII auth identifiers from the principal when present.
       // Only subject and issuer are safe for logs; fields like email,

--- a/packages/routecraft/test/logger.bun.test.ts
+++ b/packages/routecraft/test/logger.bun.test.ts
@@ -75,4 +75,39 @@ describe("logger", () => {
     expect(bindings).toHaveProperty("exchangeId", exchange.id);
     expect(bindings).toHaveProperty("correlationId");
   });
+
+  /**
+   * @case childBindings omits service.name when no context name is configured
+   * @preconditions testContext built without a `name`
+   * @expectedResult bindings do not contain a service.name key
+   */
+  test("childBindings omits service.name when context has no name", async () => {
+    const t = await testContext()
+      .routes(craft().id("r").from(simple("x")))
+      .build();
+    // Array path form so the literal dotted key is not treated as a nested path.
+    expect(childBindings(t.ctx)).not.toHaveProperty(["service.name"]);
+  });
+
+  /**
+   * @case childBindings emits service.name for CraftContext, Route, and Exchange when a name is configured
+   * @preconditions testContext built with `name: "eywa"` and a named route
+   * @expectedResult context, route, and exchange bindings all contain service.name === "eywa"
+   */
+  test("childBindings emits configured name as service.name across context, route, and exchange", async () => {
+    const t = await testContext()
+      .with({ name: "eywa" })
+      .routes(craft().id("zoe-mail").from(simple("x")))
+      .build();
+    const ctx = t.ctx;
+
+    // Array path form so the literal dotted key is not treated as a nested path.
+    expect(childBindings(ctx)).toHaveProperty(["service.name"], "eywa");
+
+    const route = ctx.getRoutes()[0]!;
+    expect(childBindings(route)).toHaveProperty(["service.name"], "eywa");
+
+    const exchange = new DefaultExchange(ctx, { body: "test" });
+    expect(childBindings(exchange)).toHaveProperty(["service.name"], "eywa");
+  });
 });


### PR DESCRIPTION
## Summary

Adds support for a `name` field on `CraftConfig` that tags every log line emitted through a context, its routes, and their exchanges with a `service.name` field (OpenTelemetry semantic convention). This enables log aggregators to identify the originating application when shipping logs.

## Changes

- **CraftConfig interface**: Added optional `name?: string` field with JSDoc explaining its purpose and relationship to OTel resource mappings
- **CraftContext class**: 
  - Added `public readonly name?: string` property
  - Constructor now assigns `config?.name` to the instance
- **Logger bindings**: Updated `childBindings()` to emit `service.name` when a context has a name configured:
  - For `CraftContext`: includes `service.name` in bindings
  - For `Route`: includes `service.name` from the route's context
  - For `Exchange`: includes `service.name` from the exchange's context
- **Documentation**: Added "Service name" section to configuration reference with example usage and guidance on OTel trace resource alignment
- **Tests**: Added two test cases covering:
  - Omission of `service.name` when no context name is configured
  - Emission of `service.name` across context, route, and exchange bindings when configured

## Implementation Details

The `name` field is a per-context log binding that does not configure OpenTelemetry trace resources. When omitted, no `service.name` field is added to logs. The implementation uses the existing `childBindings()` mechanism to propagate the name through the logging hierarchy, ensuring consistency across all log lines from a given context instance.

https://claude.ai/code/session_01F1Dj8r2rbuD4zzd8XrHZdo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `name` on `CraftConfig` that tags all logs with `service.name` (OpenTelemetry) across the context, routes, and exchanges. Omitted when unset; helps aggregators identify the app; does not configure OTel trace resources.

- **New Features**
  - Added `CraftConfig.name` and `CraftContext.name`; logger `childBindings` emit `service.name` when set.
  - Route and Exchange bindings inherit `service.name` from the context.
  - Updated docs with examples and added tests for presence/absence of `service.name`.

<sup>Written for commit 80b2d5cbce1e5ac8dcbb37d0f4eb0535a1602dc2. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/360?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

