### PR TITLE
chore: bump dev version to 0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "routecraft-skills",
       "source": "./",
       "description": "Skills for authoring Routecraft adapters and capabilities. Each skill points Claude at the closest example and the matching public docs, then runs lint, typecheck, and tests until clean.",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "author": {
         "name": "routecraftjs"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "routecraft-skills",
   "description": "Skills for authoring Routecraft adapters and capabilities. Each skill points Claude at the closest existing example and the relevant public docs, then runs lint, typecheck, and tests until they pass.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "routecraftjs",
     "url": "https://routecraft.dev"

--- a/apps/routecraft.dev/package.json
+++ b/apps/routecraft.dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "routecraft.dev",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "apps/routecraft.dev": {
       "name": "routecraft.dev",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@algolia/autocomplete-core": "^1.19.8",
         "@headlessui/react": "^2.2.10",
@@ -73,7 +73,7 @@
     },
     "examples": {
       "name": "examples",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@routecraft/ai": "workspace:^0.5.0",
         "@routecraft/routecraft": "workspace:^0.5.0",
@@ -91,9 +91,9 @@
     },
     "packages/ai": {
       "name": "@routecraft/ai",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
-        "@routecraft/routecraft": "workspace:^0.5.0",
+        "@routecraft/routecraft": "workspace:^0.6.0",
         "@standard-schema/spec": "^1.1.0",
         "ai": "^6.0.174",
       },
@@ -139,7 +139,7 @@
     },
     "packages/browser": {
       "name": "@routecraft/browser",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@routecraft/routecraft": "workspace:^0.5.0",
       },
@@ -157,7 +157,7 @@
     },
     "packages/cli": {
       "name": "@routecraft/cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "craft": "./dist/index.js",
       },
@@ -187,7 +187,7 @@
     },
     "packages/create-routecraft": {
       "name": "create-routecraft",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "create-routecraft": "./dist/index.js",
       },
@@ -200,7 +200,7 @@
     },
     "packages/eslint-plugin-routecraft": {
       "name": "@routecraft/eslint-plugin-routecraft",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "devDependencies": {
         "@types/eslint": "^9.6.1",
         "tsup": "^8.5.1",
@@ -213,9 +213,9 @@
     },
     "packages/os": {
       "name": "@routecraft/os",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
-        "@routecraft/routecraft": "workspace:^0.5.0",
+        "@routecraft/routecraft": "workspace:^0.6.0",
       },
       "devDependencies": {
         "vitest": "^4.1.5",
@@ -227,7 +227,7 @@
     },
     "packages/routecraft": {
       "name": "@routecraft/routecraft",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@standard-schema/spec": "^1.1.0",
@@ -235,7 +235,7 @@
       },
       "devDependencies": {
         "@opentelemetry/sdk-trace-base": "^2.7.1",
-        "@routecraft/testing": "workspace:^0.5.0",
+        "@routecraft/testing": "workspace:^0.6.0",
         "@sinonjs/fake-timers": "^11.3.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/mailparser": "^3.4.6",
@@ -284,9 +284,9 @@
     },
     "packages/testing": {
       "name": "@routecraft/testing",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
-        "@routecraft/routecraft": "workspace:^0.5.0",
+        "@routecraft/routecraft": "workspace:^0.6.0",
         "@standard-schema/spec": "^1.1.0",
       },
       "devDependencies": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -9,14 +9,14 @@
     "test:coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@routecraft/ai": "workspace:^0.5.0",
-    "@routecraft/routecraft": "workspace:^0.5.0",
+    "@routecraft/ai": "workspace:^0.6.0",
+    "@routecraft/routecraft": "workspace:^0.6.0",
     "commander": "^14.0.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@routecraft/cli": "workspace:^0.5.0",
-    "@routecraft/testing": "workspace:^0.5.0",
+    "@routecraft/cli": "workspace:^0.6.0",
+    "@routecraft/testing": "workspace:^0.6.0",
     "dotenv": "^17.4.2",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/workspace",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.11",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/ai",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "AI and MCP integrations for Routecraft",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -23,7 +23,7 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
-    "@routecraft/routecraft": "workspace:^0.5.0",
+    "@routecraft/routecraft": "workspace:^0.6.0",
     "@standard-schema/spec": "^1.1.0",
     "ai": "^6.0.174"
   },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/browser",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agent browser automation adapter for Routecraft",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -22,10 +22,10 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
-    "@routecraft/routecraft": "workspace:^0.5.0"
+    "@routecraft/routecraft": "workspace:^0.6.0"
   },
   "devDependencies": {
-    "@routecraft/testing": "workspace:^0.5.0",
+    "@routecraft/testing": "workspace:^0.6.0",
     "agent-browser": "^0.17.1",
     "vitest": "^4.1.5"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "CLI for running Routecraft routes",
   "private": false,
   "type": "module",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-trace-base": "^2.7.1",
-    "@routecraft/routecraft": "workspace:^0.5.0",
+    "@routecraft/routecraft": "workspace:^0.6.0",
     "agent-browser": "^0.17.1",
     "cheerio": "^1.2.0",
     "commander": "^14.0.3",

--- a/packages/create-routecraft/package.json
+++ b/packages/create-routecraft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-routecraft",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Create a new Routecraft project",
   "type": "module",
   "main": "./dist/index.js",
@@ -21,7 +21,7 @@
     "@inquirer/prompts": "^8.4.2"
   },
   "devDependencies": {
-    "@routecraft/testing": "workspace:^0.5.0"
+    "@routecraft/testing": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/eslint-plugin-routecraft/package.json
+++ b/packages/eslint-plugin-routecraft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/eslint-plugin-routecraft",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/os/package.json
+++ b/packages/os/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/os",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "System-native adapters for Routecraft: shell execution and browser automation",
   "type": "module",
@@ -24,7 +24,7 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
-    "@routecraft/routecraft": "workspace:^0.5.0"
+    "@routecraft/routecraft": "workspace:^0.6.0"
   },
   "devDependencies": {
     "vitest": "^4.1.5",

--- a/packages/routecraft/package.json
+++ b/packages/routecraft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/routecraft",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Type-safe integration and automation framework for TypeScript/Node.js",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@opentelemetry/sdk-trace-base": "^2.7.1",
-    "@routecraft/testing": "workspace:^0.5.0",
+    "@routecraft/testing": "workspace:^0.6.0",
     "@sinonjs/fake-timers": "^11.3.1",
     "@types/sinonjs__fake-timers": "^15.0.1",
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routecraft/testing",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Test utilities for Routecraft routes",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -23,7 +23,7 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
-    "@routecraft/routecraft": "workspace:^0.5.0",
+    "@routecraft/routecraft": "workspace:^0.6.0",
     "@standard-schema/spec": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Opens the post-0.5.0 development line by bumping every workspace package, plugin/marketplace manifest, and the lockfile from `0.5.0` to `0.6.0`. This is the same post-release bump done after previous releases, done by hand because `version:set` is a release-pipeline tool (it strips `workspace:` for npm publish and is restored right after in CI), not a tool for committed bumps.

This bump does double duty:

1. **Canary versioning** - Canary builds derive their base from `package.json`. With `main` still at `0.5.0`, the next canary would be `0.5.0-canary.N`, colliding with the released `0.5.0`. After this, canaries are `0.6.0-canary.N`.

2. **Fixes the GitHub Pages deploy** - The docs deploy selects the latest `v*` tag reachable from `main` that carries a `bun.lock` as the stable root build, and serves canary under `/next` (`.github/workflows/ci.yml` `build-and-deploy-docs`). `v0.1.0`-`v0.4.0` are either off the current `main` line or predate the Bun migration (no `bun.lock`), so every prior deploy fell back to "canary at root, no `/next`". That is the current live state: `https://routecraft.dev/versions.json` is `[{ "label": "next", "basePath": "", "default": true }]` and `/next/` returns a 404. `v0.5.0` is the first tag that is both on `main` (it is `main`'s HEAD) and has a `bun.lock`. Because this bump touches `apps/routecraft.dev/package.json`, merging it matches the `docs` paths-filter and re-runs the Pages deploy, which will now publish **v0.5.0 at the root** and **canary at `/next`**.

So merging this fixes the docs deploy and the canary versioning together. No need to publish a canary first.

## Notes

- Internal deps keep the `workspace:` protocol (e.g. `workspace:^0.6.0`), matching the current monorepo convention (set in #275). `version:set`'s protocol stripping is for the release/publish pipeline only.
- Left untouched: `@markdoc/next.js@^0.5.0` (third-party) and `@routecraft/routecraft >=0.5.0` in `packages/os` (peer range, still satisfied by 0.6.0).
- Minor follow-up (out of scope): `set-version.mjs` still tries to rewrite a hardcoded `.version("...")` in `packages/cli/src/index.ts`, but the CLI now imports `version` from its `package.json`, so that block is dead code and warns harmlessly. Worth removing in a separate change.

## Test plan

- [ ] CI green (`bun install --frozen-lockfile`, format, typecheck, lint, tests all pass locally)
- [ ] After merge: confirm `build-and-deploy-docs` runs on the push to `main`
- [ ] After deploy: `https://routecraft.dev/` serves the v0.5.0 docs and `https://routecraft.dev/next/` loads the canary docs (no 404)
- [ ] After deploy: `https://routecraft.dev/versions.json` lists both `v0.5.0` (default) and `next`
- [ ] Next canary publishes as `0.6.0-canary.1`

https://claude.ai/code/session_01SmLKYMkMLxAdUictFftxJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmLKYMkMLxAdUictFftxJQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps all workspace packages and plugin manifests to 0.6.0 to start the next dev cycle and prevent canary collisions with 0.5.0. Also retriggers the docs deploy so v0.5.0 builds at the site root and canary publishes under /next.

- **Dependencies**
  - Set versions to 0.6.0 in all `package.json` files, `.claude-plugin/*`, and `bun.lock`.
  - Updated internal ranges to `workspace:^0.6.0`; kept the `workspace:` protocol.
  - Left third‑party ranges unchanged.

<sup>Written for commit 462e255847b3c7212deb0d4e0fc2000bb9599c9e. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/362?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

