### PR TITLE
Fix ARC seal detection to not treat single-hop MX seals as forwards

### DIFF
--- a/packages/routecraft/src/adapters/mail/analysis.ts
+++ b/packages/routecraft/src/adapters/mail/analysis.ts
@@ -319,7 +319,16 @@ export function analyzeHeaders(
     (sender !== null &&
       headerFrom !== null &&
       sender.domain !== headerFrom.domain);
-  const hasArc = arcResults.length > 0 || arcChain.cv !== "none";
+  // The delivering MX adds a single first-hop ARC set (i=1, cv=none) to direct
+  // mail (Gmail/Workspace seals everything it accepts), so the presence of ARC
+  // headers is not by itself evidence of forwarding. Real forwarding shows
+  // either a validated chain (cv=pass/fail) or more than one ARC instance.
+  const maxArcInstance = Math.max(
+    0,
+    ...arcResults.map((r) => r.instance),
+    ...arcChain.domainsByInstance.keys(),
+  );
+  const hasArc = arcChain.cv !== "none" || maxArcInstance >= 2;
 
   let forwardType: ForwardType = "direct";
   let effective: EmailAddress | null = headerFrom;

--- a/packages/routecraft/test/mail.bun.test.ts
+++ b/packages/routecraft/test/mail.bun.test.ts
@@ -2084,6 +2084,75 @@ describe("Mail Adapter", () => {
     });
 
     /**
+     * @case A first-hop ARC seal added by the delivering MX does not make direct mail look forwarded
+     * @preconditions No List-Id; a single ARC set (i=1, cv=none) such as Gmail/Workspace stamps on
+     *                everything it accepts; boundary Authentication-Results dmarc=pass
+     * @expectedResult forwardType "direct", trust "verified", empty forwardChain, reason
+     *                 "direct-dmarc-aligned" (not "auto-forward-arc-unverified")
+     */
+    test("direct mail with a delivering-MX ARC seal stays direct and verified", () => {
+      const headers = extractAnalysisHeaders(
+        headerLines([
+          "From: Jane <jane@example.com>",
+          "ARC-Seal: i=1; cv=none; d=google.com",
+          "ARC-Authentication-Results: i=1; mx.google.com; dkim=pass; spf=pass; dmarc=pass header.from=example.com",
+          "Authentication-Results: mx.google.com; dkim=pass header.i=@example.com; spf=pass; dmarc=pass header.from=example.com",
+        ]),
+      );
+      const sender = analyzeHeaders(headers);
+      expect(sender.forwardType).toBe("direct");
+      expect(sender.trust).toBe("verified");
+      expect(sender.address).toBe("jane@example.com");
+      expect(sender.forwardChain).toEqual([]);
+      expect(sender.reason).toBe("direct-dmarc-aligned");
+      // The ARC seal is still surfaced as cv=none, it just no longer drives routing.
+      expect(sender.authentication.arc).toBe("none");
+    });
+
+    /**
+     * @case A subdomain From: with org-level DMARC alignment and an MX ARC seal stays direct
+     * @preconditions From: uses a sending subdomain, DMARC reports the organisational domain,
+     *                single ARC set (i=1, cv=none), no List-Id
+     * @expectedResult forwardType "direct", trust "verified", effective sender is the From: address
+     */
+    test("subdomain sender with MX ARC seal is direct and verified", () => {
+      const headers = extractAnalysisHeaders(
+        headerLines([
+          'From: "monday.com" <team@learn.mail.monday.com>',
+          "ARC-Seal: i=1; cv=none; d=google.com",
+          "ARC-Authentication-Results: i=1; mx.google.com; dkim=pass header.i=@learn.mail.monday.com; spf=pass; dmarc=pass header.from=monday.com",
+          "Authentication-Results: mx.google.com; dkim=pass header.i=@learn.mail.monday.com; spf=pass; dmarc=pass header.from=monday.com",
+        ]),
+      );
+      const sender = analyzeHeaders(headers);
+      expect(sender.forwardType).toBe("direct");
+      expect(sender.trust).toBe("verified");
+      expect(sender.address).toBe("team@learn.mail.monday.com");
+      expect(sender.forwardChain).toEqual([]);
+    });
+
+    /**
+     * @case A multi-instance ARC chain is still recognised as a forward
+     * @preconditions No List-Id; two ARC instances present (i=1 and i=2), chain not validated
+     * @expectedResult forwardType "auto-forward" with a hop per instance; cv=none keeps it unverified
+     */
+    test("multi-instance ARC chain is still treated as auto-forward", () => {
+      const headers = extractAnalysisHeaders(
+        headerLines([
+          "From: Jane <jane@example.com>",
+          "ARC-Seal: i=1; cv=none; d=relay-one.com",
+          "ARC-Seal: i=2; cv=none; d=relay-two.com",
+          "ARC-Authentication-Results: i=1; mx.relay-one.com; dkim=pass; spf=pass; dmarc=pass header.from=example.com",
+          "ARC-Authentication-Results: i=2; mx.relay-two.com; dkim=pass; spf=pass; dmarc=pass header.from=example.com",
+        ]),
+      );
+      const sender = analyzeHeaders(headers);
+      expect(sender.forwardType).toBe("auto-forward");
+      expect(sender.forwardChain).toHaveLength(2);
+      expect(sender.trust).toBe("unverified");
+    });
+
+    /**
      * @case Google Groups forward exposes the original sender via X-Original-From
      * @preconditions List-Id present, X-Original-From points to the real sender, ARC cv=pass
      * @expectedResult forwardType "mailing-list", effective sender is the X-Original-From address,


### PR DESCRIPTION
## Summary

Updates the mail adapter's ARC seal detection logic to correctly distinguish between a single first-hop ARC seal (added by delivering MTAs like Gmail/Workspace to all accepted mail) and genuine forwarding chains. Previously, the presence of any ARC headers would trigger auto-forward classification; now only validated chains (cv=pass/fail) or multi-instance ARC sets are treated as evidence of forwarding.

## Changes

- **analysis.ts**: Modified `hasArc` detection to check for either a validated ARC chain (`cv !== "none"`) or multiple ARC instances (`maxArcInstance >= 2`), rather than simply checking for the presence of ARC headers. This allows direct mail with a delivering-MX ARC seal to remain classified as "direct" with "verified" trust when DMARC alignment is present.

- **mail.bun.test.ts**: Added three new test cases covering the updated behavior:
  - Direct mail with a delivering-MX ARC seal (i=1, cv=none) stays direct and verified
  - Subdomain sender with MX ARC seal is direct and verified
  - Multi-instance ARC chain is still treated as auto-forward

All new tests include JSDoc with `@case`, `@preconditions`, and `@expectedResult` per project conventions.

## Implementation Details

The fix computes the maximum ARC instance number across both `arcResults` and `arcChain.domainsByInstance` to detect multi-hop chains. A single first-hop seal (i=1, cv=none) no longer triggers forwarding classification, while chains with cv=pass/fail or multiple instances continue to be recognized as forwards.

https://claude.ai/code/session_01Bwvi15fyNnVGZe6EZBhg6Q

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ARC seal detection to stop treating single-hop MX seals (`i=1, cv=none`) as forwarding. Direct, DMARC‑aligned mail now stays direct and verified, reducing false auto-forward flags from Gmail/Workspace mail.

- **Bug Fixes**
  - Updated `packages/routecraft/src/adapters/mail/analysis.ts`: treat ARC as forwarding only when `cv !== "none"` or there are 2+ ARC instances; compute `maxArcInstance` from ARC results and chain.
  - Added tests in `packages/routecraft/test/mail.bun.test.ts` for: single `i=1, cv=none` stays direct/verified; subdomain sender stays direct/verified; multi-instance ARC chain remains auto-forward and unverified.
  - Mailing list handling and validated auto-forwards are unchanged.

<sup>Written for commit b37f2cff11b8edc9f34ba986ba252d72b6258455. Summary will update on new commits. <a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/371?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

