### PR TITLE
docs(examples): add real-world support-triage agent example

### DIFF
--- a/apps/routecraft.dev/src/app/docs/examples/page.md
+++ b/apps/routecraft.dev/src/app/docs/examples/page.md
@@ -8,5 +8,6 @@ Working, focused example capabilities you can copy and adapt. {% .lead %}
 
 {% quick-link title="File to HTTP" icon="installation" href="/docs/examples/api-sync" description="Read a CSV file and send each row to an API." /%}
 {% quick-link title="MCP tool" icon="plugins" href="/docs/examples/mcp" description="Expose a capability as an MCP tool, and call a remote MCP server." /%}
+{% quick-link title="Support triage agent" icon="plugins" href="/docs/examples/support-triage" description="Let a bounded agent triage incoming support email." /%}
 
 {% /quick-links %}

--- a/apps/routecraft.dev/src/app/docs/examples/support-triage/page.md
+++ b/apps/routecraft.dev/src/app/docs/examples/support-triage/page.md
@@ -1,0 +1,145 @@
+---
+title: Support triage agent
+---
+
+Let an agent triage incoming support email, bounded to a two-tool allowlist. {% .lead %}
+
+This is the "whole agent" mode: the capability is the agent loop. A support email arrives over
+IMAP, and an `agent()` destination reads it, looks the customer up, decides a priority, and
+posts an internal brief. The agent is the brain, but it has **hands, not keys**: it can call
+exactly two capabilities and nothing else, no arbitrary HTTP, no shell, no open-ended tools.
+
+## The bounded tools
+
+Each tool is an ordinary capability with a `direct()` source, a description (the agent reads
+it to decide when to call), and a typed input. Because they are normal capabilities, they are
+testable and reusable on their own.
+
+```ts
+// capabilities/support/lookup-customer/route.ts
+import { craft, direct, http } from '@routecraft/routecraft'
+import { z } from 'zod'
+
+export const LookupInput = z.object({ email: z.string().email() })
+export type LookupInput = z.infer<typeof LookupInput>
+
+export default craft()
+  .id('lookup-customer')
+  .description('Look up a customer and their plan by email address')
+  .input({ body: LookupInput })
+  .from<LookupInput>(direct())
+  .to(http({ method: 'GET', url: (ex) => `https://api.example.com/customers/${ex.body.email}` }))
+```
+
+```ts
+// capabilities/support/post-brief/route.ts
+import { craft, direct, http } from '@routecraft/routecraft'
+import { z } from 'zod'
+
+export const BriefInput = z.object({
+  priority: z.enum(['P1', 'P2', 'P3']),
+  customer: z.string(),
+  summary: z.string(),
+})
+export type BriefInput = z.infer<typeof BriefInput>
+
+export default craft()
+  .id('post-brief')
+  .description('Post a triage brief to the internal support channel')
+  .input({ body: BriefInput })
+  .from<BriefInput>(direct())
+  .to(http({ method: 'POST', url: 'https://chat.example.com/support/briefs' }))
+```
+
+## The agent
+
+The triage capability sources from the inbox and hands each message to `agent()`. The
+`tools([...])` allowlist is the guardrail: `Direct(lookup-customer)` and `Direct(post-brief)`
+are the only tools the model can call.
+
+```ts
+// capabilities/support/triage/route.ts
+import { craft, mail } from '@routecraft/routecraft'
+import { agent, tools } from '@routecraft/ai'
+
+export default craft()
+  .id('triage-support')
+  .description('Triage an incoming support email')
+  .from(mail('INBOX', { unseen: true, markSeen: true }))
+  .to(
+    agent({
+      model: 'anthropic:claude-sonnet-4-6',
+      system:
+        'You are a support triage assistant. Look the sender up, decide a priority (P1 urgent, P2 normal, P3 low), and post one concise internal brief. Do not reply to the customer.',
+      user: (ex) => `From: ${ex.body.from}\nSubject: ${ex.body.subject}\n\n${ex.body.text}`,
+      tools: tools(['Direct(lookup-customer)', 'Direct(post-brief)']),
+    }),
+  )
+```
+
+`Direct(<id>)` references a registered capability as a tool; the agent sees its
+`.description()` and `.input()` schema and calls it with validated arguments. `CurrentTime` and
+`MCP(server:tool)` are also valid allowlist entries, and the object form
+`{ name, guard, description }` adds a per-tool [guard](/docs/advanced/securing-capabilities) or
+a per-agent description override. A guard receives the tool input and a context carrying the
+caller's principal, and throws to deny the call:
+
+```ts
+tools([
+  'Direct(lookup-customer)',
+  {
+    name: 'Direct(post-brief)',
+    guard: (_input, ctx) => {
+      if (!ctx.principal?.roles?.includes('support')) throw new Error('not authorised to post briefs')
+    },
+  },
+])
+```
+
+## Config
+
+Model providers live on `llmPlugin`; the mail account is configured where you set up the
+`mail` adapter. The agent inherits the provider from the plugin.
+
+```ts
+// craft.config.ts
+import { llmPlugin } from '@routecraft/ai'
+import type { CraftConfig } from '@routecraft/routecraft'
+
+export default {
+  plugins: [llmPlugin({ providers: { anthropic: { apiKey: process.env.ANTHROPIC_API_KEY! } } })],
+} satisfies CraftConfig
+```
+
+## Giving the agent durable context
+
+For standing instructions the agent should always have (tone, escalation policy, product
+facts), attach `blocks` instead of stuffing the `system` string. `skills(...)` loads markdown
+files as blocks; by default they are surfaced progressively (the model sees each skill's name
+and description and loads the body via a tool call only when relevant). It is async, so resolve
+it once and spread it into `blocks`:
+
+```ts
+import { agent, tools, skills } from '@routecraft/ai'
+
+const supportKnowledge = await skills({ source: './support-knowledge' })
+
+agent({
+  model: 'anthropic:claude-sonnet-4-6',
+  system: 'You are a support triage assistant.',
+  blocks: { ...supportKnowledge },
+  tools: tools(['Direct(lookup-customer)', 'Direct(post-brief)']),
+})
+```
+
+---
+
+## Related
+
+{% quick-links %}
+
+{% quick-link title="agent() adapter reference" icon="presets" href="/docs/reference/adapters/agent" description="Model, system, tools, blocks, and loop options." /%}
+{% quick-link title="Securing capabilities" icon="plugins" href="/docs/advanced/securing-capabilities" description="Guards, principals, and authorizing what an agent can reach." /%}
+{% quick-link title="MCP tool" icon="installation" href="/docs/examples/mcp" description="Expose a capability as a tool an external agent can call." /%}
+
+{% /quick-links %}

--- a/apps/routecraft.dev/src/lib/navigation.ts
+++ b/apps/routecraft.dev/src/lib/navigation.ts
@@ -73,6 +73,7 @@ export const navigation = [
     links: [
       { title: 'File to HTTP', href: '/docs/examples/api-sync' },
       { title: 'MCP tool', href: '/docs/examples/mcp' },
+      { title: 'Support triage agent', href: '/docs/examples/support-triage' },
     ],
   },
   {


### PR DESCRIPTION
Adds a real-world agent example to the docs Examples section: triaging a support inbox with a bounded agent. Built against the post-#375 blocks/tools API.

## What it shows
- The "whole agent" mode: `.from(mail('INBOX'))` -> `.to(agent({ model, system, user, tools }))`.
- The bounded-tool guardrail thesis, concretely: `tools(['Direct(lookup-customer)', 'Direct(post-brief)'])`, a two-entry allowlist. Two ordinary `direct()` capabilities become the only tools the model can call.
- The object-form per-tool guard: `{ name, guard }` where `guard: (input, ctx) => { ... throw }` reads `ctx.principal` and throws to deny.
- Durable system context via `blocks` / `skills()`: `const k = await skills({ source: './support-knowledge' }); blocks: { ...k }`.

## API correctness
Every call was verified against the merged #375 source, not from memory:
- `skills()` is async and takes `source` (not `dir`); resolved and spread into `blocks`.
- `ToolGuard` is `(input, ctx) => void` that throws to deny; the principal is on `ctx`, not the exchange.
- Models are `provider:model` with the provider configured on `llmPlugin({ providers })`.

## Notes
- Stacked on top of #376 (the docs IA pass), so this PR's diff is just the example page plus its Examples nav/index entries. Retarget to `main` once #376 merges.
- New page only, self-contained (inline code, like the File to HTTP example). No runtime code changed.

Verified: docs build compiles and prerenders `/docs/examples/support-triage`; typecheck, lint, and Prettier green.

https://claude.ai/code/session_012spZhJ1rw1WgW1TgCrPnPk

---
_Generated by [Claude Code](https://claude.ai/code/session_012spZhJ1rw1WgW1TgCrPnPk)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real-world support triage agent example to Docs. It reads inbox mail, runs a bounded `agent()` with a two-tool allowlist, and shows guardrails and durable context. Also wires the page into the Examples index and navigation.

- **New Features**
  - Demonstrates the "whole agent" flow: `.from(mail('INBOX'))` -> `.to(agent({ ... }))`.
  - Shows `tools(['Direct(lookup-customer)', 'Direct(post-brief)'])` allowlist with an object-form guard that checks `ctx.principal`.
  - Uses `skills({ source })` to load markdown knowledge into `blocks` for durable context.
  - Built against the updated blocks/tools API; adds quick link and nav entry for the new example.

<sup>Written for commit eda046e6d38177a97b3502e20b3baad23cd12efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

