### PR TITLE
fix(docs-site): blog cover scales on mobile Safari

### DIFF
--- a/apps/routecraft.dev/src/components/BlogCover.tsx
+++ b/apps/routecraft.dev/src/components/BlogCover.tsx
@@ -481,7 +481,15 @@ export function BlogCoverFrame({
         height: '100%',
         display: 'block',
       }
-    : { display: 'block', width: '100%', height: 'auto' }
+    : {
+        display: 'block',
+        width: '100%',
+        height: 'auto',
+        // Explicit ratio so the height is definite cross-browser. Safari does
+        // not infer an inline SVG's height from its viewBox when height is auto
+        // (the foreignObject cover then collapses on mobile), so pin it here.
+        aspectRatio: `${COVER_WIDTH} / ${COVER_HEIGHT}`,
+      }
   return (
     <svg
       className={className}


### PR DESCRIPTION
## Why

Blog posts that don't set a frontmatter `image` use the generated cover — an inline `<svg>` wrapping a `<foreignObject>`, sized `width:100%; height:auto`. Mobile Safari does not infer an inline SVG's height from its `viewBox` when the height is `auto`, so the post **header cover collapsed / misscaled on mobile** while rendering fine on desktop.

## What

Pin an explicit `aspect-ratio: 1200 / 630` on the default (non-`fill`) `BlogCoverFrame`, so the cover has a definite height across browsers. Desktop rendering is unchanged, and the blog index cards (same default frame) benefit too.

## Verification

- Build passes; `eslint`, `prettier`, and `tsc --noEmit` clean (pre-commit hook).
- Confirmed in the build output that the post header cover SVG now renders with `style="display:block;width:100%;height:auto;aspect-ratio:1200 / 630"`.

## Caveat

The fix can't be rendered against real mobile Safari in CI; the markup/CSS is the standard remedy for this known SVG/`foreignObject` height bug. Worth eyeballing a blog post on a phone once deployed to confirm end to end.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RzjfJPxLtMwPCf3kBF9aup)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blog cover collapsing/misscaling on mobile Safari by setting an explicit aspect ratio on the default inline SVG cover. Ensures a consistent height across browsers with no change to desktop; blog index cards benefit too.

<sup>Written for commit 0262704d9a18f1ef079da00ecf662c318a69ea98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

