### PR TITLE
chore(site): update hero tagline to "agent harness"

### DIFF
--- a/apps/routecraft.dev/post-templates/01-text-image-portrait.html
+++ b/apps/routecraft.dev/post-templates/01-text-image-portrait.html
@@ -190,7 +190,7 @@
           <span
             class="text-cobalt-500 italic"
             style="font-variation-settings: 'opsz' 144"
-            >harness</span
+            >agent harness</span
           >
           itself.
         </h1>

--- a/apps/routecraft.dev/post-templates/15-linkedin-company-banner.html
+++ b/apps/routecraft.dev/post-templates/15-linkedin-company-banner.html
@@ -200,11 +200,16 @@
           class="text-right font-editorial text-[40px] leading-[1.04] tracking-[-0.025em]"
           style="font-variation-settings: 'opsz' 144"
         >
-          Tools for agents. Or the
+          Tools for
           <em
             class="text-cobalt-500"
             style="font-variation-settings: 'opsz' 144"
-            >harness</em
+            >agents</em
+          >. Or the
+          <em
+            class="text-cobalt-500"
+            style="font-variation-settings: 'opsz' 144"
+            >agent harness</em
           >
           itself.
         </p>

--- a/apps/routecraft.dev/src/app/opengraph-image.tsx
+++ b/apps/routecraft.dev/src/app/opengraph-image.tsx
@@ -80,7 +80,7 @@ export default async function Image() {
         <span style={{ display: 'flex' }}>
           <span style={{ fontStyle: 'italic' }}>Or the</span>
           <span style={{ fontStyle: 'italic', color: cobalt, marginLeft: 18 }}>
-            harness
+            agent harness
           </span>
           <span style={{ marginLeft: 18 }}>itself.</span>
         </span>

--- a/apps/routecraft.dev/src/app/page.tsx
+++ b/apps/routecraft.dev/src/app/page.tsx
@@ -161,7 +161,7 @@ function Hero() {
               className="font-editorial text-cobalt-500 italic"
               style={{ fontVariationSettings: '"opsz" 144, "SOFT" 100' }}
             >
-              harness
+              agent harness
             </span>{' '}
             itself.
           </h1>

--- a/brand/index.html
+++ b/brand/index.html
@@ -1384,7 +1384,7 @@
                   class="font-editorial text-[1.4rem] leading-[1.3] text-ink italic"
                   style="font-variation-settings: &quot;opsz&quot; 96"
                 >
-                  "Tools for agents. Or the harness itself."
+                  "Tools for agents. Or the agent harness itself."
                 </p>
                 <p
                   class="mt-1 font-mono text-[0.65rem] tracking-[0.22em] text-ink/45 uppercase"


### PR DESCRIPTION
## Summary

Refines the brand tagline from "Or the **harness** itself." to "Or the **agent harness** itself." so the standalone line reads unambiguously about agents. Applied consistently across:

- Marketing site hero ([page.tsx](apps/routecraft.dev/src/app/page.tsx))
- Home OG image ([opengraph-image.tsx](apps/routecraft.dev/src/app/opengraph-image.tsx))
- Brand page quote ([brand/index.html](brand/index.html))
- Post templates ([01-text-image-portrait.html](apps/routecraft.dev/post-templates/01-text-image-portrait.html), [15-linkedin-company-banner.html](apps/routecraft.dev/post-templates/15-linkedin-company-banner.html))

## Note for reviewers

The canonical tagline accents a **single** phrase (`agent harness`) in 4 places. The LinkedIn banner intentionally accents **two** phrases (`agents` and `agent harness`) for that layout. This is deliberate, not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the tagline from "Or the harness itself." to "Or the agent harness itself." across the site hero, OG image, brand page, and post templates for clearer agent-focused messaging. The LinkedIn company banner intentionally highlights both "agents" and "agent harness" to fit its layout.

<sup>Written for commit b891309bd5315fbb8d1227bcebc928f8b824866b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

