### PR TITLE
Rebrand "routes" to "capabilities" across docs and packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
   <img src="./routecraft.svg" alt="Routecraft" width="120" />
 
-  <p><strong>AI automation as code</strong></p>
+  <p><strong>Tools for agents. Or the agent harness itself.</strong></p>
 
   <a href="https://github.com/routecraftjs/routecraft/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/routecraftjs/routecraft/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="Bun" src="https://img.shields.io/badge/Bun-1.1%2B-fbf0df?logo=bun">
@@ -16,7 +16,7 @@
 
 ## About
 
-Routecraft is a code-first automation platform for TypeScript. Write routes that send emails, manage calendars, and automate work. Expose them to any AI agent via MCP.
+Routecraft is a type-safe framework for AI automation. Build the tools an agent uses, or the agent itself, with the same fluent DSL. Write capabilities that send emails, manage calendars, and automate work, then expose them to any AI agent via MCP.
 
 ## Why Routecraft?
 
@@ -27,14 +27,14 @@ Routecraft is a code-first automation platform for TypeScript. Write routes that
 
 ## Quick Start
 
-### Write a tool
+### Write a capability
 
 ```ts
 import { mcp } from '@routecraft/ai'
 import { craft, mail } from '@routecraft/routecraft'
 import { z } from 'zod'
 
-// Define a tool AI can call
+// Define a capability AI can call
 export default craft()
   .from(mcp('send-team-email', {
     description: 'Send email to team members',
@@ -97,7 +97,7 @@ Claude discovers your tool and uses it automatically. ✨
 
 ## Examples
 
-Browse runnable examples in [`examples/src/`](./examples/src/) — `hello-world.ts`, `mcp-greet.ts`, `agent.ts`, `mail-noreply-notify.ts`, `programmatic-invocation.ts`, `split.ts`. Each demonstrates a different feature combination.
+Browse runnable examples in [`examples/src/`](./examples/src/): `hello-world.ts`, `mcp-greet.ts`, `agent.ts`, `mail-noreply-notify.ts`, `programmatic-invocation.ts`, `split.ts`. Each demonstrates a different feature combination.
 
 Try one:
 
@@ -111,7 +111,7 @@ For end-to-end walkthroughs, see [the docs site](https://routecraft.dev/docs/exa
 
 ## Contributing
 
-Contributions are welcome! Please read our contribution guide at https://routecraft.dev/docs/community/contribution-guide for guidelines on how to propose changes, add adapters, and write routes.
+Contributions are welcome! Please read our contribution guide at https://routecraft.dev/docs/community/contribution-guide for guidelines on how to propose changes, add adapters, and write capabilities.
 
 ## License
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@routecraft/cli",
   "version": "0.6.0",
-  "description": "CLI for running Routecraft routes",
+  "description": "CLI for running Routecraft capabilities",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin-routecraft/package.json
+++ b/packages/eslint-plugin-routecraft/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@routecraft/eslint-plugin-routecraft",
   "version": "0.6.0",
+  "description": "ESLint rules for authoring Routecraft capabilities",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/routecraft/README.md
+++ b/packages/routecraft/README.md
@@ -1,6 +1,6 @@
 # @routecraft/routecraft
 
-AI automation as code.
+Tools for agents. Or the agent harness itself.
 
 Routecraft is a TypeScript-first framework for building automation capabilities that agents can invoke. Write deterministic pipelines for Software 1.0. Hand them to an AI agent as tools for Software 3.0. Both, from the same code.
 

--- a/packages/routecraft/package.json
+++ b/packages/routecraft/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@routecraft/routecraft",
   "version": "0.6.0",
-  "description": "Type-safe integration and automation framework for TypeScript/Node.js",
+  "description": "Type-safe framework for AI automation: build the tools an agent uses, or the agent itself, in TypeScript",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@routecraft/testing",
   "version": "0.6.0",
-  "description": "Test utilities for Routecraft routes",
+  "description": "Test utilities for Routecraft capabilities",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Updates terminology throughout the project to use "capabilities" instead of "routes" to better reflect the dual nature of Routecraft as both a tool-building framework for agents and an agent harness itself.

## Changes

- **README.md**: Updated tagline from "AI automation as code" to "Tools for agents. Or the agent harness itself." and revised the About section to describe building "capabilities" instead of "routes"
- **Quick Start section**: Renamed "Write a tool" to "Write a capability" and updated code comments
- **Examples section**: Minor punctuation fix (em-dash to colon)
- **Contributing section**: Changed "write routes" to "write capabilities"
- **Package descriptions**:
  - `@routecraft/cli`: "CLI for running Routecraft capabilities"
  - `@routecraft/routecraft`: Updated to "Type-safe framework for AI automation: build the tools an agent uses, or the agent itself, in TypeScript"
  - `@routecraft/testing`: "Test utilities for Routecraft capabilities"
  - `@routecraft/eslint-plugin-routecraft`: Added description "ESLint rules for authoring Routecraft capabilities"
- **packages/routecraft/README.md**: Updated tagline to match main README

## Notes

This is a documentation and metadata update that clarifies the project's positioning without changing any functional code. The term "capability" better captures that Routecraft enables building both agent tools and agent implementations from the same DSL.

https://claude.ai/code/session_01UumkEaWB4dQodUgUafqmzc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebrands “routes” to “capabilities” across docs and package metadata, and standardizes the headline to “Tools for agents. Or the agent harness itself.” No functional changes.

- **Refactors**
  - Update README headline and About; Quick Start now “Write a capability” with updated comments.
  - Fix Examples punctuation (em dash to colon).
  - Contributing now refers to writing capabilities.
  - Refresh package descriptions: `@routecraft/cli`, `@routecraft/routecraft`, `@routecraft/testing`, `@routecraft/eslint-plugin-routecraft`.
  - Align `packages/routecraft/README.md` headline with the main README.

<sup>Written for commit 8ebd82e72e294df6ba910b1477f287fa3eeb74bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

