### PR TITLE
Document adapter structure and naming conventions

### DIFF
--- a/apps/routecraft.dev/src/app/docs/advanced/custom-adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/custom-adapters/page.md
@@ -191,7 +191,7 @@ For a multi-interface factory, tag at every return path:
 
 ```ts
 export function myQueue(
-  options: MyQueueSourceOptions | MyQueueDestinationOptions,
+  options: MyQueueServerOptions | MyQueueClientOptions,
 ) {
   if ('consumerGroup' in options) {
     return tagAdapter(new MyQueueSourceAdapter(options), myQueue, factoryArgs(options))

--- a/apps/routecraft.dev/src/app/docs/advanced/custom-adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/custom-adapters/page.md
@@ -138,6 +138,39 @@ export function myQueue(options: MyQueueOptions) {
 .to(myQueue({ queue: 'results' }))
 ```
 
+Discriminate the role structurally -- by `arguments.length`, `typeof`, or the shape of the options (`'consumerGroup' in options`) -- never by inspecting an option's *value*. Class names carry the role, `{Concept}{Role}Adapter` (`MyQueueSourceAdapter`, `MyQueueDestinationAdapter`), even for single-role adapters, so growing a role later stays additive.
+
+## File structure
+
+A non-trivial adapter is a folder named for its concept, with one file per role it plays:
+
+```text
+adapters/
+  my-queue/
+    index.ts          # public factory + exports -- the only file consumers import
+    types.ts          # exported option and result types
+    source.ts         # MyQueueSourceAdapter -- present because it can be a .from() source
+    destination.ts    # MyQueueDestinationAdapter -- present because it can be a .to() destination
+    shared.ts         # option parsing / helpers shared between the role files
+```
+
+The files present are the documentation: a folder with both `source.ts` and `destination.ts` is visibly a two-role adapter, while one with only `source.ts` is source-only. Adding a role later means adding a file, not reshaping the existing ones.
+
+A trivial single-role adapter with no shared helpers can stay a single file (`adapters/my-queue.ts`), the same shorthand the examples above use. Reach for the folder once the adapter grows a second role, shared helpers, or a types module.
+
+## Options naming
+
+When an adapter plays two roles with different options for each, name the option types so the role is readable from the type alone. Interfaces use Source/Destination; option *types* use Server/Client:
+
+| Type | Role |
+| --- | --- |
+| `MyQueueBaseOptions` | fields shared by both roles |
+| `MyQueueServerOptions extends MyQueueBaseOptions` | the source / `.from()` side |
+| `MyQueueClientOptions` | the destination / `.to()` side |
+| `MyQueueOptions` | the exported union `MyQueueServerOptions \| MyQueueClientOptions`, used as the factory parameter type |
+
+If the roles share no fields, declare each independently and drop the base. A single-role adapter needs only `MyQueueOptions`, plus an optional `MyQueueResult`.
+
 ## Making your adapter mockable
 
 Tag every adapter instance your factory returns so consumers can mock it with `mockAdapter(yourFactory, ...)` instead of having to import the internal adapter class. Tagging is a one-line addition per return path:

--- a/apps/routecraft.dev/src/app/docs/advanced/custom-adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/custom-adapters/page.md
@@ -190,9 +190,7 @@ export function myQueue(options: MyQueueOptions) {
 For a multi-interface factory, tag at every return path:
 
 ```ts
-export function myQueue(
-  options: MyQueueServerOptions | MyQueueClientOptions,
-) {
+export function myQueue(options: MyQueueOptions) {
   if ('consumerGroup' in options) {
     return tagAdapter(new MyQueueSourceAdapter(options), myQueue, factoryArgs(options))
   }

--- a/apps/routecraft.dev/src/app/docs/advanced/custom-adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/custom-adapters/page.md
@@ -166,10 +166,10 @@ When an adapter plays two roles with different options for each, name the option
 | --- | --- |
 | `MyQueueBaseOptions` | fields shared by both roles |
 | `MyQueueServerOptions extends MyQueueBaseOptions` | the source / `.from()` side |
-| `MyQueueClientOptions` | the destination / `.to()` side |
+| `MyQueueClientOptions extends MyQueueBaseOptions` | the destination / `.to()` side |
 | `MyQueueOptions` | the exported union `MyQueueServerOptions \| MyQueueClientOptions`, used as the factory parameter type |
 
-If the roles share no fields, declare each independently and drop the base. A single-role adapter needs only `MyQueueOptions`, plus an optional `MyQueueResult`.
+Both role types carry the base. A role that adds nothing of its own can alias it (`type MyQueueClientOptions = MyQueueBaseOptions`). If the roles share no fields at all, declare each independently and drop the base. A single-role adapter needs only `MyQueueOptions`, plus an optional `MyQueueResult`.
 
 ## Making your adapter mockable
 

--- a/apps/routecraft.dev/src/app/docs/introduction/project-structure/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/project-structure/page.md
@@ -24,6 +24,8 @@ my-app
 │           ├── route.test.ts
 │           ├── summarise.ts          # internal helper, private to this capability
 │           └── __fixtures__
+├── shared
+│   └── amount.ts                     # pure helper shared by several capabilities
 ├── adapters
 │   └── google-sheets.ts
 ├── plugins
@@ -89,9 +91,24 @@ capabilities. Internals stay free to change.
 
 ### Shared helpers
 
-Pure helpers used by a single capability stay inside its folder. The moment a helper is
-shared by two or more capabilities, move it into a shared workspace package rather than a
-loose `lib/` folder, so the dependency is explicit and the boundary stays clean.
+A helper used by a single capability stays inside that capability's folder. When two or more
+capabilities need the same pure helper (validate an amount, parse a date, a shared domain
+type), put it in a top-level `shared/` folder next to `capabilities/`:
+
+```text
+shared
+├── amount.ts          # parseAmount, assertPositive
+└── dates.ts           # toIsoDate
+```
+
+Any capability may import from `shared/`. Keep it pure: validators, parsers, formatters, and
+types, with no side effects and no imports back into a capability's internals. `shared/` is the
+single-project answer, so a one-app repo never needs workspace tooling just to share a date
+parser.
+
+When the repo grows into multiple runtimes (several apps under `apps/`), shared code graduates
+from `shared/` to a workspace package that each app depends on as a local dependency, so the
+boundary stays explicit across app lines.
 
 ### Single-file shorthand
 
@@ -106,6 +123,7 @@ Sub-folders inside `capabilities/` are supported to any depth. The capability id
 
 | Folder | Purpose |
 | --- | --- |
+| `shared/` | Pure helpers (validators, parsers, formatters, shared types) used by two or more capabilities in a single-app project. No side effects; never imports a capability's internals. Graduates to a workspace package once the repo goes multi-app. |
 | `adapters/` | Custom adapters that connect to external systems. Each implements one of the adapter interfaces: `subscribe`, `send`, or `process`. |
 | `plugins/` | Runtime plugins that hook into the Routecraft context lifecycle, such as MCP transport or custom telemetry. |
 

--- a/skills/create-adapter/SKILL.md
+++ b/skills/create-adapter/SKILL.md
@@ -32,7 +32,9 @@ Before writing, confirm answers to these questions. Ask the user only the ones t
 
 ## Step 2: pick the closest example
 
-Read [`reference/examples-index.md`](reference/examples-index.md) and pick the row that best matches the answers above. The index maps intent to the relevant public doc page and the closest existing adapter on GitHub.
+First read [`reference/adapter-structure.md`](reference/adapter-structure.md). It is the file layout, single-factory, class-naming, and options-naming convention every adapter follows; the rest of this skill assumes it.
+
+Then read [`reference/examples-index.md`](reference/examples-index.md) and pick the row that best matches the answers above. The index maps intent to the relevant public doc page and the closest existing adapter on GitHub.
 
 Then, in this order:
 
@@ -45,23 +47,13 @@ Do not write the adapter from memory. The patterns are precise and the examples 
 
 ## Step 3: write the adapter
 
-Create the adapter under `packages/routecraft/src/adapters/<concept>/` if you are inside this monorepo, or under your project's adapters folder otherwise. Mirror the file layout of the example you read. Typical files:
+Create the adapter under `packages/routecraft/src/adapters/<concept>/` if you are inside this monorepo, or under your project's `adapters/<concept>/` folder otherwise. Follow [`reference/adapter-structure.md`](reference/adapter-structure.md) for the file layout, the single per-concept factory and how it dispatches by payload, class naming, and the options-naming convention, and mirror the example you read.
 
-- `index.ts` -- the public factory function. Calls `tagAdapter(instance, factory, factoryArgs(...))`. This is what users import
-- `source.ts` -- the source class (if applicable)
-- `destination.ts` -- the destination class (if applicable)
-- `transformer.ts` -- the transformer class (if applicable)
-- `shared.ts` -- option parsing or helpers shared between the role files
-- `types.ts` -- exported option and result types
+The remaining authoring rules to keep in mind while writing:
 
-Authoring rules to keep in mind while writing:
-
-- **Naming**: classes are `{Concept}{Role}Adapter` (e.g. `HttpDestinationAdapter`, `CronSourceAdapter`). The factory function is the lowercase concept (`http`, `cron`)
-- **Single factory per concept**: one factory, one concept. Use overloads to discriminate roles by `arguments.length` and `typeof`, never by inspecting option values
-- **Tagging**: every factory return value goes through `tagAdapter(instance, factory, factoryArgs(...))`. The eslint plugin and tests rely on this
-- **Two-sided naming**: when an adapter is both server and client, name the option types `{Concept}ServerOptions` and `{Concept}ClientOptions`, and export the union as `{Concept}Options`. If the two roles share fields, factor them into `{Concept}BaseOptions` and have both `Server` and `Client` extend it; if they do not, declare each independently. Source/Destination is for *interface* names; Server/Client is for *option type* names
+- **Tagging**: every factory return value goes through `tagAdapter(instance, factory, factoryArgs(...))`, at every return path. The eslint plugin and tests rely on this
 - **Store keys**: use `Symbol.for("routecraft.adapter.<concept>.<key>")` so keys survive duplicate package copies in the same process
-- **No mutation**: transformers return new objects via spread (`{ ...exchange, body: newBody }`). Do not mutate the incoming exchange
+- **No mutation**: transformers and processors return new objects via spread (`{ ...exchange, body: newBody }`). Do not mutate the incoming exchange
 - **Errors**: throw at adapter boundaries with a stable `rc` error code from `@routecraft/routecraft`. Capabilities catch and surface these via the capability-level error handler
 
 ## Step 4: write tests

--- a/skills/create-adapter/reference/adapter-structure.md
+++ b/skills/create-adapter/reference/adapter-structure.md
@@ -50,10 +50,10 @@ Option type names follow a fixed convention so a reader knows the role from the 
 | --- | --- |
 | `{Concept}BaseOptions` | fields shared by every role |
 | `{Concept}ServerOptions extends {Concept}BaseOptions` | options for the source / `.from()` side |
-| `{Concept}ClientOptions` | options for the destination / `.to()` side |
+| `{Concept}ClientOptions extends {Concept}BaseOptions` | options for the destination / `.to()` side |
 | `{Concept}Options` | the exported union `{Concept}ServerOptions \| {Concept}ClientOptions`; the factory's parameter type |
 
-If the two roles share no fields, declare each independently and skip the base. The internal intersection used for stored or merged options (`{Concept}ServerOptions & {Concept}ClientOptions`) stays unexported. A single-role adapter needs only `{Concept}Options`, plus an optional `{Concept}Result`.
+Both role types carry the base, since the base is what both roles share. A role that adds nothing of its own can alias the base directly (`type {Concept}ClientOptions = {Concept}BaseOptions`). If the two roles share no fields at all, declare each independently and skip the base. The internal intersection used for stored or merged options (`{Concept}ServerOptions & {Concept}ClientOptions`) stays unexported. A single-role adapter needs only `{Concept}Options`, plus an optional `{Concept}Result`.
 
 ## Before you submit
 

--- a/skills/create-adapter/reference/adapter-structure.md
+++ b/skills/create-adapter/reference/adapter-structure.md
@@ -1,0 +1,64 @@
+# Adapter structure and naming convention
+
+Read this before writing an adapter. It is the layout, factory, and options-naming convention every Routecraft adapter follows, built-in or user-written. Following it means anyone can tell, at a glance, which roles an adapter plays and how to call it. The public guide with runnable code is the [custom adapters page](https://routecraft.dev/docs/advanced/custom-adapters); this file is the convention checklist.
+
+## One folder per adapter concept
+
+A non-trivial adapter is a folder named for its concept (`http`, `cron`, `mail`), with one file per role plus shared wiring:
+
+```text
+adapters/
+  <concept>/
+    index.ts          # public factory + exports (the only file consumers import)
+    types.ts          # exported option and result types
+    source.ts         # {Concept}SourceAdapter       (present only if it can be a .from() source)
+    destination.ts    # {Concept}DestinationAdapter  (present only if it can be a .to()/.enrich()/.tap() destination)
+    transformer.ts    # {Concept}TransformerAdapter  (present only if it transforms bodies)
+    shared.ts         # option parsing / helpers shared between the role files
+```
+
+The files present are the documentation. A folder with both `source.ts` and `destination.ts` is visibly a two-role adapter; one with only `source.ts` is source-only. Adding a role later means adding a file, not reshaping the existing ones.
+
+A trivial single-role adapter with no shared helpers and no separate types may be a single file, `adapters/<concept>.ts`. The folder shape is the default once it grows a second role, shared helpers, or a types module.
+
+## One factory per concept, dispatched by payload
+
+Expose exactly one factory function per concept, named for the lowercase concept (`http`, `cron`). The same function serves every role; it decides which role to return from the arguments it receives, never from a separate import:
+
+```ts
+// one import, both roles
+import { myQueue } from "./adapters/my-queue";
+
+route.from(myQueue({ queue: "orders" }));  // returns the source
+route.to(myQueue({ queue: "results" }));   // returns the destination
+```
+
+Rules:
+
+- Discriminate roles structurally: by `arguments.length`, `typeof`, or the shape of the options (`"consumerGroup" in options`). Never by inspecting option *values*.
+- The factory returns the interface type (`Source<T>`, `Destination<T, R>`), never the concrete class.
+- Do not ship `myQueueSource` / `myQueueDestination` as separate exports. Users think in concepts, not roles.
+- Tag every return path with `tagAdapter(instance, factory, factoryArgs(...))` so the adapter is mockable. A multi-role factory tags at each branch.
+
+Class names carry the role: `{Concept}{Role}Adapter` (`HttpDestinationAdapter`, `CronSourceAdapter`), even for single-role adapters, so adding a role later stays additive.
+
+## Options naming
+
+Option type names follow a fixed convention so a reader knows the role from the type name. Interfaces use Source/Destination; option *types* use Server/Client:
+
+| Type | Meaning |
+| --- | --- |
+| `{Concept}BaseOptions` | fields shared by every role |
+| `{Concept}ServerOptions extends {Concept}BaseOptions` | options for the source / `.from()` side |
+| `{Concept}ClientOptions` | options for the destination / `.to()` side |
+| `{Concept}Options` | the exported union `{Concept}ServerOptions \| {Concept}ClientOptions`; the factory's parameter type |
+
+If the two roles share no fields, declare each independently and skip the base. The internal intersection used for stored or merged options (`{Concept}ServerOptions & {Concept}ClientOptions`) stays unexported. A single-role adapter needs only `{Concept}Options`, plus an optional `{Concept}Result`.
+
+## Before you submit
+
+- The folder has one file per role it plays, plus `index.ts` and, when non-trivial, `types.ts`.
+- One factory, named for the lowercase concept, dispatching by payload shape, returning the interface type.
+- Classes named `{Concept}{Role}Adapter`; every factory return path tagged with `tagAdapter(...)`.
+- Option types follow the Base / Server / Client / union convention.
+- Full walkthrough with code: https://routecraft.dev/docs/advanced/custom-adapters

--- a/skills/create-adapter/reference/examples-index.md
+++ b/skills/create-adapter/reference/examples-index.md
@@ -2,20 +2,22 @@
 
 Pick the row that best matches what the user is building. Then `WebFetch` both URLs in that row before writing.
 
+Each "Read this doc" link points to that adapter's own reference page (its options, exchange shape, and usage), not the combined adapters index. That keeps the context returned to you specific to the closest existing adapter. For the general authoring guide that applies to every adapter, see the Useful URLs in `SKILL.md` (adapters reference and the custom-adapters guide).
+
 | If the user wants... | Read this doc | Then study this example |
 |---|---|---|
-| HTTP request or response (REST, webhook caller, JSON API) | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/http/index.ts |
-| Polling or scheduled trigger on an interval | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/cron/index.ts |
-| Reading or writing files on disk | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/file/index.ts |
-| Parsing CSV input (rows in, rows out) | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/csv/index.ts |
-| Parsing JSON or JSONL streams | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/jsonl/index.ts |
-| Two-sided protocol (server inbox plus client outbox, e.g. mail or queues) | https://routecraft.dev/raw/docs/advanced/custom-adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/mail/index.ts |
-| In-process direct-call routing (call one route from another) | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/direct/index.ts |
-| Logging or side-effect-only destination | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/log/index.ts |
-| HTML scraping or DOM querying | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/html/index.ts |
-| Cosine similarity or embedding-based search transformer | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/cosine/index.ts |
-| Simple in-memory source for tests or fixed payloads | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/simple/index.ts |
-| Group-by or stateful aggregation transformer | https://routecraft.dev/raw/docs/reference/adapters.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/group/index.ts |
+| HTTP request or response (REST, webhook caller, JSON API) | https://routecraft.dev/raw/docs/reference/adapters/http.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/http/index.ts |
+| Polling or scheduled trigger on an interval | https://routecraft.dev/raw/docs/reference/adapters/cron.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/cron/index.ts |
+| Reading or writing files on disk | https://routecraft.dev/raw/docs/reference/adapters/file.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/file/index.ts |
+| Parsing CSV input (rows in, rows out) | https://routecraft.dev/raw/docs/reference/adapters/csv.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/csv/index.ts |
+| Parsing JSON or JSONL streams | https://routecraft.dev/raw/docs/reference/adapters/jsonl.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/jsonl/index.ts |
+| Two-sided protocol (server inbox plus client outbox, e.g. mail or queues) | https://routecraft.dev/raw/docs/reference/adapters/mail.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/mail/index.ts |
+| In-process direct-call routing (call one route from another) | https://routecraft.dev/raw/docs/reference/adapters/direct.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/direct/index.ts |
+| Logging or side-effect-only destination | https://routecraft.dev/raw/docs/reference/adapters/log.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/log/index.ts |
+| HTML scraping or DOM querying | https://routecraft.dev/raw/docs/reference/adapters/html.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/html/index.ts |
+| Cosine similarity or embedding-based search transformer | https://routecraft.dev/raw/docs/reference/adapters/cosine.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/cosine/index.ts |
+| Simple in-memory source for tests or fixed payloads | https://routecraft.dev/raw/docs/reference/adapters/simple.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/simple/index.ts |
+| Group-by or stateful aggregation transformer | https://routecraft.dev/raw/docs/reference/adapters/group.md | https://raw.githubusercontent.com/routecraftjs/routecraft/main/packages/routecraft/src/adapters/group/index.ts |
 
 If none of the rows are a clean match, pick the closest by **mechanism** (request/response, polling, streaming, two-sided) rather than by **domain**. The mechanism determines the file layout; the domain only changes the option types and the body shape.
 

--- a/skills/create-capability/SKILL.md
+++ b/skills/create-capability/SKILL.md
@@ -101,8 +101,8 @@ Rules:
 - **`route.ts` is the readable main flow.** It is both the public surface and the file a human reads to understand what the capability does. Keep it to the DSL chain plus its schemas: a reader should follow the flow top to bottom without paging through transform internals. The heavy logic lives in the sibling internal files and is pulled in by name (see the readability rule in Step 3). If `route.ts` is becoming hard to scan, that is the signal to extract, not to add a comment.
 - `route.ts` is the only file other capabilities may import. Re-export the capability's input/output types from it so callers depend on the contract, not the internals.
 - Internal files (`summarise.ts`, `map-order.ts`, `__fixtures__`, ...) hold the implementation detail of each step. They are private to the folder; never import them from another capability.
-- Cross-capability reuse goes through `direct('<id>')` plus the types re-exported from the callee's `route.ts`. Never reach into another capability's internal files.
-- Pure helpers shared by several capabilities graduate to a shared workspace package, not a loose `lib/` folder.
+- Reuse capability *behavior* through `direct('<id>')` plus the types re-exported from the callee's `route.ts`. Never reach into another capability's internal files.
+- Reuse *pure helpers* (validate an amount, parse a date, a shared domain type) through a top-level `shared/` folder next to `capabilities/`. Any capability may import from `shared/`; keep it pure (validators, parsers, formatters, types), with no side effects and no imports back into a capability's internals. This is the single-project answer, so a one-app repo never needs workspace tooling just to share a date parser. Once the repo grows into multiple apps under `apps/`, shared helpers graduate from `shared/` to a workspace package each app depends on.
 - A single-file capability (`capabilities/<id>.ts`) is acceptable shorthand for a trivial, internal-free capability, but the folder shape is the default the scaffolder produces.
 
 ## Step 4: write tests

--- a/skills/create-capability/SKILL.md
+++ b/skills/create-capability/SKILL.md
@@ -68,6 +68,7 @@ export default craft()
 
 Authoring rules to keep in mind:
 
+- **Keep the DSL readable -- this is the point of the framework**: `route.ts` exists so a reader can follow the *flow* (where data comes from, what happens to it in order, where it lands) without reading the inner workings of every step. A wall of inline logic defeats that. Never inline a large `transform`, `process`, `enrich`, or `filter` body. Extract anything beyond a couple of trivial lines into a named function in a sibling internal file in the capability folder (e.g. `summarise.ts`, `map-order.ts`) and pass the reference: `.transform(toOrderLine)` instead of `.transform((x) => { /* 30 lines */ })`. The named step then reads like a verb in the pipeline. Inline lambdas are fine only when they are short and self-evident
 - **Metadata first**: `.id()`, `.title()`, `.description()`, `.input()`, `.output()`, `.error()`, `.batch()` come **before** `.from(...)`. Once you call `.from(...)`, you are in the pipeline and metadata methods no longer apply
 - **Typed bodies**: pass the input type to `.from<Input>(...)` so the operations downstream stay typed without casts
 - **No mutation**: pure transforms return new objects via spread. Side effects belong in `.tap(destination)`
@@ -81,21 +82,25 @@ Authoring rules to keep in mind:
 
 ## Project structure: one folder per capability
 
-In a Routecraft project, each capability is its own folder under `capabilities/`, grouped by domain:
+This is a documented Routecraft standard, not a suggestion. `bunx create-routecraft` scaffolds this shape, and the project-structure page is the source of truth: https://routecraft.dev/raw/docs/introduction/project-structure.md (read it if you are setting up a new project or unsure where a file belongs).
+
+Each capability is its own folder under `capabilities/`, grouped by domain:
 
 ```text
 capabilities/
   <domain>/
     <id>/
-      route.ts        # public surface: default export plus its input/output types
+      route.ts        # public surface AND the readable main flow (default export + input/output types)
       route.test.ts   # colocated test (see Step 4)
       README.md       # short description; mermaid + integrations table for complex ones
-      <internal>.ts   # mappers, helpers; never imported from outside this folder
+      <internal>.ts   # mappers, transforms, helpers; never imported from outside this folder
 ```
 
 Rules:
 
+- **`route.ts` is the readable main flow.** It is both the public surface and the file a human reads to understand what the capability does. Keep it to the DSL chain plus its schemas: a reader should follow the flow top to bottom without paging through transform internals. The heavy logic lives in the sibling internal files and is pulled in by name (see the readability rule in Step 3). If `route.ts` is becoming hard to scan, that is the signal to extract, not to add a comment.
 - `route.ts` is the only file other capabilities may import. Re-export the capability's input/output types from it so callers depend on the contract, not the internals.
+- Internal files (`summarise.ts`, `map-order.ts`, `__fixtures__`, ...) hold the implementation detail of each step. They are private to the folder; never import them from another capability.
 - Cross-capability reuse goes through `direct('<id>')` plus the types re-exported from the callee's `route.ts`. Never reach into another capability's internal files.
 - Pure helpers shared by several capabilities graduate to a shared workspace package, not a loose `lib/` folder.
 - A single-file capability (`capabilities/<id>.ts`) is acceptable shorthand for a trivial, internal-free capability, but the folder shape is the default the scaffolder produces.
@@ -146,6 +151,7 @@ Use `bun run <script>` (not `bun <script>`) so Bun invokes the package.json scri
 
 ## Useful URLs
 
+- Project structure (folder-per-capability standard): https://routecraft.dev/raw/docs/introduction/project-structure.md
 - Capabilities introduction: https://routecraft.dev/raw/docs/introduction/capabilities.md
 - Operations introduction: https://routecraft.dev/raw/docs/introduction/operations.md
 - Operations reference: https://routecraft.dev/raw/docs/reference/operations.md


### PR DESCRIPTION
Adds comprehensive documentation of the adapter authoring conventions that every Routecraft adapter (built-in or user-written) must follow, making the patterns explicit and checkable before submission.

## Summary

This change establishes a single source of truth for adapter file layout, factory dispatch, class naming, and options-naming conventions. It consolidates guidance that was previously scattered across the custom-adapters guide into a dedicated reference document, and updates related documentation to point to it.

## Key Changes

- **New reference document** (`skills/create-adapter/reference/adapter-structure.md`): Comprehensive checklist covering:
  - One folder per adapter concept with one file per role
  - Single factory per concept, dispatched by payload shape (never by option values)
  - Class naming convention: `{Concept}{Role}Adapter`
  - Options naming: `{Concept}BaseOptions`, `{Concept}ServerOptions`, `{Concept}ClientOptions`, `{Concept}Options` union
  - Tagging requirement for mockability
  - Pre-submission checklist

- **Enhanced custom-adapters guide** (`apps/routecraft.dev/src/app/docs/advanced/custom-adapters/page.md`): Adds three new sections mirroring the reference document:
  - File structure with folder layout examples
  - Options naming convention table
  - Clarifies role discrimination rules (structural, never by value inspection)

- **Updated examples index** (`skills/create-adapter/reference/examples-index.md`):
  - Points each adapter type to its own reference page (e.g., `adapters/http.md`) rather than the combined index
  - Adds context note explaining the per-adapter reference pages vs. the general authoring guide

- **Updated skill workflow** (`skills/create-adapter/SKILL.md`):
  - Adds step to read `adapter-structure.md` before picking an example
  - Simplifies Step 3 by removing redundant file-layout explanation (now in the reference)
  - Clarifies that tagging is required at every return path

- **Project structure documentation** (`apps/routecraft.dev/src/app/docs/introduction/project-structure/page.md`):
  - Adds `shared/` folder guidance for pure helpers used by multiple capabilities
  - Clarifies the boundary: `shared/` is for validators, parsers, formatters, and types with no side effects
  - Documents graduation path from `shared/` to workspace packages in multi-app repos

- **Capability authoring skill** (`skills/create-capability/SKILL.md`):
  - Adds readability rule: keep `route.ts` scannable by extracting large transforms into named internal files
  - Clarifies that `route.ts` is both public surface and the readable main flow
  - Adds guidance on reusing pure helpers through `shared/` folder
  - References the project-structure page as the source of truth

## Implementation Details

- The adapter-structure reference is a checklist-style document designed to be consulted before submission, complementing the walkthrough examples
- Options naming convention uses a table for clarity and consistency across all adapters
- All guidance aligns with existing `.standards/adapter-architecture.md` and naming conventions already in use
- Documentation updates maintain the distinction between Source/Destination (interface names) and Server/Client (option type names)

https://claude.ai/code/session_014vcTWSP3FEkxEcKfetZP5X

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single, checkable reference for adapter structure and naming, updates related docs and skills to align with it, and documents a `shared/` folder for pure helpers in single-app repos. Also tightens capability readability guidance, points examples to per-adapter reference pages, and clarifies that both Server and Client option types extend the Base options.

- New Features
  - New reference: `skills/create-adapter/reference/adapter-structure.md` (folder layout, single factory with structural dispatch, `{Concept}{Role}Adapter` classes, Base/Server/Client options, tagging).
  - Custom-adapters guide adds File structure and Options naming; examples index links to per-adapter pages (e.g., `adapters/http.md`). Options table corrected: Client extends Base; roles may alias Base when they add nothing.
  - Project structure docs add `shared/` for pure, side-effect-free helpers; guidance on promoting to a workspace package in multi-app repos.
  - Skills updated:
    - `create-adapter`: read the new reference first; Step 3 trimmed to that source of truth; examples and factories now use `Server`/`Client` option names and the `{Concept}Options` union alias.
    - `create-capability`: make `route.ts` the readable main flow; extract heavy logic; reuse pure helpers via `shared/`; link the project-structure standard.

- Migration
  - Read `skills/create-adapter/reference/adapter-structure.md` before writing adapters.
  - Use one factory per concept; dispatch roles by argument shape; name classes `{Concept}{Role}Adapter`.
  - Name options Base/Server/Client; export `{Concept}Options` as the union; have both `{Concept}ServerOptions` and `{Concept}ClientOptions` extend `{Concept}BaseOptions` (alias Base if a role adds nothing); tag every return path with `tagAdapter(...)`.
  - Put shared pure helpers in top-level `shared/` for single-app repos; promote to a workspace package in multi-app setups.

<sup>Written for commit 61bf5d31b2c2af0ee00bdee600fb4b98f06ff375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

