### PR TITLE
feat(ai): nested named block groups for agents

### DIFF
--- a/apps/routecraft.dev/src/app/changelog/page.md
+++ b/apps/routecraft.dev/src/app/changelog/page.md
@@ -16,6 +16,7 @@ This section tracks changes landing on `main` since the v0.5.0 release. Release 
 
 - **Agent blocks replace skills** -- `AgentOptions.skills` and `agentPlugin({ skills })` are removed in favour of a `blocks` record that unifies skills, memory, identity, and instructions, with progressive disclosure now the default. See the [migration guide](/docs/migrating/0.5-to-0.6).
 - **`skills({ source })` and `fromFile(path)` builders** -- `skills` now returns a `blocks` record to spread into `blocks: { ... }`; `fromFile` reads a UTF-8 file at resolution time.
+- **Nested block groups** -- a `blocks` value can be a single block or a nested `blocks` group, so `skills({ source })` can stay grouped under one key (`blocks: { skills: await skills(...) }`) instead of being spread flat. Groups flatten to `group__leaf` names. See the [migration guide](/docs/migrating/0.5-to-0.6).
 - **Tag selectors on `tools()` removed** -- the `{ tagged }` / `{ tagged, from }` variants and the `tags` override on `directTool` are gone. Use the new `tools((catalog) => [...])` builder form for dynamic selection.
 - **Block-loader calls partitioned out of `toolCalls`** -- progressive loads surface on `AgentResult.blocksLoaded` and emit `agent:block:*` events instead of `agent:tool:*`.
 - **`skills:` frontmatter on `agents()` rejected** -- supply `blocks` through the per-agent overrides map instead.

--- a/apps/routecraft.dev/src/app/docs/examples/support-triage/page.md
+++ b/apps/routecraft.dev/src/app/docs/examples/support-triage/page.md
@@ -117,7 +117,7 @@ For standing instructions the agent should always have (tone, escalation policy,
 facts), attach `blocks` instead of stuffing the `system` string. `skills(...)` loads markdown
 files as blocks; by default they are surfaced progressively (the model sees each skill's name
 and description and loads the body via a tool call only when relevant). It is async, so resolve
-it once and spread it into `blocks`:
+it once and assign it to a named group so every skill stays under one key:
 
 ```ts
 import { agent, tools, skills } from '@routecraft/ai'
@@ -127,10 +127,14 @@ const supportKnowledge = await skills({ source: './support-knowledge' })
 agent({
   model: 'anthropic:claude-sonnet-4-6',
   system: 'You are a support triage assistant.',
-  blocks: { ...supportKnowledge },
+  blocks: { knowledge: supportKnowledge },
   tools: tools(['Direct(lookup-customer)', 'Direct(post-brief)']),
 })
 ```
+
+Each skill then resolves to `knowledge__<skill-name>` (its loader tool and `blocksLoaded`
+entry). Spreading `...supportKnowledge` still works if you would rather keep each skill at the
+top level.
 
 ---
 

--- a/apps/routecraft.dev/src/app/docs/migrating/0.5-to-0.6/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.5-to-0.6/page.md
@@ -105,6 +105,27 @@ agent({
 
 The function signature changed from `skills(path)` to `skills({ source })`. The return type changed from `Record<name, Skill>` to `Blocks`. Both are visible at the call site.
 
+Spreading flattens every skill into the top-level namespace. To keep them grouped under one addressable key, assign the result to a nested block instead of spreading it (see [1.2b](#1-2b-grouping-skills-under-one-key)).
+
+### 1.2b Grouping skills under one key
+
+A `blocks` value may be a single `BlockBody` (a leaf) or a nested `Blocks` record (a group). Assigning `skills({ source })` to a key, rather than spreading it, keeps every skill under that namespace instead of dissolving them into the top level:
+
+```ts
+agent({
+  model: "anthropic:claude-sonnet-4-6",
+  system: "You are an analyst.",
+  blocks: {
+    skills: await skills({ source: "./skills" }), // a named group
+    tone: { mode: "inject", value: "Be terse." }, // a single block
+  },
+});
+```
+
+Groups flatten depth-first into a single canonical name joined by `__`. A skill `onboarding` under the `skills` group resolves to `skills__onboarding` for its system-prompt heading, its loader tool (`_block_load_skills__onboarding`), and its `AgentResult.blocksLoaded` entry. `__` (not `/`) is used because loader tool names reach the provider unsanitised and must match `^[a-zA-Z0-9_-]{1,64}$`.
+
+Grouping isolates collisions (a skill named `tone` resolves to `skills__tone`, distinct from a top-level `tone` block) and lets you remove or replace the whole collection by its top-level key. Two blocks that flatten to the same name are rejected with `RC5026`. The empty-name and reserved-`_block_`-prefix rules apply at every nesting level. Per-member merge inside a group is not supported in 0.6.0: a per-agent group replaces a default group of the same name wholesale, and `skills: false` removes the whole group.
+
 ### 1.3 `agents()` markdown loader: `skills:` frontmatter is rejected
 
 The agent markdown loader (`agents("./agents")`) used to accept a `skills:` frontmatter field. That field is now rejected with `RC5003` "not yet supported" because blocks accept function-form resolvers that YAML cannot express. Set `blocks` on the registered agent in code instead, either via the per-agent `overrides` map handed to `agents()` or via the agent's call site.
@@ -336,6 +357,7 @@ For context, no migration required:
 
 - **HTTP source adapter.** `http({ path, method? })` exposes a route over HTTP, configured via `defineConfig({ http: { port, host, auth } })`. Bun runtimes bind via `Bun.serve`; Node 22+ uses a `node:http` shim. Global auth (`jwt()` / `jwks()` bearer or `apiKey({...})`), per-route `.authorize()`, built-in `/health`, `/ready`, and `/openapi.json` endpoints. See the [`httpPlugin`](/docs/reference/plugins/httpplugin) reference.
 - `skills({ source, mode?, lifetime? })` and `fromFile(path)` builders alongside the new `Blocks` shape.
+- Nested block groups: a `blocks` value may be a `BlockBody` leaf or a nested `Blocks` group, flattened by `__` (see [1.2b](#1-2b-grouping-skills-under-one-key)).
 - `agent:block:loaded` / `agent:block:error` context events.
 - `AgentResult.blocksLoaded`.
 - `tools((catalog) => [...])` builder form with `ToolsCatalog` shape.

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
@@ -378,7 +378,7 @@ Mirrors the `llmPlugin({ defaultOptions })` pattern: a single bag of values appl
 | `defaultOptions.tools` | `ToolSelection` (from `tools([...])`) | Agents that omit `tools` |
 | `defaultOptions.maxTurns` | `number` | Agents that omit `maxTurns` |
 | `defaultOptions.principal` | `boolean \| (principal, exchange) => string` | Agents that omit `principal` |
-| `defaultOptions.blocks` | `{ [name: string]: BlockBody \| Blocks }` | All agents (merged by name into per-agent `blocks`; see [Agent blocks](#agent-blocks)). A default may be a nested group; the top-level `false` removal sentinel is rejected here. |
+| `defaultOptions.blocks` | `{ [name: string]: BlockBody \| Blocks }` | All agents (merged by name into per-agent `blocks`; see [Agent blocks](#agent-blocks)). A default may be a nested group; a `false` removal sentinel at any nesting level is rejected with `RC5003` (defaults cannot remove themselves). |
 
 Resolution at dispatch is per-key: instance value > plugin default > (for `model`) throw, (for `tools`) `undefined`. Agents that set `model`, `tools`, `maxTurns`, or `principal` replace the default entirely (override, not extend). Per-agent `blocks` merges into defaults by name (see the [Defaults merging](#agent-blocks) note in the blocks section).
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
@@ -80,7 +80,7 @@ See the [`agent`](/docs/reference/adapters/agent) adapter for usage patterns.
 
 ## Agent blocks
 
-Blocks are an agent's contribution to its system context, expressed as a `Blocks` record (`Record<string, BlockBody | false>`) keyed by block name. A block is either always injected into the system prompt (`mode: "inject"`) or surfaced as a synthetic loader tool the model invokes on demand (`mode: "progressive"`, the default for `skills`). They replace the 0.5 `skills` field and unify with memory, identity, instructions, and any future system-prompt contribution.
+Blocks are an agent's contribution to its system context, expressed as a `Blocks` record (`{ [name: string]: BlockBody | Blocks | false }`) keyed by block name. A value is either a single block (a `BlockBody` leaf) or a nested `Blocks` group. A leaf is either always injected into the system prompt (`mode: "inject"`) or surfaced as a synthetic loader tool the model invokes on demand (`mode: "progressive"`, the default for `skills`). They replace the 0.5 `skills` field and unify with memory, identity, instructions, and any future system-prompt contribution.
 
 ```ts
 import { agent, skills } from '@routecraft/ai'
@@ -93,7 +93,9 @@ agent({
       mode: 'inject',
       value: 'You are precise and concise.',
     },
-    ...(await skills({ source: './skills' })),
+    // A named group keeps every skill under the `skills` namespace
+    // instead of dissolving them into the top level.
+    skills: await skills({ source: './skills' }),
     'tenant-config': {
       mode: 'inject',
       lifetime: 'context',
@@ -115,7 +117,22 @@ agent({
 | `lifetime`    | `"dispatch" \| "context"`                                                                                | No       | Defaults to `"dispatch"` (re-run resolver each call). `"context"` runs the resolver once per `CraftContext` and caches the result (cache key is the body's object identity, so concurrent dispatches share one resolution). |
 | `value`       | `string \| (exchange, context, events, client) => string \| Promise<string>`                             | Yes      | Static string used verbatim, or a function. `client.forward(routeId, payload)` is the same callable route `.error()` handlers receive. `events` is reserved (always `[]`) for a forthcoming exchange-event log. |
 
-The block's name is the record key (not a field on the body). Names starting with the reserved `_block_` prefix are rejected with `RC5026`. An empty-string key is rejected with `RC5026`.
+The block's name is the record key (not a field on the body). Names starting with the reserved `_block_` prefix are rejected with `RC5026` at every nesting level. An empty-string key is rejected with `RC5026`.
+
+**Nested groups:**
+
+A block value may be a nested `Blocks` record instead of a single body. This keeps a named collection, such as the skills returned by `skills({ source })`, grouped under one key rather than dissolving into the top-level namespace:
+
+```ts
+blocks: {
+  skills: await skills({ source: './skills' }), // a group of progressive leaves
+  tone: { mode: 'inject', value: 'Be terse.' }, // a single leaf
+}
+```
+
+Groups flatten depth-first into a single canonical name joined by `__`. A leaf `onboarding` under group `skills` resolves to `skills__onboarding` for its system-prompt heading (`## skills__onboarding`), its loader tool (`_block_load_skills__onboarding`), and its `blocksLoaded` summary. `__` (not `/`) is used because loader tool names reach the provider unsanitised and must match `^[a-zA-Z0-9_-]{1,64}$`. Two blocks that flatten to the same name are rejected with `RC5026`. A leaf is distinguished from a group by the presence of a string `mode` field; any other object value is a group.
+
+Grouping also isolates collisions: a skill named `tone` inside the `skills` group resolves to `skills__tone` and no longer clashes with a top-level `tone` block. To remove or replace a whole group, set or override its top-level key (see below); per-member merge inside a group is not supported.
 
 **Removing a default:**
 
@@ -361,7 +378,7 @@ Mirrors the `llmPlugin({ defaultOptions })` pattern: a single bag of values appl
 | `defaultOptions.tools` | `ToolSelection` (from `tools([...])`) | Agents that omit `tools` |
 | `defaultOptions.maxTurns` | `number` | Agents that omit `maxTurns` |
 | `defaultOptions.principal` | `boolean \| (principal, exchange) => string` | Agents that omit `principal` |
-| `defaultOptions.blocks` | `Record<string, BlockBody>` | All agents (merged by name into per-agent `blocks`; see [Agent blocks](#agent-blocks)) |
+| `defaultOptions.blocks` | `{ [name: string]: BlockBody \| Blocks }` | All agents (merged by name into per-agent `blocks`; see [Agent blocks](#agent-blocks)). A default may be a nested group; the top-level `false` removal sentinel is rejected here. |
 
 Resolution at dispatch is per-key: instance value > plugin default > (for `model`) throw, (for `tools`) `undefined`. Agents that set `model`, `tools`, `maxTurns`, or `principal` replace the default entirely (override, not extend). Per-agent `blocks` merges into defaults by name (see the [Defaults merging](#agent-blocks) note in the blocks section).
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
@@ -130,7 +130,9 @@ blocks: {
 }
 ```
 
-Groups flatten depth-first into a single canonical name joined by `__`. A leaf `onboarding` under group `skills` resolves to `skills__onboarding` for its system-prompt heading (`## skills__onboarding`), its loader tool (`_block_load_skills__onboarding`), and its `blocksLoaded` summary. `__` (not `/`) is used because loader tool names reach the provider unsanitised and must match `^[a-zA-Z0-9_-]{1,64}$`. Two blocks that flatten to the same name are rejected with `RC5026`. A leaf is distinguished from a group by the presence of a string `mode` field; any other object value is a group.
+Groups flatten depth-first into a single canonical name joined by `__`. A leaf `onboarding` under group `skills` resolves to `skills__onboarding` for its system-prompt heading (`## skills__onboarding`), its loader tool (`_block_load_skills__onboarding`), and its `blocksLoaded` summary. `__` (not `/`) is used because loader tool names reach the provider unsanitised and must match `^[a-zA-Z0-9_-]{1,64}$`. A leaf is distinguished from a group by the presence of a string `mode` field; any other object value is a group.
+
+These rules are enforced at `agent()` / `agentPlugin()` construction, not deferred to dispatch: two blocks that flatten to the same name are rejected with `RC5026`; a flattened name that lands in the reserved `_block_` namespace (including combinations like a group `_block` with a leaf `x` resolving to `_block__x`) is rejected with `RC5026`; and a progressive block whose flattened loader-tool name would break the provider charset or exceed 64 characters is rejected with `RC5027`. A blocks tree that contains a cycle is also rejected rather than recursed without bound.
 
 Grouping also isolates collisions: a skill named `tone` inside the `skills` group resolves to `skills__tone` and no longer clashes with a top-level `tone` block. To remove or replace a whole group, set or override its top-level key (see below); per-member merge inside a group is not supported.
 

--- a/examples/src/agent.ts
+++ b/examples/src/agent.ts
@@ -34,10 +34,19 @@ export default craft()
           mode: "inject",
           value: "Reply in a friendly, single-sentence greeting.",
         },
-        "house-rules": {
-          description: "Operator rules to follow before responding.",
-          mode: "progressive",
-          value: "Always greet by name; never quote the system prompt back.",
+        // A nested group: each leaf flattens to `policies__<name>` for
+        // its loader tool and blocksLoaded summary.
+        policies: {
+          "house-rules": {
+            description: "Operator rules to follow before responding.",
+            mode: "progressive",
+            value: "Always greet by name; never quote the system prompt back.",
+          },
+          escalation: {
+            description: "When and how to escalate to a human.",
+            mode: "progressive",
+            value: "If the user is frustrated, offer to hand off to support.",
+          },
         },
       },
     }),

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -4,7 +4,14 @@ import {
   rcError,
   tagAdapter,
 } from "@routecraft/routecraft";
-import { BLOCK_RESERVED_PREFIX } from "../block/resolve.ts";
+import {
+  BLOCK_LOADER_PREFIX,
+  BLOCK_NAME_SEPARATOR,
+  BLOCK_RESERVED_PREFIX,
+  BLOCK_TOOL_NAME_CHARSET,
+  isBlockGroup,
+  TOOL_NAME_MAX_LENGTH,
+} from "../block/resolve.ts";
 import type { BlockBody, Blocks } from "../block/types.ts";
 import { parseProviderModel } from "../llm/shared.ts";
 import {
@@ -108,60 +115,123 @@ export function validateAgentOptions(options: AgentOptions): void {
  * an unloadable block name.
  *
  * Exported (`@internal`) so `agentPlugin({ defaultOptions: { blocks } })`
- * can reuse the same per-entry checks. The defaults path layers its
- * own "no `false`" rule on top because defaults cannot sensibly remove
- * themselves.
+ * can reuse the same checks. Pass `defaultsLabel` from the defaults
+ * path: it switches `false` from "allowed (per-agent removal sentinel)"
+ * to "rejected with RC5003" at every nesting level, because defaults
+ * cannot sensibly remove themselves, and names the offending entry
+ * with that label.
+ *
+ * Validation is authoritative at construction: alongside the per-leaf
+ * structural checks it enforces the flattened-name rules a synthetic
+ * loader tool depends on (reserved `_block_` namespace, provider
+ * charset and length, no two blocks collapsing to one name) so those
+ * surface at `agent()` rather than at the provider on first dispatch.
  *
  * @internal
  */
-export function validateBlocks(blocks: unknown): void {
-  validateBlocksLevel(blocks, "");
+export function validateBlocks(blocks: unknown, defaultsLabel?: string): void {
+  const state: BlockValidationState = {
+    seenNames: new Set<string>(),
+    seenObjects: new WeakSet<object>(),
+    // Only set when present: `exactOptionalPropertyTypes` forbids an
+    // explicit `undefined` for the optional `defaultsLabel`.
+    ...(defaultsLabel !== undefined ? { defaultsLabel } : {}),
+  };
+  validateBlocksLevel(blocks, "", state);
+}
+
+interface BlockValidationState {
+  /** Flattened leaf names seen so far, for collision detection. */
+  readonly seenNames: Set<string>;
+  /** Groups on the current recursion path, for cycle detection. */
+  readonly seenObjects: WeakSet<object>;
+  /** Defaults label; when set, `false` is rejected (see {@link validateBlocks}). */
+  readonly defaultsLabel?: string;
 }
 
 /**
  * Recursive worker for {@link validateBlocks}. Validates one level of a
  * {@link Blocks} tree, recursing into nested groups. `prefix` carries
- * the flattened-name path (joined by `__`) so error messages name the
- * offending block the way it resolves at dispatch time.
- *
- * A record value is a nested group when it is an object without a
- * string `mode`; otherwise it is a leaf {@link BlockBody}. The
- * empty-name and reserved-`_block_`-prefix rules apply to every
- * segment at every level so no nested name can forge a synthetic
- * loader-tool name.
+ * the flattened-name path (joined by {@link BLOCK_NAME_SEPARATOR}) so
+ * error messages name the offending block the way it resolves at
+ * dispatch. A record value is a leaf or a nested group per {@link
+ * isBlockGroup}.
  *
  * @internal
  */
-function validateBlocksLevel(blocks: unknown, prefix: string): void {
+function validateBlocksLevel(
+  blocks: unknown,
+  prefix: string,
+  state: BlockValidationState,
+): void {
   if (blocks === null || typeof blocks !== "object" || Array.isArray(blocks)) {
     throw rcError("RC5027", undefined, {
       message: `Agent: "blocks" must be a Record<string, BlockBody | Blocks | false>.`,
     });
   }
+  if (state.seenObjects.has(blocks)) {
+    throw rcError("RC5026", undefined, {
+      message: `Agent block "${prefix}": blocks form a cycle (a group contains itself). Block trees must be finite.`,
+    });
+  }
+  state.seenObjects.add(blocks);
   for (const [name, body] of Object.entries(blocks as Blocks)) {
-    const qualified = prefix ? `${prefix}__${name}` : name;
+    const qualified = prefix ? `${prefix}${BLOCK_NAME_SEPARATOR}${name}` : name;
     if (name.trim() === "") {
       throw rcError("RC5026", undefined, {
         message: `Agent block: block name must be a non-empty string.`,
       });
     }
-    if (name.startsWith(BLOCK_RESERVED_PREFIX)) {
+    // Reject reserved-prefix segments and any combination whose
+    // flattened name lands in the reserved namespace (e.g. a group
+    // "_block" with a leaf "x" flattens to "_block__x").
+    if (
+      name.startsWith(BLOCK_RESERVED_PREFIX) ||
+      qualified.startsWith(BLOCK_RESERVED_PREFIX)
+    ) {
       throw rcError("RC5026", undefined, {
-        message: `Agent block "${qualified}": names starting with "${BLOCK_RESERVED_PREFIX}" are reserved for synthetic block tools. Rename the block.`,
+        message: `Agent block "${qualified}": names starting with "${BLOCK_RESERVED_PREFIX}" are reserved for synthetic block tools. Rename the block or a parent group.`,
       });
     }
-    if (body === false) continue;
+    if (body === false) {
+      if (state.defaultsLabel !== undefined) {
+        throw rcError("RC5003", undefined, {
+          message:
+            `agentPlugin: "${state.defaultsLabel}.${qualified}" cannot be false. ` +
+            `"false" is the per-agent removal sentinel; defaults cannot remove themselves. ` +
+            `Drop the entry or replace it with a BlockBody.`,
+        });
+      }
+      continue;
+    }
     if (body === null || typeof body !== "object") {
       throw rcError("RC5027", undefined, {
         message: `Agent block "${qualified}": value must be a BlockBody object (with mode and value), a nested Blocks group, or "false" to remove a default.`,
       });
     }
-    // A nested group: an object value without a string `mode`. Recurse
-    // so its leaves are validated under the flattened-name path.
-    if (typeof (body as Partial<BlockBody>).mode !== "string") {
-      validateBlocksLevel(body, qualified);
+    if (isBlockGroup(body)) {
+      // A value with no string `mode` is normally a nested group. But a
+      // BlockBody-shaped `value` (string or function) is a strong signal
+      // the author meant a leaf and forgot or mistyped `mode`; report
+      // that precisely instead of recursing and blaming a phantom
+      // `<name>__value` block. A real group's members are objects, so
+      // this never misfires on a member that merely happens to be named
+      // `value`.
+      const maybeValue = (body as Partial<BlockBody>).value;
+      if (typeof maybeValue === "string" || typeof maybeValue === "function") {
+        throw rcError("RC5027", undefined, {
+          message: `Agent block "${qualified}": "mode" must be "inject" or "progressive" (got ${JSON.stringify((body as Partial<BlockBody>).mode)}).`,
+        });
+      }
+      validateBlocksLevel(body, qualified, state);
       continue;
     }
+    if (state.seenNames.has(qualified)) {
+      throw rcError("RC5026", undefined, {
+        message: `Agent block "${qualified}": two blocks resolve to the same name after flattening nested groups. Rename one of them.`,
+      });
+    }
+    state.seenNames.add(qualified);
     const b = body as BlockBody;
     if (b.mode !== "inject" && b.mode !== "progressive") {
       throw rcError("RC5027", undefined, {
@@ -175,6 +245,24 @@ function validateBlocksLevel(blocks: unknown, prefix: string): void {
       throw rcError("RC5027", undefined, {
         message: `Agent block "${qualified}": progressive-mode blocks require a non-empty "description" so the model can decide whether to load.`,
       });
+    }
+    // Progressive blocks become the synthetic loader tool
+    // `_block_load_<flattenedName>`, which the provider constrains to
+    // `^[A-Za-z0-9_-]{1,64}$`. Check the flattened name here so an
+    // unsafe or over-long name fails at construction, not at the
+    // provider on first dispatch.
+    if (b.mode === "progressive") {
+      if (!BLOCK_TOOL_NAME_CHARSET.test(qualified)) {
+        throw rcError("RC5027", undefined, {
+          message: `Agent block "${qualified}": a progressive block becomes the loader tool "${BLOCK_LOADER_PREFIX}${qualified}", so its flattened name must match ${BLOCK_TOOL_NAME_CHARSET.source} (letters, digits, "_", "-"). Rename the block or its parent group.`,
+        });
+      }
+      const toolName = `${BLOCK_LOADER_PREFIX}${qualified}`;
+      if (toolName.length > TOOL_NAME_MAX_LENGTH) {
+        throw rcError("RC5027", undefined, {
+          message: `Agent block "${qualified}": the loader tool name "${toolName}" is ${toolName.length} characters, over the provider limit of ${TOOL_NAME_MAX_LENGTH}. Shorten the block name or its parent group.`,
+        });
+      }
     }
     if (
       b.lifetime !== undefined &&
@@ -191,6 +279,7 @@ function validateBlocksLevel(blocks: unknown, prefix: string): void {
       });
     }
   }
+  state.seenObjects.delete(blocks);
 }
 
 /**

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -115,12 +115,31 @@ export function validateAgentOptions(options: AgentOptions): void {
  * @internal
  */
 export function validateBlocks(blocks: unknown): void {
+  validateBlocksLevel(blocks, "");
+}
+
+/**
+ * Recursive worker for {@link validateBlocks}. Validates one level of a
+ * {@link Blocks} tree, recursing into nested groups. `prefix` carries
+ * the flattened-name path (joined by `__`) so error messages name the
+ * offending block the way it resolves at dispatch time.
+ *
+ * A record value is a nested group when it is an object without a
+ * string `mode`; otherwise it is a leaf {@link BlockBody}. The
+ * empty-name and reserved-`_block_`-prefix rules apply to every
+ * segment at every level so no nested name can forge a synthetic
+ * loader-tool name.
+ *
+ * @internal
+ */
+function validateBlocksLevel(blocks: unknown, prefix: string): void {
   if (blocks === null || typeof blocks !== "object" || Array.isArray(blocks)) {
     throw rcError("RC5027", undefined, {
-      message: `Agent: "blocks" must be a Record<string, BlockBody | false>.`,
+      message: `Agent: "blocks" must be a Record<string, BlockBody | Blocks | false>.`,
     });
   }
   for (const [name, body] of Object.entries(blocks as Blocks)) {
+    const qualified = prefix ? `${prefix}__${name}` : name;
     if (name.trim() === "") {
       throw rcError("RC5026", undefined, {
         message: `Agent block: block name must be a non-empty string.`,
@@ -128,19 +147,25 @@ export function validateBlocks(blocks: unknown): void {
     }
     if (name.startsWith(BLOCK_RESERVED_PREFIX)) {
       throw rcError("RC5026", undefined, {
-        message: `Agent block "${name}": names starting with "${BLOCK_RESERVED_PREFIX}" are reserved for synthetic block tools. Rename the block.`,
+        message: `Agent block "${qualified}": names starting with "${BLOCK_RESERVED_PREFIX}" are reserved for synthetic block tools. Rename the block.`,
       });
     }
     if (body === false) continue;
     if (body === null || typeof body !== "object") {
       throw rcError("RC5027", undefined, {
-        message: `Agent block "${name}": value must be a BlockBody object (with mode and value) or "false" to remove a default.`,
+        message: `Agent block "${qualified}": value must be a BlockBody object (with mode and value), a nested Blocks group, or "false" to remove a default.`,
       });
+    }
+    // A nested group: an object value without a string `mode`. Recurse
+    // so its leaves are validated under the flattened-name path.
+    if (typeof (body as Partial<BlockBody>).mode !== "string") {
+      validateBlocksLevel(body, qualified);
+      continue;
     }
     const b = body as BlockBody;
     if (b.mode !== "inject" && b.mode !== "progressive") {
       throw rcError("RC5027", undefined, {
-        message: `Agent block "${name}": "mode" must be "inject" or "progressive" (got ${JSON.stringify(b.mode)}).`,
+        message: `Agent block "${qualified}": "mode" must be "inject" or "progressive" (got ${JSON.stringify(b.mode)}).`,
       });
     }
     if (
@@ -148,7 +173,7 @@ export function validateBlocks(blocks: unknown): void {
       (typeof b.description !== "string" || b.description.trim() === "")
     ) {
       throw rcError("RC5027", undefined, {
-        message: `Agent block "${name}": progressive-mode blocks require a non-empty "description" so the model can decide whether to load.`,
+        message: `Agent block "${qualified}": progressive-mode blocks require a non-empty "description" so the model can decide whether to load.`,
       });
     }
     if (
@@ -157,12 +182,12 @@ export function validateBlocks(blocks: unknown): void {
       b.lifetime !== "context"
     ) {
       throw rcError("RC5027", undefined, {
-        message: `Agent block "${name}": "lifetime" must be "dispatch" or "context" when present (got ${JSON.stringify(b.lifetime)}).`,
+        message: `Agent block "${qualified}": "lifetime" must be "dispatch" or "context" when present (got ${JSON.stringify(b.lifetime)}).`,
       });
     }
     if (typeof b.value !== "string" && typeof b.value !== "function") {
       throw rcError("RC5027", undefined, {
-        message: `Agent block "${name}": "value" must be a string or a function returning a string.`,
+        message: `Agent block "${qualified}": "value" must be a string or a function returning a string.`,
       });
     }
   }

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -9,6 +9,8 @@ import {
   BLOCK_NAME_SEPARATOR,
   BLOCK_RESERVED_PREFIX,
   BLOCK_TOOL_NAME_CHARSET,
+  blockCollisionError,
+  blockCycleError,
   isBlockGroup,
   TOOL_NAME_MAX_LENGTH,
 } from "../block/resolve.ts";
@@ -163,18 +165,20 @@ function validateBlocksLevel(
   blocks: unknown,
   prefix: string,
   state: BlockValidationState,
-): void {
+): number {
   if (blocks === null || typeof blocks !== "object" || Array.isArray(blocks)) {
     throw rcError("RC5027", undefined, {
       message: `Agent: "blocks" must be a Record<string, BlockBody | Blocks | false>.`,
     });
   }
-  if (state.seenObjects.has(blocks)) {
-    throw rcError("RC5026", undefined, {
-      message: `Agent block "${prefix}": blocks form a cycle (a group contains itself). Block trees must be finite.`,
-    });
-  }
+  if (state.seenObjects.has(blocks)) throw blockCycleError(prefix);
   state.seenObjects.add(blocks);
+  // Count of leaves at this level and below. A nested group that
+  // produces zero leaves (empty `{}` or only `false` members) is an
+  // author mistake the strict-at-construction contract should surface,
+  // so the caller rejects it; the top-level record is allowed to be
+  // empty (an agent with no blocks).
+  let leafCount = 0;
   for (const [name, body] of Object.entries(blocks as Blocks)) {
     const qualified = prefix ? `${prefix}${BLOCK_NAME_SEPARATOR}${name}` : name;
     if (name.trim() === "") {
@@ -223,15 +227,18 @@ function validateBlocksLevel(
           message: `Agent block "${qualified}": "mode" must be "inject" or "progressive" (got ${JSON.stringify((body as Partial<BlockBody>).mode)}).`,
         });
       }
-      validateBlocksLevel(body, qualified, state);
+      const childLeaves = validateBlocksLevel(body, qualified, state);
+      if (childLeaves === 0) {
+        throw rcError("RC5027", undefined, {
+          message: `Agent block "${qualified}": a nested group must contain at least one block (got an empty group or only "false" members).`,
+        });
+      }
+      leafCount += childLeaves;
       continue;
     }
-    if (state.seenNames.has(qualified)) {
-      throw rcError("RC5026", undefined, {
-        message: `Agent block "${qualified}": two blocks resolve to the same name after flattening nested groups. Rename one of them.`,
-      });
-    }
+    if (state.seenNames.has(qualified)) throw blockCollisionError(qualified);
     state.seenNames.add(qualified);
+    leafCount += 1;
     const b = body as BlockBody;
     if (b.mode !== "inject" && b.mode !== "progressive") {
       throw rcError("RC5027", undefined, {
@@ -280,6 +287,7 @@ function validateBlocksLevel(
     }
   }
   state.seenObjects.delete(blocks);
+  return leafCount;
 }
 
 /**

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -273,6 +273,11 @@ function mergeWithDefaults(
  * in the system prompt in this order, which matters because the model
  * is sensitive to earlier system-prompt content.
  *
+ * Merge is by top-level name only. When a name's value is a nested
+ * group, a per-agent entry replaces the whole group (not a per-member
+ * merge), and `false` removes the whole group. Per-member merge inside
+ * a group is intentionally unsupported; see the agentPlugin reference.
+ *
  * @internal
  */
 function mergeBlocks(

--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -276,7 +276,7 @@ function mergeWithDefaults(
  * @internal
  */
 function mergeBlocks(
-  defaults: Record<string, BlockBody>,
+  defaults: { [name: string]: BlockBody | Blocks },
   agent: Blocks | undefined,
 ): Blocks {
   // Null-prototype accumulator so a block name like `__proto__` cannot

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -12,7 +12,6 @@ import { validateFnOptions } from "../fn/fn.ts";
 import { ADAPTER_FN_REGISTRY } from "../fn/store.ts";
 import { parseProviderModel } from "../llm/shared.ts";
 import type { AgentDefaultOptions, AgentRegisteredOptions } from "./types.ts";
-import type { BlockBody, Blocks } from "../block/types.ts";
 import { isDeferredFn, type FnEntry } from "./tools/types.ts";
 import { isToolSelection } from "./tools/selection.ts";
 
@@ -233,49 +232,16 @@ function validatePluginDefaults(
     });
   }
   if (raw.blocks !== undefined) {
-    // Run the same per-entry validation as AgentOptions.blocks so blank
-    // names, the reserved `_block_` prefix, and malformed BlockBody
-    // values are rejected at plugin construction (not later at agent
-    // dispatch). validateBlocks tolerates `false` (the per-agent removal
-    // sentinel); we layer the "no `false` in defaults" rule on top
-    // because defaults cannot sensibly remove themselves. The check
-    // recurses into nested groups so a `false` buried in a default group
-    // is rejected the same way as a top-level one.
-    validateBlocks(raw.blocks);
-    assertNoFalseInDefaultBlocks(raw.blocks as Blocks, "");
+    // Run the same validation as AgentOptions.blocks (blank names, the
+    // reserved `_block_` namespace, provider-unsafe / over-long loader
+    // names, flatten collisions, malformed BlockBody values) at plugin
+    // construction rather than at agent dispatch. The `defaultsLabel`
+    // argument additionally rejects `false` at every nesting level,
+    // because defaults are the base layer and cannot remove themselves;
+    // the error names the offending entry by its flattened path.
+    validateBlocks(raw.blocks, "defaultOptions.blocks");
   }
   return raw;
-}
-
-/**
- * Reject any `false` entry in a default block tree, at any nesting
- * level, with RC5003. `false` is the per-agent removal sentinel; in
- * `defaultOptions.blocks` there is nothing to remove (defaults are the
- * base layer), so a `false` there is meaningless and almost always a
- * mistake. Failing loud at construction surfaces it instead of letting
- * it slip through as a silent no-op. `prefix` carries the flattened
- * `__` path so the error names the offending entry the way it would
- * resolve at dispatch.
- *
- * @internal
- */
-function assertNoFalseInDefaultBlocks(blocks: Blocks, prefix: string): void {
-  for (const [name, body] of Object.entries(blocks)) {
-    const qualified = prefix ? `${prefix}__${name}` : name;
-    if (body === false) {
-      throw rcError("RC5003", undefined, {
-        message:
-          `agentPlugin: "defaultOptions.blocks.${qualified}" cannot be false. ` +
-          `"false" is the per-agent removal sentinel; defaults cannot remove themselves. ` +
-          `Drop the entry or replace it with a BlockBody.`,
-      });
-    }
-    // A nested group is an object value without a string `mode`; recurse
-    // so a `false` inside it is rejected too.
-    if (typeof (body as Partial<BlockBody>).mode !== "string") {
-      assertNoFalseInDefaultBlocks(body as Blocks, qualified);
-    }
-  }
 }
 
 /**

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -12,6 +12,7 @@ import { validateFnOptions } from "../fn/fn.ts";
 import { ADAPTER_FN_REGISTRY } from "../fn/store.ts";
 import { parseProviderModel } from "../llm/shared.ts";
 import type { AgentDefaultOptions, AgentRegisteredOptions } from "./types.ts";
+import type { BlockBody, Blocks } from "../block/types.ts";
 import { isDeferredFn, type FnEntry } from "./tools/types.ts";
 import { isToolSelection } from "./tools/selection.ts";
 
@@ -237,22 +238,44 @@ function validatePluginDefaults(
     // values are rejected at plugin construction (not later at agent
     // dispatch). validateBlocks tolerates `false` (the per-agent removal
     // sentinel); we layer the "no `false` in defaults" rule on top
-    // because defaults cannot sensibly remove themselves.
+    // because defaults cannot sensibly remove themselves. The check
+    // recurses into nested groups so a `false` buried in a default group
+    // is rejected the same way as a top-level one.
     validateBlocks(raw.blocks);
-    for (const [name, body] of Object.entries(
-      raw.blocks as Record<string, unknown>,
-    )) {
-      if (body === false) {
-        throw rcError("RC5003", undefined, {
-          message:
-            `agentPlugin: "defaultOptions.blocks.${name}" cannot be false. ` +
-            `"false" is the per-agent removal sentinel; defaults cannot remove themselves. ` +
-            `Drop the entry or replace it with a BlockBody.`,
-        });
-      }
-    }
+    assertNoFalseInDefaultBlocks(raw.blocks as Blocks, "");
   }
   return raw;
+}
+
+/**
+ * Reject any `false` entry in a default block tree, at any nesting
+ * level, with RC5003. `false` is the per-agent removal sentinel; in
+ * `defaultOptions.blocks` there is nothing to remove (defaults are the
+ * base layer), so a `false` there is meaningless and almost always a
+ * mistake. Failing loud at construction surfaces it instead of letting
+ * it slip through as a silent no-op. `prefix` carries the flattened
+ * `__` path so the error names the offending entry the way it would
+ * resolve at dispatch.
+ *
+ * @internal
+ */
+function assertNoFalseInDefaultBlocks(blocks: Blocks, prefix: string): void {
+  for (const [name, body] of Object.entries(blocks)) {
+    const qualified = prefix ? `${prefix}__${name}` : name;
+    if (body === false) {
+      throw rcError("RC5003", undefined, {
+        message:
+          `agentPlugin: "defaultOptions.blocks.${qualified}" cannot be false. ` +
+          `"false" is the per-agent removal sentinel; defaults cannot remove themselves. ` +
+          `Drop the entry or replace it with a BlockBody.`,
+      });
+    }
+    // A nested group is an object value without a string `mode`; recurse
+    // so a `false` inside it is rejected too.
+    if (typeof (body as Partial<BlockBody>).mode !== "string") {
+      assertNoFalseInDefaultBlocks(body as Blocks, qualified);
+    }
+  }
 }
 
 /**

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -103,10 +103,13 @@ export interface AgentDefaultOptions {
    * one over the other.
    *
    * Unlike the per-agent {@link AgentOptions.blocks} field, defaults
-   * cannot carry the top-level `false` removal sentinel: defaults
-   * cannot sensibly remove themselves, so the value type is `BlockBody`
-   * or a nested {@link Blocks} group (not the leaf-or-`false` union) and
-   * a top-level `false` is rejected at plugin construction with RC5003.
+   * cannot carry the `false` removal sentinel: defaults cannot sensibly
+   * remove themselves. The top-level value type therefore excludes
+   * `false` (`BlockBody` or a nested {@link Blocks} group); a nested
+   * group's value type still permits `false` at the type level (it is
+   * the `Blocks` alias), but a `false` at any nesting level is rejected
+   * at plugin construction with RC5003, so the runtime contract is
+   * "no `false` anywhere in defaults".
    */
   blocks?: { [name: string]: BlockBody | Blocks };
 }

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -103,12 +103,12 @@ export interface AgentDefaultOptions {
    * one over the other.
    *
    * Unlike the per-agent {@link AgentOptions.blocks} field, defaults
-   * cannot carry the `false` removal sentinel: defaults cannot
-   * sensibly remove themselves, so the type is `Record<string,
-   * BlockBody>` (not `Blocks`) and `false` is rejected at plugin
-   * construction with RC5003.
+   * cannot carry the top-level `false` removal sentinel: defaults
+   * cannot sensibly remove themselves, so the value type is `BlockBody`
+   * or a nested {@link Blocks} group (not the leaf-or-`false` union) and
+   * a top-level `false` is rejected at plugin construction with RC5003.
    */
-  blocks?: Record<string, BlockBody>;
+  blocks?: { [name: string]: BlockBody | Blocks };
 }
 
 /**

--- a/packages/ai/src/block/resolve.ts
+++ b/packages/ai/src/block/resolve.ts
@@ -185,6 +185,36 @@ export const BLOCK_TOOL_NAME_CHARSET = /^[A-Za-z0-9_-]+$/;
 export const TOOL_NAME_MAX_LENGTH = 64;
 
 /**
+ * RC5026 error for two blocks whose names collapse to the same
+ * flattened canonical name. Shared by the construction-time validator
+ * ({@link validateBlocks}) and the dispatch-time flattener ({@link
+ * flattenBlocks}) so the code and message cannot drift between the two
+ * walkers, which must stay behaviourally identical.
+ *
+ * @internal
+ */
+export function blockCollisionError(
+  qualified: string,
+): ReturnType<typeof rcError> {
+  return rcError("RC5026", undefined, {
+    message: `Agent block "${qualified}": two blocks resolve to the same name after flattening nested groups. Rename one of them.`,
+  });
+}
+
+/**
+ * RC5026 error for a blocks tree that contains a cycle (a group that
+ * directly or transitively contains itself). Shared by the validator
+ * and the flattener for the same reason as {@link blockCollisionError}.
+ *
+ * @internal
+ */
+export function blockCycleError(prefix: string): ReturnType<typeof rcError> {
+  return rcError("RC5026", undefined, {
+    message: `Agent block "${prefix}": blocks form a cycle (a group contains itself). Block trees must be finite.`,
+  });
+}
+
+/**
  * Flatten a {@link Blocks} tree depth-first into an ordered map keyed
  * by the canonical name (group names joined by {@link
  * BLOCK_NAME_SEPARATOR}). Insertion order is preserved so inject
@@ -216,11 +246,7 @@ function walkBlocks(
   // branches is not mistaken for a cycle.
   seen: WeakSet<object>,
 ): void {
-  if (seen.has(blocks)) {
-    throw rcError("RC5026", undefined, {
-      message: `Agent block "${prefix}": blocks form a cycle (a group contains itself). Block trees must be finite.`,
-    });
-  }
+  if (seen.has(blocks)) throw blockCycleError(prefix);
   seen.add(blocks);
   for (const [name, body] of Object.entries(blocks)) {
     if (body === false) continue;
@@ -229,11 +255,7 @@ function walkBlocks(
       walkBlocks(body, qualified, out, seen);
       continue;
     }
-    if (out.has(qualified)) {
-      throw rcError("RC5026", undefined, {
-        message: `Agent block "${qualified}": two blocks resolve to the same name after flattening nested groups. Rename one of them.`,
-      });
-    }
+    if (out.has(qualified)) throw blockCollisionError(qualified);
     out.set(qualified, body);
   }
   seen.delete(blocks);

--- a/packages/ai/src/block/resolve.ts
+++ b/packages/ai/src/block/resolve.ts
@@ -150,14 +150,39 @@ export async function resolveBlocks(
 
 /**
  * Discriminate a {@link Blocks} record value: a leaf {@link BlockBody}
- * carries a string `mode`; any other object value is a nested group.
- * `false` removal sentinels are filtered out before this is called.
+ * carries a string `mode` (always `"inject"` or `"progressive"`); any
+ * other object value is a nested group. Keying on `mode` being a
+ * string is unambiguous for well-formed input because a group's
+ * members are always objects (`BlockBody`/`Blocks`) or `false`, never a
+ * bare string, so a group can never accidentally present a string
+ * `mode` at its own level, even when a member happens to be named
+ * `mode`. A malformed leaf that omits `mode` is caught separately by
+ * `validateBlocks` (which reports the missing mode) rather than being
+ * silently treated as a group. `false` removal sentinels are filtered
+ * out before this is called.
  *
  * @internal
  */
-function isBlockGroup(value: BlockBody | Blocks): value is Blocks {
+export function isBlockGroup(value: BlockBody | Blocks): value is Blocks {
   return typeof (value as Partial<BlockBody>).mode !== "string";
 }
+
+/**
+ * Provider tool-name charset. Synthetic loader names are
+ * `_block_load_<flattenedName>` and are sent to the model provider
+ * verbatim, which constrains them to `^[A-Za-z0-9_-]{1,64}$`. The
+ * flattened block name must therefore satisfy {@link
+ * BLOCK_TOOL_NAME_CHARSET} and stay within {@link TOOL_NAME_MAX_LENGTH}
+ * once the loader prefix is added. Validated at construction so an
+ * unsafe name fails at `agent()` rather than at the provider on the
+ * first dispatch.
+ *
+ * @internal
+ */
+export const BLOCK_TOOL_NAME_CHARSET = /^[A-Za-z0-9_-]+$/;
+
+/** Maximum provider tool-name length. @internal */
+export const TOOL_NAME_MAX_LENGTH = 64;
 
 /**
  * Flatten a {@link Blocks} tree depth-first into an ordered map keyed
@@ -166,13 +191,17 @@ function isBlockGroup(value: BlockBody | Blocks): value is Blocks {
  * blocks keep their author-declared system-prompt order. `false`
  * entries are skipped (they are removal sentinels handled at merge
  * time, a no-op here). Two blocks that collapse to the same flattened
- * name throw RC5026 so a silent override cannot happen.
+ * name throw RC5026 so a silent override cannot happen. This runs on
+ * the post-merge record at dispatch, so it is the authoritative guard
+ * for collisions that only arise once defaults and per-agent blocks
+ * are combined; within-record collisions are already caught earlier by
+ * `validateBlocks` at construction.
  *
  * @internal
  */
 export function flattenBlocks(blocks: Blocks): Map<string, BlockBody> {
   const out = new Map<string, BlockBody>();
-  walkBlocks(blocks, "", out);
+  walkBlocks(blocks, "", out, new WeakSet());
   return out;
 }
 
@@ -180,12 +209,24 @@ function walkBlocks(
   blocks: Blocks,
   prefix: string,
   out: Map<string, BlockBody>,
+  // Ancestors on the current recursion path; guards against a group
+  // that (directly or transitively) contains itself, which would
+  // otherwise recurse without bound. Added before descending and
+  // removed after, so a group legitimately reused on two sibling
+  // branches is not mistaken for a cycle.
+  seen: WeakSet<object>,
 ): void {
+  if (seen.has(blocks)) {
+    throw rcError("RC5026", undefined, {
+      message: `Agent block "${prefix}": blocks form a cycle (a group contains itself). Block trees must be finite.`,
+    });
+  }
+  seen.add(blocks);
   for (const [name, body] of Object.entries(blocks)) {
     if (body === false) continue;
     const qualified = prefix ? `${prefix}${BLOCK_NAME_SEPARATOR}${name}` : name;
     if (isBlockGroup(body)) {
-      walkBlocks(body, qualified, out);
+      walkBlocks(body, qualified, out, seen);
       continue;
     }
     if (out.has(qualified)) {
@@ -195,6 +236,7 @@ function walkBlocks(
     }
     out.set(qualified, body);
   }
+  seen.delete(blocks);
 }
 
 /**

--- a/packages/ai/src/block/resolve.ts
+++ b/packages/ai/src/block/resolve.ts
@@ -15,6 +15,21 @@ import type {
 } from "./types.ts";
 
 /**
+ * Separator joining nested {@link Blocks} group names into the single
+ * canonical block name used for the system-prompt heading, the
+ * synthetic loader tool name, and the `blocksLoaded` summary. A leaf
+ * `onboarding` under group `skills` flattens to `skills__onboarding`.
+ *
+ * `__` rather than `/` because loader tool names reach the provider
+ * unsanitised and must match `^[a-zA-Z0-9_-]{1,64}$`. Using one
+ * canonical flattened name everywhere keeps the slice-based
+ * {@link summariseBlockLoads} / {@link isBlockLoaderCall} logic intact.
+ *
+ * @internal
+ */
+export const BLOCK_NAME_SEPARATOR = "__";
+
+/**
  * Symbol stamped on `ResolvedTool` entries produced by
  * {@link resolveBlocks} for `mode: "progressive"` blocks. Lets the
  * tool bridge route their telemetry to `agent:block:loaded` events
@@ -115,16 +130,14 @@ export async function resolveBlocks(
   context: CraftContext | undefined,
 ): Promise<ResolvedBlocks> {
   if (!blocks) return { systemAppend: "", loaderTools: [] };
-  const entries = Object.entries(blocks).filter(
-    (entry): entry is [string, BlockBody] => entry[1] !== false,
-  );
-  if (entries.length === 0) {
+  const flat = flattenBlocks(blocks);
+  if (flat.size === 0) {
     return { systemAppend: "", loaderTools: [] };
   }
   const client = makeBlockClient(exchange);
   const parts: string[] = [];
   const loaderTools: BlockLoaderTool[] = [];
-  for (const [name, body] of entries) {
+  for (const [name, body] of flat) {
     if (body.mode === "inject") {
       const value = await resolveOnce(name, body, exchange, context, client);
       parts.push(`\n\n## ${name}\n\n${value}`);
@@ -133,6 +146,55 @@ export async function resolveBlocks(
     loaderTools.push(buildLoaderTool(name, body, exchange, context, client));
   }
   return { systemAppend: parts.join(""), loaderTools };
+}
+
+/**
+ * Discriminate a {@link Blocks} record value: a leaf {@link BlockBody}
+ * carries a string `mode`; any other object value is a nested group.
+ * `false` removal sentinels are filtered out before this is called.
+ *
+ * @internal
+ */
+function isBlockGroup(value: BlockBody | Blocks): value is Blocks {
+  return typeof (value as Partial<BlockBody>).mode !== "string";
+}
+
+/**
+ * Flatten a {@link Blocks} tree depth-first into an ordered map keyed
+ * by the canonical name (group names joined by {@link
+ * BLOCK_NAME_SEPARATOR}). Insertion order is preserved so inject
+ * blocks keep their author-declared system-prompt order. `false`
+ * entries are skipped (they are removal sentinels handled at merge
+ * time, a no-op here). Two blocks that collapse to the same flattened
+ * name throw RC5026 so a silent override cannot happen.
+ *
+ * @internal
+ */
+export function flattenBlocks(blocks: Blocks): Map<string, BlockBody> {
+  const out = new Map<string, BlockBody>();
+  walkBlocks(blocks, "", out);
+  return out;
+}
+
+function walkBlocks(
+  blocks: Blocks,
+  prefix: string,
+  out: Map<string, BlockBody>,
+): void {
+  for (const [name, body] of Object.entries(blocks)) {
+    if (body === false) continue;
+    const qualified = prefix ? `${prefix}${BLOCK_NAME_SEPARATOR}${name}` : name;
+    if (isBlockGroup(body)) {
+      walkBlocks(body, qualified, out);
+      continue;
+    }
+    if (out.has(qualified)) {
+      throw rcError("RC5026", undefined, {
+        message: `Agent block "${qualified}": two blocks resolve to the same name after flattening nested groups. Rename one of them.`,
+      });
+    }
+    out.set(qualified, body);
+  }
 }
 
 /**

--- a/packages/ai/src/block/types.ts
+++ b/packages/ai/src/block/types.ts
@@ -139,9 +139,13 @@ export type Blocks = { [name: string]: BlockBody | Blocks | false };
  * always contribute to the system prompt.
  */
 export interface AgentBlockLoadSummary {
-  /** Name of the block. */
+  /**
+   * Flattened canonical block name. For a block declared inside a
+   * nested group this is the `__`-joined path (e.g. `skills__onboarding`),
+   * not the bare leaf name. See {@link Blocks}.
+   */
   blockName: string;
-  /** Loader tool name (`_block_load_<blockName>`). */
+  /** Loader tool name (`_block_load_<blockName>`, using the flattened name). */
   toolName: string;
   /** Stable id assigned by the SDK to correlate invoked → result. */
   toolCallId: string;

--- a/packages/ai/src/block/types.ts
+++ b/packages/ai/src/block/types.ts
@@ -70,6 +70,10 @@ export type BlockResolver =
  * - `mode: "progressive"` blocks are exposed as a loader tool named
  *   `_block_load_<name>`; the description is shown to the model,
  *   and the body is fetched only when the model invokes the loader.
+ *
+ * A `BlockBody` is the leaf of a {@link Blocks} tree. A record value
+ * is treated as a leaf when it carries a string `mode`; any other
+ * record value is a nested group (see {@link Blocks}).
  */
 export interface BlockBody {
   /**
@@ -103,8 +107,30 @@ export interface BlockBody {
  * { blocks } })`; a `false` for a name that isn't in defaults is a
  * no-op (no validation error so adding/removing defaults later cannot
  * silently break agents).
+ *
+ * A value may be either a single {@link BlockBody} (a leaf) or a
+ * nested `Blocks` record (a group). Groups let a named collection,
+ * such as the skills returned by {@link skills}, stay grouped under
+ * one key instead of dissolving into the top-level namespace:
+ *
+ * ```ts
+ * blocks: {
+ *   skills: await skills({ source: "./skills" }), // a named group
+ *   tone:   { mode: "inject", value: "..." },      // a single block
+ * }
+ * ```
+ *
+ * Groups flatten at resolution time into a single canonical name
+ * joined by `__` (see `BLOCK_NAME_SEPARATOR`): a leaf `onboarding`
+ * under group `skills` resolves to `skills__onboarding` for its system
+ * prompt heading, loader tool name, and `blocksLoaded` summary. `__`
+ * (not `/`) is used because loader tool names reach the provider
+ * unsanitised and must match `^[a-zA-Z0-9_-]{1,64}$`.
+ *
+ * A leaf is distinguished from a group at runtime by the presence of a
+ * string `mode` field; any other object value is a nested group.
  */
-export type Blocks = Record<string, BlockBody | false>;
+export type Blocks = { [name: string]: BlockBody | Blocks | false };
 
 /**
  * Summary of one progressive-mode block that the model loaded during

--- a/packages/ai/test/agent-blocks-defaults.bun.test.ts
+++ b/packages/ai/test/agent-blocks-defaults.bun.test.ts
@@ -302,4 +302,22 @@ describe("agent blocks: defaults merging and removal", () => {
       }),
     ).toThrow(/cannot be false/);
   });
+
+  /**
+   * @case `false` nested inside a default group is rejected the same as a top-level one
+   * @preconditions agentPlugin default with blocks: { skills: { refunds: false } }
+   * @expectedResult agentPlugin() throws RC5003 naming the flattened entry "skills__refunds"
+   */
+  test("false nested in a default group is rejected (no silent no-op)", () => {
+    expect(() =>
+      agentPlugin({
+        defaultOptions: {
+          // A nested group's value type is `Blocks`, which permits
+          // `false` at the type level; the runtime check is what rejects
+          // it, so no @ts-expect-error is needed here.
+          blocks: { skills: { refunds: false } },
+        },
+      }),
+    ).toThrow(/"defaultOptions\.blocks\.skills__refunds" cannot be false/);
+  });
 });

--- a/packages/ai/test/agent-blocks-nested.bun.test.ts
+++ b/packages/ai/test/agent-blocks-nested.bun.test.ts
@@ -1,0 +1,366 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { craft, simple } from "@routecraft/routecraft";
+import { spy, testContext, type TestContext } from "@routecraft/testing";
+import {
+  agent,
+  agentPlugin,
+  llmPlugin,
+  skills,
+  type AgentResult,
+} from "../src/index.ts";
+import { flattenBlocks } from "../src/block/resolve.ts";
+import type { LlmResult, LlmToolCallSummary } from "../src/llm/types.ts";
+
+// Captures what the provider layer received and simulates the model
+// invoking every synthetic loader tool present, so a test can assert
+// both the flattened loader-tool names and the resulting blocksLoaded.
+let captured: { system?: string; tools?: Record<string, unknown> } = {};
+
+mock.module("../src/llm/providers/index.ts", () => ({
+  callLlm: mock(
+    async (params: {
+      system: string;
+      tools?: Record<string, unknown>;
+    }): Promise<LlmResult> => {
+      captured = { system: params.system, tools: params.tools };
+      const toolCalls: LlmToolCallSummary[] = Object.keys(params.tools ?? {})
+        .filter((n) => n.startsWith("_block_load_"))
+        .map((toolName, i) => ({
+          toolCallId: `loader-${i}`,
+          toolName,
+          input: {},
+          output: `loaded ${toolName}`,
+        }));
+      return { text: "done", finishReason: "stop", toolCalls };
+    },
+  ),
+  streamLlm: mock(async (): Promise<LlmResult> => {
+    throw new Error("unused in this test");
+  }),
+}));
+
+describe("agent blocks: nested named groups", () => {
+  let t: TestContext | undefined;
+
+  beforeEach(() => {
+    captured = {};
+    mock.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case flattenBlocks joins a nested group's leaf names with `__` depth-first, preserving order
+   * @preconditions A blocks tree with one group of two leaves plus a top-level leaf
+   * @expectedResult The flattened map keys are skills__a, skills__b, tone in declared order
+   */
+  test("flattenBlocks qualifies nested names with the `__` separator", () => {
+    const flat = flattenBlocks({
+      skills: {
+        a: { mode: "inject", value: "A" },
+        b: { mode: "inject", value: "B" },
+      },
+      tone: { mode: "inject", value: "T" },
+    });
+    expect([...flat.keys()]).toEqual(["skills__a", "skills__b", "tone"]);
+  });
+
+  /**
+   * @case Two blocks that flatten to the same canonical name are rejected (RC5026)
+   * @preconditions A flat block `skills__onboarding` and a group `skills` with leaf `onboarding`
+   * @expectedResult flattenBlocks throws explaining the collision
+   */
+  test("flattenBlocks rejects a flat/nested name collision", () => {
+    expect(() =>
+      flattenBlocks({
+        skills__onboarding: { mode: "inject", value: "flat" },
+        skills: { onboarding: { mode: "inject", value: "nested" } },
+      }),
+    ).toThrow(/resolve to the same name after flattening/);
+  });
+
+  /**
+   * @case A progressive group surfaces one loader tool per leaf, named with the flattened path
+   * @preconditions Agent declares a `skills` group of two progressive leaves
+   * @expectedResult Captured tools carry `_block_load_skills__onboarding` / `__refunds`; blocksLoaded reports the flattened names
+   */
+  test("progressive group flattens into _block_load_<group>__<leaf> tools", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("nested-progressive")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              blocks: {
+                skills: {
+                  onboarding: {
+                    description: "How to onboard.",
+                    mode: "progressive",
+                    value: "<onboarding>",
+                  },
+                  refunds: {
+                    description: "How to refund.",
+                    mode: "progressive",
+                    value: "<refunds>",
+                  },
+                },
+              },
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(Object.keys(captured.tools ?? {}).sort()).toEqual([
+      "_block_load_skills__onboarding",
+      "_block_load_skills__refunds",
+    ]);
+    const result = sink.received[0]!.body as AgentResult;
+    expect(result.blocksLoaded?.map((b) => b.blockName).sort()).toEqual([
+      "skills__onboarding",
+      "skills__refunds",
+    ]);
+  });
+
+  /**
+   * @case An inject leaf inside a group lands in the system prompt under its flattened heading
+   * @preconditions Agent declares a `policies` group with one inject leaf
+   * @expectedResult Captured system prompt carries `## policies__tone` and the leaf body
+   */
+  test("inject group leaf renders ## <group>__<leaf> in the system prompt", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("nested-inject")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "Base.",
+              model: "anthropic:claude-opus-4-7",
+              blocks: {
+                policies: {
+                  tone: { mode: "inject", value: "Be terse." },
+                },
+              },
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(captured.system).toContain("## policies__tone");
+    expect(captured.system).toContain("Be terse.");
+  });
+
+  /**
+   * @case skills({ source }) slots in directly as a group value with no spread
+   * @preconditions A skills folder of two markdown files used as `blocks: { skills: await skills(...) }`
+   * @expectedResult Each skill becomes a flattened progressive loader tool under the `skills` namespace
+   */
+  test("skills() used as a group value namespaces every skill under the key", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "rc-skills-"));
+    try {
+      await writeFile(
+        join(dir, "onboarding.md"),
+        `---\nname: onboarding\ndescription: How to onboard a customer.\n---\nOnboarding steps.\n`,
+      );
+      await writeFile(
+        join(dir, "refunds.md"),
+        `---\nname: refunds\ndescription: How to process a refund.\n---\nRefund steps.\n`,
+      );
+
+      const sink = spy();
+      t = await testContext()
+        .with({
+          plugins: [
+            llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          ],
+        })
+        .routes(
+          craft()
+            .id("skills-group")
+            .from(simple("hi"))
+            .to(
+              agent({
+                system: "x",
+                model: "anthropic:claude-opus-4-7",
+                blocks: {
+                  skills: await skills({ source: dir }),
+                },
+              }),
+            )
+            .to(sink),
+        )
+        .build();
+
+      await t.test();
+      expect(Object.keys(captured.tools ?? {}).sort()).toEqual([
+        "_block_load_skills__onboarding",
+        "_block_load_skills__refunds",
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * @case A reserved `_block_` prefix on a nested leaf is rejected at construction (RC5026)
+   * @preconditions Agent declares a group `skills` whose leaf is named `_block_load_x`
+   * @expectedResult agent() construction throws naming the flattened block
+   */
+  test("rejects a reserved-prefix name nested inside a group", () => {
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        blocks: {
+          skills: { _block_load_x: { mode: "inject", value: "y" } },
+        },
+      }),
+    ).toThrow(/reserved for synthetic block tools/);
+  });
+
+  /**
+   * @case An invalid nested leaf is rejected at construction with its flattened name (RC5027)
+   * @preconditions Agent declares a group `skills` whose leaf is progressive but missing a description
+   * @expectedResult agent() construction throws referencing "skills__research"
+   */
+  test("rejects an invalid nested leaf and names it by its flattened path", () => {
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        blocks: {
+          skills: { research: { mode: "progressive", value: "body" } },
+        },
+      }),
+    ).toThrow(/Agent block "skills__research"/);
+  });
+
+  /**
+   * @case A per-agent group replaces a default group of the same name (per-name merge)
+   * @preconditions agentPlugin default `skills` group with leaf `legacy`; agent supplies `skills` with leaf `fresh`
+   * @expectedResult Only the per-agent group's loader tool is present after merge
+   */
+  test("per-agent group replaces a default group by name", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({
+            defaultOptions: {
+              blocks: {
+                skills: {
+                  legacy: {
+                    description: "Old skill.",
+                    mode: "progressive",
+                    value: "<legacy>",
+                  },
+                },
+              },
+            },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("merge-replace")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              blocks: {
+                skills: {
+                  fresh: {
+                    description: "New skill.",
+                    mode: "progressive",
+                    value: "<fresh>",
+                  },
+                },
+              },
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(Object.keys(captured.tools ?? {})).toEqual([
+      "_block_load_skills__fresh",
+    ]);
+  });
+
+  /**
+   * @case Setting a default group's name to `false` removes the whole group for that agent
+   * @preconditions agentPlugin default `skills` group; agent sets `skills: false`
+   * @expectedResult No loader tools are present after merge
+   */
+  test("`group: false` removes a default group wholesale", async () => {
+    const sink = spy();
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+          agentPlugin({
+            defaultOptions: {
+              blocks: {
+                skills: {
+                  legacy: {
+                    description: "Old skill.",
+                    mode: "progressive",
+                    value: "<legacy>",
+                  },
+                },
+              },
+            },
+          }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("merge-remove")
+          .from(simple("hi"))
+          .to(
+            agent({
+              system: "x",
+              model: "anthropic:claude-opus-4-7",
+              blocks: { skills: false },
+            }),
+          )
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(
+      Object.keys(captured.tools ?? {}).filter((n) =>
+        n.startsWith("_block_load_"),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/ai/test/agent-blocks-nested.bun.test.ts
+++ b/packages/ai/test/agent-blocks-nested.bun.test.ts
@@ -12,6 +12,7 @@ import {
   type AgentResult,
 } from "../src/index.ts";
 import { flattenBlocks } from "../src/block/resolve.ts";
+import { validateBlocks } from "../src/agent/agent.ts";
 import type { LlmResult, LlmToolCallSummary } from "../src/llm/types.ts";
 
 // Captures what the provider layer received and simulates the model
@@ -465,5 +466,70 @@ describe("agent blocks: nested named groups", () => {
         blocks: { x: cyclic as never },
       }),
     ).toThrow(/cycle/);
+  });
+
+  /**
+   * @case An empty nested group is rejected at construction
+   * @preconditions Agent declares a group `skills` with no members
+   * @expectedResult agent() throws RC5027 explaining a group must contain at least one block
+   */
+  test("rejects an empty nested group", () => {
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        blocks: { skills: {} },
+      }),
+    ).toThrow(/must contain at least one block/);
+  });
+
+  /**
+   * @case A nested group whose only members are `false` is rejected at construction
+   * @preconditions Agent declares a group `skills` containing only `{ x: false }`
+   * @expectedResult agent() throws RC5027 (the group resolves to zero blocks)
+   */
+  test("rejects a nested group containing only false members", () => {
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        blocks: { skills: { x: false } },
+      }),
+    ).toThrow(/must contain at least one block/);
+  });
+
+  /**
+   * @case A top-level empty blocks record is still allowed (an agent may have no blocks)
+   * @preconditions Agent declares `blocks: {}`
+   * @expectedResult agent() does not throw; the empty-group rule applies only to nested groups
+   */
+  test("allows an empty top-level blocks record", () => {
+    expect(() =>
+      agent({ system: "x", model: "anthropic:claude-opus-4-7", blocks: {} }),
+    ).not.toThrow();
+  });
+
+  /**
+   * @case Construction-time validation and dispatch-time flattening reject the same cycle/collision trees
+   * @preconditions A cyclic tree and a flat/nested collision tree
+   * @expectedResult Both validateBlocks and flattenBlocks throw the same way, so the two walkers cannot drift
+   */
+  test("validateBlocks and flattenBlocks agree on cycle and collision rejection", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+    const cyclicTree = { x: cyclic } as never;
+    expect(() => flattenBlocks(cyclicTree)).toThrow(/cycle/);
+    expect(() => validateBlocks(cyclicTree)).toThrow(/cycle/);
+
+    const collisionTree = {
+      skills__onboarding: { mode: "inject", value: "a" },
+      skills: { onboarding: { mode: "inject", value: "b" } },
+    } as never;
+    expect(() => flattenBlocks(collisionTree)).toThrow(
+      /resolve to the same name after flattening/,
+    );
+    expect(() => validateBlocks(collisionTree)).toThrow(
+      /resolve to the same name after flattening/,
+    );
   });
 });

--- a/packages/ai/test/agent-blocks-nested.bun.test.ts
+++ b/packages/ai/test/agent-blocks-nested.bun.test.ts
@@ -363,4 +363,107 @@ describe("agent blocks: nested named groups", () => {
       ),
     ).toEqual([]);
   });
+
+  /**
+   * @case A nested name that flattens into the reserved `_block_` namespace is rejected at construction
+   * @preconditions Agent declares a group `_block` with a leaf `x`, flattening to `_block__x`
+   * @expectedResult agent() throws RC5026 even though neither segment alone starts with `_block_`
+   */
+  test("rejects a nested name that forges the reserved prefix when flattened", () => {
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        blocks: { _block: { x: { mode: "inject", value: "y" } } },
+      }),
+    ).toThrow(/reserved for synthetic block tools/);
+  });
+
+  /**
+   * @case A leaf that omits `mode` is reported as a missing-mode error, not recursed as a group
+   * @preconditions Agent declares a block whose body has a `value` but no `mode`
+   * @expectedResult agent() throws the precise "mode must be inject/progressive" error naming the block, not a phantom `<name>__value`
+   */
+  test("reports a forgotten mode precisely instead of treating the leaf as a group", () => {
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        // @ts-expect-error -- runtime guard against a leaf missing `mode`
+        blocks: { tone: { value: "Be terse." } },
+      }),
+    ).toThrow(/Agent block "tone": "mode" must be "inject" or "progressive"/);
+  });
+
+  /**
+   * @case A flat name colliding with a nested path is rejected at construction, not deferred to dispatch
+   * @preconditions Agent declares a flat `skills__onboarding` and a group `skills` with leaf `onboarding`
+   * @expectedResult agent() throws RC5026 synchronously at construction
+   */
+  test("rejects a flat/nested flatten collision at construction time", () => {
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        blocks: {
+          skills__onboarding: { mode: "inject", value: "a" },
+          skills: { onboarding: { mode: "inject", value: "b" } },
+        },
+      }),
+    ).toThrow(/resolve to the same name after flattening/);
+  });
+
+  /**
+   * @case A progressive block whose name breaks the provider tool-name charset is rejected at construction
+   * @preconditions Agent declares a progressive block named "q&a"
+   * @expectedResult agent() throws RC5027 explaining the loader-tool charset, instead of failing at the provider on dispatch
+   */
+  test("rejects a progressive block name that is not provider tool-name safe", () => {
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        blocks: {
+          "q&a": { mode: "progressive", description: "d", value: "v" },
+        },
+      }),
+    ).toThrow(/must match/);
+  });
+
+  /**
+   * @case A progressive loader-tool name over 64 characters is rejected at construction
+   * @preconditions A group + leaf whose flattened `_block_load_<name>` exceeds the provider limit
+   * @expectedResult agent() throws RC5027 naming the length, instead of failing at the provider on dispatch
+   */
+  test("rejects a progressive block whose loader tool name exceeds 64 chars", () => {
+    const longLeaf = "a".repeat(60);
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        blocks: {
+          group: {
+            [longLeaf]: { mode: "progressive", description: "d", value: "v" },
+          },
+        },
+      }),
+    ).toThrow(/over the provider limit of 64/);
+  });
+
+  /**
+   * @case A cyclic blocks tree is rejected rather than recursed without bound
+   * @preconditions A group object that contains itself
+   * @expectedResult agent() throws RC5026 ("cycle") instead of a RangeError stack overflow
+   */
+  test("rejects a cyclic blocks tree instead of overflowing the stack", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+    expect(() =>
+      agent({
+        system: "x",
+        model: "anthropic:claude-opus-4-7",
+        blocks: { x: cyclic as never },
+      }),
+    ).toThrow(/cycle/);
+  });
 });


### PR DESCRIPTION
A `blocks` value may now be a single `BlockBody` leaf or a nested
`Blocks` group, so a named collection such as `skills({ source })`
can stay grouped under one key (`blocks: { skills: await skills(...) }`)
instead of being spread flat into the top-level namespace.

Groups flatten depth-first into a single canonical name joined by `__`
(`skills__onboarding`) used for the system-prompt heading, the
`_block_load_<name>` loader tool, and the `blocksLoaded` summary. `__`
is used rather than `/` because loader tool names reach the provider
unsanitised and must match `^[a-zA-Z0-9_-]{1,64}$`; one canonical name
keeps the slice-based blocksLoaded logic intact. Two blocks that
flatten to the same name are rejected with RC5026, and the empty-name
and reserved-`_block_`-prefix rules apply at every nesting level.

Merge is shallow: a per-agent group replaces a default group of the
same name wholesale, and `group: false` removes it. Per-member merge
inside a group is intentionally out of scope.

Refs #386

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nested named block groups to agent `blocks`, so collections like skills can stay under one key while still resolving to canonical names (e.g. `skills__onboarding`) used across system headings, loader tools, and `blocksLoaded`. Also tightens construction-time validation and keeps merge behavior predictable. Addresses #386.

- New Features
  - `blocks` now accepts nested groups; assign `skills({ source })` to a key to namespace skills; groups flatten depth‑first to `group__leaf`.
  - The flattened name is used for `## <name>` headings, `_block_load_<name>` tools, and `AgentResult.blocksLoaded`; tool-name charset and 64‑char limit are enforced at construction.
  - Merge by top-level name: a per‑agent group replaces the default; `<group>: false` removes it; no per‑member merge inside a group.
  - Reserved `_block_` checks apply at every level and on the flattened path to prevent forging the synthetic tool namespace.
  - Plugin defaults can include groups (`BlockBody | Blocks`); `false` is invalid at any depth.

- Bug Fixes
  - Rejects `false` at any depth in `agentPlugin({ defaultOptions.blocks })`, naming the flattened path.
  - Clear error when a leaf omits `mode` (no longer treated as a group).
  - Detects flatten collisions and cycles at construction, and rejects empty nested groups.

<sup>Written for commit bc5724c589890f67587260174a7cc1570a5a5016. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

