### PR TITLE
docs(mcp): explain raw vs guarded vs route-wrapped agent tool access

### DIFF
--- a/apps/routecraft.dev/src/app/docs/advanced/call-an-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/call-an-mcp/page.md
@@ -83,6 +83,45 @@ If you only need to call a single external tool and do not want to register it g
 .to(mcp({ url: 'http://127.0.0.1:8089/mcp', tool: 'navigate' }))
 ```
 
+## Guardrails: raw, guarded, or wrapped
+
+A raw MCP tool carries no per-call policy. When an agent calls one, the credentials registered on the client are what reach the server; the agent does not forward the caller's principal to the MCP hop (this keeps the two trust boundaries separate -- see [Securing capabilities](/docs/advanced/securing-capabilities)). So a raw tool has no identity check, no caching, and no timeout of its own. You add those on the Routecraft side, and there are three tiers to choose from.
+
+**Pick the lowest tier that covers what you need.** The moment you need caching, a timeout, throttling, retry, a fallback, or an audit trail, you are at tier 3: a guard is a single predicate with no state and no clock, so it can answer "may John call this?" but it cannot hold a cache or a deadline.
+
+| You need | Use | Cost | Reusable |
+|---|---|---|---|
+| A read-only or otherwise harmless tool, trusted agent | raw `MCP(server:tool)` | nothing | n/a |
+| To block by identity or role, a pure yes/no | a per-tool `guard` on the binding | one inline function | no, per binding |
+| Anything stateful or time-based, or shared across agents | wrap the tool in a route, hand the agent `Direct(<id>)` | a few lines | yes |
+
+Tiers 1 and 2 are covered on the [agent plugin reference](/docs/reference/plugins/agentplugin). For tier 3, put a route in front of the tool: its entry is a `direct()` endpoint, its exit is the `.to(mcp(...))` call you have already seen, and the guardrails live on the steps between.
+
+```ts
+// capabilities/github/create-issue.ts
+import { mcp } from '@routecraft/ai'
+import { craft, direct } from '@routecraft/routecraft'
+
+export default craft()
+  .id('github.create-issue')
+  .from(direct())
+  .authorize({ roles: ['maintainer'] }) // per-call principal check
+  .to(mcp('github:create_issue'))
+```
+
+Hand the agent the governed route instead of the raw tool. The same underlying tool can be exposed both ways: wrap the ones that need policy (one route per tool), leave harmless read-only tools raw.
+
+```ts
+agent({
+  tools: tools([
+    'Direct(github.create-issue)', // governed: authorized and auditable
+    'MCP(github:list_issues)',     // raw: read-only, fine ungoverned
+  ]),
+})
+```
+
+Why a route and not a richer guard? A guard runs once and holds no state. Caching, timeouts, throttling, retries, and fallbacks each need something wrapped around the call with its own state and lifecycle, which is exactly what a route step is. Today a wrapped route gives you [`authorize()`](/docs/reference/operations/authorize), [`error()`](/docs/reference/operations/error) fallbacks, and `.tap(log())` for an audit trail immediately. [`cache()`](/docs/reference/operations/cache), [`timeout()`](/docs/reference/operations/timeout), [`throttle()`](/docs/reference/operations/throttle), and [`retry()`](/docs/reference/operations/retry) are planned; when they ship they drop onto the same route with no change to how the agent consumes the tool. The route is the only place that behaviour can ever live.
+
 ---
 
 ## Related

--- a/apps/routecraft.dev/src/app/docs/advanced/securing-capabilities/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/securing-capabilities/page.md
@@ -320,6 +320,7 @@ The OAuth-proxy mode's SDK-owned endpoints (`/register`, `/token`, `/revoke`, th
 - **Guardrails** -- use `.filter()` to reject exchanges that fail a business rule, and `.transform()` to sanitize or normalise values before they reach downstream systems
 - **Authorize per route** -- gate sensitive capabilities with [`authorize()`](/docs/reference/operations/authorize) against the verified principal's roles or scopes
 - **Principle of least privilege** -- only expose capabilities the AI actually needs
+- **Govern agent tool access** -- hand an agent a wrapped `Direct(...)` route instead of a raw `MCP(...)` tool when it needs authorization, caching, or timeouts; see [Calling an MCP](/docs/advanced/call-an-mcp#guardrails-raw-guarded-or-wrapped)
 - **Audit trail** -- add `.tap(log())` to record every invocation; subscribe to `plugin:mcp:tool:**` events for MCP-specific tracing
 - **Never hardcode credentials** -- use `process.env` and `.env` files
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
@@ -356,6 +356,8 @@ Resolution rules:
 
 MCP tools are NOT exposed via a builder. Use the `MCP(server:tool)` / `MCP(server)` grammar (or the raw `mcp__server__tool` form) inside `tools([...])` instead; the registry populated by `defineConfig.mcp` is the source of truth.
 
+When to hand an agent a raw `MCP(...)` tool versus a wrapped `Direct(...)` route -- and why a guard cannot stand in for the wrap -- is covered in [Calling an MCP](/docs/advanced/call-an-mcp#guardrails-raw-guarded-or-wrapped).
+
 #### Tags
 
 Apply with `.tag(value | values[])` on routes and `tags?: Tag[]` on `FnOptions`. Empty strings are rejected; surrounding whitespace is trimmed at storage so exact comparisons match.


### PR DESCRIPTION
Add a "Guardrails: raw, guarded, or wrapped" section to the Calling an MCP
page documenting the three tiers for governing the MCP tools an agent
consumes: raw MCP(...) for harmless tools, a per-tool guard for pure yes/no
identity checks, and wrapping in a direct route (handed to the agent as
Direct(...)) for anything stateful or time-based.

The section owns the decision table and the rule (pick the lowest tier; a
guard has no state or clock, so cache/timeout/throttle force the wrap). It
marks cache/timeout/throttle/retry as planned and authorize/error/tap(log)
as available today, so the page does not overstate what ships.

Cross-link from the agent plugin reference (where the tool reference forms
are catalogued) and the securing-capabilities checklist, keeping a single
owner per the content-and-docs "no silent duplication" rule.

https://claude.ai/code/session_01A1xcYFLXg95ybauQJDe9PX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Guardrails: raw, guarded, or wrapped” section to the Calling an MCP docs explaining when to hand agents raw `MCP(...)` tools, a per-tool guard, or a route-wrapped `Direct(...)`. Includes a simple decision rule and table, with examples and notes on what ships now vs planned.

- New Features
  - Documents the route-wrapping pattern for stateful/time-based controls with `authorize()`, `error()`, and `.tap(log())`; marks `cache()`, `timeout()`, `throttle()`, and `retry()` as planned.
  - Adds cross-links from the agent plugin reference and Securing Capabilities, guiding teams to expose governed tools as `Direct(<id>)`.

<sup>Written for commit 254bf951df7e67225a59e9ab27ffd901f0e88446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

