### PR TITLE
feat(operations): add step-scope .cache() wrapper with pluggable provider (#112)

### DIFF
--- a/.standards/pre-from-filter-chain.md
+++ b/.standards/pre-from-filter-chain.md
@@ -1,0 +1,247 @@
+# Pre-from Filter Chain
+
+The framework runs a fixed, ordered chain of filters around every
+exchange before the user pipeline runs (and a small tail after it).
+The chain is the contract: it is **not affected** by the order in
+which `.input()`, `.authorize()`, `.cache()`, `.error()`, etc. are
+called on the builder. Builder order is for ergonomics; runtime
+order is the framework's call.
+
+This document is the single source of truth for that order. Future
+resilience wrappers (`.retry()`, `.timeout()`, `.circuitBreaker()`,
+`.throttle()`) slot into the positions named below.
+
+Inspiration: Spring's `FilterChainProxy` / `WebSecurityConfigurerAdapter`
+and Resilience4J's wrapper composition. The framework picks the
+order; the user opts filters in by declaring them.
+
+---
+
+## 1. The chain
+
+Outside in. Position 1 is outermost (runs first / wraps everything
+below).
+
+| # | Filter | Status | Throws on rejection? | Notes |
+|---|---|---|---|---|
+| 1 | `error` | shipped (#119, #140) | — | catches throws from everything below; handler picks what to recover |
+| 2 | `authorize` (stacks) | shipped | yes (`RC5012` / `RC5015`) | identity gate; deterministic, not retried |
+| 3 | `parse` | shipped (source-attached) | yes (`RC5016`) | raw bytes → typed body; deterministic, not retried |
+| 4 | `input` | shipped | yes (`RC5002`) | schema validation; deterministic, not retried |
+| 5 | `throttle` | planned | yes (`RC5013`) | rate limit valid requests (not pre-auth; that's source-layer DoS protection) |
+| 6 | `circuitBreaker` | planned (#139) | yes (new RC code, fast-fail when open) | counts inner failures; trips after threshold |
+| 7 | `retry` | planned | yes (final attempt's throw) | re-runs everything below on failure |
+| 8 | `timeout` | planned | yes (`RC5011`) | per-attempt deadline |
+| 9 | `cacheCheck` | shipped (#112) | yes (`RC5028` / `RC5029`) | hit → short-circuit pipeline |
+| — | **user pipeline** | — | — | declaration order; everything after `.from()` |
+| 10 | `cacheStore` | shipped (#112) | swallows (`cache:failed phase:"set"`) | best-effort write; runs only on miss-success |
+
+---
+
+## 2. Why this order
+
+### Top half (1-4): deterministic gates
+
+These are guards, not work. They're cheap, deterministic, and run
+once per request. Retrying them is pointless — they fail the same
+way every time.
+
+- **`error` outermost.** Conceptually filter #1: its try/catch
+  wraps the rest of the chain. Same shape as Spring's
+  `ExceptionTranslationFilter`. Implementation note: realized as a
+  catch boundary around the chain rather than as a step that calls
+  `next()`, because the wrap is uniform.
+- **`authorize` before `parse`.** Authorize reads the principal
+  from headers; it doesn't need a parsed body. Running auth first
+  means an unauthenticated caller gets a clean `401` / `403`
+  without the framework leaking schema information via a `400`.
+- **`parse` before `input`.** Input validates the parsed shape, not
+  raw bytes.
+- **`input` before resilience wrappers.** A request that fails
+  schema is never going to succeed on retry. Reject before any
+  resilience layer accepts the cost.
+
+### Middle (5-8): resilience wrappers
+
+These DO retry / time out / fail fast. Standard outside-in.
+
+- **`throttle` outside `circuitBreaker`.** Rate limit comes before
+  failure stats. A throttled request shouldn't count as a breaker
+  failure (the inner operation didn't even run).
+- **`circuitBreaker` outside `retry`.** When the breaker is open,
+  fast-fail. Putting `retry` inside the breaker means retries
+  happen *within* one breaker call (Resilience4J convention).
+- **`retry` outside `timeout`.** Each retry attempt gets its own
+  deadline. If `timeout` were outside `retry`, total time would be
+  one deadline shared across attempts; per-attempt timeout is more
+  useful for the common case.
+
+### Bottom (9-10): cache
+
+Innermost. The pipeline's surface.
+
+- **`cacheCheck` innermost above pipeline.** A hit short-circuits
+  the pipeline without triggering retry / breaker / timeout (a hit
+  is a successful zero-cost call from those layers' perspective).
+- **`cacheStore` below pipeline.** Runs only on miss-success.
+  Skipped on cache hit (the check pushed an empty `steps[]`
+  short-circuit). Skipped on pipeline drop / failure. Write errors
+  are swallowed (`cache:failed phase:"set"`); the work is already
+  done.
+
+---
+
+## 3. Composition with `error`
+
+`error` catches every throw from filters 2-9 and the user pipeline.
+The handler decides what to recover:
+
+```ts
+.error((err) => {
+  // Deterministic gate rejections: re-throw so the source can
+  // translate (HTTP source → 401 / 403 / 400; MCP source → error
+  // response).
+  if (['RC5012', 'RC5015', 'RC5002', 'RC5016'].includes(err.rc)) throw err
+
+  // Throttle / breaker: re-throw to surface backpressure to the caller.
+  if (['RC5013'].includes(err.rc)) throw err
+
+  // Operational failures: recover with a fallback.
+  if (err.rc === 'RC5011') return { fallback: 'timeout' }
+  if (err.rc === 'RC5028') return { fallback: 'cache-down', data: lastKnownGood }
+
+  // Anything we didn't whitelist: propagate.
+  throw err
+})
+```
+
+Default (no `.error()`): every throw propagates to the route-level
+default error path (`route:<id>:error` + `context:error` +
+`exchange:failed`). The route is NOT stopped; the next exchange
+processes normally.
+
+---
+
+## 4. Combined-wrapper scenarios
+
+### Timeout fires inside retry
+
+1. `timeout` throws `RC5011` on deadline expiry.
+2. `retry` catches the throw, decides whether to re-attempt.
+3. After max attempts, the final `RC5011` propagates up through
+   `circuitBreaker` (counts as a failure → may trip) → `throttle`
+   (no-op) → `error` (handler decides recovery).
+
+### Breaker is open
+
+1. `circuitBreaker` fast-fails with its rejection code BEFORE
+   `retry` / `timeout` run.
+2. `retry` never sees a real attempt; it propagates the breaker
+   rejection upward unchanged (configurable — some users may want
+   `retry` to retry past an open breaker for a different breaker
+   they own).
+3. `error` catches.
+
+### Throttle rejects
+
+1. `throttle` throws `RC5013`.
+2. `circuitBreaker` is *inside* throttle, so it doesn't run; doesn't
+   count this as a failure.
+3. `error` catches.
+
+### Cache hit
+
+1. `cacheCheck` finds a hit, pushes the rewrapped exchange with no
+   remaining steps. Pipeline skipped. `cacheStore` skipped.
+2. `timeout` / `retry` / `circuitBreaker` see a successful
+   zero-cost return.
+3. `error` is not invoked. The cached body is returned to the
+   source.
+
+### Pipeline throws
+
+1. The throw propagates upward through `cacheStore` (skipped — only
+   runs on miss-success) → `cacheCheck` (already passed; just
+   re-throws) → `timeout` (still inside deadline; re-throws) →
+   `retry` (decides re-attempt) → `circuitBreaker` (counts failure)
+   → `throttle` (no-op) → `error`.
+
+### `cacheStore` write fails (custom provider)
+
+1. The write throws inside `cacheStore`.
+2. `cacheStore` swallows the throw and emits `cache:failed
+   phase:"set"` instead.
+3. The exchange completes successfully with the freshly-computed
+   body. `error` is not invoked.
+
+Rationale: by the time `cacheStore` runs, the work is done.
+Surfacing a cache-backend blip as an exchange failure would discard
+the result we just computed, which is worse than failing the cache
+write.
+
+---
+
+## 5. What this commits the framework to
+
+- **No reorder API.** Users opt filters in by declaring them; the
+  chain order is the framework's call. If a future use case really
+  needs a different order, it's an explicit RFC, not a per-route
+  knob.
+- **All wrappers throw on rejection.** `error` is the universal
+  catch; recovery is opt-in per RC code in the handler.
+- **Deterministic gates above resilience wrappers.** Auth / parse /
+  input run once per request, not retried.
+- **Cache is below resilience wrappers.** A timeout / retry /
+  breaker around cache means the framework can retry pipeline
+  calls that exceeded their deadline; cache hits short-circuit
+  without triggering them.
+
+---
+
+## 6. Implementation status
+
+Today (as of #112 / 0.6.0):
+
+- Filters 1-4 and 9-10 are implemented; the chain runs in the
+  order documented above.
+- The chain is implicit in `runSteps` (the cache check / store
+  are inserted into `initialSteps` at known positions; authorize
+  steps are peeled from the head of `userSteps` via
+  `RouteDefinition.authorizerCount`).
+
+Planned (next refactor PR):
+
+- Promote the chain to a first-class data model: `RouteDefinition`
+  gains explicit `preFromFilters: Step<Adapter>[]` and
+  `postFromFilters: Step<Adapter>[]`. `authorizerCount` goes
+  away. `cacheConfig` is folded into the relevant filters'
+  closures.
+- `runSteps` collapses to a single chain loop:
+  `[...preFromFilters, ...steps, ...postFromFilters]` wrapped in
+  the `error` catch boundary.
+- Eager input validation (currently in `start()`, outside
+  `runSteps`) moves into the chain as the `input` filter. One code
+  path for parse and non-parse sources.
+
+Filters 5-8 will be added by their respective issues
+(`.throttle()`, `.circuitBreaker()` (#139), `.retry()`,
+`.timeout()`) into the slots reserved above. Each adds ~one
+filter implementation, not ~100 lines of inlined `runSteps`
+logic.
+
+---
+
+## 7. Cross-references
+
+- `.standards/resilience-wrappers.md` -- the dual-mode wrapper
+  pattern (step-scope wrappers); the route-scope half is this
+  chain.
+- #112 -- `.cache()` operation (filters 9-10 shipped here).
+- #119 -- route-level `.error()` (filter 1 shipped here).
+- #140 -- dual-mode wrapper pattern (closed; the contract this
+  chain inherits at the route-scope side).
+- #139 -- circuit breaker (filter 6 will land here).
+- Spring Security `FilterChainProxy`: similar pattern at a
+  different scale.
+- Resilience4J wrapper composition: the resilience-tier ordering
+  follows their convention.

--- a/.standards/resilience-wrappers.md
+++ b/.standards/resilience-wrappers.md
@@ -161,9 +161,19 @@ For `.error()` the wrapper emits the existing `error-handler:*` set.
 A new wrapper picks its own family (e.g. `retry:*`, `timeout:*`,
 `cache:*`).
 
+The `invoked` / `recovered` / `failed` triple above is the default
+shape, but a wrapper whose domain does not map cleanly onto it MAY
+emit a domain-specific family instead, as long as it keeps the
+`scope` / `stepLabel` bindings. `.cache()` is the first such case: it
+emits `cache:hit` / `cache:miss` / `cache:stored` / `cache:failed`
+(with `cache:failed` carrying a `phase` discriminator) because
+"hit/miss/stored" describes cache behaviour far better than
+"invoked/recovered". When you diverge, document the family in the
+operation's reference page and in `docs/reference/events`.
+
 Wildcard subscribers (`route:*:error-handler:*`,
-`route:*:retry:*`) keep matching; the new `scope` and `stepLabel`
-fields are additive.
+`route:*:retry:*`, `route:*:cache:*`) keep matching; the new `scope`
+and `stepLabel` fields are additive.
 
 ## 7. When a wrapper is not enough
 
@@ -212,8 +222,19 @@ accordingly.
 - `#139` (Circuit Breaker): see "When a wrapper is not enough"; the
   step-scope side is a wrapper, the route-scope side needs consumer
   integration.
-- `#112` (Cache): pure wrapper at both scopes; first wrapper after
-  `.error()` to validate the pattern at scale.
+- `#112` (Cache): dual-mode at both scopes. Step-scope wraps the
+  immediately-next step via `CacheWrapperStep`. Route-scope (called
+  BEFORE `.from()`) caches the route's terminal body keyed by the
+  source-emitted message and skips the whole pipeline on a hit;
+  wired into `RouteDefinition.cacheConfig` and applied in `runSteps`.
+  Routes containing `.split()` reject route-scope cache at build time
+  (`RC5003`) until split-then-aggregate semantics are decided.
+- [Pre-from Filter Chain](./pre-from-filter-chain.md): the
+  route-scope counterpart of this contract. Documents the fixed
+  ordered chain (`error` -> `authorize` -> `parse` -> `input` ->
+  `throttle` -> `circuitBreaker` -> `retry` -> `timeout` ->
+  `cacheCheck` -> pipeline -> `cacheStore`) and reserves slots for
+  the future resilience wrappers listed in section 1.
 - `WrapperStep` source: `packages/routecraft/src/operations/wrapper.ts`.
 - `ErrorWrapperStep` source:
   `packages/routecraft/src/operations/error-wrapper.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Detailed coding standards for contributors live in `.standards/`:
 - [Testing](.standards/testing.md) -- runner conventions, JSDoc-on-every-test, helpers, lifecycle, assertion patterns
 - [CI/CD](.standards/ci-cd.md) -- PR gates, hook policy, peer-dependency rules, release flow
 - [Resilience Wrappers](.standards/resilience-wrappers.md) -- dual-mode wrapper pattern (`.error()` and future resilience ops), authoring contract
+- [Pre-from Filter Chain](.standards/pre-from-filter-chain.md) -- fixed ordered chain at route scope (`error` / `authorize` / `parse` / `input` / `throttle` / `circuitBreaker` / `retry` / `timeout` / `cacheCheck` / pipeline / `cacheStore`); framework picks the order, future wrappers slot into reserved positions
 - [Security](.standards/security.md) -- JWT / JWKS verification, principal propagation, bearer-token handling, `userinfo` enrichment, RFC 9728 metadata, `authorize()` semantics
 - [API Stability](.standards/api-stability.md) -- the v0 policy: the whole public API is unstable, so we tag only `@internal` and `@deprecated`; per-symbol `@experimental` / `@beta` / `@stable` tiers arrive at v1
 - [Content and Docs](.standards/content-and-docs.md) -- where content belongs across docs and blog (the five surfaces), introduction-vs-advanced depth axis, code-lives-once, nav-matches-folders, the `route.ts` public-surface decision, static-export redirect constraint

--- a/apps/routecraft.dev/src/app/docs/advanced/filter-chain/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/filter-chain/page.md
@@ -1,0 +1,230 @@
+---
+title: Pre-from Filter Chain
+---
+
+How `.authorize()`, `.input()`, `.cache()`, `.error()` (and future
+`.retry()` / `.timeout()` / `.circuitBreaker()` / `.throttle()`)
+compose around your route. {% .lead %}
+
+Routecraft runs a **fixed ordered chain** of framework filters
+around every exchange before and after your user pipeline. The
+chain order is the framework's call -- the order you happen to
+type `.authorize()`, `.input()`, or `.cache()` on the builder does
+not change runtime behaviour. This is the same idea as Spring's
+`FilterChainProxy` or ASP.NET middleware: the framework picks the
+order; you opt in by declaring which filters you want.
+
+## The chain
+
+Outside in (position 1 wraps everything below):
+
+| # | Filter | Status | Opts in via | Reads / produces |
+|---|---|---|---|---|
+| 1 | `error` | shipped | `.error(handler)` | catches throws from everything below |
+| 2 | `authorize` (stacks) | shipped | `.authorize({ roles, scopes, predicate })` | principal on `exchange.headers` |
+| 3 | `parse` | shipped | source adapter (HTTP, mail, CSV, ...) | raw body bytes → typed body |
+| 4 | `input` | shipped | `.input(schema)` | typed body / headers |
+| 5 | `throttle` | planned | `.throttle({...})` | rate limit on the route |
+| 6 | `circuitBreaker` | planned ([#139](https://github.com/routecraftjs/routecraft/issues/139)) | `.circuitBreaker({...})` | failure stats; fast-fails when open |
+| 7 | `retry` | planned | `.retry({...})` | re-runs everything below on failure |
+| 8 | `timeout` | planned | `.timeout({...})` | per-attempt deadline |
+| 9 | `cacheCheck` | shipped | `.cache({...})` | validated body → cache key |
+| - | **your pipeline** | - | `.transform()`, `.to()`, `.process()`, ... | the work |
+| 10 | `cacheStore` | shipped | `.cache({...})` | terminal body, written best-effort |
+
+## What this means in practice
+
+### The chain runs in this order regardless of how you typed it
+
+These three routes behave identically:
+
+```ts
+craft()
+  .id('list-employees')
+  .authorize({ roles: ['hr'] })
+  .input(schema)
+  .cache({ ttl: 60_000 })
+  .from(http({ path: '/employees' }))
+  .enrich(loadEmployees)
+  .to(noop())
+
+craft()
+  .id('list-employees')
+  .cache({ ttl: 60_000 })
+  .input(schema)
+  .authorize({ roles: ['hr'] })
+  .from(http({ path: '/employees' }))
+  .enrich(loadEmployees)
+  .to(noop())
+
+craft()
+  .id('list-employees')
+  .input(schema)
+  .cache({ ttl: 60_000 })
+  .authorize({ roles: ['hr'] })
+  .from(http({ path: '/employees' }))
+  .enrich(loadEmployees)
+  .to(noop())
+```
+
+All three run `error` → `authorize` → `parse` → `input` →
+`cacheCheck` → `enrich` → `to` → `cacheStore`. The DSL is
+declarative; you state which filters apply, not what order they
+run in.
+
+### Each filter throws on rejection; `.error()` decides what to recover
+
+Filters 2-9 propagate failures upward by throwing. `.error()` is
+the outermost catch:
+
+```ts
+.error((err) => {
+  // Deterministic rejections: re-throw so the source can translate
+  // (e.g. HTTP returns 401, 403, or 400).
+  if (['RC5012', 'RC5015', 'RC5002', 'RC5016'].includes(err.rc)) throw err
+
+  // Backpressure: re-throw so the caller sees it.
+  if (err.rc === 'RC5013') throw err
+
+  // Operational failures: recover with a fallback.
+  if (err.rc === 'RC5011') return { fallback: 'timeout', data: stale }
+  if (err.rc === 'RC5028') return { fallback: 'cache-down', data: stale }
+
+  throw err
+})
+```
+
+Without `.error()`, every throw goes to the route's default error
+path (`route:<id>:error` + `context:error` + `exchange:failed`).
+The route is **not** stopped -- the next exchange processes
+normally.
+
+## Why this order
+
+### Top half (1-4): deterministic gates
+
+These are guards, not work. They're cheap, deterministic, and run
+once per request. Retrying them is pointless.
+
+- **`error` outermost.** Conceptually filter #1: its try/catch
+  wraps the rest. Same shape as Spring's
+  `ExceptionTranslationFilter`.
+- **`authorize` before `parse`.** Authorize reads the principal
+  from headers; it doesn't need a parsed body. Running it first
+  means an unauthenticated caller gets a clean `401` / `403`
+  without the framework leaking schema information via a `400`.
+- **`parse` before `input`.** Input validates the parsed shape, not
+  raw bytes.
+- **`input` before resilience wrappers.** A request that fails
+  schema is never going to succeed on retry. Reject early.
+
+### Middle (5-8): resilience wrappers (planned)
+
+These DO retry / time out / fail fast. Standard outside-in
+following Resilience4J conventions.
+
+- **`throttle` outside `circuitBreaker`.** A throttled request
+  shouldn't count as a breaker failure (the inner operation didn't
+  even run).
+- **`circuitBreaker` outside `retry`.** When the breaker is open,
+  fast-fail. Retries happen *within* one breaker call.
+- **`retry` outside `timeout`.** Each retry attempt gets its own
+  deadline; per-attempt timeout is more useful than a shared budget.
+
+### Bottom (9-10): cache
+
+Innermost. The pipeline's surface.
+
+- **`cacheCheck` just above the pipeline.** A hit short-circuits
+  the pipeline without triggering retry / breaker / timeout (a hit
+  is a successful zero-cost call from those layers' perspective).
+- **`cacheStore` just below the pipeline.** Runs only on
+  miss-success. Cache write errors are swallowed (the result is
+  already computed); they emit `cache:failed phase:"set"` for
+  observability but don't fail the exchange.
+
+## Combined scenarios
+
+### Authorize fails
+
+```
+error
+  └─ authorize throws RC5012  (no principal) or RC5015 (forbidden)
+       └─ everything below is skipped
+```
+
+`.error()` catches. If your handler re-throws auth errors (the
+default for most apps), the source translates: HTTP returns 401 /
+403, MCP returns an auth error.
+
+### Cache hit
+
+```
+error
+  └─ authorize  PASS
+       └─ parse  PASS
+            └─ input  PASS
+                 └─ cacheCheck  HIT  → cached body returned, pipeline skipped
+```
+
+The pipeline (including `cacheStore`) never runs. Filters 2-4 still
+ran, so an unauthorized caller never sees a hit.
+
+### Pipeline throws
+
+```
+error
+  └─ authorize  PASS
+       └─ parse  PASS
+            └─ input  PASS
+                 └─ cacheCheck  MISS
+                      └─ pipeline  THROWS
+                           └─ cacheStore  SKIPPED  (only runs on success)
+```
+
+The throw propagates up through `cacheCheck` (already passed; just
+re-throws), out to `.error()`. Nothing is cached. Next request with
+the same body re-runs the pipeline.
+
+### Future: retry inside timeout
+
+Once `.retry()` and `.timeout()` ship:
+
+```
+error
+  └─ authorize  PASS
+       └─ parse  PASS
+            └─ input  PASS
+                 └─ retry  attempt 1
+                      └─ timeout  hits 5s deadline → throws RC5011
+                 ←  retry catches RC5011, attempt 2
+                 └─ timeout  pipeline returns in 800ms → SUCCESS
+                      └─ cacheStore  writes result
+```
+
+Per-attempt deadlines. Retry sees individual failures and decides
+whether to re-attempt.
+
+## What the chain commits the framework to
+
+- **No reorder API.** You opt filters in by declaring them; the
+  order is the framework's call. If a future use case really needs
+  a different order, it's an explicit RFC, not a per-route knob.
+- **All wrappers throw on rejection.** `.error()` is the universal
+  catch; recovery is opt-in per RC code in the handler.
+- **Deterministic gates above resilience wrappers.** Auth, parse,
+  input run once; they're not retried.
+- **Cache is below resilience wrappers.** A timeout / retry /
+  breaker around cache means the framework retries pipeline calls
+  that exceeded their deadline; cache hits short-circuit without
+  triggering them.
+
+## Reference
+
+- The full contract (with implementation notes for contributors)
+  lives at [`.standards/pre-from-filter-chain.md`](https://github.com/routecraftjs/routecraft/blob/main/.standards/pre-from-filter-chain.md).
+- Operation reference pages link back here from their "where this
+  slots into the chain" section.
+- The step-scope wrapper pattern (for `.error()` / `.cache()`
+  applied *after* `.from()` to wrap a single step) is documented
+  separately at [`.standards/resilience-wrappers.md`](https://github.com/routecraftjs/routecraft/blob/main/.standards/resilience-wrappers.md).

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -356,6 +356,30 @@ A block's shape is invalid at construction:
 - Progressive-mode blocks: `{ mode: "progressive", description: "...", value: <string | function> }`.
 - Use the `BlockMode` and `BlockLifetime` types exported from `@routecraft/ai` to catch typos at the type level.
 
+## RC5028
+Cache provider failed
+
+**Why it happens**  
+The `.cache()` wrapper's provider threw while reading a value or while a custom provider executed its backend operations. Typical cause: a remote cache backend (Redis, etc.) is unreachable. Also raised by `MemoryCacheProvider.set` if called with `undefined` (the cache-miss sentinel), which is a contract violation.
+
+**Suggestion**  
+Inspect the underlying backend. Transient connectivity errors are retryable; consider wrapping the step with `.retry()` once that wrapper ships. If you hit the `undefined` set error, use `null` for an intentional empty value.
+
+## RC5029
+Cache key derivation failed
+
+**Why it happens**  
+The default `.cache()` key hashes `JSON.stringify(body)`, which fails on bodies containing functions, symbols, circular references, or `BigInt`. Also raised when a custom `key` function throws.
+
+**Suggestion**  
+Supply an explicit `key` function that returns a stable string identifier:
+
+```ts
+.cache({ key: (e) => String(e.body.id) })
+```
+
+This error is not retryable: the same body fails key derivation the same way every time.
+
 ## RC9901
 Unknown error
 

--- a/apps/routecraft.dev/src/app/docs/reference/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/events/page.md
@@ -116,6 +116,27 @@ After a split, each child exchange emits its own `exchange:started`. When aggreg
 
 `scope` is `"route"` for the catch-all set via `.error()` BEFORE `.from()`, and `"step"` for a wrapper attached AFTER `.from()`. `stepLabel` is the label of the wrapped step when `scope === "step"`. Wildcard subscribers (`route:*:error-handler:*`) keep matching.
 
+### Cache wrapper operations
+
+| Event | When it fires | Details |
+| --- | --- | --- |
+| `route:{routeId}:cache:hit` | A cached value was reused; the wrapped step (or whole pipeline, at route scope) was skipped | `{ routeId, exchangeId, correlationId, stepLabel, scope: "route" \| "step", key }` |
+| `route:{routeId}:cache:miss` | No cached value; the wrapped step ran (or was dropped) | Same plus `dropped?: true` when the wrapped step dropped the exchange |
+| `route:{routeId}:cache:stored` | A fresh value was written to the cache | Same plus `ttl?: number` when a per-call TTL was set |
+| `route:{routeId}:cache:failed` | Key derivation, a provider read/write, or the wrapped step threw | `{ ..., stepLabel, scope: "route" \| "step", phase: "key" \| "get" \| "inner" \| "set", error, key? }` |
+
+Failure phases:
+- `phase: "key"` - key derivation threw (no `key` field, since none was produced). Raised as `RC5029` (not retryable).
+- `phase: "get"` - the provider read threw before the wrapped step ran. Non-RoutecraftError provider failures are raised as `RC5028` (retryable).
+- `phase: "inner"` - the wrapped step itself threw. The original error is rethrown unchanged so outer wrappers / route-level handlers cascade as usual. This event fires **alongside** the wrapped step's own `step:failed` event for the same exchange; they describe one failure, so do not double-count them.
+- `phase: "set"` - the wrapped step succeeded but the provider write threw. The bundled in-memory provider never fails on write, so this only applies to custom providers. Step-scope rethrows as `RC5028` (retryable); **route-scope does NOT fail the exchange** (the result was already computed and returned to the source), it just emits the event for observability.
+
+At route scope, `cache:hit` is accompanied by an `exchange:restored` event with `source: "cache"` (per the exchange lifecycle).
+
+Concurrent exchanges that share one computation (stampede dedupe) currently emit `cache:hit` for the waiters at step scope, which can inflate hit-rate metrics. A distinct dedupe signal is planned and needs a provider-interface change. Route scope does not dedupe concurrent same-key callers at all in this release: each runs the pipeline once.
+
+### Reserved operation-error events
+
 | Event | When it fires | Details |
 | --- | --- | --- |
 | `route:{routeId}:operation:error:invoked` | Reserved for the planned `.onError()` operation | `{ routeId, exchangeId, correlationId }` |

--- a/apps/routecraft.dev/src/app/docs/reference/operations/cache/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/cache/page.md
@@ -1,8 +1,8 @@
 ---
 title: cache
 titleBadges:
-  - text: planned
-    color: purple
+  - text: experimental
+    color: green
 ---
 
 [← All operations](/docs/reference/operations) {% .lead %}
@@ -11,12 +11,12 @@ titleBadges:
 cache(options?: CacheOptions): RouteBuilder<Current>
 ```
 
-Cache and reuse the result of an expensive operation. When a cached value exists for the derived key, it replaces the body and the wrapped operation is skipped. Only successful executions are cached.
+Cache and reuse the result of an expensive operation. When a cached value exists for the derived key, the body is replaced with the cached value and the wrapped operation is skipped. Only successful executions are cached; errors and dropped exchanges leave the cache untouched.
 
-**Mental model:** A wrapper around the next operation. Similar to `retry`, but driven by duplicate input rather than failure.
+**Mental model:** Dual-mode. After `.from()` it wraps the immediately-next step. Before `.from()` it caches the entire route's terminal output keyed by the source message; on a hit the whole pipeline is skipped and the cached body is returned to the source.
 
 ```ts
-// Default: key derived from body hash
+// Default: key derived from body hash, process-wide in-memory provider
 craft()
   .id('document-processor')
   .from(source)
@@ -40,16 +40,84 @@ craft()
   .process(expensiveOperation) // Result is cached per file content hash
   .to(destination)
 
-// Both key and TTL
+// Custom provider (e.g. an isolated in-memory store, or future Redis)
+import { MemoryCacheProvider } from '@routecraft/routecraft'
+
+const provider = new MemoryCacheProvider({ max: 10_000, ttl: 60_000 })
+
 craft()
   .id('file-processor')
   .from(fileWatcher())
-  .cache({ key: e => e.headers[HeadersKeys.FILE_CONTENT_HASH] as string, ttl: 3600000 })
-  .process(expensiveOperation) // Cached for 1 hour per file content hash
+  .cache({ provider, key: e => e.headers[HeadersKeys.FILE_CONTENT_HASH] as string })
+  .process(expensiveOperation)
   .to(destination)
 ```
 
 **Options:**
-- `key` (optional) - Function to derive the cache key from the exchange. If omitted, a key is derived by hashing the exchange body.
-- `ttl` - Time to live in milliseconds. After expiry, the next execution recomputes the value
-- `scope` - What to cache: `'body'` (default) or `'exchange'` (body plus selected headers)
+- `key` (optional) - Function to derive the cache key from the exchange. If omitted, a key is derived by SHA-256 hashing `JSON.stringify(body)`. Supply an explicit `key` when the body is not JSON-serialisable or when a stable identity lives in headers.
+- `ttl` (optional) - Time to live in milliseconds. After expiry, the next execution recomputes the value. When omitted, the provider's default expiry applies (the bundled in-memory provider keeps entries until LRU eviction).
+- `provider` (optional) - A `CacheProvider` implementation. Defaults to a process-wide `MemoryCacheProvider` backed by `lru-cache`. Pass a custom provider to plug in Redis, multi-tier, or file-backed stores.
+
+**Concurrency:** When multiple exchanges race against the same key, the provider's `getOrCompute` is responsible for deduplication. The bundled `MemoryCacheProvider` runs the wrapped step at most once per key per TTL window; concurrent waiters share the result.
+
+**Caching semantics:**
+- Only successful executions are cached. A wrapped step that throws propagates the error and writes nothing.
+- `null` is a valid cached value; `undefined` is treated as "no value" and is never cached (the step recomputes next time).
+- A cache hit replaces the body but does NOT replay the wrapped step's side effects (header writes, etc.); those only happen on a miss when the step actually runs.
+
+**Ordering with `.error()`:** Place `.error()` OUTSIDE the cache (`.error(h).cache().to(d)`) so failures are handled without caching the fallback. Putting it inside (`.cache().error(h).to(d)`) caches the handler's recovery value, making a fallback the permanent answer for that key.
+
+**Performance:** The default key hashes a JSON serialisation of the body on every exchange. For hot paths or large bodies, supply a `key` that returns a stable identifier already to hand (an id field, a content hash in a header) to avoid re-serialising and re-hashing.
+
+**Custom providers:** Implement `CacheProvider` (`get`, `set`, `delete`, `has`, `getOrCompute`) and pass an instance via `cache({ provider })`. A future release will allow a global default to be set on `CraftConfig`.
+
+## Route scope
+
+Place `.cache()` BEFORE `.from()` to cache the entire route's terminal output (the body returned to the source) keyed by the source-emitted message.
+
+```ts
+craft()
+  .id('weather')
+  .cache({ ttl: 60_000 })
+  .from(direct())
+  .enrich(weatherApi)
+  .transform(formatForecast)
+  .to(noop())
+```
+
+On a hit, **the whole pipeline is skipped** (no `.enrich`, no `.transform`, no `.to`) and the cached body is returned to the caller as the route's result. On a miss, the pipeline runs and the terminal body is stored for next time. An additional `route:<id>:exchange:restored` event fires alongside `cache:hit` so dashboards can count restores separately.
+
+**Side effects do not replay on a hit.** This is a much larger surface than step-scope: every `.to()`, `.tap()`, and `.header()` in the route is bypassed. If the route has destinations whose side effects must run on every input, use step-scope `.cache()` to wrap the expensive step instead.
+
+**Routes containing `.split()` are rejected at build time** with `RC5003`. The pipeline produces multiple terminal exchanges when split is unbalanced by aggregate, which has no single "result" to cache. Use step-scope `.cache()` to wrap the expensive step inside such a route. Split-followed-by-aggregate routes will be revisited in a follow-up.
+
+**`.cache()` slots into the framework's pre-from filter chain at a fixed position.** Auth runs first (unauthenticated callers never see cached responses); parse and `.input()` validation run before the cache check (so stale-schema entries can't slip through); the cache hit-check sits just above the user pipeline; the cache write sits just below. See [Filter Chain](/docs/advanced/filter-chain) for the full chain, including reserved slots for `.throttle()`, `.circuitBreaker()`, `.retry()`, `.timeout()`.
+
+**Cache key partitions the *data*, not the authorization.** Pick the key based on what the cached response represents:
+
+```ts
+// Shared role-gated data: every authorized caller sees the same list.
+// Default body-hash key is correct.
+craft()
+  .id('list-employees')
+  .authorize({ roles: ['hr'] })
+  .cache({ ttl: 60_000 })
+  .from(http({ path: '/employees' }))
+  .enrich(loadEmployees)
+  .to(noop())
+
+// Per-user data: include the user identity in the key.
+craft()
+  .id('get-my-leave')
+  .authorize()
+  .cache({ ttl: 60_000, key: e => `leave:${e.principal?.subject}` })
+  .from(http({ path: '/me/leave' }))
+  .enrich(loadLeaveForUser)
+  .to(noop())
+```
+
+This is the same pattern any application-level cache follows: the key reflects the data's identity, not the caller's permissions.
+
+**Stampede protection:** route scope does NOT dedupe concurrent same-key callers in this release. Each concurrent caller runs the pipeline once before the cache is populated. Use step-scope `.cache()` around the expensive step if stampede dedupe matters.
+
+**Failure mode:** provider read failures throw `RC5028` (retryable). Key derivation failures throw `RC5029` (not retryable). Provider write failures emit `cache:failed phase:"set"` but do NOT fail the exchange (the result was already computed and returned).

--- a/apps/routecraft.dev/src/lib/navigation.ts
+++ b/apps/routecraft.dev/src/lib/navigation.ts
@@ -37,6 +37,7 @@ export const navigation = [
         href: '/docs/advanced/composing-capabilities',
       },
       { title: 'Error Handling', href: '/docs/advanced/error-handling' },
+      { title: 'Filter Chain', href: '/docs/advanced/filter-chain' },
       { title: 'Merged Options', href: '/docs/advanced/merged-options' },
       { title: 'Creating adapters', href: '/docs/advanced/custom-adapters' },
       {

--- a/bun.lock
+++ b/bun.lock
@@ -235,6 +235,7 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@standard-schema/spec": "^1.1.0",
+        "lru-cache": "^11.2.2",
         "pino": "^10.3.1",
       },
       "devDependencies": {
@@ -1915,7 +1916,7 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
-    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
 
     "madge": ["madge@8.0.0", "", { "dependencies": { "chalk": "^4.1.2", "commander": "^7.2.0", "commondir": "^1.0.1", "debug": "^4.3.4", "dependency-tree": "^11.0.0", "ora": "^5.4.1", "pluralize": "^8.0.0", "pretty-ms": "^7.0.1", "rc": "^1.2.8", "stream-to-array": "^2.3.0", "ts-graphviz": "^2.1.2", "walkdir": "^0.4.1" }, "peerDependencies": { "typescript": "^5.4.4" }, "optionalPeers": ["typescript"], "bin": { "madge": "bin/cli.js" } }, "sha512-9sSsi3TBPhmkTCIpVQF0SPiChj1L7Rq9kU2KDG1o6v2XH9cCw086MopjVCD+vuoL5v8S77DTbVopTO8OUiQpIw=="],
 
@@ -2615,6 +2616,8 @@
 
     "@appium/logger/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
+    "@appium/logger/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -2826,6 +2829,8 @@
     "ora/cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 

--- a/packages/routecraft/package.json
+++ b/packages/routecraft/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@standard-schema/spec": "^1.1.0",
+    "lru-cache": "^11.2.2",
     "pino": "^10.3.1"
   },
   "publishConfig": {

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -31,6 +31,7 @@ import {
   type Exchange,
   DefaultExchange,
   getExchangeContext,
+  OperationType,
 } from "./exchange.ts";
 import {
   type Splitter,
@@ -47,6 +48,11 @@ import { COLLECT_STEPS } from "./dsl-symbol.ts";
 import { ChoiceStep, ChoiceSubBuilder } from "./operations/choice.ts";
 import { ValidateStep } from "./operations/validate.ts";
 import { authorize, type AuthorizeOptions } from "./auth/authorize.ts";
+import {
+  type CacheOptions,
+  resolveCacheOptions,
+  type ResolvedCacheOptions,
+} from "./operations/cache-wrapper.ts";
 
 /**
  * Builder for creating a Routecraft context with routes and configuration.
@@ -354,6 +360,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
           options?: unknown;
         };
         errorHandler?: ErrorHandler;
+        cacheConfig?: ResolvedCacheOptions;
         discovery?: RouteDiscovery;
         authorizers?: AuthorizeOptions[];
       }
@@ -576,6 +583,42 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   }
 
   /**
+   * Cache. Dual-mode:
+   *
+   * - **Before `.from()` (route scope):** the route looks up its
+   *   provider before any pipeline step runs. On a hit, the entire
+   *   pipeline is skipped and the cached body is returned to the
+   *   source as the route's final exchange body. On a miss, the
+   *   pipeline runs normally and the terminal body is stored for
+   *   future hits. Side effects (e.g. `.to(destination)` calls) do
+   *   NOT replay on a hit; the whole pipeline is bypassed.
+   *
+   * - **After `.from()` (step scope):** wraps the immediately-next
+   *   step; see {@link StepBuilderBase.cache} for the step-scope
+   *   contract.
+   *
+   * Routes with `.split()` are not supported at route scope (the
+   * pipeline produces N terminals rather than one) and throw
+   * `RC5003` at build time. Use step-scope `.cache()` to wrap the
+   * expensive step inside such a route.
+   *
+   * @experimental
+   */
+  override cache(options: CacheOptions<Current> = {}): this {
+    if (this.currentRoute === undefined || this.pendingOptions !== undefined) {
+      // Route scope: stage the resolved config onto pendingOptions so
+      // the next `.from()` writes it into the new RouteDefinition.
+      this.pendingOptions = {
+        ...(this.pendingOptions ?? {}),
+        cacheConfig: resolveCacheOptions(options as CacheOptions),
+      };
+      logger.trace("Staging route-scope cache config for next route");
+      return this;
+    }
+    return super.cache(options);
+  }
+
+  /**
    * Declare an authorization requirement on the next route. **Route-only**:
    * stages the authorizer onto the next-route options and runs at route
    * entry, before any pipeline step. Same staging convention as `.id`,
@@ -670,6 +713,7 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       options: undefined,
     };
     const errorHandler = this.pendingOptions?.errorHandler;
+    const cacheConfig = this.pendingOptions?.cacheConfig;
     const discovery = this.pendingOptions?.discovery;
     const authorizers = this.pendingOptions?.authorizers ?? [];
 
@@ -691,6 +735,10 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
         options: consumer.options ?? undefined,
       },
       ...(errorHandler ? { errorHandler } : {}),
+      ...(cacheConfig ? { cacheConfig } : {}),
+      ...(authorizerSteps.length > 0
+        ? { authorizerCount: authorizerSteps.length }
+        : {}),
       ...(discovery ? { discovery } : {}),
     };
     setBrand(this.currentRoute, BRAND.RouteDefinition);
@@ -738,6 +786,23 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   protected override pushStep<T extends Adapter>(step: Step<T>): void {
     const route = this.requireSource();
     const wrapped = this.applyPendingWrappers(step);
+    // Route-scope `.cache()` skips the entire pipeline on a hit and
+    // caches a single terminal body on a miss. `split` produces N
+    // terminal exchanges (with no aggregate to fold them back), which
+    // breaks the "one cached value per source message" contract.
+    // Reject loud rather than silently mis-cache. Step-scope `.cache()`
+    // is still usable around the expensive step inside such a route.
+    if (
+      route.cacheConfig !== undefined &&
+      wrapped.operation === OperationType.SPLIT
+    ) {
+      throw rcError("RC5003", undefined, {
+        message:
+          `Route-scope .cache() does not support routes containing .split(). ` +
+          `The pipeline produces multiple terminal exchanges, so there is no single body to cache. ` +
+          `Use step-scope .cache() to wrap the expensive operation, or remove the route-scope .cache().`,
+      });
+    }
     logger.trace(
       { operation: wrapped.operation, route: route.id },
       "Adding step to route",

--- a/packages/routecraft/src/error.ts
+++ b/packages/routecraft/src/error.ts
@@ -29,6 +29,8 @@ export type RCCode =
   | "RC5025"
   | "RC5026"
   | "RC5027"
+  | "RC5028"
+  | "RC5029"
   | "RC9901";
 
 export type RCMeta = {
@@ -258,6 +260,22 @@ export const RC: Record<RCCode, RCMeta> = {
     suggestion:
       "A block is missing required fields or has an invalid shape: every block needs a non-empty `name`, a `mode` of `inject` or `progressive`, and a string-or-function `value`. Progressive blocks additionally require a non-empty `description` so the model can decide whether to load them.",
     docs: `${DOCS_BASE}#rc-5027`,
+    retryable: false,
+  },
+  RC5028: {
+    category: "Adapter",
+    message: "Cache provider failed",
+    suggestion:
+      "Inspect the underlying cache backend (in-memory, Redis, etc.); transient backend errors may resolve on retry.",
+    docs: `${DOCS_BASE}#rc-5028`,
+    retryable: true,
+  },
+  RC5029: {
+    category: "Adapter",
+    message: "Cache key derivation failed",
+    suggestion:
+      "The default key hashes JSON.stringify(body); it fails on non-serialisable bodies (functions, symbols, circular refs, BigInt). Supply an explicit `key` function in cache({ key: ... }). Retrying will not help: the same body fails the same way.",
+    docs: `${DOCS_BASE}#rc-5029`,
     retryable: false,
   },
   RC9901: {

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -121,6 +121,15 @@ export {
 
 export { WrapperStep } from "./operations/wrapper.ts";
 export { ErrorWrapperStep } from "./operations/error-wrapper.ts";
+export {
+  CacheWrapperStep,
+  type CacheOptions,
+} from "./operations/cache-wrapper.ts";
+export {
+  type CacheProvider,
+  MemoryCacheProvider,
+  type MemoryCacheProviderOptions,
+} from "./operations/cache-provider.ts";
 
 export {
   ContextBuilder,

--- a/packages/routecraft/src/operations/cache-provider.ts
+++ b/packages/routecraft/src/operations/cache-provider.ts
@@ -1,0 +1,241 @@
+import { LRUCache } from "lru-cache";
+
+import { rcError } from "../error.ts";
+
+/**
+ * Internal storage envelope. Wrapping the value keeps `lru-cache`'s
+ * non-nullable value constraint satisfied while still allowing `null`
+ * to be a legitimate cached value (a bare `null` cannot be stored in
+ * `lru-cache`, but `{ v: null }` can). A missing key returns
+ * `undefined` from the LRU; a cached `null` returns `{ v: null }`, so
+ * the two are never conflated.
+ */
+type CacheEnvelope = { v: unknown };
+
+/**
+ * Pluggable backend for the `.cache()` operation. Implementations decide
+ * where cached values live (in-memory, Redis, file-backed, multi-tier,
+ * etc.) and how eviction works. The contract is async-by-default so
+ * remote backends fit without breaking the call signature.
+ *
+ * A reference implementation backed by `lru-cache` ships as
+ * {@link MemoryCacheProvider}. Custom providers can be supplied
+ * per-operation via `cache({ provider })`; a future change will allow a
+ * global default to be set on `CraftConfig` (tracked in #112).
+ *
+ * Stampede protection (deduping concurrent computations for the same
+ * key) is the provider's responsibility via {@link getOrCompute} so the
+ * dedupe strategy can match the backend. In-memory providers track an
+ * in-flight Promise per key; distributed providers like Redis can use a
+ * lock key or rely on the underlying store's atomicity.
+ *
+ * @experimental Shipped with the first dual-mode wrapper after
+ * `.error()`; see `.standards/resilience-wrappers.md`.
+ */
+export interface CacheProvider {
+  /**
+   * Fetch a value by key. Returns `undefined` when there is no entry
+   * for the key (cache miss) or when the entry has expired. Treat
+   * `undefined` as "miss"; do not store `undefined` as a cached value.
+   *
+   * `null` is a valid cached value and is distinct from a miss: a
+   * cached `null` returns `null`, not `undefined`.
+   *
+   * @param key The cache key.
+   */
+  get(key: string): Promise<unknown>;
+
+  /**
+   * Store a value under `key`. When `ttl` is provided, the entry
+   * expires after `ttl` milliseconds; otherwise the provider's default
+   * expiry applies (which may be "never").
+   *
+   * `undefined` is not a storable value (it is the miss sentinel);
+   * implementations must reject it. `null` is storable.
+   *
+   * @param key The cache key.
+   * @param value The value to cache. Must not be `undefined`.
+   * @param ttl Optional time to live in milliseconds.
+   */
+  set(key: string, value: unknown, ttl?: number): Promise<void>;
+
+  /** Remove an entry by key. No-op if the key is absent. */
+  delete(key: string): Promise<void>;
+
+  /** Check existence without producing a "hit" side effect. */
+  has(key: string): Promise<boolean>;
+
+  /**
+   * Atomic "get-or-compute" with stampede protection. On a hit, returns
+   * the cached value. On a miss, runs `loader()` exactly once across
+   * concurrent callers with the same key and caches the result before
+   * resolving. If `loader` throws, the error propagates and nothing is
+   * cached.
+   *
+   * Wrappers and adapters should prefer this over manual
+   * `get` / `set` round-trips so the dedupe strategy stays with the
+   * provider.
+   *
+   * If `loader` resolves to `undefined`, treat it as a non-value:
+   * return it to the caller but do NOT store it (consistent with `get`
+   * returning `undefined` for a miss). Do not throw in this case, even
+   * though `set` rejects `undefined`. `null` is a value and is cached.
+   *
+   * @param key The cache key.
+   * @param loader Producer for the cached value on a miss.
+   * @param ttl Optional time to live for the produced value.
+   */
+  getOrCompute<T>(
+    key: string,
+    loader: () => Promise<T>,
+    ttl?: number,
+  ): Promise<T>;
+}
+
+/**
+ * Construction options for {@link MemoryCacheProvider}.
+ *
+ * @experimental
+ */
+export interface MemoryCacheProviderOptions {
+  /**
+   * Maximum number of entries to keep. When the cache is full, the
+   * least-recently-used entry is evicted to make room. Defaults to
+   * 1000.
+   */
+  max?: number;
+  /**
+   * Default time to live in milliseconds, applied when a `set` call
+   * omits `ttl`. Defaults to no expiry (entries live until evicted by
+   * the LRU policy or explicitly deleted).
+   */
+  ttl?: number;
+}
+
+/**
+ * Default in-process cache provider. Backed by `lru-cache` for
+ * size-bounded LRU eviction with optional TTL, plus an in-flight
+ * Promise map for stampede protection.
+ *
+ * Two instances are independent stores; the framework does not share
+ * state across `MemoryCacheProvider` instances. The module-level
+ * `defaultMemoryCacheProvider` is shared by every `.cache()` call that
+ * does not supply its own provider.
+ *
+ * Thread-safe within the JS event loop: `getOrCompute` reads, registers
+ * an in-flight Promise, and resolves it atomically with respect to
+ * other JS turns on the same key. Across workers / processes the cache
+ * is local to the host.
+ *
+ * @experimental
+ */
+export class MemoryCacheProvider implements CacheProvider {
+  // Values are wrapped in a `CacheEnvelope` so `null` can be cached
+  // (lru-cache rejects null/undefined values) and so a missing key
+  // (LRU returns `undefined`) is never confused with a cached `null`
+  // (LRU returns `{ v: null }`).
+  readonly #lru: LRUCache<string, CacheEnvelope>;
+  readonly #inFlight = new Map<string, Promise<unknown>>();
+
+  constructor(options: MemoryCacheProviderOptions = {}) {
+    this.#lru = new LRUCache<string, CacheEnvelope>({
+      max: options.max ?? 1000,
+      ...(options.ttl !== undefined ? { ttl: options.ttl } : {}),
+    });
+  }
+
+  async get(key: string): Promise<unknown> {
+    const entry = this.#lru.get(key);
+    return entry === undefined ? undefined : entry.v;
+  }
+
+  async set(key: string, value: unknown, ttl?: number): Promise<void> {
+    if (value === undefined) {
+      throw rcError("RC5028", undefined, {
+        message:
+          "CacheProvider.set received `undefined`, which is the cache-miss sentinel and cannot be stored. " +
+          "Use `null` for an intentional empty value, or skip the write.",
+      });
+    }
+    this.#store(key, value, ttl);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.#lru.delete(key);
+  }
+
+  async has(key: string): Promise<boolean> {
+    return this.#lru.has(key);
+  }
+
+  async getOrCompute<T>(
+    key: string,
+    loader: () => Promise<T>,
+    ttl?: number,
+  ): Promise<T> {
+    const cached = this.#lru.get(key);
+    if (cached !== undefined) return cached.v as T;
+
+    const existing = this.#inFlight.get(key);
+    if (existing) return existing as Promise<T>;
+
+    const promise = (async () => {
+      try {
+        const value = await loader();
+        // Cache everything except `undefined` (the miss sentinel).
+        // `null` and other falsy values are cached.
+        if (value !== undefined) this.#store(key, value, ttl);
+        return value;
+      } finally {
+        this.#inFlight.delete(key);
+      }
+    })();
+
+    this.#inFlight.set(key, promise);
+    return promise;
+  }
+
+  #store(key: string, value: unknown, ttl?: number): void {
+    const entry: CacheEnvelope = { v: value };
+    if (ttl !== undefined) {
+      this.#lru.set(key, entry, { ttl });
+    } else {
+      this.#lru.set(key, entry);
+    }
+  }
+
+  /**
+   * Drop all entries. Mainly for tests and explicit invalidation.
+   *
+   * Not part of the {@link CacheProvider} interface: clearing semantics
+   * vary by backend (a Redis `FLUSHDB` is destructive and shared), so
+   * this helper is specific to the in-memory provider. Construct a fresh
+   * provider for test isolation rather than relying on `clear()` against
+   * an arbitrary `CacheProvider`.
+   */
+  clear(): void {
+    this.#lru.clear();
+    this.#inFlight.clear();
+  }
+
+  /**
+   * Number of live entries (excludes in-flight loaders).
+   *
+   * Not part of the {@link CacheProvider} interface; specific to the
+   * in-memory provider and intended for tests and diagnostics.
+   */
+  get size(): number {
+    return this.#lru.size;
+  }
+}
+
+/**
+ * Process-wide default provider used by `.cache()` when the call site
+ * does not supply its own. Sized at 1000 entries, no default TTL. Tests
+ * that need isolation should pass their own provider via
+ * `cache({ provider: new MemoryCacheProvider() })` rather than mutating
+ * this one.
+ *
+ * @internal
+ */
+export const defaultMemoryCacheProvider = new MemoryCacheProvider();

--- a/packages/routecraft/src/operations/cache-wrapper.ts
+++ b/packages/routecraft/src/operations/cache-wrapper.ts
@@ -1,0 +1,345 @@
+import { createHash } from "node:crypto";
+
+import {
+  type Exchange,
+  DefaultExchange,
+  getExchangeContext,
+  getExchangeRoute,
+  HeadersKeys,
+  isDropped,
+  markDropped,
+} from "../exchange.ts";
+import { rcError, RoutecraftError } from "../error.ts";
+import { isRoutecraftError } from "../brand.ts";
+import type { Adapter, EventName, Step } from "../types.ts";
+import { WrapperStep, type WrapperOutcome } from "./wrapper.ts";
+import {
+  type CacheProvider,
+  defaultMemoryCacheProvider,
+} from "./cache-provider.ts";
+
+/**
+ * Options for the `.cache()` step-scope wrapper.
+ *
+ * @template Current Body type entering the wrapped step.
+ * @experimental
+ */
+export interface CacheOptions<Current = unknown> {
+  /**
+   * Derive the cache key from the exchange. The returned string is the
+   * identity used by the provider's `get` / `set`. When omitted, a key
+   * is computed by SHA-256 hashing `JSON.stringify(body)`.
+   *
+   * The default works for plain JSON-shaped bodies (primitives, arrays,
+   * plain objects with string keys). For bodies containing functions,
+   * symbols, circular references, or anything else `JSON.stringify`
+   * cannot represent, supply an explicit `key` function.
+   *
+   * Performance: the default hashes a JSON serialisation of the body on
+   * every exchange. For hot paths or large bodies (file contents, large
+   * payloads), supply a `key` that returns a stable identifier already
+   * to hand (an id field, a content hash in a header, a tuple of the
+   * relevant fields) to avoid re-serialising and re-hashing.
+   */
+  key?: (exchange: Exchange<Current>) => string;
+  /**
+   * Time to live in milliseconds. After expiry, the next execution
+   * with the same key recomputes the value. When omitted, the
+   * provider's default applies (the bundled in-memory provider keeps
+   * entries until LRU eviction).
+   */
+  ttl?: number;
+  /**
+   * Cache backend. Defaults to a process-wide in-memory provider. Pass
+   * a custom provider (Redis, multi-tier, file-backed, etc.) by
+   * constructing an implementation of {@link CacheProvider} and
+   * handing it in here.
+   */
+  provider?: CacheProvider;
+}
+
+/**
+ * Internal resolved shape of {@link CacheOptions}: every field is
+ * populated, with defaults filled in. Shared between the step-scope
+ * wrapper and the route-scope path in `route.ts`.
+ *
+ * @internal
+ */
+export interface ResolvedCacheOptions<Current = unknown> {
+  key: (exchange: Exchange<Current>) => string;
+  ttl: number | undefined;
+  provider: CacheProvider;
+}
+
+/**
+ * Resolve a user-supplied {@link CacheOptions} into a fully populated
+ * {@link ResolvedCacheOptions}, filling defaults: the SHA-256 body
+ * hasher for `key`, no TTL, and the module-level in-memory provider.
+ *
+ * @internal
+ */
+export function resolveCacheOptions<Current = unknown>(
+  options: CacheOptions<Current> = {},
+): ResolvedCacheOptions<Current> {
+  return {
+    key: options.key ?? (defaultKey as (e: Exchange<Current>) => string),
+    ttl: options.ttl,
+    provider: options.provider ?? defaultMemoryCacheProvider,
+  };
+}
+
+function defaultKey(exchange: Exchange<unknown>): string {
+  try {
+    const stringified = JSON.stringify(exchange.body);
+    if (stringified === undefined) {
+      throw rcError("RC5029", undefined, {
+        message:
+          "Default cache key derivation failed: exchange body is not JSON-serialisable. " +
+          "Supply an explicit `key` function in cache({ key: ... }).",
+      });
+    }
+    return createHash("sha256").update(stringified).digest("hex");
+  } catch (err) {
+    if (err instanceof RoutecraftError) throw err;
+    throw rcError("RC5029", err, {
+      message:
+        "Default cache key derivation threw while hashing the exchange body. " +
+        "Supply an explicit `key` function in cache({ key: ... }).",
+    });
+  }
+}
+
+/**
+ * Sentinel error thrown by the cache loader when the wrapped step
+ * dropped the exchange (filter rejection, halt, etc.). Used to abort
+ * the provider's `getOrCompute` so nothing is written to the cache,
+ * while letting concurrent waiters observe the drop and mark their
+ * own exchanges accordingly. Internal; never escapes the wrapper.
+ */
+class CacheLoaderDrop extends Error {
+  constructor() {
+    super("routecraft.cache.drop");
+    this.name = "CacheLoaderDrop";
+  }
+}
+
+/**
+ * Step-scope `.cache()` wrapper. On a cache hit, replaces
+ * `exchange.body` with the cached value and skips the wrapped step. On
+ * a miss, runs the wrapped step, caches its produced body, and lets
+ * the pipeline continue normally. Errors from the wrapped step are
+ * NOT cached and propagate to outer wrappers / route-level handlers.
+ *
+ * Concurrent exchanges with the same derived key share a single
+ * computation via the provider's `getOrCompute`, so a slow underlying
+ * operation runs at most once per key per TTL window.
+ *
+ * Emits cache lifecycle events on the route's event bus:
+ * - `route:<id>:cache:hit` when a cached value is reused.
+ * - `route:<id>:cache:miss` when the wrapped step runs.
+ * - `route:<id>:cache:stored` when a fresh value is written.
+ * - `route:<id>:cache:failed` when key derivation or the provider throws.
+ *
+ * Known limitation: concurrent exchanges that share a single
+ * `getOrCompute` computation (stampede dedupe) currently report
+ * `cache:hit` for the waiters rather than a distinct "deduped" signal,
+ * which can inflate hit-rate metrics. Tracked separately; needs a
+ * provider-interface change to report whether the current call ran the
+ * loader.
+ *
+ * Ordering note: a step-scope `.error()` placed INSIDE the cache
+ * (`.cache().error(h).to(d)`) feeds the handler's recovery value into
+ * the cache, so a fallback becomes the permanent cached answer for that
+ * key. Put `.error()` OUTSIDE the cache (`.error(h).cache().to(d)`)
+ * unless caching recovery results is intended.
+ *
+ * @experimental Surfaced via the dual-mode `.cache()` builder method;
+ * route-scope behaviour is tracked in #112 and currently throws when
+ * staged before `.from()`.
+ */
+export class CacheWrapperStep<
+  T extends Adapter = Adapter,
+> extends WrapperStep<T> {
+  readonly #options: ResolvedCacheOptions;
+
+  constructor(inner: Step<T>, options: CacheOptions = {}) {
+    super(inner);
+    this.#options = resolveCacheOptions(options);
+  }
+
+  protected override async runInner(
+    exchange: Exchange,
+    innerQueue: { exchange: Exchange; steps: Step<Adapter>[] }[],
+  ): Promise<WrapperOutcome> {
+    const route = getExchangeRoute(exchange);
+    const context = getExchangeContext(exchange);
+    const routeId = route?.definition.id;
+    const stepLabel = this.label ?? String(this.operation);
+    const correlationId = exchange.headers[
+      HeadersKeys.CORRELATION_ID
+    ] as string;
+    const shouldEmit = route && context && routeId;
+
+    let key: string;
+    try {
+      key = this.#options.key(exchange);
+    } catch (err) {
+      if (shouldEmit) {
+        context.emit(`route:${routeId}:cache:failed` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          stepLabel,
+          scope: "step",
+          phase: "key",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      throw isRoutecraftError(err)
+        ? err
+        : rcError("RC5029", err, {
+            message: `cache({ key }) for "${stepLabel}" threw while deriving the cache key`,
+          });
+    }
+
+    let ranInner = false;
+    // Flips true once the inner step has produced its value inside the
+    // loader. Lets the catch below tell an inner-step failure (loader
+    // not yet resolved) from a provider write failure (loader resolved,
+    // `getOrCompute` rejected while caching).
+    let loaderResolved = false;
+    // Set only by the call that runs the loader (the cache miss). On a
+    // hit or stampede-dedup this stays undefined and the wrapper rewraps
+    // the current exchange with the cached body instead.
+    let producedExchange: Exchange | undefined;
+    let computed: unknown;
+
+    try {
+      computed = await this.#options.provider.getOrCompute(
+        key,
+        async () => {
+          ranInner = true;
+          // Run the inner step against an isolated local buffer so the
+          // shared `innerQueue` is populated uniformly from the cache
+          // result below. Concurrent callers waiting on this loader
+          // never see the inner's intermediate pushes.
+          const localQueue: {
+            exchange: Exchange;
+            steps: Step<Adapter>[];
+          }[] = [];
+          await this.inner.execute(exchange, [], localQueue);
+          // A genuine drop is signalled by the framework's dropped flag
+          // (filter reject / halt), NOT by an undefined body: a step
+          // such as `transform(() => undefined)` legitimately sets the
+          // body to undefined and must not be misread as a drop.
+          if (isDropped(exchange) || localQueue.length === 0) {
+            // Abort via sentinel so `getOrCompute` writes nothing.
+            throw new CacheLoaderDrop();
+          }
+          if (localQueue.length > 1) {
+            // The wrapper caches and replays a single output. A
+            // multi-emit inner step would have all but one output
+            // silently dropped, so fail loud instead. split / aggregate
+            // are already blocked at construction by WrapperStep.
+            throw rcError("RC5003", undefined, {
+              message:
+                `.cache() cannot wrap "${stepLabel}": the step emitted ${localQueue.length} ` +
+                `exchanges, but cache replays a single output. Wrap a single-output step instead.`,
+            });
+          }
+          const produced = localQueue[0]!;
+          producedExchange = produced.exchange;
+          loaderResolved = true;
+          return produced.exchange.body;
+        },
+        this.#options.ttl,
+      );
+    } catch (err) {
+      if (err instanceof CacheLoaderDrop) {
+        // Mark this exchange (may be a concurrent waiter whose own
+        // inner never ran) so the template's empty-queue branch
+        // forwards a drop, not a live exchange.
+        markDropped(exchange);
+        if (shouldEmit) {
+          context.emit(`route:${routeId}:cache:miss` as EventName, {
+            routeId,
+            exchangeId: exchange.id,
+            correlationId,
+            stepLabel,
+            scope: "step",
+            key,
+            dropped: true,
+          });
+        }
+        return "ok";
+      }
+      // Attribute the failure:
+      // - `"get"`   provider read threw before the inner ran.
+      // - `"inner"` the wrapped step itself threw (loader not resolved).
+      // - `"set"`   the inner succeeded but the provider write threw.
+      const phase = !ranInner ? "get" : loaderResolved ? "set" : "inner";
+      if (shouldEmit) {
+        context.emit(`route:${routeId}:cache:failed` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          stepLabel,
+          scope: "step",
+          phase,
+          key,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      // Inner-step failures propagate unchanged so route-level handlers
+      // see the real cause (matching unwrapped step behaviour). Provider
+      // read / write failures map to the retryable RC5028 boundary code
+      // unless the provider already threw a RoutecraftError.
+      if (phase !== "inner" && !isRoutecraftError(err)) {
+        throw rcError("RC5028", err, {
+          message: `cache() provider ${phase === "get" ? "read" : "write"} failed for "${stepLabel}"`,
+        });
+      }
+      throw err;
+    }
+
+    if (shouldEmit) {
+      context.emit(
+        `route:${routeId}:cache:${ranInner ? "miss" : "hit"}` as EventName,
+        {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          stepLabel,
+          scope: "step",
+          key,
+        },
+      );
+      if (ranInner) {
+        context.emit(`route:${routeId}:cache:stored` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          stepLabel,
+          scope: "step",
+          key,
+          ...(this.#options.ttl !== undefined
+            ? { ttl: this.#options.ttl }
+            : {}),
+        });
+      }
+    }
+
+    // On a miss (this call ran the inner), forward the inner's produced
+    // exchange so its header mutations and body survive. On a hit or
+    // stampede-dedup the inner did not run for THIS exchange, so rewrap
+    // the current exchange with the cached body: a cache hit means the
+    // wrapped step's side effects (including header writes) did not
+    // happen for this exchange.
+    const forwarded =
+      ranInner && producedExchange !== undefined
+        ? producedExchange
+        : DefaultExchange.rewrap(exchange, { body: computed });
+    innerQueue.push({ exchange: forwarded, steps: [] });
+    return "ok";
+  }
+}

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -260,6 +260,208 @@ function buildParseStep(
 }
 
 /**
+ * Synthetic adapter used as the carrier for the route-scope cache
+ * synthetic steps. Has no behaviour; the steps' `execute` does the work.
+ */
+const CACHE_STEP_ADAPTER: Adapter = { adapterId: "routecraft.cache" };
+
+/**
+ * Mutable holder shared between the cache-check and cache-store steps
+ * within a single `runSteps` invocation. The check derives the key and
+ * stores it here; the store reads it back after the user steps run.
+ * Lives only for one `runSteps` call so concurrent exchanges don't
+ * cross-contaminate.
+ */
+type CacheKeyHolder = { key?: string };
+
+/**
+ * Build the route-scope cache HIT-CHECK synthetic step. Inserted into
+ * `initialSteps` AFTER `buildParseStep` (so parse + `applyValidation`
+ * have already run) and BEFORE the user steps. Derives the cache key
+ * from the parsed/validated exchange, looks it up in the provider, and
+ * on a hit pushes a rewrapped exchange with `steps: []` to short-circuit
+ * the rest of the pipeline (including the matching cache-store step).
+ * On a miss pushes the exchange with the unchanged `remainingSteps` so
+ * the user pipeline runs.
+ *
+ * Manages its own observability: emits `cache:hit` / `cache:miss` /
+ * `cache:failed` plus `exchange:restored` on a hit. `skipStepEvents:
+ * true` keeps `runSteps` from emitting generic `step:started` /
+ * `step:completed` for this internal step.
+ */
+function buildCacheCheckStep(
+  cacheConfig: import("./operations/cache-wrapper.ts").ResolvedCacheOptions,
+  keyHolder: CacheKeyHolder,
+): Step<Adapter> {
+  return {
+    operation: OperationType.PROCESS,
+    label: "cache-check",
+    adapter: CACHE_STEP_ADAPTER,
+    skipStepEvents: true,
+    async execute(exchange, remainingSteps, queue) {
+      const internals = EXCHANGE_INTERNALS.get(exchange);
+      const context = internals?.context;
+      const route = internals?.route;
+      const routeId =
+        route?.definition.id ??
+        (exchange.headers[HeadersKeys.ROUTE_ID] as string);
+      const correlationId = exchange.headers[
+        HeadersKeys.CORRELATION_ID
+      ] as string;
+
+      let key: string;
+      try {
+        key = cacheConfig.key(exchange);
+      } catch (err) {
+        context?.emit(`route:${routeId}:cache:failed` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          stepLabel: "route",
+          scope: "route",
+          phase: "key",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw isRoutecraftError(err)
+          ? err
+          : rcError("RC5029", err, {
+              message: `Route-scope .cache({ key }) for "${routeId}" threw while deriving the cache key`,
+            });
+      }
+      keyHolder.key = key;
+
+      let cached: unknown;
+      try {
+        cached = await cacheConfig.provider.get(key);
+      } catch (err) {
+        context?.emit(`route:${routeId}:cache:failed` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          stepLabel: "route",
+          scope: "route",
+          phase: "get",
+          key,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw isRoutecraftError(err)
+          ? err
+          : rcError("RC5028", err, {
+              message: `Route-scope .cache() provider read failed for "${routeId}"`,
+            });
+      }
+
+      if (cached !== undefined) {
+        // HIT: short-circuit the pipeline by pushing the rewrapped
+        // exchange with no remaining steps. The matching cache-store
+        // step (tail of initialSteps) is therefore skipped too.
+        context?.emit(`route:${routeId}:cache:hit` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          stepLabel: "route",
+          scope: "route",
+          key,
+        });
+        context?.emit(`route:${routeId}:exchange:restored` as EventName, {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          source: "cache",
+        });
+        queue.push({
+          exchange: DefaultExchange.rewrap(exchange, { body: cached }),
+          steps: [],
+        });
+        return;
+      }
+
+      // MISS: continue the pipeline.
+      context?.emit(`route:${routeId}:cache:miss` as EventName, {
+        routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        stepLabel: "route",
+        scope: "route",
+        key,
+      });
+      queue.push({ exchange, steps: remainingSteps });
+    },
+  };
+}
+
+/**
+ * Build the route-scope cache STORE synthetic step. Inserted as the
+ * tail of `initialSteps` after the user steps. Reached only on the
+ * miss path (the cache-check step pushes `steps: []` on a hit to skip
+ * everything including this step). Writes the terminal body using the
+ * key captured by the matching check step.
+ *
+ * Provider write failures emit `cache:failed phase:"set"` for
+ * observability but do NOT fail the exchange: the result was already
+ * computed by the user pipeline. This diverges from step-scope, where
+ * a write failure throws RC5028; the divergence is intentional and
+ * documented on the operation reference page.
+ *
+ * `skipStepEvents: true` keeps `runSteps` from emitting generic
+ * lifecycle events for this internal step.
+ */
+function buildCacheStoreStep(
+  cacheConfig: import("./operations/cache-wrapper.ts").ResolvedCacheOptions,
+  keyHolder: CacheKeyHolder,
+): Step<Adapter> {
+  return {
+    operation: OperationType.PROCESS,
+    label: "cache-store",
+    adapter: CACHE_STEP_ADAPTER,
+    skipStepEvents: true,
+    async execute(exchange, remainingSteps, queue) {
+      const internals = EXCHANGE_INTERNALS.get(exchange);
+      const context = internals?.context;
+      const route = internals?.route;
+      const routeId =
+        route?.definition.id ??
+        (exchange.headers[HeadersKeys.ROUTE_ID] as string);
+      const correlationId = exchange.headers[
+        HeadersKeys.CORRELATION_ID
+      ] as string;
+      const key = keyHolder.key;
+
+      // Only cache successful runs whose terminal body is not
+      // `undefined`. `null` is cached (envelope handles it). Dropped
+      // exchanges never reach this step because the queue loop stops
+      // pushing on a drop.
+      if (key !== undefined && exchange.body !== undefined) {
+        try {
+          await cacheConfig.provider.set(key, exchange.body, cacheConfig.ttl);
+          context?.emit(`route:${routeId}:cache:stored` as EventName, {
+            routeId,
+            exchangeId: exchange.id,
+            correlationId,
+            stepLabel: "route",
+            scope: "route",
+            key,
+            ...(cacheConfig.ttl !== undefined ? { ttl: cacheConfig.ttl } : {}),
+          });
+        } catch (err) {
+          context?.emit(`route:${routeId}:cache:failed` as EventName, {
+            routeId,
+            exchangeId: exchange.id,
+            correlationId,
+            stepLabel: "route",
+            scope: "route",
+            phase: "set",
+            key,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      queue.push({ exchange, steps: remainingSteps });
+    },
+  };
+}
+
+/**
  * Configuration for a route: source, steps, and consumer.
  *
  * Describes how data flows from a source through processing steps to destinations.
@@ -303,6 +505,30 @@ export type RouteDefinition<T = unknown> = {
    * If not defined, the error is logged and emitted via the error event (current behavior).
    */
   readonly errorHandler?: ErrorHandler;
+
+  /**
+   * Optional route-scope `.cache()` configuration. When present, the
+   * route looks up its cache provider before any pipeline step runs;
+   * on a hit, the wrapped step list is skipped entirely and the
+   * cached body is returned to the source. On a miss, the pipeline
+   * runs and the terminal exchange's body is stored for future hits.
+   *
+   * Set by `RouteBuilder.cache()` when called BEFORE `.from()`. See
+   * `.standards/resilience-wrappers.md` for the dual-mode pattern.
+   *
+   * @experimental
+   */
+  readonly cacheConfig?: import("./operations/cache-wrapper.ts").ResolvedCacheOptions;
+
+  /**
+   * Number of leading entries in `steps` that came from `.authorize()`
+   * calls staged before `.from()`. The runtime peels these off and runs
+   * them BEFORE the route-scope cache hit-check so an unauthorized
+   * caller never receives a cached response. Defaults to 0.
+   *
+   * @internal
+   */
+  readonly authorizerCount?: number;
 
   /**
    * Optional route-level discovery bundle: title, description, and input /
@@ -1018,13 +1244,55 @@ export class DefaultRoute implements Route {
       delete internals.applyValidation;
     }
 
-    const userSteps = [...this.definition.steps];
-    const initialSteps: Step<Adapter>[] = sourceParse
-      ? [
-          buildParseStep(sourceParse, sourceFailureMode, sourceValidate),
-          ...userSteps,
-        ]
-      : userSteps;
+    // Route-scope `.cache()`: wired in as a pair of synthetic steps so
+    // it composes naturally with parse / input validation / authorize.
+    // The check step is inserted AFTER `buildParseStep` (so parse +
+    // `applyValidation` have already produced a validated body) and
+    // BEFORE the user steps. On a hit it pushes the rewrapped exchange
+    // with `steps: []` to short-circuit everything including the
+    // matching store step. The store step runs only on the miss path,
+    // after the user pipeline, and writes the terminal body using the
+    // key captured by the check step.
+    //
+    // Stampede protection is NOT applied at route scope in this
+    // release; concurrent callers with the same key all run the
+    // pipeline. Tracked as a follow-up. See `.standards/resilience-wrappers.md`.
+    //
+    // Auth note: route-scope `.authorize()` steps live at the head of
+    // `userSteps`, so the cache check (which precedes user steps but
+    // follows parse + input validation) runs BEFORE authorize. If your
+    // route combines `.cache()` with `.authorize()`, the cache key MUST
+    // partition by every fact authorize depends on (subject / roles /
+    // scopes); otherwise a cached response written by an authorized
+    // caller can be served to a caller who would have failed
+    // authorization. The default body-hash key does NOT include the
+    // principal; supply a custom `key` that does, e.g.
+    // `key: e => sha(JSON.stringify({ b: e.body, sub: e.principal?.subject }))`.
+    const cacheConfig = this.definition.cacheConfig;
+    const cacheKeyHolder: CacheKeyHolder = {};
+
+    // `.authorize()` steps were pushed to the front of `steps` by the
+    // builder and tracked via `authorizerCount`. Peel them off here so
+    // they run BEFORE the route-scope cache check: an unauthorized
+    // caller must not receive a cached response.
+    const allSteps = [...this.definition.steps];
+    const authorizerCount = this.definition.authorizerCount ?? 0;
+    const authorizeSteps = allSteps.slice(0, authorizerCount);
+    const businessSteps = allSteps.slice(authorizerCount);
+
+    const initialSteps: Step<Adapter>[] = [
+      ...(sourceParse
+        ? [buildParseStep(sourceParse, sourceFailureMode, sourceValidate)]
+        : []),
+      ...authorizeSteps,
+      ...(cacheConfig
+        ? [buildCacheCheckStep(cacheConfig, cacheKeyHolder)]
+        : []),
+      ...businessSteps,
+      ...(cacheConfig
+        ? [buildCacheStoreStep(cacheConfig, cacheKeyHolder)]
+        : []),
+    ];
 
     const queue: { exchange: Exchange; steps: Step<Adapter>[] }[] = [
       { exchange: exchange, steps: initialSteps },
@@ -1374,6 +1642,10 @@ export class DefaultRoute implements Route {
     if (isDropped(exchange)) {
       dropped = true;
     }
+
+    // Route-scope cache writes (`cacheConfig`) are handled inline by
+    // the `cache-store` synthetic step appended to `initialSteps` at
+    // the top of this function. Nothing to do here.
 
     return {
       exchange: lastProcessedExchange,

--- a/packages/routecraft/src/step-builder-base.ts
+++ b/packages/routecraft/src/step-builder-base.ts
@@ -23,6 +23,10 @@ import {
 } from "./operations/enrich.ts";
 import { ErrorWrapperStep } from "./operations/error-wrapper.ts";
 import {
+  CacheWrapperStep,
+  type CacheOptions,
+} from "./operations/cache-wrapper.ts";
+import {
   type Processor,
   type CallableProcessor,
   ProcessStep,
@@ -180,6 +184,43 @@ export abstract class StepBuilderBase<Current = unknown> {
   error(handler: ErrorHandler): this {
     this.pendingStepWrappers.push(
       (inner) => new ErrorWrapperStep(inner, handler),
+    );
+    return this;
+  }
+
+  /**
+   * Cache the result of the next step. When a cached value exists for
+   * the derived key, the wrapped step is skipped and the cached body
+   * replaces `exchange.body`. On a miss, the step runs and its output
+   * body is written to the cache for future calls.
+   *
+   * Only successful executions are cached: if the wrapped step throws,
+   * the error propagates and the cache is left untouched. Dropped
+   * exchanges (filter / halt) are not cached.
+   *
+   * Concurrent exchanges with the same key share one computation via
+   * the provider's `getOrCompute`, so a slow underlying operation
+   * runs at most once per key per TTL window.
+   *
+   * On `RouteBuilder`, this method is dual-mode. The route-scope
+   * variant (called BEFORE `.from()`) is not yet implemented and
+   * throws RC2001; for now use the step-scope form chained after
+   * `.from()`. On `BranchBuilder`, it is always step-scope.
+   *
+   * Stacks left-to-right with other wrappers: `.error(h).cache().to(d)`
+   * produces `error(cache(d))` -- the cache runs inside the error
+   * handler's recovery scope.
+   *
+   * @param options Optional `{ key, ttl, provider }`. Defaults: key
+   *   derived from a SHA-256 of `JSON.stringify(body)`, no TTL,
+   *   process-wide in-memory provider.
+   *
+   * @experimental Step-scope behaviour ships with the dual-mode
+   * wrapper pattern (see `.standards/resilience-wrappers.md`).
+   */
+  cache(options: CacheOptions<Current> = {}): this {
+    this.pendingStepWrappers.push(
+      (inner) => new CacheWrapperStep(inner, options as CacheOptions),
     );
     return this;
   }

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -322,6 +322,10 @@ export type SpecialEventName =
   | `route:${string}:error-handler:invoked`
   | `route:${string}:error-handler:recovered`
   | `route:${string}:error-handler:failed`
+  | `route:${string}:cache:hit`
+  | `route:${string}:cache:miss`
+  | `route:${string}:cache:stored`
+  | `route:${string}:cache:failed`
   | `route:${string}:operation:choice:matched`
   | `route:${string}:operation:choice:unmatched`
   | `route:${string}:agent:tool:invoked`
@@ -567,136 +571,196 @@ type RouteEventDetails<S extends string> =
                                         /** Step label when `scope === "step"`. */
                                         stepLabel?: string;
                                       }
-                                    : // Choice operation
-                                      S extends "operation:choice:matched"
+                                    : // Cache wrapper
+                                      S extends "cache:hit"
                                       ? {
                                           routeId: string;
                                           exchangeId: string;
                                           correlationId: string;
-                                          branchIndex: number;
-                                          branchLabel: "when" | "otherwise";
+                                          /** Label of the wrapped step, or `"route"` when `scope === "route"`. */
+                                          stepLabel: string;
+                                          scope: "route" | "step";
+                                          /** The derived cache key. */
+                                          key: string;
                                         }
-                                      : S extends "operation:choice:unmatched"
+                                      : S extends "cache:miss"
                                         ? {
                                             routeId: string;
                                             exchangeId: string;
                                             correlationId: string;
+                                            stepLabel: string;
+                                            scope: "route" | "step";
+                                            key: string;
+                                            /** True when the wrapped step dropped the exchange (filter/halt). */
+                                            dropped?: boolean;
                                           }
-                                        : // Agent events
-                                          S extends "agent:tool:invoked"
+                                        : S extends "cache:stored"
                                           ? {
                                               routeId: string;
                                               exchangeId: string;
                                               correlationId: string;
-                                              toolCallId: string;
-                                              toolName: string;
-                                              input: unknown;
+                                              stepLabel: string;
+                                              scope: "route" | "step";
+                                              key: string;
+                                              /** TTL in ms when one was configured. */
+                                              ttl?: number;
                                             }
-                                          : S extends "agent:tool:result"
+                                          : S extends "cache:failed"
                                             ? {
                                                 routeId: string;
                                                 exchangeId: string;
                                                 correlationId: string;
-                                                toolCallId: string;
-                                                toolName: string;
-                                                output: unknown;
-                                                duration: number;
+                                                stepLabel: string;
+                                                scope: "route" | "step";
+                                                /**
+                                                 * Where the failure occurred:
+                                                 * `"key"` = key derivation threw,
+                                                 * `"get"` = provider read threw,
+                                                 * `"inner"` = the wrapped step threw,
+                                                 * `"set"` = the provider write threw
+                                                 * after the wrapped step succeeded.
+                                                 */
+                                                phase:
+                                                  | "key"
+                                                  | "get"
+                                                  | "inner"
+                                                  | "set";
+                                                error: string;
+                                                /** Present for `"get"` / `"inner"` / `"set"`; absent when key derivation itself failed. */
+                                                key?: string;
                                               }
-                                            : S extends "agent:tool:error"
+                                            : // Choice operation
+                                              S extends "operation:choice:matched"
                                               ? {
                                                   routeId: string;
                                                   exchangeId: string;
                                                   correlationId: string;
-                                                  toolCallId: string;
-                                                  toolName: string;
-                                                  error: unknown;
-                                                  duration: number;
+                                                  branchIndex: number;
+                                                  branchLabel:
+                                                    | "when"
+                                                    | "otherwise";
                                                 }
-                                              : S extends "agent:block:loaded"
+                                              : S extends "operation:choice:unmatched"
                                                 ? {
                                                     routeId: string;
                                                     exchangeId: string;
                                                     correlationId: string;
-                                                    toolCallId: string;
-                                                    blockName: string;
-                                                    output: unknown;
-                                                    duration: number;
                                                   }
-                                                : S extends "agent:block:error"
+                                                : // Agent events
+                                                  S extends "agent:tool:invoked"
                                                   ? {
                                                       routeId: string;
                                                       exchangeId: string;
                                                       correlationId: string;
                                                       toolCallId: string;
-                                                      blockName: string;
-                                                      error: unknown;
-                                                      duration: number;
+                                                      toolName: string;
+                                                      input: unknown;
                                                     }
-                                                  : S extends "agent:finished"
+                                                  : S extends "agent:tool:result"
                                                     ? {
                                                         routeId: string;
                                                         exchangeId: string;
                                                         correlationId: string;
-                                                        finishReason: string;
-                                                        inputTokens?: number;
-                                                        outputTokens?: number;
-                                                        totalTokens?: number;
+                                                        toolCallId: string;
+                                                        toolName: string;
+                                                        output: unknown;
+                                                        duration: number;
                                                       }
-                                                    : S extends "agent:error"
+                                                    : S extends "agent:tool:error"
                                                       ? {
                                                           routeId: string;
                                                           exchangeId: string;
                                                           correlationId: string;
+                                                          toolCallId: string;
+                                                          toolName: string;
                                                           error: unknown;
+                                                          duration: number;
                                                         }
-                                                      : // Step errors (multi-segment suffix)
-                                                        S extends `step:${string}:error:caught`
+                                                      : S extends "agent:block:loaded"
                                                         ? {
-                                                            error: unknown;
-                                                            route?: Route;
-                                                            exchange?: Exchange<unknown>;
-                                                            operation: string;
+                                                            routeId: string;
+                                                            exchangeId: string;
+                                                            correlationId: string;
+                                                            toolCallId: string;
+                                                            blockName: string;
+                                                            output: unknown;
+                                                            duration: number;
                                                           }
-                                                        : S extends `step:${string}:error`
+                                                        : S extends "agent:block:error"
                                                           ? {
+                                                              routeId: string;
+                                                              exchangeId: string;
+                                                              correlationId: string;
+                                                              toolCallId: string;
+                                                              blockName: string;
                                                               error: unknown;
-                                                              route?: Route;
-                                                              exchange?: Exchange<unknown>;
-                                                              operation: string;
+                                                              duration: number;
                                                             }
-                                                          : // Route errors
-                                                            S extends "error:caught"
+                                                          : S extends "agent:finished"
                                                             ? {
-                                                                error: unknown;
-                                                                route?: Route;
-                                                                exchange?: Exchange<unknown>;
+                                                                routeId: string;
+                                                                exchangeId: string;
+                                                                correlationId: string;
+                                                                finishReason: string;
+                                                                inputTokens?: number;
+                                                                outputTokens?: number;
+                                                                totalTokens?: number;
                                                               }
-                                                            : S extends "error"
+                                                            : S extends "agent:error"
                                                               ? {
+                                                                  routeId: string;
+                                                                  exchangeId: string;
+                                                                  correlationId: string;
                                                                   error: unknown;
-                                                                  route?: Route;
-                                                                  exchange?: Exchange<unknown>;
                                                                 }
-                                                              : // Route lifecycle (must be last to avoid matching multi-segment suffixes)
-                                                                S extends
-                                                                    | "registered"
-                                                                    | "starting"
-                                                                    | "started"
+                                                              : // Step errors (multi-segment suffix)
+                                                                S extends `step:${string}:error:caught`
                                                                 ? {
-                                                                    route: Route;
+                                                                    error: unknown;
+                                                                    route?: Route;
+                                                                    exchange?: Exchange<unknown>;
+                                                                    operation: string;
                                                                   }
-                                                                : S extends "stopping"
+                                                                : S extends `step:${string}:error`
                                                                   ? {
-                                                                      route: Route;
-                                                                      reason?: unknown;
+                                                                      error: unknown;
+                                                                      route?: Route;
                                                                       exchange?: Exchange<unknown>;
+                                                                      operation: string;
                                                                     }
-                                                                  : S extends "stopped"
+                                                                  : // Route errors
+                                                                    S extends "error:caught"
                                                                     ? {
-                                                                        route: Route;
+                                                                        error: unknown;
+                                                                        route?: Route;
                                                                         exchange?: Exchange<unknown>;
                                                                       }
-                                                                    : never;
+                                                                    : S extends "error"
+                                                                      ? {
+                                                                          error: unknown;
+                                                                          route?: Route;
+                                                                          exchange?: Exchange<unknown>;
+                                                                        }
+                                                                      : // Route lifecycle (must be last to avoid matching multi-segment suffixes)
+                                                                        S extends
+                                                                            | "registered"
+                                                                            | "starting"
+                                                                            | "started"
+                                                                        ? {
+                                                                            route: Route;
+                                                                          }
+                                                                        : S extends "stopping"
+                                                                          ? {
+                                                                              route: Route;
+                                                                              reason?: unknown;
+                                                                              exchange?: Exchange<unknown>;
+                                                                            }
+                                                                          : S extends "stopped"
+                                                                            ? {
+                                                                                route: Route;
+                                                                                exchange?: Exchange<unknown>;
+                                                                              }
+                                                                            : never;
 
 /** Detail types for `plugin:<pluginId>:<suffix>` events. */
 type PluginEventDetails<S extends string> = S extends

--- a/packages/routecraft/test/cache.bun.test.ts
+++ b/packages/routecraft/test/cache.bun.test.ts
@@ -1,0 +1,1325 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { testContext, spy, type TestContext } from "@routecraft/testing";
+import {
+  craft,
+  CacheWrapperStep,
+  DefaultExchange,
+  direct,
+  markAuthentic,
+  MemoryCacheProvider,
+  noop,
+  type Adapter,
+  type CacheProvider,
+  type Exchange,
+  type Principal,
+  type Source,
+  type Step,
+  simple,
+} from "@routecraft/routecraft";
+
+/**
+ * Helper: build a CacheProvider spy that records every call and
+ * delegates to a real in-memory provider. Lets tests assert ordering
+ * (get -> miss -> set on first call; get -> hit on second) without
+ * reaching into internal state.
+ */
+function spyProvider(): CacheProvider & {
+  calls: { method: string; args: unknown[] }[];
+  inner: MemoryCacheProvider;
+} {
+  const inner = new MemoryCacheProvider();
+  const calls: { method: string; args: unknown[] }[] = [];
+  return {
+    calls,
+    inner,
+    async get(key) {
+      calls.push({ method: "get", args: [key] });
+      return inner.get(key);
+    },
+    async set(key, value, ttl) {
+      calls.push({ method: "set", args: [key, value, ttl] });
+      return inner.set(key, value, ttl);
+    },
+    async delete(key) {
+      calls.push({ method: "delete", args: [key] });
+      return inner.delete(key);
+    },
+    async has(key) {
+      calls.push({ method: "has", args: [key] });
+      return inner.has(key);
+    },
+    async getOrCompute(key, loader, ttl) {
+      calls.push({ method: "getOrCompute", args: [key, ttl] });
+      return inner.getOrCompute(key, loader, ttl);
+    },
+  };
+}
+
+describe(".cache() step scope: dual-mode wrapper", () => {
+  let t: TestContext | undefined;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case First exchange misses cache and runs the wrapped step; cached body forwarded
+   * @preconditions .from(simple).cache({ provider }).transform(compute).to(sink)
+   * @expectedResult sink receives compute's output; provider was queried once and stored once
+   */
+  test("first exchange misses, runs inner, and caches the result", async () => {
+    const provider = spyProvider();
+    const compute = mock((b: string) => `computed:${b}`);
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-miss")
+          .from(simple("hello"))
+          .cache({ provider })
+          .transform(compute)
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(sink.received).toHaveLength(1);
+    expect(sink.received[0].body).toBe("computed:hello");
+    // First exchange: getOrCompute is the only public entry point
+    // because the wrapper routes both hit/miss through it.
+    const methods = provider.calls.map((c) => c.method);
+    expect(methods).toContain("getOrCompute");
+  });
+
+  /**
+   * @case Repeat invocations with the same body reuse the cached value
+   * @preconditions Two client.send calls with identical input through the same direct route
+   * @expectedResult compute runs only once across both invocations
+   */
+  test("second exchange with same key hits the cache and skips the wrapped step", async () => {
+    const provider = new MemoryCacheProvider();
+    const compute = mock((b: string) => `computed:${b}`);
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-hit")
+          .from(direct())
+          .cache({ provider })
+          .transform(compute)
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("cache-hit", "hello");
+    await t.client.send("cache-hit", "hello");
+
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(sink.received).toHaveLength(2);
+    expect(sink.received[0].body).toBe("computed:hello");
+    expect(sink.received[1].body).toBe("computed:hello");
+  });
+
+  /**
+   * @case Different keys do not collide; same key reuses the entry
+   * @preconditions Custom key function partitions the cache by body.id
+   * @expectedResult Distinct ids each trigger one compute; duplicates reuse
+   */
+  test("custom key function isolates entries by derived key", async () => {
+    const provider = new MemoryCacheProvider();
+    const compute = mock((b: { id: number }) => ({ id: b.id, v: b.id * 2 }));
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-by-id")
+          .from(direct())
+          .cache({
+            key: (e) => String((e.body as { id: number }).id),
+            provider,
+          })
+          .transform(compute)
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("cache-by-id", { id: 1 });
+    await t.client.send("cache-by-id", { id: 1 });
+    await t.client.send("cache-by-id", { id: 2 });
+    await t.client.send("cache-by-id", { id: 1 });
+
+    // id=1 computed once, id=2 computed once
+    expect(compute).toHaveBeenCalledTimes(2);
+    expect(sink.received).toHaveLength(4);
+    expect(sink.received[0].body).toEqual({ id: 1, v: 2 });
+    expect(sink.received[1].body).toEqual({ id: 1, v: 2 });
+    expect(sink.received[2].body).toEqual({ id: 2, v: 4 });
+    expect(sink.received[3].body).toEqual({ id: 1, v: 2 });
+  });
+
+  /**
+   * @case Wrapped step throws; the error propagates and nothing is cached
+   * @preconditions transform throws on every call
+   * @expectedResult Subsequent calls retry (no poisoned cache entry)
+   */
+  test("errors from the wrapped step are not cached", async () => {
+    const provider = new MemoryCacheProvider();
+    let attempts = 0;
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-no-poison")
+          .from(direct())
+          .cache({ provider })
+          .transform(() => {
+            attempts++;
+            throw new Error(`attempt-${attempts}`);
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await expect(t.client.send("cache-no-poison", "input")).rejects.toThrow();
+    await expect(t.client.send("cache-no-poison", "input")).rejects.toThrow();
+
+    expect(attempts).toBe(2);
+    expect(sink.received).toHaveLength(0);
+    expect(provider.size).toBe(0);
+  });
+
+  /**
+   * @case TTL expiry triggers a recompute
+   * @preconditions ttl: 1ms; wait > 1ms between calls
+   * @expectedResult compute runs twice; second sink value reflects fresh compute
+   */
+  test("TTL expiry forces a recompute on next call", async () => {
+    const provider = new MemoryCacheProvider();
+    let counter = 0;
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-ttl")
+          .from(direct())
+          .cache({ provider, ttl: 5 })
+          .transform(() => ({ counter: ++counter }))
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("cache-ttl", "hello");
+    await new Promise((r) => setTimeout(r, 30));
+    await t.client.send("cache-ttl", "hello");
+
+    expect(counter).toBe(2);
+    expect(sink.received).toHaveLength(2);
+    expect(sink.received[0].body).toEqual({ counter: 1 });
+    expect(sink.received[1].body).toEqual({ counter: 2 });
+  });
+
+  /**
+   * @case Concurrent same-key calls share one inner execution (stampede protection)
+   * @preconditions Provider.getOrCompute dedupes; two concurrent calls with same key
+   * @expectedResult Loader runs once; both calls resolve with the same value
+   */
+  test("MemoryCacheProvider.getOrCompute dedupes concurrent loaders", async () => {
+    const provider = new MemoryCacheProvider();
+    let runs = 0;
+    const loader = async (): Promise<string> => {
+      runs++;
+      await new Promise((r) => setTimeout(r, 10));
+      return "value";
+    };
+
+    const [a, b, c] = await Promise.all([
+      provider.getOrCompute("k", loader),
+      provider.getOrCompute("k", loader),
+      provider.getOrCompute("k", loader),
+    ]);
+
+    expect(runs).toBe(1);
+    expect(a).toBe("value");
+    expect(b).toBe("value");
+    expect(c).toBe("value");
+  });
+
+  /**
+   * @case A failing loader does not poison the cache
+   * @preconditions Loader rejects on first call; succeeds on retry
+   * @expectedResult First call rejects; second call invokes loader again and caches success
+   */
+  test("MemoryCacheProvider.getOrCompute does not cache a thrown loader", async () => {
+    const provider = new MemoryCacheProvider();
+    let calls = 0;
+    const loader = async (): Promise<string> => {
+      calls++;
+      if (calls === 1) throw new Error("fail");
+      return "ok";
+    };
+
+    await expect(provider.getOrCompute("k", loader)).rejects.toThrow("fail");
+    const second = await provider.getOrCompute("k", loader);
+    expect(second).toBe("ok");
+    expect(calls).toBe(2);
+  });
+
+  /**
+   * @case Provider rotation: explicit provider overrides the module default
+   * @preconditions Two separate providers; the user's provider stores; default does not
+   * @expectedResult provider.size === 1; default provider untouched for this key
+   */
+  test("explicit provider does not share state with the module default", async () => {
+    const provider = new MemoryCacheProvider();
+    const compute = mock((b: string) => `computed:${b}`);
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("explicit-provider")
+          .from(simple("isolated"))
+          .cache({ provider })
+          .transform(compute)
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(provider.size).toBe(1);
+  });
+
+  /**
+   * @case Pre-from .cache() stages route-scope config (does not throw)
+   * @preconditions craft().cache(...) called BEFORE .from()
+   * @expectedResult Builder accepts the call; the next route carries the route-scope config
+   */
+  test("route-scope .cache() (before .from()) stages without throwing", () => {
+    expect(() => {
+      craft()
+        .id("route-scope")
+        .cache({ ttl: 1000 })
+        .from(simple("x"))
+        .to(noop());
+    }).not.toThrow();
+  });
+
+  /**
+   * @case Dropped exchanges (filter) are not cached
+   * @preconditions Wrapped filter drops every exchange
+   * @expectedResult Sink receives nothing; provider stays empty
+   */
+  test("dropped exchanges are not cached", async () => {
+    const provider = new MemoryCacheProvider();
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-drop")
+          .from(simple("drop-me"))
+          .cache({ provider })
+          .filter(() => false)
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(sink.received).toHaveLength(0);
+    expect(provider.size).toBe(0);
+  });
+
+  /**
+   * @case Wrapper emits cache:miss + cache:stored on miss; cache:hit on subsequent run
+   * @preconditions Subscribed to cache lifecycle events
+   * @expectedResult Event ordering matches the spec; details carry scope/stepLabel/key
+   */
+  test("emits scope-aware cache lifecycle events", async () => {
+    const provider = new MemoryCacheProvider();
+    const events: string[] = [];
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-events")
+          .from(direct())
+          .cache({ provider })
+          .transform((b: string) => `out:${b}`)
+          .to(sink),
+      )
+      .build();
+
+    for (const name of ["hit", "miss", "stored", "failed"] as const) {
+      t.ctx.on(
+        `route:cache-events:cache:${name}` as never,
+        (payload: { details: { scope?: string; stepLabel?: string } }) => {
+          events.push(name);
+          expect(payload.details.scope).toBe("step");
+          expect(payload.details.stepLabel).toBeDefined();
+        },
+      );
+    }
+
+    await t.startAndWaitReady();
+    await t.client.send("cache-events", "hello");
+    await t.client.send("cache-events", "hello");
+
+    expect(events).toContain("miss");
+    expect(events).toContain("stored");
+    expect(events).toContain("hit");
+    expect(events.indexOf("hit")).toBeGreaterThan(events.indexOf("miss"));
+  });
+
+  /**
+   * @case On a miss the wrapped step's header mutations survive downstream
+   * @preconditions .cache().header('x-test', 'yes').to(sink); single send (miss)
+   * @expectedResult sink sees the header set by the wrapped step (not stripped by the cache rewrap)
+   */
+  test("preserves the wrapped step's header mutations on a miss", async () => {
+    const provider = new MemoryCacheProvider();
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-headers")
+          .from(direct())
+          .cache({ provider })
+          .header("x-test", "yes")
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("cache-headers", "body");
+
+    expect(sink.received).toHaveLength(1);
+    expect(sink.received[0].headers["x-test"]).toBe("yes");
+  });
+
+  /**
+   * @case A `null` result is a valid cached value (not a perpetual miss)
+   * @preconditions Wrapped transform returns null
+   * @expectedResult compute runs once across two sends; both sink bodies are null
+   */
+  test("caches a null result instead of recomputing forever", async () => {
+    const provider = new MemoryCacheProvider();
+    let calls = 0;
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-null")
+          .from(direct())
+          .cache({ provider })
+          .transform(() => {
+            calls++;
+            return null;
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("cache-null", "x");
+    await t.client.send("cache-null", "x");
+
+    expect(calls).toBe(1);
+    expect(sink.received).toHaveLength(2);
+    expect(sink.received[0].body).toBeNull();
+    expect(sink.received[1].body).toBeNull();
+  });
+
+  /**
+   * @case A legitimate `undefined` body is not mistaken for a drop
+   * @preconditions Wrapped transform returns undefined
+   * @expectedResult Pipeline continues (sink reached); undefined is not cached so it recomputes
+   */
+  test("an undefined body is forwarded, not treated as a drop", async () => {
+    const provider = new MemoryCacheProvider();
+    let calls = 0;
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-undefined")
+          .from(direct())
+          .cache({ provider })
+          .transform(() => {
+            calls++;
+            return undefined;
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("cache-undefined", "x");
+    await t.client.send("cache-undefined", "x");
+
+    // undefined is the miss sentinel: never cached, so it recomputes.
+    expect(calls).toBe(2);
+    expect(provider.size).toBe(0);
+    // The exchange still flowed to the sink (not dropped).
+    expect(sink.received).toHaveLength(2);
+    expect(sink.received[0].body).toBeUndefined();
+  });
+
+  /**
+   * @case Stacked .error(h).cache().to(d): error OUTSIDE cache catches the rethrow
+   * @preconditions error wraps cache wraps a throwing transform
+   * @expectedResult Handler recovers; nothing is cached (error is outside the cache)
+   */
+  test("stacked .error().cache(): handler recovers and nothing is cached", async () => {
+    const provider = new MemoryCacheProvider();
+    const sink = spy();
+    let attempts = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("error-outside-cache")
+          .from(direct())
+          .error(() => ({ recovered: true }))
+          .cache({ provider })
+          .transform(() => {
+            attempts++;
+            throw new Error("boom");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("error-outside-cache", "x");
+    await t.client.send("error-outside-cache", "x");
+
+    expect(attempts).toBe(2);
+    expect(provider.size).toBe(0);
+    expect(sink.received).toHaveLength(2);
+    expect(sink.received[0].body).toEqual({ recovered: true });
+  });
+
+  /**
+   * @case Stacked .cache().error(h): recovery value IS cached (documented footgun)
+   * @preconditions cache wraps error wraps a throwing transform
+   * @expectedResult Handler runs once; recovered value is cached and replayed on the second send
+   */
+  test("stacked .cache().error(): recovery value is cached and replayed", async () => {
+    const provider = new MemoryCacheProvider();
+    const sink = spy();
+    let handlerCalls = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("error-inside-cache")
+          .from(direct())
+          .cache({ provider })
+          .error(() => {
+            handlerCalls++;
+            return { recovered: true };
+          })
+          .transform(() => {
+            throw new Error("boom");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("error-inside-cache", "x");
+    await t.client.send("error-inside-cache", "x");
+
+    // Second send is a cache hit: the handler is not invoked again.
+    expect(handlerCalls).toBe(1);
+    expect(sink.received).toHaveLength(2);
+    expect(sink.received[0].body).toEqual({ recovered: true });
+    expect(sink.received[1].body).toEqual({ recovered: true });
+  });
+
+  /**
+   * @case A cache rethrow cascades to a route-level .error() handler
+   * @preconditions Route-level .error() before .from(); wrapped transform throws
+   * @expectedResult Route handler is invoked once and the route reports no unhandled errors (route-scope recovery does not resume the pipeline, matching existing .error() semantics)
+   */
+  test("cache failure cascades to the route-level error handler", async () => {
+    const provider = new MemoryCacheProvider();
+    const routeHandler = mock(() => ({ caughtAtRoute: true }));
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-cascade")
+          .error(routeHandler)
+          .from(simple("x"))
+          .cache({ provider })
+          .transform(() => {
+            throw new Error("boom");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+
+    expect(routeHandler).toHaveBeenCalledTimes(1);
+    expect(t.errors).toHaveLength(0);
+    expect(provider.size).toBe(0);
+  });
+
+  /**
+   * @case With no handler, a cache rethrow hits the default error path
+   * @preconditions No route/step handler; wrapped transform throws; simple source
+   * @expectedResult t.errors records the failure; sink not reached; route not stopped
+   */
+  test("cache failure with no handler hits the default error path", async () => {
+    const provider = new MemoryCacheProvider();
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-default-error")
+          .from(simple("x"))
+          .cache({ provider })
+          .transform(() => {
+            throw new Error("boom-default");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.test();
+    expect(t.errors[0]?.message).toMatch(/boom-default/);
+    expect(sink.received).toHaveLength(0);
+    expect(provider.size).toBe(0);
+  });
+
+  /**
+   * @case Builder body type is preserved across .cache()
+   * @preconditions transform<string,number> then .cache() then transform<number,number>
+   * @expectedResult Compiles (tsc enforces the number input after cache) and runs end to end
+   */
+  test("preserves the builder body type across the wrapper", async () => {
+    const provider = new MemoryCacheProvider();
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-types")
+          .from(direct())
+          .transform((b: string) => b.length)
+          .cache({ provider })
+          // If .cache() dropped the type, `n: number` would not type-check.
+          .transform((n: number) => n * 2)
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("cache-types", "abcd");
+
+    expect(sink.received).toHaveLength(1);
+    expect(sink.received[0].body).toBe(8);
+  });
+
+  /**
+   * @case Concurrent same-key exchanges share one inner run through the wrapper (stampede)
+   * @preconditions Hand-built CacheWrapperStep over a slow inner; two real exchanges, same key, executed concurrently
+   * @expectedResult Inner runs once; the loser deduped via the in-flight path; both queues forward the shared body
+   */
+  test("concurrent same-key exchanges share one inner run through the wrapper", async () => {
+    // A real context is needed so the dedup path's DefaultExchange.rewrap
+    // works on the waiter exchange. Hand-build the wrapper (rather than
+    // routing) to drive deterministic concurrency into a single instance.
+    t = await testContext()
+      .routes(craft().id("ctx-host").from(simple("x")).to(noop()))
+      .build();
+    await t.startAndWaitReady();
+    const ctx = t.ctx;
+
+    const provider = new MemoryCacheProvider();
+    let runs = 0;
+    const innerStep: Step<Adapter> = {
+      operation: "transform" as Step<Adapter>["operation"],
+      adapter: { adapterId: "fake.inner" } as unknown as Adapter,
+      async execute(
+        exchange: Exchange,
+        _remaining: Step<Adapter>[],
+        queue: { exchange: Exchange; steps: Step<Adapter>[] }[],
+      ): Promise<void> {
+        runs++;
+        await new Promise((r) => setTimeout(r, 20));
+        queue.push({
+          exchange: DefaultExchange.rewrap(exchange, { body: "value" }),
+          steps: [],
+        });
+      },
+    };
+    const wrapper = new CacheWrapperStep(innerStep, {
+      provider,
+      key: () => "same",
+    });
+
+    const ex1 = new DefaultExchange(ctx, { body: "a" });
+    const ex2 = new DefaultExchange(ctx, { body: "b" });
+    const q1: { exchange: Exchange; steps: Step<Adapter>[] }[] = [];
+    const q2: { exchange: Exchange; steps: Step<Adapter>[] }[] = [];
+
+    await Promise.all([
+      wrapper.execute(ex1, [], q1),
+      wrapper.execute(ex2, [], q2),
+    ]);
+
+    expect(runs).toBe(1);
+    expect(q1).toHaveLength(1);
+    expect(q2).toHaveLength(1);
+    expect(q1[0]!.exchange.body).toBe("value");
+    expect(q2[0]!.exchange.body).toBe("value");
+  });
+
+  /**
+   * @case Concurrent drop: when the loader drops, the deduped waiter drops too
+   * @preconditions Hand-built wrapper; slow inner that pushes nothing (a drop); two concurrent same-key exchanges
+   * @expectedResult Inner runs once; neither exchange is forwarded; nothing is cached
+   */
+  test("concurrent drop propagates to the deduped waiter", async () => {
+    t = await testContext()
+      .routes(craft().id("ctx-host-drop").from(simple("x")).to(noop()))
+      .build();
+    await t.startAndWaitReady();
+    const ctx = t.ctx;
+
+    const provider = new MemoryCacheProvider();
+    let runs = 0;
+    const droppingInner: Step<Adapter> = {
+      operation: "filter" as Step<Adapter>["operation"],
+      adapter: { adapterId: "fake.filter" } as unknown as Adapter,
+      async execute(): Promise<void> {
+        runs++;
+        await new Promise((r) => setTimeout(r, 20));
+        // Push nothing: an empty inner queue signals a drop to the wrapper.
+      },
+    };
+    const wrapper = new CacheWrapperStep(droppingInner, {
+      provider,
+      key: () => "same",
+    });
+
+    const ex1 = new DefaultExchange(ctx, { body: "a" });
+    const ex2 = new DefaultExchange(ctx, { body: "b" });
+    const q1: { exchange: Exchange; steps: Step<Adapter>[] }[] = [];
+    const q2: { exchange: Exchange; steps: Step<Adapter>[] }[] = [];
+
+    await Promise.all([
+      wrapper.execute(ex1, [], q1),
+      wrapper.execute(ex2, [], q2),
+    ]);
+
+    expect(runs).toBe(1);
+    // Both exchanges dropped: nothing forwarded downstream, nothing cached.
+    expect(q1).toHaveLength(0);
+    expect(q2).toHaveLength(0);
+    expect(provider.size).toBe(0);
+  });
+
+  /**
+   * @case A provider read failure is wrapped as RC5028 (retryable boundary code)
+   * @preconditions Custom provider whose getOrCompute throws before running the loader
+   * @expectedResult The wrapped step never runs; the failure surfaces as RC5028
+   */
+  test("provider read failure surfaces as RC5028", async () => {
+    let innerRuns = 0;
+    const failing: CacheProvider = {
+      async get() {
+        return undefined;
+      },
+      async set() {},
+      async delete() {},
+      async has() {
+        return false;
+      },
+      async getOrCompute() {
+        throw new Error("redis-unreachable");
+      },
+    };
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-provider-read-fail")
+          .from(direct())
+          .cache({ provider: failing })
+          .transform((b: string) => {
+            innerRuns++;
+            return b;
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await expect(
+      t.client.send("cache-provider-read-fail", "x"),
+    ).rejects.toThrow(/provider read failed/);
+    expect(innerRuns).toBe(0);
+    expect(sink.received).toHaveLength(0);
+  });
+
+  /**
+   * @case A provider write failure (after the step succeeds) is wrapped as RC5028
+   * @preconditions Custom provider whose getOrCompute runs the loader then throws
+   * @expectedResult The wrapped step runs once; the failure surfaces as RC5028 (phase "set")
+   */
+  test("provider write failure surfaces as RC5028", async () => {
+    let innerRuns = 0;
+    const failing: CacheProvider = {
+      async get() {
+        return undefined;
+      },
+      async set() {},
+      async delete() {},
+      async has() {
+        return false;
+      },
+      async getOrCompute<T>(_key: string, loader: () => Promise<T>) {
+        await loader();
+        throw new Error("write-failed");
+      },
+    };
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-provider-write-fail")
+          .from(direct())
+          .cache({ provider: failing })
+          .transform((b: string) => {
+            innerRuns++;
+            return b;
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await expect(
+      t.client.send("cache-provider-write-fail", "x"),
+    ).rejects.toThrow(/provider write failed/);
+    expect(innerRuns).toBe(1);
+    expect(sink.received).toHaveLength(0);
+  });
+});
+
+describe(".cache() route scope: dual-mode wrapper", () => {
+  let t: TestContext | undefined;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case First send misses cache and runs the full pipeline; result returned to caller
+   * @preconditions craft().cache(...).from(direct()).transform(slow).to(noop()) and one send
+   * @expectedResult Pipeline runs; client.send returns the computed body
+   */
+  test("first send misses and runs the pipeline", async () => {
+    const provider = new MemoryCacheProvider();
+    const compute = mock((b: string) => `out:${b}`);
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("route-cache-miss")
+          .cache({ provider })
+          .from(direct())
+          .transform(compute)
+          .to(noop()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    const result = await t.client.send("route-cache-miss", "hello");
+
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(result).toBe("out:hello");
+  });
+
+  /**
+   * @case Second send with the same body skips the WHOLE pipeline
+   * @preconditions Same route as above, two sends with identical input
+   * @expectedResult compute runs once; both sends return the cached body; sink not reached on hit
+   */
+  test("second send with same key skips the entire pipeline", async () => {
+    const provider = new MemoryCacheProvider();
+    const compute = mock((b: string) => `out:${b}`);
+    const sink = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("route-cache-hit")
+          .cache({ provider })
+          .from(direct())
+          .transform(compute)
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    const a = await t.client.send("route-cache-hit", "x");
+    const b = await t.client.send("route-cache-hit", "x");
+
+    // Pipeline ran exactly once.
+    expect(compute).toHaveBeenCalledTimes(1);
+    // Sink saw the miss output; the hit reuses the cached body without
+    // invoking the destination (the whole pipeline is skipped).
+    expect(sink.received).toHaveLength(1);
+    // Both callers see the same returned body.
+    expect(a).toBe("out:x");
+    expect(b).toBe("out:x");
+  });
+
+  /**
+   * @case Side effects do not replay on a cache hit
+   * @preconditions Wrapped transform increments an external counter
+   * @expectedResult Counter increments once across N identical sends
+   */
+  test("side effects are skipped on a hit (the pipeline does not run)", async () => {
+    const provider = new MemoryCacheProvider();
+    let sideEffects = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("route-cache-sideeffect")
+          .cache({ provider })
+          .from(direct())
+          .transform((b: string) => {
+            sideEffects++;
+            return `out:${b}`;
+          })
+          .to(noop()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    for (let i = 0; i < 5; i++) {
+      await t.client.send("route-cache-sideeffect", "same");
+    }
+
+    expect(sideEffects).toBe(1);
+  });
+
+  /**
+   * @case TTL expiry forces a fresh pipeline run
+   * @preconditions cache({ ttl: 5 }); second send after a 30ms wait
+   * @expectedResult Pipeline runs twice; second result reflects the fresh compute
+   */
+  test("TTL expiry recomputes at route scope", async () => {
+    const provider = new MemoryCacheProvider();
+    let counter = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("route-cache-ttl")
+          .cache({ provider, ttl: 5 })
+          .from(direct())
+          .transform(() => ({ counter: ++counter }))
+          .to(noop()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    const a = await t.client.send("route-cache-ttl", "x");
+    await new Promise((r) => setTimeout(r, 30));
+    const b = await t.client.send("route-cache-ttl", "x");
+
+    expect(counter).toBe(2);
+    expect(a).toEqual({ counter: 1 });
+    expect(b).toEqual({ counter: 2 });
+  });
+
+  /**
+   * @case Custom key isolates entries
+   * @preconditions key derived from body.id; different ids miss, repeats hit
+   * @expectedResult Distinct ids each trigger one compute; same id reuses
+   */
+  test("custom key partitions the cache at route scope", async () => {
+    const provider = new MemoryCacheProvider();
+    const compute = mock((b: { id: number }) => ({ id: b.id, v: b.id * 2 }));
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("route-cache-custom-key")
+          .cache({
+            provider,
+            key: (e) => String((e.body as { id: number }).id),
+          })
+          .from(direct())
+          .transform(compute)
+          .to(noop()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.send("route-cache-custom-key", { id: 1 });
+    await t.client.send("route-cache-custom-key", { id: 1 });
+    await t.client.send("route-cache-custom-key", { id: 2 });
+
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * @case Routes containing .split() are rejected at build time
+   * @preconditions craft().cache().from().split().to() at build time
+   * @expectedResult RC5003 thrown synchronously with a clear pointer to step-scope cache
+   */
+  test("routes containing .split() reject route-scope cache at build time", () => {
+    expect(() => {
+      craft()
+        .id("route-cache-split")
+        .cache({ ttl: 1000 })
+        .from<number[]>(simple([1, 2, 3]))
+        .split()
+        .to(noop());
+    }).toThrow(/does not support routes containing \.split\(\)/);
+  });
+
+  /**
+   * @case Route-scope cache emits scope-aware lifecycle events
+   * @preconditions Subscribed to route:*:cache:hit / miss / stored
+   * @expectedResult Events fire with scope: "route" and the derived key
+   */
+  test("emits scope: 'route' lifecycle events", async () => {
+    const provider = new MemoryCacheProvider();
+    const events: { name: string; scope?: string; stepLabel?: string }[] = [];
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("route-cache-events")
+          .cache({ provider })
+          .from(direct())
+          .transform((b: string) => `out:${b}`)
+          .to(noop()),
+      )
+      .build();
+
+    for (const name of ["hit", "miss", "stored"] as const) {
+      t.ctx.on(
+        `route:route-cache-events:cache:${name}` as never,
+        (payload: {
+          details: { scope?: string; stepLabel?: string; key?: string };
+        }) => {
+          events.push({
+            name,
+            scope: payload.details.scope,
+            stepLabel: payload.details.stepLabel,
+          });
+        },
+      );
+    }
+
+    await t.startAndWaitReady();
+    await t.client.send("route-cache-events", "hello");
+    await t.client.send("route-cache-events", "hello");
+
+    const names = events.map((e) => e.name);
+    expect(names).toContain("miss");
+    expect(names).toContain("stored");
+    expect(names).toContain("hit");
+    for (const e of events) {
+      expect(e.scope).toBe("route");
+      expect(e.stepLabel).toBe("route");
+    }
+  });
+
+  /**
+   * @case A cache hit emits exchange:restored alongside cache:hit
+   * @preconditions Subscribed to route:*:exchange:restored
+   * @expectedResult exchange:restored fires once with source: "cache" on the second (hit) send
+   */
+  test("cache hit emits exchange:restored", async () => {
+    const provider = new MemoryCacheProvider();
+    const restored: { source?: string }[] = [];
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("route-cache-restored")
+          .cache({ provider })
+          .from(direct())
+          .transform((b: string) => `out:${b}`)
+          .to(noop()),
+      )
+      .build();
+
+    t.ctx.on(
+      `route:route-cache-restored:exchange:restored` as never,
+      (payload: { details: { source?: string } }) => {
+        restored.push({ source: payload.details.source });
+      },
+    );
+
+    await t.startAndWaitReady();
+    await t.client.send("route-cache-restored", "x");
+    await t.client.send("route-cache-restored", "x");
+
+    expect(restored).toHaveLength(1);
+    expect(restored[0]!.source).toBe("cache");
+  });
+
+  /**
+   * @case .input() validation runs before the cache check (not bypassed on hit)
+   * @preconditions Route has .input({ body: schema }).cache(); send an invalid body
+   * @expectedResult Validation rejects the request; the cache provider is never consulted, nothing cached
+   */
+  test(".input() validation runs before the cache check", async () => {
+    const schema = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: (value: unknown) => {
+          if (typeof value === "object" && value !== null && "ok" in value) {
+            return { value: value as { ok: true } };
+          }
+          return { issues: [{ message: "must have ok:true" }] };
+        },
+      },
+    } as const;
+    const provider = new MemoryCacheProvider();
+    let pipelineRuns = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("route-cache-input")
+          .input(schema as never)
+          .cache({ provider })
+          .from(direct())
+          .transform((b) => {
+            pipelineRuns++;
+            return b;
+          })
+          .to(noop()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+
+    // Invalid input is rejected before the cache is consulted; pipeline never runs.
+    await expect(
+      t.client.send("route-cache-input", { bad: 1 }),
+    ).rejects.toThrow();
+    expect(pipelineRuns).toBe(0);
+    expect(provider.size).toBe(0);
+
+    // A valid input runs the pipeline once and caches.
+    await t.client.send("route-cache-input", { ok: true });
+    expect(pipelineRuns).toBe(1);
+    expect(provider.size).toBe(1);
+
+    // Repeat: cache hit, pipeline does not run again.
+    await t.client.send("route-cache-input", { ok: true });
+    expect(pipelineRuns).toBe(1);
+  });
+
+  /**
+   * @case .authorize() runs before the cache check; unauthorized callers do not see cached responses
+   * @preconditions Route has .authorize({ roles: ['admin'] }).cache({ provider }); admin populates the cache, then a non-admin caller hits the same key
+   * @expectedResult Admin's call caches; non-admin's call fails with RC5015 even though the cache has an entry for the body; cache provider was never read for the rejected call
+   */
+  test(".authorize() runs BEFORE the cache check (no unauthorized cache hits)", async () => {
+    function principalSource(
+      body: unknown,
+      principal?: Principal,
+    ): Source<unknown> {
+      return {
+        subscribe: async (_ctx, handler) => {
+          const headers = principal
+            ? { "routecraft.auth.principal": markAuthentic(principal) }
+            : undefined;
+          await handler(body, headers);
+        },
+      };
+    }
+
+    const provider = new MemoryCacheProvider();
+    let pipelineRuns = 0;
+
+    // First route: admin populates the cache.
+    const adminPrincipal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "alice",
+      roles: ["admin"],
+    };
+    const adminCtx = await testContext()
+      .routes(
+        craft()
+          .id("auth-before-cache")
+          .authorize({ roles: ["admin"] })
+          .cache({ provider })
+          .from(principalSource("payload", adminPrincipal))
+          .transform((b: string) => {
+            pipelineRuns++;
+            return `done:${b}`;
+          })
+          .to(noop()),
+      )
+      .build();
+    await adminCtx.test();
+    await adminCtx.stop();
+    expect(pipelineRuns).toBe(1);
+    expect(provider.size).toBe(1);
+
+    // Second route: a non-admin sends the SAME body. The cache has a hit
+    // for that body, but .authorize() runs first and rejects the call.
+    const guestPrincipal: Principal = {
+      kind: "custom",
+      scheme: "bearer",
+      subject: "bob",
+      roles: ["guest"],
+    };
+    const guestErrors: unknown[] = [];
+    const guestCtx = await testContext()
+      .routes(
+        craft()
+          .id("auth-before-cache")
+          .authorize({ roles: ["admin"] })
+          .cache({ provider })
+          .from(principalSource("payload", guestPrincipal))
+          .transform((b: string) => {
+            pipelineRuns++;
+            return `done:${b}`;
+          })
+          .to(noop()),
+      )
+      .on("route:auth-before-cache:exchange:failed", ({ details }) => {
+        guestErrors.push((details as { error: { rc?: string } }).error);
+      })
+      .build();
+    await guestCtx.test();
+    await guestCtx.stop();
+
+    // Authorize rejected the guest BEFORE the cache check, so:
+    // - the pipeline did NOT run again (still 1 total run)
+    // - the cache wasn't consulted for the guest, no extra entry
+    // - the guest saw RC5015 (permission denied)
+    expect(pipelineRuns).toBe(1);
+    expect(provider.size).toBe(1);
+    expect(guestErrors).toHaveLength(1);
+    expect((guestErrors[0] as { rc: string }).rc).toBe("RC5015");
+  });
+});
+
+describe("MemoryCacheProvider", () => {
+  let provider: MemoryCacheProvider;
+  beforeEach(() => {
+    provider = new MemoryCacheProvider({ max: 4 });
+  });
+
+  /**
+   * @case Basic get/set/has/delete semantics
+   * @preconditions Fresh provider
+   * @expectedResult Each method behaves like a TTL-less map
+   */
+  test("supports get / set / has / delete", async () => {
+    expect(await provider.has("k")).toBe(false);
+    expect(await provider.get("k")).toBeUndefined();
+    await provider.set("k", 42);
+    expect(await provider.has("k")).toBe(true);
+    expect(await provider.get("k")).toBe(42);
+    await provider.delete("k");
+    expect(await provider.has("k")).toBe(false);
+  });
+
+  /**
+   * @case `null` is storable and distinct from a miss
+   * @preconditions set a null value, then get
+   * @expectedResult get returns null (a hit), has returns true
+   */
+  test("stores null as a value distinct from a cache miss", async () => {
+    await provider.set("k", null);
+    expect(await provider.has("k")).toBe(true);
+    expect(await provider.get("k")).toBeNull();
+    expect(await provider.get("absent")).toBeUndefined();
+  });
+
+  /**
+   * @case set() rejects undefined (the miss sentinel)
+   * @preconditions set with undefined value
+   * @expectedResult Throws RC5028 rather than silently no-opping
+   */
+  test("set() throws on undefined instead of silently dropping", async () => {
+    await expect(provider.set("k", undefined)).rejects.toThrow(
+      /RC5028|undefined/,
+    );
+  });
+
+  /**
+   * @case LRU eviction kicks in past `max`
+   * @preconditions max: 4; insert 5 distinct keys
+   * @expectedResult Oldest (least-recently-used) entry is gone
+   */
+  test("evicts the least-recently-used entry when max is exceeded", async () => {
+    await provider.set("a", 1);
+    await provider.set("b", 2);
+    await provider.set("c", 3);
+    await provider.set("d", 4);
+    // Touch a so b becomes LRU.
+    await provider.get("a");
+    await provider.set("e", 5);
+    expect(await provider.has("a")).toBe(true);
+    expect(await provider.has("b")).toBe(false);
+  });
+
+  /**
+   * @case Per-set TTL overrides the default
+   * @preconditions Provider default ttl unset; set with ttl: 5ms
+   * @expectedResult Entry disappears after the TTL elapses
+   */
+  test("per-call ttl expires the entry", async () => {
+    await provider.set("k", "v", 5);
+    expect(await provider.get("k")).toBe("v");
+    await new Promise((r) => setTimeout(r, 30));
+    expect(await provider.get("k")).toBeUndefined();
+  });
+
+  /**
+   * @case clear() empties the cache
+   * @preconditions Two entries
+   * @expectedResult size returns to zero
+   */
+  test("clear() drops every entry", async () => {
+    await provider.set("a", 1);
+    await provider.set("b", 2);
+    expect(provider.size).toBe(2);
+    provider.clear();
+    expect(provider.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Ships the first cache wrapper as a dual-mode-ready step operation:
CacheWrapperStep extends WrapperStep and runs the inner step through a
pluggable CacheProvider. The bundled MemoryCacheProvider is backed by
lru-cache for size-bounded LRU eviction plus optional TTL, with
in-flight Promise dedup so concurrent same-key exchanges share one
computation. Custom providers plug in per-call via cache({ provider }),
keeping the door open for Redis or multi-tier backends.

Cache hits replace exchange.body and skip the wrapped step; errors and
dropped exchanges leave the cache untouched. Route-scope .cache()
(called before .from()) throws RC2001 with a pointer to #112 until the
whole-pipeline semantics are nailed down.

Adds RC5018 for provider failures, exports CacheProvider /
MemoryCacheProvider / CacheOptions, and documents cache lifecycle
events (hit/miss/stored/failed) in the events reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pluggable `.cache()` wrapper at step and route scope to reuse results and skip work. Ships a default in-memory provider with LRU + TTL and emits cache lifecycle events with clear error codes.

- **New Features**
  - `.cache()` supports step scope (wraps the next step with in-flight dedupe) and route scope (short-circuits the whole pipeline on a hit; caches the terminal body).
  - Pluggable `CacheProvider`; default `MemoryCacheProvider` uses `lru-cache` with size-bound LRU and optional TTL.
  - Behavior: cache hits replace `exchange.body`; errors and dropped exchanges are not cached; `null` is cacheable; `undefined` is rejected.
  - Events: `cache:hit`, `cache:miss`, `cache:stored`, `cache:failed` with `phase: "key" | "get" | "inner" | "set"` and `scope: "step" | "route"`.
  - Errors: `RC5028` (cache provider failed, retryable) and `RC5029` (cache key derivation failed, non-retryable).
  - Route-scope order follows the fixed filter chain: authorize → parse → input → cacheCheck → user steps → cacheStore; split routes are rejected for route-scope cache.
  - Exports: `CacheWrapperStep`, `CacheOptions`, `CacheProvider`, `MemoryCacheProvider`; event typings extended. Docs added for the Filter Chain and updated for cache, events, and errors. Tests cover both scopes and edge cases.

- **Dependencies**
  - Add `lru-cache` and update lockfile.

<sup>Written for commit 109c8baacdc565298b071635bf76844019fc8d08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

