### PR TITLE
feat(routecraft): expose one capability on multiple ingresses via variadic .from()

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/adapters/mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/mcp/page.md
@@ -75,6 +75,14 @@ These mirror the [MCP specification (2025-03-26) `ToolAnnotations`](https://mode
 | `idempotentHint` | `boolean` | When `true`, calling the tool repeatedly with the same arguments has no additional effect. Clients assume `false` when omitted. |
 | `openWorldHint` | `boolean` | When `true`, the tool may interact with external systems (network, filesystem, etc.). Clients assume `true` when omitted. |
 
+**Derived from route tags:** the four behavior hints are also derived from the route's `.tag()` values, so you declare the fact once instead of as both a tag and an annotation. `read-only` sets `readOnlyHint`, `destructive` sets `destructiveHint`, `idempotent` sets `idempotentHint`, and `open-world` sets `openWorldHint`. Explicit `annotations` passed to `mcp()` override the derived values per-key.
+
+```ts
+// These two routes expose the same annotations to MCP clients:
+.tag('read-only').tag('open-world').from(mcp())
+.from(mcp({ annotations: { readOnlyHint: true, openWorldHint: true } }))
+```
+
 **Options (McpClientOptions -- destination):**
 
 | Option | Type | Required | Description |

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -45,15 +45,22 @@ craft().from(timer()).id('orders');
 Invalid operation type
 
 **Why it happens**  
-The step received unsupported input.
+Either a step received unsupported input (e.g. `split()` on a non-array), or `from()` was called with no sources, or with multiple sources but without a preceding `input({ body })`. Multi-ingress routes share one pipeline, so they need one shared input schema to validate and normalize every channel to the same body type.
 
 **Suggestion**  
-Use a supported operator and verify the step name.
+Use a supported operator and verify the step name. For a multi-ingress route, declare `input({ body })` before `from()`, or expose each channel as its own single-source route.
 
 **Example**
 ```ts
 // split requires an array
 craft().from(simple(['a','b'])).split()
+
+// multi-ingress requires a shared input schema
+craft()
+  .id('my-route')
+  .input(MyBodySchema) // required with multiple sources
+  .from(direct(), mcp())
+  .to(handler)
 ```
 
 ## RC2002

--- a/apps/routecraft.dev/src/app/docs/reference/operations/from/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/from/page.md
@@ -6,7 +6,11 @@ title: from
 
 ```ts
 from<T>(src: Source<T> | CallableSource<T>): RouteBuilder<T>
-from<T>(...sources: Source<unknown>[]): RouteBuilder<T>
+from<T>(
+  source1: Source<unknown> | CallableSource<unknown>,
+  source2: Source<unknown> | CallableSource<unknown>,
+  ...moreSources: Array<Source<unknown> | CallableSource<unknown>>
+): RouteBuilder<T>
 ```
 
 Defines the source adapter(s) and creates the capability. Must come after all other route-level operations (`id`, `batch`, `error`).

--- a/apps/routecraft.dev/src/app/docs/reference/operations/from/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/from/page.md
@@ -6,9 +6,10 @@ title: from
 
 ```ts
 from<T>(src: Source<T> | CallableSource<T>): RouteBuilder<T>
+from<T>(...sources: Source<unknown>[]): RouteBuilder<T>
 ```
 
-Defines the source adapter and creates the capability. Must come after all other route-level operations (`id`, `batch`, `error`).
+Defines the source adapter(s) and creates the capability. Must come after all other route-level operations (`id`, `batch`, `error`).
 
 **Returns:** `RouteBuilder<T>` where `T` is the body type produced by the source.
 
@@ -20,3 +21,30 @@ Defines the source adapter and creates the capability. Must come after all other
 .id('data-fetcher')
 .from(async () => await fetchData())
 ```
+
+## Multiple ingresses
+
+A capability often needs to be reachable on more than one channel: `direct` for internal callers, `mcp` for agents, `http` for integrations. Pass several sources to a single `.from()` and they all feed the same pipeline. The capability stays one route: one id, one lifecycle event stream, and one public name on the registries that derive it from the route id (`direct` endpoint, `mcp` tool name).
+
+```ts
+craft()
+  .id('servicenow-fetch')
+  .description('Fetch an incident by number.')
+  .input(ServiceNowInputSchema)
+  .tag('read-only') // also derives the mcp readOnlyHint
+  .from(
+    direct(), // internal callers
+    mcp(), // agents
+    http({ path: '/servicenow/fetch', method: 'POST' }), // integrations
+  )
+  .transform((body) => incidents.find((i) => i.number === body.incidentId))
+  .log()
+```
+
+Rules:
+
+- **`.input()` is required** with multiple sources. Each ingress emits a different raw body type (`direct` is `unknown`, `mcp` is the tool argument, `http` is the request body); the input schema validates and normalizes all of them to one shared type before the pipeline runs. Without it the pipeline body would be an unsound union, so the build fails with `RC2001`.
+- **Authorization applies uniformly.** A route-level `.authorize()` runs for every ingress. When channels need *different* auth (for example, an unauthenticated internal `direct` ingress next to a scoped `mcp` one), express each channel as its own single-source route instead.
+- **`.batch()` works per ingress.** Each source gets its own batch window, so a batch never merges items arriving on different channels.
+
+When a channel genuinely needs a different contract, keep it as a separate route that delegates to the canonical one via `to(direct('...'))`.

--- a/apps/routecraft.dev/src/app/docs/reference/operations/tag/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/tag/page.md
@@ -20,7 +20,7 @@ tools((catalog) =>
 )
 ```
 
-The `KnownTag` literals `"read-only"`, `"destructive"`, and `"idempotent"` autocomplete; any other string is also accepted.
+The `KnownTag` literals `"read-only"`, `"destructive"`, `"idempotent"`, and `"open-world"` autocomplete; any other string is also accepted. On a route exposed via `from(mcp())`, these four tags also derive the corresponding MCP tool annotation hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`).
 
 ```ts
 craft()

--- a/packages/ai/src/mcp/adapters/mcp/source.ts
+++ b/packages/ai/src/mcp/adapters/mcp/source.ts
@@ -17,6 +17,7 @@ import {
 } from "../../types.ts";
 import type { McpMessage } from "./types.ts";
 import { BRAND_MCP_ADAPTER } from "./shared.ts";
+import { deriveAnnotationsFromTags } from "../../annotation-tags.ts";
 
 /**
  * Characters allowed in an MCP tool name. Matches OpenAI's function-calling
@@ -36,25 +37,6 @@ function assertValidMcpToolName(endpoint: string): void {
         "MCP tool names must match /^[A-Za-z0-9_-]{1,64}$/ for client interoperability (OpenAI, Anthropic, etc.). Use alphanumerics, underscore, or hyphen in the route's .id().",
     });
   }
-}
-
-/**
- * Map route tags to the MCP tool annotation hints they describe. Only the
- * four well-known tags carry MCP meaning; any other tag is ignored here (it
- * still drives `tools()` selectors). Returns only the hints present as tags so
- * the result can be merged under explicit `annotations` without clobbering
- * unrelated keys.
- */
-function deriveAnnotationsFromTags(
-  tags: readonly string[] | undefined,
-): McpToolAnnotations {
-  if (!tags || tags.length === 0) return {};
-  const derived: McpToolAnnotations = {};
-  if (tags.includes("read-only")) derived.readOnlyHint = true;
-  if (tags.includes("destructive")) derived.destructiveHint = true;
-  if (tags.includes("idempotent")) derived.idempotentHint = true;
-  if (tags.includes("open-world")) derived.openWorldHint = true;
-  return derived;
 }
 
 /**

--- a/packages/ai/src/mcp/adapters/mcp/source.ts
+++ b/packages/ai/src/mcp/adapters/mcp/source.ts
@@ -13,6 +13,7 @@ import {
   MCP_PLUGIN_REGISTERED,
   type McpLocalToolEntry,
   type McpServerOptions,
+  type McpToolAnnotations,
 } from "../../types.ts";
 import type { McpMessage } from "./types.ts";
 import { BRAND_MCP_ADAPTER } from "./shared.ts";
@@ -35,6 +36,39 @@ function assertValidMcpToolName(endpoint: string): void {
         "MCP tool names must match /^[A-Za-z0-9_-]{1,64}$/ for client interoperability (OpenAI, Anthropic, etc.). Use alphanumerics, underscore, or hyphen in the route's .id().",
     });
   }
+}
+
+/**
+ * Map route tags to the MCP tool annotation hints they describe. Only the
+ * four well-known tags carry MCP meaning; any other tag is ignored here (it
+ * still drives `tools()` selectors). Returns only the hints present as tags so
+ * the result can be merged under explicit `annotations` without clobbering
+ * unrelated keys.
+ */
+function deriveAnnotationsFromTags(
+  tags: readonly string[] | undefined,
+): McpToolAnnotations {
+  if (!tags || tags.length === 0) return {};
+  const derived: McpToolAnnotations = {};
+  if (tags.includes("read-only")) derived.readOnlyHint = true;
+  if (tags.includes("destructive")) derived.destructiveHint = true;
+  if (tags.includes("idempotent")) derived.idempotentHint = true;
+  if (tags.includes("open-world")) derived.openWorldHint = true;
+  return derived;
+}
+
+/**
+ * Merge tag-derived annotation hints with the explicit hints passed to
+ * `mcp()`. Explicit values win per-key. Returns `undefined` when neither
+ * source contributes anything, so the entry omits `annotations` entirely
+ * rather than carrying an empty object.
+ */
+function mergeAnnotations(
+  derived: McpToolAnnotations,
+  explicit: McpToolAnnotations | undefined,
+): McpToolAnnotations | undefined {
+  const merged: McpToolAnnotations = { ...derived, ...explicit };
+  return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
 /**
@@ -147,9 +181,18 @@ export class McpSourceAdapter implements Source<McpMessage<undefined>> {
     if (discovery?.title !== undefined) entry.title = discovery.title;
     if (discovery?.input !== undefined) entry.input = discovery.input;
     if (discovery?.output !== undefined) entry.output = discovery.output;
-    if (this.options.annotations !== undefined) {
-      entry.annotations = this.options.annotations;
-    }
+
+    // Derive the MCP tool annotation hints from the route's tags so the same
+    // fact (does this tool mutate state? is it idempotent? does it reach
+    // external systems?) is declared once via `.tag()` rather than duplicated
+    // as both a tag and an annotation. Explicit `annotations` passed to
+    // `mcp()` override the derived values per-key, so callers retain full
+    // control when they need it.
+    const annotations = mergeAnnotations(
+      deriveAnnotationsFromTags(discovery?.tags),
+      this.options.annotations,
+    );
+    if (annotations !== undefined) entry.annotations = annotations;
     if (this.options.icons !== undefined) entry.icons = this.options.icons;
 
     // Register the cleanup listener before the insert. Any abort from now on

--- a/packages/ai/src/mcp/annotation-tags.ts
+++ b/packages/ai/src/mcp/annotation-tags.ts
@@ -1,0 +1,61 @@
+import type { KnownTag, Tag } from "@routecraft/routecraft";
+import type { McpToolAnnotations } from "./types.ts";
+
+/**
+ * The canonical correspondence between the well-known route tags and the MCP
+ * tool annotation hints they describe. Both directions derive from this single
+ * table, so the four pairs are declared once: `deriveAnnotationsFromTags`
+ * (tag -> hint) and `deriveTagsFromAnnotations` (hint -> tag) stay exact
+ * inverses, and adding a fifth correspondence is a one-line edit here rather
+ * than two functions plus prose drifting apart.
+ *
+ * @internal
+ */
+export const TAG_ANNOTATION_HINTS = [
+  ["read-only", "readOnlyHint"],
+  ["destructive", "destructiveHint"],
+  ["idempotent", "idempotentHint"],
+  ["open-world", "openWorldHint"],
+] as const satisfies ReadonlyArray<
+  readonly [KnownTag, keyof McpToolAnnotations]
+>;
+
+/**
+ * Derive the MCP tool annotation hints implied by a route's tags. Only the
+ * well-known tags carry MCP meaning; any other tag is ignored here (it still
+ * drives `tools()` selectors). Returns only the hints present as tags so the
+ * result can merge under explicit annotations without clobbering unrelated
+ * keys.
+ *
+ * @internal
+ */
+export function deriveAnnotationsFromTags(
+  tags: readonly string[] | undefined,
+): McpToolAnnotations {
+  if (!tags || tags.length === 0) return {};
+  const derived: McpToolAnnotations = {};
+  for (const [tag, hint] of TAG_ANNOTATION_HINTS) {
+    if (tags.includes(tag)) derived[hint] = true;
+  }
+  return derived;
+}
+
+/**
+ * Derive capability tags from MCP `annotations` hints so MCP tools surface
+ * alongside fns and direct routes under the same `Tag` shape (visible on
+ * `ToolsCatalog.mcp[].tags` for the builder form of `tools()`, and on the
+ * resolved tool's `tags` for downstream inspection). Returns an empty array
+ * (omitted from the entry) when no hints apply.
+ *
+ * @internal
+ */
+export function deriveTagsFromAnnotations(
+  annotations: McpToolAnnotations | undefined,
+): Tag[] {
+  if (!annotations) return [];
+  const tags: Tag[] = [];
+  for (const [tag, hint] of TAG_ANNOTATION_HINTS) {
+    if (annotations[hint]) tags.push(tag);
+  }
+  return tags;
+}

--- a/packages/ai/src/mcp/tool-registry.ts
+++ b/packages/ai/src/mcp/tool-registry.ts
@@ -1,35 +1,5 @@
-import type { Tag } from "@routecraft/routecraft";
-import type {
-  McpTool,
-  McpToolAnnotations,
-  McpToolRegistryEntry,
-} from "./types.ts";
-
-/**
- * Derive capability tags from MCP `annotations` hints so MCP tools
- * surface alongside fns and direct routes under the same `Tag` shape
- * (visible on `ToolsCatalog.mcp[].tags` for the builder form of
- * `tools()`, and on the resolved tool's `tags` for downstream
- * inspection).
- *
- * Mapping: `readOnlyHint -> "read-only"`,
- * `destructiveHint -> "destructive"`, `idempotentHint -> "idempotent"`,
- * `openWorldHint -> "open-world"`. Returns an empty array (omitted
- * from the entry) when no hints apply.
- *
- * @internal
- */
-function deriveTagsFromAnnotations(
-  annotations: McpToolAnnotations | undefined,
-): Tag[] {
-  if (!annotations) return [];
-  const tags: Tag[] = [];
-  if (annotations.readOnlyHint) tags.push("read-only");
-  if (annotations.destructiveHint) tags.push("destructive");
-  if (annotations.idempotentHint) tags.push("idempotent");
-  if (annotations.openWorldHint) tags.push("open-world");
-  return tags;
-}
+import type { McpTool, McpToolRegistryEntry } from "./types.ts";
+import { deriveTagsFromAnnotations } from "./annotation-tags.ts";
 
 /**
  * Central registry of MCP tools discovered from remote MCP servers.

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -215,6 +215,84 @@ describe("McpServer", () => {
   });
 
   /**
+   * @case Route tags derive the MCP tool annotation hints
+   * @preconditions Route uses .tag(["read-only", "open-world"]) and .from(mcp()) with no annotations option
+   * @expectedResult getAvailableTools() reports readOnlyHint and openWorldHint derived from the tags
+   */
+  test("derives annotation hints from route tags", async () => {
+    t = await testContext()
+      .routes([
+        craft()
+          .id("tagged")
+          .description("A tagged tool")
+          .tag(["read-only", "open-world"])
+          .from(mcp())
+          .to(noop()),
+      ])
+      .store(MCP_STORE_KEY, true)
+      .build();
+    server = new McpServer(t.ctx);
+    await t.startAndWaitReady();
+    const tools = server.getAvailableTools();
+    expect(tools).toHaveLength(1);
+    expect(tools[0].annotations).toEqual({
+      readOnlyHint: true,
+      openWorldHint: true,
+    });
+  });
+
+  /**
+   * @case All four well-known tags map to their annotation hints
+   * @preconditions Route tagged read-only, destructive, idempotent, open-world with .from(mcp())
+   * @expectedResult getAvailableTools() reports all four hints as true
+   */
+  test("maps all four well-known tags to annotation hints", async () => {
+    t = await testContext()
+      .routes([
+        craft()
+          .id("all-hints")
+          .description("Every hint")
+          .tag(["read-only", "destructive", "idempotent", "open-world"])
+          .from(mcp())
+          .to(noop()),
+      ])
+      .store(MCP_STORE_KEY, true)
+      .build();
+    server = new McpServer(t.ctx);
+    await t.startAndWaitReady();
+    const tools = server.getAvailableTools();
+    expect(tools[0].annotations).toEqual({
+      readOnlyHint: true,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    });
+  });
+
+  /**
+   * @case Explicit mcp() annotations override the tag-derived hints per-key
+   * @preconditions Route tagged read-only but mcp({ annotations: { readOnlyHint: false } })
+   * @expectedResult The explicit readOnlyHint: false wins over the tag-derived true
+   */
+  test("explicit annotations override tag-derived hints", async () => {
+    t = await testContext()
+      .routes([
+        craft()
+          .id("override")
+          .description("Override hint")
+          .tag("read-only")
+          .from(mcp({ annotations: { readOnlyHint: false } }))
+          .to(noop()),
+      ])
+      .store(MCP_STORE_KEY, true)
+      .build();
+    server = new McpServer(t.ctx);
+    await t.startAndWaitReady();
+    const tools = server.getAvailableTools();
+    expect(tools[0].annotations).toEqual({ readOnlyHint: false });
+  });
+
+  /**
    * @case A tool without its own icons inherits the default Routecraft server icons
    * @preconditions Default server options; route uses mcp() without icons
    * @expectedResult getAvailableTools() reports the tool carrying ROUTECRAFT_DEFAULT_ICONS

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -710,6 +710,13 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    * // integrations) that all feed the same pipeline. Multi-ingress requires
    * // `.input()` so every channel validates and normalizes to one body type:
    * // .input(QuerySchema).from(direct(), mcp(), http({ path: '/q', method: 'POST' }))
+   *
+   * The multiple-source `.input()` requirement is a deliberate build-time
+   * precondition, enforced at `.from()` with RC2001 rather than in the type
+   * system: the variadic overload is statically reachable and `T` defaults to
+   * `unknown` unless you pass it explicitly (`.from<Query>(...)`). A type-level
+   * flag threaded through the builder could make it compile-time, but that is a
+   * larger change deferred for the v0 unstable surface.
    */
   from<T>(source: Source<T> | CallableSource<T>): RouteBuilder<T>;
   from<T>(source: Source<unknown> | CallableSource<unknown>): RouteBuilder<T>;

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -443,8 +443,11 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    *
    * Tags drive selectors like `tools({ tagged: "read-only" })` in
    * `@routecraft/ai`; use the `KnownTag` literals (`"read-only"`,
-   * `"destructive"`, `"idempotent"`) where they fit, and any string
-   * otherwise.
+   * `"destructive"`, `"idempotent"`, `"open-world"`) where they fit, and any
+   * string otherwise. On a route exposed via `.from(mcp())`, these four tags
+   * also derive the MCP tool annotation hints (`readOnlyHint`,
+   * `destructiveHint`, `idempotentHint`, `openWorldHint`), so the same fact is
+   * declared once; explicit `annotations` on `mcp()` still override per-key.
    */
   tag(value: Tag | Tag[]): this {
     const incoming = (Array.isArray(value) ? value : [value]).map((t) => {
@@ -702,11 +705,28 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
    * // After `.input({ body: schema })`, pass the inferred body type to
    * // flow it through the chain:
    * // .input({ body: MySchema }).from<z.infer<typeof MySchema>>(direct())
+   *
+   * // Expose one capability on several ingresses (internal + agents +
+   * // integrations) that all feed the same pipeline. Multi-ingress requires
+   * // `.input()` so every channel validates and normalizes to one body type:
+   * // .input(QuerySchema).from(direct(), mcp(), http({ path: '/q', method: 'POST' }))
    */
   from<T>(source: Source<T> | CallableSource<T>): RouteBuilder<T>;
   from<T>(source: Source<unknown> | CallableSource<unknown>): RouteBuilder<T>;
-  from<T>(source: Source<T> | CallableSource<T>): RouteBuilder<T> {
+  from<T>(
+    ...sources: [
+      Source<unknown> | CallableSource<unknown>,
+      Source<unknown> | CallableSource<unknown>,
+      ...Array<Source<unknown> | CallableSource<unknown>>,
+    ]
+  ): RouteBuilder<T>;
+  from<T>(...sources: Array<Source<T> | CallableSource<T>>): RouteBuilder<T> {
     this.assertNoPendingWrappers("from");
+    if (sources.length === 0) {
+      throw rcError("RC2001", undefined, {
+        message: `Route .from() requires at least one source.`,
+      });
+    }
     const id = this.pendingOptions?.id ?? randomUUID();
     const consumer = this.pendingOptions?.consumer ?? {
       type: SimpleConsumer as unknown as ConsumerType<Consumer>,
@@ -717,18 +737,41 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     const discovery = this.pendingOptions?.discovery;
     const authorizers = this.pendingOptions?.authorizers ?? [];
 
-    logger.trace({ route: id }, "Creating route definition");
+    // Multi-ingress routes feed one shared pipeline, so they need one shared
+    // input contract. Require `.input()` (with a body schema) so every
+    // ingress validates and normalizes its heterogeneous raw body (direct
+    // `unknown`, mcp `McpMessage`, http `HttpRequestBody`) to the same type
+    // before the pipeline runs. Without it the pipeline body would be an
+    // unsound union of the raw source types. A single source keeps the
+    // existing behaviour (type flows from `.from<T>()` or the source).
+    if (sources.length > 1 && !discovery?.input?.body) {
+      throw rcError("RC2001", undefined, {
+        message: `Route "${id}": .from() with multiple sources requires .input({ body }) so every ingress validates to one shared body type. Declare .input() before .from(), or expose each channel as its own single-source route.`,
+      });
+    }
+
+    logger.trace(
+      { route: id, sourceCount: sources.length },
+      "Creating route definition",
+    );
 
     // Staged `.authorize()` calls become the route's first steps so they
-    // run before any pipeline operation. Multiple authorizers stack in
-    // declaration order; the first failure short-circuits the rest.
+    // run before any pipeline operation. They apply uniformly to every
+    // ingress. Multiple authorizers stack in declaration order; the first
+    // failure short-circuits the rest. Per-channel auth (e.g. an unauthored
+    // internal direct ingress alongside a scoped mcp ingress) is expressed
+    // as separate single-source routes, not here.
     const authorizerSteps = authorizers.map(
       (opts) => new ValidateStep(authorize(opts)),
     );
 
+    const normalizedSources: Source<T>[] = sources.map((source) =>
+      typeof source === "function" ? { subscribe: source } : source,
+    );
+
     this.currentRoute = {
       id,
-      source: typeof source === "function" ? { subscribe: source } : source,
+      sources: normalizedSources,
       steps: authorizerSteps,
       consumer: {
         type: consumer.type,

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -712,7 +712,11 @@ export class CraftContext {
 
     // 5) Register each definition now that there's no duplication
     for (const definition of definitions) {
-      if (!definition.source || !definition.source.subscribe) {
+      if (
+        !definition.sources ||
+        definition.sources.length === 0 ||
+        definition.sources.some((source) => !source || !source.subscribe)
+      ) {
         throw rcError("RC1001", undefined, {
           message: `${RC["RC1001"].message}: ${definition.id}`,
         });

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -713,9 +713,11 @@ export class CraftContext {
     // 5) Register each definition now that there's no duplication
     for (const definition of definitions) {
       if (
-        !definition.sources ||
+        !Array.isArray(definition.sources) ||
         definition.sources.length === 0 ||
-        definition.sources.some((source) => !source || !source.subscribe)
+        definition.sources.some(
+          (source) => !source || typeof source.subscribe !== "function",
+        )
       ) {
         throw rcError("RC1001", undefined, {
           message: `${RC["RC1001"].message}: ${definition.id}`,

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -576,19 +576,19 @@ export interface Route<T = unknown> {
   logger: ReturnType<typeof logger.child>;
 
   /**
-   * Start processing: subscribe to the source and begin delivering messages through the steps.
-   * @returns Promise that resolves when the source has been subscribed and the consumer is ready
+   * Start processing: subscribe to every source and begin delivering messages through the steps.
+   * @returns Promise that resolves when all sources have been subscribed and the consumers are ready
    */
   start(): Promise<void>;
 
   /**
-   * Stop the route: abort the source subscription and clear the internal queue.
+   * Stop the route: abort all source subscriptions and clear the internal queues.
    */
   stop(): void;
 
   /**
    * Wait until all in-flight message handlers and tracked tasks (e.g. tap) have completed.
-   * Does not stop the route; use stop() to abort the source.
+   * Does not stop the route; use stop() to abort the sources.
    */
   drain(): Promise<void>;
 
@@ -1025,8 +1025,8 @@ export class DefaultRoute implements Route {
    * Start processing data on this route.
    *
    * This method:
-   * 1. Registers the consumer to process messages
-   * 2. Subscribes to the source to receive data
+   * 1. Registers each per-source consumer to process messages
+   * 2. Subscribes to every source to receive data
    *
    * @returns A promise that resolves when the route has started
    * @throws {RoutecraftError} If the route has been aborted
@@ -1121,7 +1121,34 @@ export class DefaultRoute implements Route {
       },
     );
 
-    await Promise.all(subscriptions);
+    try {
+      await Promise.all(subscriptions);
+    } catch (err) {
+      // One ingress failed to subscribe. Abort the route so any sibling
+      // ingresses that already subscribed are torn down (their registry
+      // entries cleared, their pending subscribe promises resolved) instead of
+      // leaking, then surface the error. `context.start()` already aborts on a
+      // failed route.start(); this makes start() self-cleaning for direct
+      // callers too. Harmless for the single-source case (no siblings).
+      if (!this.abortController.signal.aborted) {
+        this.abortController.abort(err);
+      }
+      throw err;
+    }
+
+    // Every ingress's subscription resolved. For a multi-ingress route whose
+    // sources are all finite this means every ingress has completed: mirror the
+    // single-source contract (where a finite source aborts the route's own
+    // controller on completion) by aborting here so the route's terminal
+    // lifecycle events fire even when an indefinite sibling route keeps the
+    // context alive. A route holding any server ingress never reaches this with
+    // an un-aborted controller (a server's subscribe only resolves once the
+    // controller is aborted), so the guard makes this a no-op there. The
+    // single-source path is left exactly as before: its source drives
+    // completion.
+    if (total > 1 && !this.abortController.signal.aborted) {
+      this.abortController.abort("All ingresses completed");
+    }
   }
 
   /**

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -1077,59 +1077,65 @@ export class DefaultRoute implements Route {
     // http, mcp) hold open until abort, so a multi-ingress route with any
     // server ingress keeps the context alive, while a route whose sources are
     // all finite completes and lets the context auto-stop.
-    const subscriptions = this.definition.sources.map(
-      (definitionSource, index) => {
-        const channel = this.messageChannels[index];
-        const sourceOverride = resolveAdapterOverride(
-          definitionSource,
-          this.context,
-        );
-        const activeSource =
-          sourceOverride && sourceOverride.source
-            ? wrapSourceWithOverride(definitionSource, sourceOverride)
-            : definitionSource;
-        // A single-source route hands the source the route's own controller
-        // so a finite source completing (such sources call abort() when done)
-        // stops the route exactly as before. A multi-ingress route gives each
-        // source a child controller linked to the route's: the route aborts
-        // every child, but one finite ingress completing only aborts its own
-        // child and never tears down a sibling ingress (e.g. a long-lived
-        // http/mcp server holding the route open).
-        const sourceController =
-          total === 1 ? this.abortController : this.linkedChildController();
-        return activeSource.subscribe(
-          this.context,
-          (message, headers, parse, parseFailureMode) => {
-            markReady(index); // fallback: fire before first message if adapter never called onReady
-            return channel.enqueue({
-              message,
-              headers: headers ?? {},
-              ...(parse
-                ? {
-                    parse: parse as (
-                      raw: unknown,
-                    ) => unknown | Promise<unknown>,
-                    parseFailureMode: parseFailureMode ?? "fail",
-                  }
-                : {}),
-            });
-          },
-          sourceController,
-          () => markReady(index),
-          meta,
-        );
-      },
-    );
-
+    // Build AND await every subscription inside the try so both a synchronous
+    // throw while wiring a source (override resolution, a sync callable source)
+    // and an async subscribe rejection hit the same cleanup path. On failure,
+    // abort the route so any sibling ingresses that already subscribed are torn
+    // down (registry entries cleared, pending subscribes resolved) instead of
+    // leaking, then surface the error. `context.start()` already aborts on a
+    // failed route.start(); this makes start() self-cleaning for direct callers
+    // too. Harmless for the single-source case (no siblings).
     try {
+      const subscriptions = this.definition.sources.map(
+        (definitionSource, index) => {
+          const channel = this.messageChannels[index];
+          const sourceOverride = resolveAdapterOverride(
+            definitionSource,
+            this.context,
+          );
+          const activeSource =
+            sourceOverride && sourceOverride.source
+              ? wrapSourceWithOverride(definitionSource, sourceOverride)
+              : definitionSource;
+          // A single-source route hands the source the route's own controller
+          // so a finite source completing (such sources call abort() when done)
+          // stops the route exactly as before. A multi-ingress route gives each
+          // source a child controller linked to the route's: the route aborts
+          // every child, but one finite ingress completing only aborts its own
+          // child and never tears down a sibling ingress (e.g. a long-lived
+          // http/mcp server holding the route open).
+          const sourceController =
+            total === 1 ? this.abortController : this.linkedChildController();
+          // Coerce to a promise so a void return and an async rejection are
+          // handled uniformly by Promise.all; a synchronous throw is caught by
+          // the surrounding try because the map runs inside it.
+          return Promise.resolve(
+            activeSource.subscribe(
+              this.context,
+              (message, headers, parse, parseFailureMode) => {
+                markReady(index); // fallback: fire before first message if adapter never called onReady
+                return channel.enqueue({
+                  message,
+                  headers: headers ?? {},
+                  ...(parse
+                    ? {
+                        parse: parse as (
+                          raw: unknown,
+                        ) => unknown | Promise<unknown>,
+                        parseFailureMode: parseFailureMode ?? "fail",
+                      }
+                    : {}),
+                });
+              },
+              sourceController,
+              () => markReady(index),
+              meta,
+            ),
+          );
+        },
+      );
       await Promise.all(subscriptions);
     } catch (err) {
-      // One ingress failed to subscribe. Abort the route so any sibling
-      // ingresses that already subscribed are torn down (their registry
-      // entries cleared, their pending subscribe promises resolved) instead of
-      // leaking, then surface the error. `context.start()` already aborts on a
-      // failed route.start(); this makes start() self-cleaning for direct
-      // callers too. Harmless for the single-source case (no siblings).
       if (!this.abortController.signal.aborted) {
         this.abortController.abort(err);
       }

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -86,7 +86,11 @@ export interface RouteSchemas {
  * downstream filtering (e.g. an agent that only whitelists `"read-only"`
  * tools).
  */
-export type KnownTag = "read-only" | "destructive" | "idempotent";
+export type KnownTag =
+  | "read-only"
+  | "destructive"
+  | "idempotent"
+  | "open-world";
 
 /**
  * Tag value: one of the framework's well-known tags or any user string.
@@ -474,7 +478,7 @@ function buildCacheStoreStep(
  * ```typescript
  * const def: RouteDefinition<string> = {
  *   id: 'my-route',
- *   source: simple('hello'),
+ *   sources: [simple('hello')],
  *   steps: [...],
  *   consumer: { type: SimpleConsumer, options: undefined }
  * };
@@ -484,8 +488,16 @@ export type RouteDefinition<T = unknown> = {
   /** Unique identifier for the route */
   readonly id: string;
 
-  /** The source that provides data to the route */
-  readonly source: Source<T>;
+  /**
+   * The sources that feed data into the route. A route may expose multiple
+   * ingresses (e.g. `direct` for internal callers, `mcp` for agents, `http`
+   * for integrations) that all drive the same downstream pipeline. The route
+   * stays a single logical entity: one id, one set of lifecycle events, and
+   * (where the registries derive a public name from the route id) one name
+   * across ingresses. Every entry must be non-empty; the builder normalizes a
+   * single `.from(x)` to `[x]`.
+   */
+  readonly sources: readonly Source<T>[];
 
   /** Processing steps that transform, filter, or direct the data */
   readonly steps: Step<Adapter>[];
@@ -613,11 +625,11 @@ export class DefaultRoute implements Route {
   /** Logger for this route (pino child logger) */
   public readonly logger: ReturnType<typeof logger.child>;
 
-  /** Internal queue for passing messages between the source and consumer */
-  private messageChannel: ProcessingQueue<Message>;
+  /** Internal queues, one per source, for passing messages to the consumers */
+  private messageChannels: ProcessingQueue<Message>[];
 
-  /** Processes messages from the message channel */
-  private consumer: Consumer;
+  /** Processes messages from the message channels, one consumer per source */
+  private consumers: Consumer[];
 
   /** All in-flight work (handler and task promises) for drain */
   private inFlight = new Set<Promise<unknown>>();
@@ -638,12 +650,22 @@ export class DefaultRoute implements Route {
     this.assertNotAborted();
     this.abortController = abortController ?? new AbortController();
     this.logger = logger.child(childBindings(this));
-    this.messageChannel = new InMemoryProcessingQueue<Message>();
-    this.consumer = new this.definition.consumer.type(
-      this.context,
-      this.definition,
-      this.messageChannel,
-      this.definition.consumer.options,
+    // One (channel, consumer) pair per source so each ingress gets its own
+    // delivery queue and, for batch routes, its own batch window. All
+    // consumers drive the same shared step pipeline via the handler
+    // registered in start(); the route stays a single logical entity (one id,
+    // one lifecycle event stream) regardless of how many ingresses it exposes.
+    this.messageChannels = this.definition.sources.map(
+      () => new InMemoryProcessingQueue<Message>(),
+    );
+    this.consumers = this.messageChannels.map(
+      (channel) =>
+        new this.definition.consumer.type(
+          this.context,
+          this.definition,
+          channel,
+          this.definition.consumer.options,
+        ),
     );
 
     // Emit routeStopping/routeStopped when the controller is aborted externally
@@ -1013,101 +1035,166 @@ export class DefaultRoute implements Route {
     this.assertNotAborted();
     // Lifecycle log is emitted only by context (one log per event).
 
-    // Start consuming messages from the internal processing queue.
+    // Register the shared pipeline handler on every per-source consumer.
     // Framework-level input validation runs here, before the step pipeline,
     // so any source adapter with an `.input()` schema on the route inherits
     // validation without per-adapter wiring. On failure the engine emits
     // `exchange:dropped` for telemetry and re-throws so the source's own
     // caller (e.g. a direct channel's `send`) sees the validation error.
-    this.consumer.register(
-      async (message, headers, parse, parseFailureMode) => {
-        const initialExchange = this.buildExchange(message, headers);
-        const inputSchemas = this.definition.discovery?.input;
-        const hasInputSchema = !!inputSchemas?.body || !!inputSchemas?.headers;
+    const consumerHandler = this.buildConsumerHandler();
+    for (const consumer of this.consumers) {
+      consumer.register(consumerHandler);
+    }
 
-        let exchange: Exchange = initialExchange;
-        if (parse) {
-          // Stash the source-supplied parser on exchange internals so
-          // `runSteps` can apply it as a synthetic first pipeline step.
-          // This is what makes parse errors surface as normal pipeline
-          // events the route can observe (`.error()` for `'fail'`,
-          // `exchange:dropped` for `'drop'`). See #187.
-          const internals = EXCHANGE_INTERNALS.get(exchange);
-          if (internals) {
-            internals.parse = parse;
-            internals.parseFailureMode = parseFailureMode ?? "fail";
-            // Validation must run AFTER parse so `.input()` schemas
-            // validate the parsed body, not the raw bytes. The synthetic
-            // parse step calls this hook once parse succeeds. Use the
-            // non-emitting variant so a validation failure inside the parse
-            // step throws RC5002 cleanly into the step loop's catch path
-            // (which emits `step:failed` and then `exchange:failed`),
-            // without firing duplicate `exchange:started` /
-            // `exchange:dropped` events (see #187).
-            if (hasInputSchema) {
-              internals.applyValidation = (ex: Exchange) =>
-                this.validateInputOrThrow(ex, inputSchemas);
-            }
-          }
-        } else if (hasInputSchema) {
-          // No parse: run validation eagerly. The validated exchange
-          // replaces the initial one; with frozen headers/body the
-          // validator returns a new instance via `rewrap`.
-          exchange = await this.applyInputValidation(exchange, inputSchemas);
-        }
-
-        return this.handler(exchange);
-      },
-    );
-
-    let emitted = false;
-    const onReady = () => {
-      if (!emitted) {
-        emitted = true;
+    // Emit `route:started` once ALL sources have signalled readiness. The
+    // route is a single logical entity, so its lifecycle events fire once no
+    // matter how many ingresses it exposes. Every built-in source calls
+    // `onReady`; the enqueue callback also marks readiness as a fallback for
+    // callable sources that produce a message without calling it.
+    const total = this.definition.sources.length;
+    const readyIndices = new Set<number>();
+    let startedEmitted = false;
+    const markReady = (index: number): void => {
+      readyIndices.add(index);
+      if (!startedEmitted && readyIndices.size === total) {
+        startedEmitted = true;
         this.context.emit(`route:${this.definition.id}:started` as EventName, {
           route: this,
         });
       }
     };
 
-    // If a test-time override is registered for this source adapter, route the
-    // subscribe call through the mock's source behaviour instead of invoking
-    // the real adapter. Falls through unchanged when no override matches.
-    const sourceOverride = resolveAdapterOverride(
-      this.definition.source,
-      this.context,
-    );
-    const activeSource =
-      sourceOverride && sourceOverride.source
-        ? wrapSourceWithOverride(this.definition.source, sourceOverride)
-        : this.definition.source;
-
-    // Subscribe to the source and enqueue messages to the internal processing queue
     const meta = {
       routeId: this.definition.id,
       ...(this.definition.discovery
         ? { discovery: this.definition.discovery }
         : {}),
     };
-    return activeSource.subscribe(
-      this.context,
-      (message, headers, parse, parseFailureMode) => {
-        onReady(); // fallback: fire before first message if adapter never called it
-        return this.messageChannel.enqueue({
-          message,
-          headers: headers ?? {},
-          ...(parse
-            ? {
-                parse: parse as (raw: unknown) => unknown | Promise<unknown>,
-                parseFailureMode: parseFailureMode ?? "fail",
-              }
-            : {}),
-        });
+
+    // Subscribe every source, each into its own channel. A test-time override
+    // is resolved per source so individual ingresses can be mocked. start()
+    // resolves only when ALL subscriptions resolve: server ingresses (direct,
+    // http, mcp) hold open until abort, so a multi-ingress route with any
+    // server ingress keeps the context alive, while a route whose sources are
+    // all finite completes and lets the context auto-stop.
+    const subscriptions = this.definition.sources.map(
+      (definitionSource, index) => {
+        const channel = this.messageChannels[index];
+        const sourceOverride = resolveAdapterOverride(
+          definitionSource,
+          this.context,
+        );
+        const activeSource =
+          sourceOverride && sourceOverride.source
+            ? wrapSourceWithOverride(definitionSource, sourceOverride)
+            : definitionSource;
+        // A single-source route hands the source the route's own controller
+        // so a finite source completing (such sources call abort() when done)
+        // stops the route exactly as before. A multi-ingress route gives each
+        // source a child controller linked to the route's: the route aborts
+        // every child, but one finite ingress completing only aborts its own
+        // child and never tears down a sibling ingress (e.g. a long-lived
+        // http/mcp server holding the route open).
+        const sourceController =
+          total === 1 ? this.abortController : this.linkedChildController();
+        return activeSource.subscribe(
+          this.context,
+          (message, headers, parse, parseFailureMode) => {
+            markReady(index); // fallback: fire before first message if adapter never called onReady
+            return channel.enqueue({
+              message,
+              headers: headers ?? {},
+              ...(parse
+                ? {
+                    parse: parse as (
+                      raw: unknown,
+                    ) => unknown | Promise<unknown>,
+                    parseFailureMode: parseFailureMode ?? "fail",
+                  }
+                : {}),
+            });
+          },
+          sourceController,
+          () => markReady(index),
+          meta,
+        );
       },
-      this.abortController,
-      onReady,
-      meta,
     );
+
+    await Promise.all(subscriptions);
+  }
+
+  /**
+   * Create an AbortController that aborts when the route's controller aborts,
+   * but whose own abort does not propagate back to the route. Used to give
+   * each ingress of a multi-source route an independent lifetime so a finite
+   * source completing does not tear down its sibling ingresses.
+   */
+  private linkedChildController(): AbortController {
+    const child = new AbortController();
+    if (this.abortController.signal.aborted) {
+      child.abort(this.abortController.signal.reason);
+    } else {
+      this.abortController.signal.addEventListener(
+        "abort",
+        () => child.abort(this.abortController.signal.reason),
+        { once: true },
+      );
+    }
+    return child;
+  }
+
+  /**
+   * Build the handler registered on every per-source consumer. The handler is
+   * shared across all of a route's ingresses so they drive one pipeline; it
+   * applies framework-level `.input()` validation (eagerly, or deferred to the
+   * synthetic parse step when the source supplies a parser) before running the
+   * route's steps.
+   */
+  private buildConsumerHandler(): (
+    message: unknown,
+    headers?: ExchangeHeaders,
+    parse?: (raw: unknown) => unknown | Promise<unknown>,
+    parseFailureMode?: OnParseError,
+  ) => Promise<Exchange> {
+    return async (message, headers, parse, parseFailureMode) => {
+      const initialExchange = this.buildExchange(message, headers);
+      const inputSchemas = this.definition.discovery?.input;
+      const hasInputSchema = !!inputSchemas?.body || !!inputSchemas?.headers;
+
+      let exchange: Exchange = initialExchange;
+      if (parse) {
+        // Stash the source-supplied parser on exchange internals so
+        // `runSteps` can apply it as a synthetic first pipeline step.
+        // This is what makes parse errors surface as normal pipeline
+        // events the route can observe (`.error()` for `'fail'`,
+        // `exchange:dropped` for `'drop'`). See #187.
+        const internals = EXCHANGE_INTERNALS.get(exchange);
+        if (internals) {
+          internals.parse = parse;
+          internals.parseFailureMode = parseFailureMode ?? "fail";
+          // Validation must run AFTER parse so `.input()` schemas
+          // validate the parsed body, not the raw bytes. The synthetic
+          // parse step calls this hook once parse succeeds. Use the
+          // non-emitting variant so a validation failure inside the parse
+          // step throws RC5002 cleanly into the step loop's catch path
+          // (which emits `step:failed` and then `exchange:failed`),
+          // without firing duplicate `exchange:started` /
+          // `exchange:dropped` events (see #187).
+          if (hasInputSchema && inputSchemas) {
+            internals.applyValidation = (ex: Exchange) =>
+              this.validateInputOrThrow(ex, inputSchemas);
+          }
+        }
+      } else if (hasInputSchema && inputSchemas) {
+        // No parse: run validation eagerly. The validated exchange
+        // replaces the initial one; with frozen headers/body the
+        // validator returns a new instance via `rewrap`.
+        exchange = await this.applyInputValidation(exchange, inputSchemas);
+      }
+
+      return this.handler(exchange);
+    };
   }
 
   /**
@@ -1119,7 +1206,9 @@ export class DefaultRoute implements Route {
    */
   stop(): void {
     // Lifecycle log is emitted only by context (one log per event).
-    this.messageChannel.clear();
+    for (const channel of this.messageChannels) {
+      channel.clear();
+    }
     this.abortController.abort("Route stop() called");
   }
 

--- a/packages/routecraft/test/batch.bun.test.ts
+++ b/packages/routecraft/test/batch.bun.test.ts
@@ -10,7 +10,7 @@ import type { EventName, Message } from "../src/types.ts";
 function createRouteDefinition(id: string): RouteDefinition {
   return {
     id,
-    source: { subscribe: async () => {} },
+    sources: [{ subscribe: async () => {} }],
     steps: [],
     consumer: { type: BatchConsumer as never, options: {} },
   } as RouteDefinition;

--- a/packages/routecraft/test/brand.bun.test.ts
+++ b/packages/routecraft/test/brand.bun.test.ts
@@ -82,7 +82,7 @@ describe("Brand type guards (cross-instance identity)", () => {
     expect(isRouteDefinition(def[0])).toBe(true);
     expect(isRouteDefinition(null)).toBe(false);
     expect(
-      isRouteDefinition({ id: "x", source: {}, steps: [], consumer: {} }),
+      isRouteDefinition({ id: "x", sources: [], steps: [], consumer: {} }),
     ).toBe(false);
   });
 

--- a/packages/routecraft/test/multi-ingress.bun.test.ts
+++ b/packages/routecraft/test/multi-ingress.bun.test.ts
@@ -22,12 +22,13 @@ function expectRC2001(thunk: () => unknown): void {
 }
 
 describe("Multi-ingress routes", () => {
-  let t: TestContext;
+  let t: TestContext | undefined;
 
   afterEach(async () => {
     if (t) {
       await t.stop();
     }
+    t = undefined;
   });
 
   /**
@@ -43,6 +44,18 @@ describe("Multi-ingress routes", () => {
         .to(noop())
         .build(),
     );
+  });
+
+  /**
+   * @case A zero-source .from() is rejected at the public boundary
+   * @preconditions craft().from() called with no arguments (only reachable via untyped callers)
+   * @expectedResult Throws RC2001; the runtime guard protects the published API from JS callers the overloads cannot constrain
+   */
+  test("zero-source .from() throws RC2001", () => {
+    const builder = craft().id("empty") as unknown as {
+      from: (...sources: unknown[]) => unknown;
+    };
+    expectRC2001(() => builder.from());
   });
 
   /**

--- a/packages/routecraft/test/multi-ingress.bun.test.ts
+++ b/packages/routecraft/test/multi-ingress.bun.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import {
+  craft,
+  direct,
+  isRoutecraftError,
+  noop,
+  simple,
+} from "@routecraft/routecraft";
+import { testContext, spy, type TestContext } from "@routecraft/testing";
+
+function expectRC2001(thunk: () => unknown): void {
+  let caught: unknown;
+  try {
+    thunk();
+  } catch (err) {
+    caught = err;
+  }
+  expect(caught).toBeDefined();
+  expect(isRoutecraftError(caught)).toBe(true);
+  expect((caught as { rc?: string }).rc).toBe("RC2001");
+}
+
+describe("Multi-ingress routes", () => {
+  let t: TestContext;
+
+  afterEach(async () => {
+    if (t) {
+      await t.stop();
+    }
+  });
+
+  /**
+   * @case A route with several sources but no .input() is rejected at build time
+   * @preconditions craft().from(simple(a), simple(b)) with no .input()
+   * @expectedResult Building throws RC2001 because a shared pipeline needs a shared input contract
+   */
+  test("multi-source .from() without .input() throws RC2001", () => {
+    expectRC2001(() =>
+      craft()
+        .id("multi-no-input")
+        .from(simple({ id: "a" }), simple({ id: "b" }))
+        .to(noop())
+        .build(),
+    );
+  });
+
+  /**
+   * @case Multi-ingress build produces a single route holding every source
+   * @preconditions craft().input(schema).from(simple, direct, callable)
+   * @expectedResult One RouteDefinition with all three sources under the same id
+   */
+  test("multi-source .from() with .input() builds one route with all sources", () => {
+    const def = craft()
+      .id("multi-ok")
+      .input(z.object({ id: z.string() }))
+      .from(simple({ id: "a" }), direct(), async () => ({ id: "c" }))
+      .to(noop())
+      .build();
+
+    expect(def).toHaveLength(1);
+    expect(def[0].id).toBe("multi-ok");
+    expect(def[0].sources).toHaveLength(3);
+  });
+
+  /**
+   * @case A single source still builds with the original (non-variadic) behaviour
+   * @preconditions craft().from(simple(x)) with no .input()
+   * @expectedResult One route with exactly one source; no input requirement for the single-source case
+   */
+  test("single source keeps building without .input()", () => {
+    const def = craft().id("single").from(simple("x")).to(noop()).build();
+
+    expect(def).toHaveLength(1);
+    expect(def[0].sources).toHaveLength(1);
+  });
+
+  /**
+   * @case Two ingresses feed one shared pipeline and the route stays a single logical entity
+   * @preconditions Route with .input() and two simple() ingresses producing {id:"a"} and {id:"b"}
+   * @expectedResult Both validated bodies reach the destination and route:started fires exactly once
+   */
+  test("two ingresses feed one pipeline and route:started fires once", async () => {
+    const s = spy();
+    let startedCount = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("dual")
+          .input(z.object({ id: z.string() }))
+          .from(simple({ id: "a" }), simple({ id: "b" }))
+          .to(s),
+      )
+      .build();
+
+    t.ctx.on("route:dual:started", () => {
+      startedCount++;
+    });
+
+    await t.ctx.start();
+
+    const ids = s.received
+      .map((exchange) => (exchange.body as { id: string }).id)
+      .sort();
+    expect(ids).toEqual(["a", "b"]);
+    expect(startedCount).toBe(1);
+  });
+
+  /**
+   * @case Framework input validation normalizes each ingress to the schema output
+   * @preconditions Route .input() strips unknown keys; both ingresses send an extra field
+   * @expectedResult Every body delivered to the pipeline matches the validated shape regardless of ingress
+   */
+  test("input validation normalizes the body for every ingress", async () => {
+    const s = spy();
+    const schema = z.object({ id: z.string() }).strip();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("normalize")
+          .input(schema)
+          .from(simple({ id: "a", extra: 1 }), simple({ id: "b", extra: 2 }))
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    for (const exchange of s.received) {
+      expect(Object.keys(exchange.body as object).sort()).toEqual(["id"]);
+    }
+    expect(s.received).toHaveLength(2);
+  });
+
+  /**
+   * @case Batch windows are per ingress, so a batch never merges items across channels
+   * @preconditions Batch route (size 2) with two ingresses producing [1,2] and [3,4]
+   * @expectedResult Two independent flushes (distinct batch ids), each carrying only its own ingress's pair
+   */
+  test("each ingress batches independently (no cross-ingress merge)", async () => {
+    const s = spy();
+    const flushed: { batchId: string; batchSize: number }[] = [];
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("batched-dual")
+          .batch({ size: 2 })
+          .input(z.array(z.number()))
+          .from(simple([1, 2]), simple([3, 4]))
+          .to(s),
+      )
+      .build();
+
+    t.ctx.on("route:batched-dual:batch:flushed", ({ details }) => {
+      flushed.push({
+        batchId: (details as { batchId: string }).batchId,
+        batchSize: (details as { batchSize: number }).batchSize,
+      });
+    });
+
+    await t.ctx.start();
+
+    // Two independent windows, each flushing its own pair under a distinct id.
+    expect(flushed).toHaveLength(2);
+    expect(new Set(flushed.map((f) => f.batchId)).size).toBe(2);
+
+    const delivered = s.received
+      .map((exchange) =>
+        [...(exchange.body as number[])].sort((a, b) => a - b).join(","),
+      )
+      .sort();
+    expect(delivered).toEqual(["1,2", "3,4"]);
+  });
+});

--- a/packages/routecraft/test/multi-ingress.bun.test.ts
+++ b/packages/routecraft/test/multi-ingress.bun.test.ts
@@ -187,4 +187,41 @@ describe("Multi-ingress routes", () => {
       .sort();
     expect(delivered).toEqual(["1,2", "3,4"]);
   });
+
+  /**
+   * @case A synchronous subscribe failure on one ingress aborts the whole route
+   * @preconditions Multi-ingress route where a sibling source's subscribe() throws synchronously while start() is wiring sources
+   * @expectedResult start() rejects and the route's controller is aborted, so already-subscribed sibling ingresses are torn down rather than leaked
+   */
+  test("synchronous subscribe failure aborts the route and tears down siblings", async () => {
+    const boom = {
+      subscribe: () => {
+        throw new Error("subscribe boom");
+      },
+    };
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("sync-fail")
+          .input(z.object({ id: z.string() }))
+          .from(direct(), boom)
+          .to(noop()),
+      )
+      .build();
+
+    const route = t.ctx.getRouteById("sync-fail");
+    expect(route).toBeDefined();
+
+    let caught: unknown;
+    try {
+      await route!.start();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("subscribe boom");
+    expect(route!.signal.aborted).toBe(true);
+  });
 });


### PR DESCRIPTION
A route can now take several sources in a single `.from(direct(), mcp(),
http())` call, all feeding the same validated pipeline. This removes the
duplication of declaring a capability's contract once per channel and the
forwarder routes (`.to(direct(...))`) that only existed because `.from()` took
a single source.

The capability stays one logical entity: one id, one lifecycle event stream,
and one public name on the registries that derive it from the route id (direct
endpoint, mcp tool name). Internally each ingress gets its own channel and
consumer, so batch windows are per ingress (a batch never merges items across
channels) and finite sources no longer tear down sibling ingresses (each
non-trivial route hands its sources child abort controllers).

- `RouteDefinition.source` becomes `sources: readonly Source<T>[]`; the builder
  normalizes a single `.from(x)` to `[x]`, preserving existing behaviour.
- Multi-source `.from()` requires `.input({ body })` so every ingress validates
  and normalizes its heterogeneous raw body to one shared type; otherwise the
  build fails with RC2001.
- Route-level `.authorize()` applies uniformly to every ingress. Per-channel
  auth stays the old way: separate single-source routes.

Also derive the four MCP tool annotation hints from route tags (`read-only`,
`destructive`, `idempotent`, `open-world`), so the same fact is declared once
via `.tag()` rather than as both a tag and an annotation; explicit `annotations`
on `mcp()` still override per-key.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose one capability on multiple ingresses with variadic `.from(direct(), mcp(), http())`, and derive MCP tool annotation hints from route tags to reduce duplication and keep contracts consistent. This also hardens multi-ingress lifecycle and startup behavior.

- **New Features**
  - Variadic `.from()` lets one route accept multiple sources. Each ingress has its own queue and consumer; batch windows are per-ingress.
  - Robust lifecycle for multi-ingress routes: finite sources no longer stop siblings (each gets a child AbortController), the route aborts once all finite ingresses finish, and if any ingress fails to subscribe, `start()` aborts the route and tears down already-subscribed siblings.
  - MCP tool annotation hints are derived from tags. `read-only`, `destructive`, `idempotent`, `open-world` map to `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`; explicit `mcp({ annotations })` still override.

- **Migration**
  - `RouteDefinition.source` is now `sources: Source[]`. A single `.from(x)` is normalized to `[x]`. Update any code or tests constructing definitions directly.
  - With multiple sources, declare `.input({ body })` before `.from()`, or keep channels as separate single-source routes. Calling `.from()` with no sources throws `RC2001`.

<sup>Written for commit 2ec42a9459113a462dc3fbb015004934f56bd157. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

