### PR TITLE
refactor(mail)!: relocate envelope metadata from body to headers

### DIFF
--- a/.standards/exchange-state-model.md
+++ b/.standards/exchange-state-model.md
@@ -181,8 +181,6 @@ Attachments stay on `body` because they are message content (the same call the "
 
 The fetch destination (`.enrich(mail(...))`) is the one place the whole `MailMessage` (envelope + payload in one object) still appears: a batch fetch returns many messages and single-valued headers cannot hold N envelopes, so each element keeps its envelope inline. That is a result collection, not a per-message exchange, so the convention does not apply.
 
-> Mail's source shape aligned with this convention in 0.6.0; the historical envelope-on-`body` shape is documented in the [0.5.x to 0.6.0 migration guide](https://routecraft.dev/docs/migrating/0.5-to-0.6#mail-envelope-headers).
-
 ### Worked example: cookies
 
 Cookies show the rule handling a value that is *both* a wire header and a structured concept, and that direction matters:

--- a/.standards/exchange-state-model.md
+++ b/.standards/exchange-state-model.md
@@ -144,9 +144,22 @@ Content the route is meant to transform stays on `body` even when it could plaus
 
 The rule of thumb: would a route ever `.transform(body => newBody)` it? If yes, it's payload. If it's just identification, routing identity, or signal-to-the-adapter on the way out (`Content-Type`, status code, response headers), it's envelope.
 
-### Existing tension: mail
+### Mail follows the convention too
 
-Mail's `MailMessage` shape predates this convention and currently packs envelope (`subject`, `from`, `to`, `cc`, `bcc`, `date`, `messageId`, `replyTo`, `flags`, `sender`, `rawHeaders`) *and* payload (`body.text`, `body.html`, `attachments`) onto `body`, while IMAP routing identity (`uid`, `folder`) lives on headers. That's halfway. A follow-up tracking issue covers the breaking change to align mail with this convention pre-v1; until then, mail is the documented exception.
+The mail **source** (`.from(mail(...))`) splits each message the same way: payload (`text`, `html`, `attachments`) on `body` (a `MailBody`), envelope (`from`, `to`, `cc`, `bcc`, `subject`, `date`, `messageId`, `replyTo`, `flags`, `sender`, `rawHeaders`) plus IMAP routing identity (`uid`, `folder`) on `routecraft.mail.*` headers.
+
+```ts
+ex.body.text                              // payload
+ex.headers["routecraft.mail.from"]
+ex.headers["routecraft.mail.subject"]
+ex.headers["routecraft.mail.uid"]         // routing identity
+```
+
+Attachments stay on `body` because they are message content (the same call the "What stays on `body`" section above makes for HTTP multipart files).
+
+The fetch destination (`.enrich(mail(...))`) is the one place the whole `MailMessage` (envelope + payload in one object) still appears: a batch fetch returns many messages and single-valued headers cannot hold N envelopes, so each element keeps its envelope inline. That is a result collection, not a per-message exchange, so the convention does not apply.
+
+> Mail's source shape aligned with this convention in 0.6.0; the historical envelope-on-`body` shape is documented in the [0.5.x to 0.6.0 migration guide](https://routecraft.dev/docs/migrating/0.5-to-0.6#mail-envelope-headers).
 
 ### Why the asymmetry across adapters is OK
 

--- a/.standards/exchange-state-model.md
+++ b/.standards/exchange-state-model.md
@@ -118,13 +118,35 @@ When a source adapter ingests a protocol message that has both a payload *and* a
 
 This is the rule that makes `.transform(parseInvoice)`, `.filter(predicate)`, and pipeline composition feel natural across adapters: the same operator works whether the payload arrived over HTTP, mail, or a queue, because `body` always means the operand.
 
-The HTTP source follows this convention exactly. Request method, path, params, query, request headers, and **response hints** all live on headers under `routecraft.http.*`:
+### Promote the parsed envelope, map the remainder
+
+Within the `headers` bag, a source decides where each piece of envelope goes by *what kind of thing it is*, not by whether it happens to be a wire header:
+
+- **Promote to its own typed key** (`routecraft.<adapter>.<field>`) the protocol's pre-parsed, privileged envelope: the small, known, structured set the protocol hands you already parsed. A promoted key's value may be a scalar, a map, or a structured object:
+
+  | Value shape | Examples |
+  | --- | --- |
+  | scalar | `http.method`, `http.path`, `mail.subject`, `mail.uid`, `http.response.status` |
+  | map (a collection parsed out of one transport slot) | `http.params`, `http.query`, `http.cookies` |
+  | structured object / array (a derived concept) | `mail.sender`, `http.response.cookies` |
+
+- **Map the remainder.** The open-ended, homogeneous, stringly-typed wire headers the adapter just passes through go into one map under a single `routecraft.<adapter>.rawHeaders` key. There is no privileged subset and the names are arbitrary, so a map is the right structure: you cannot type N arbitrary keys (you would fall back to an index signature, which is a map with worse ergonomics), and you want `Object.entries` over the whole set.
+
+The litmus for promotion is "did the protocol already parse this into a privileged, typed thing?" HTTP's parsed envelope is the request line (`method`, `path`, `query`, `params`); mail's is the IMAP `ENVELOPE` (`from`, `to`, `subject`, `date`, ...). That those happen to be wire headers in mail and not in HTTP is incidental to the protocols, not a difference in the rule.
+
+A field can legitimately appear in both a promoted key and the raw map (mail `subject` is at `routecraft.mail.subject` and, when raw capture is on, also in `rawHeaders["subject"]`). That is the raw-plus-parsed-view pattern, the same way `routecraft.http.url` contains the query string that `routecraft.http.query` also exposes parsed. Raw form for completeness, parsed view for ergonomics.
+
+**Capture the raw map by default, but size it per protocol.** HTTP request header sets are small and already in memory, so `routecraft.http.rawHeaders` is always populated. A full MIME header block (every `Received` / DKIM / ARC line) is large and per-message, so mail's `routecraft.mail.rawHeaders` is opt-in via `includeHeaders`. That is a payload-size default, not a model difference.
+
+The HTTP source applies this directly:
 
 ```ts
-ex.headers["routecraft.http.method"]
-ex.headers["routecraft.http.params"]
-ex.headers["routecraft.http.query"]
-ex.headers["routecraft.http.headers"]            // request headers, lower-cased
+// Promoted parsed envelope:
+ex.headers["routecraft.http.method"]              // scalar
+ex.headers["routecraft.http.params"]              // map
+ex.headers["routecraft.http.query"]               // map
+// Open-ended pass-through remainder:
+ex.headers["routecraft.http.rawHeaders"]          // map, lower-cased
 
 // Response hints, read by the dispatcher when building the Response:
 ex.headers["routecraft.http.response.status"]
@@ -160,6 +182,15 @@ Attachments stay on `body` because they are message content (the same call the "
 The fetch destination (`.enrich(mail(...))`) is the one place the whole `MailMessage` (envelope + payload in one object) still appears: a batch fetch returns many messages and single-valued headers cannot hold N envelopes, so each element keeps its envelope inline. That is a result collection, not a per-message exchange, so the convention does not apply.
 
 > Mail's source shape aligned with this convention in 0.6.0; the historical envelope-on-`body` shape is documented in the [0.5.x to 0.6.0 migration guide](https://routecraft.dev/docs/migrating/0.5-to-0.6#mail-envelope-headers).
+
+### Worked example: cookies
+
+Cookies show the rule handling a value that is *both* a wire header and a structured concept, and that direction matters:
+
+- **Inbound (`Cookie` request header).** A collection (`sid=abc; theme=dark`) encoded inside one transport slot, the same animal as the query string inside the URL. It earns a promoted *map* key, `routecraft.http.cookies: Record<string, string>`, exactly like `routecraft.http.query`. The raw form stays in `routecraft.http.rawHeaders["cookie"]`.
+- **Outbound (`Set-Cookie`).** Multi-valued, attribute-bearing (`Path` / `Domain` / `Max-Age` / `HttpOnly` / `Secure` / `SameSite`), and an instruction the adapter must serialise. It is a response hint, `routecraft.http.response.cookies: CookieSpec[]`, alongside `response.status` / `response.contentType`. It needs its own structured slot precisely because the flat `response.headers` map cannot express "two cookies, each with attributes."
+
+Neither is ever `body`: you never `.transform(body => newBody)` a cookie. (The HTTP source does not parse cookies today; `routecraft.http.cookies` and `routecraft.http.response.cookies` are the worked design for when it does.)
 
 ### Why the asymmetry across adapters is OK
 

--- a/apps/routecraft.dev/src/app/changelog/page.md
+++ b/apps/routecraft.dev/src/app/changelog/page.md
@@ -28,6 +28,7 @@ This section tracks changes landing on `main` since the v0.5.0 release. Release 
 
 ### Mail
 
+- **Mail source envelope moves to headers** {% badge color="red" %}Breaking{% /badge %} -- `.from(mail(...))` now follows the payload-on-`body`, envelope-on-`headers` convention shared with the HTTP source. The exchange `body` is a `MailBody` (`{ text?, html?, attachments? }`) and the envelope (`from`, `to`, `cc`, `bcc`, `subject`, `date`, `messageId`, `replyTo`, `flags`, `sender`, `rawHeaders`) lands on `routecraft.mail.*` headers, declaration-merged into `RoutecraftHeaders` and exported as `HEADER_MAIL_*` constants. `.input({ body })` now validates against the message content alone. The fetch destination (`.enrich(mail(...))`) still returns `MailMessage[]` unchanged. New exported type `MailBody`. See the [0.5.x to 0.6.0 migration guide](/docs/migrating/0.5-to-0.6#mail-envelope-headers).
 - **Direct mail no longer misclassified as auto-forwarded** -- a single first-hop ARC seal (`i=1`, `cv=none`) added by the delivering MX is no longer read as forwarding, so DMARC-aligned direct mail stays `direct` / `verified` instead of `unverified`. Mailing-list and validated-forward classification are unchanged.
 
 ### Docs site

--- a/apps/routecraft.dev/src/app/docs/examples/support-triage/page.md
+++ b/apps/routecraft.dev/src/app/docs/examples/support-triage/page.md
@@ -71,7 +71,9 @@ export default craft()
       model: 'anthropic:claude-sonnet-4-6',
       system:
         'You are a support triage assistant. Look the sender up, decide a priority (P1 urgent, P2 normal, P3 low), and post one concise internal brief. Do not reply to the customer.',
-      user: (ex) => `From: ${ex.body.from}\nSubject: ${ex.body.subject}\n\n${ex.body.text}`,
+      user: (ex) =>
+        `From: ${ex.headers['routecraft.mail.from']}\n` +
+        `Subject: ${ex.headers['routecraft.mail.subject']}\n\n${ex.body.text}`,
       tools: tools(['Direct(lookup-customer)', 'Direct(post-brief)']),
     }),
   )

--- a/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
@@ -78,14 +78,27 @@ Use `mockAdapter()` and `testContext().override()` instead. You import the facto
 
 ```ts
 import { mail } from "@routecraft/routecraft";
-import { mockAdapter, testContext, type TestContext } from "@routecraft/testing";
+import {
+  mockAdapter,
+  sourceMessage,
+  testContext,
+  type TestContext,
+} from "@routecraft/testing";
 import route from "../capabilities/mail-triage";
 
 const mailMock = mockAdapter(mail, {
-  // Source role: feeds the .from(mail(...)) call site
+  // Source role: feeds the .from(mail(...)) call site. The mail source puts the
+  // payload on `body` and the envelope on `routecraft.mail.*` headers, so wrap
+  // each fixture with `sourceMessage(body, headers)` to reproduce that split.
   source: [
-    { uid: 1, from: "friend@co.com", subject: "lunch?", ... },
-    { uid: 2, from: "spam@x.com",    subject: "URGENT BUY NOW", ... },
+    sourceMessage(
+      { text: "lunch?" },
+      { "routecraft.mail.uid": 1, "routecraft.mail.from": "friend@co.com", "routecraft.mail.subject": "lunch?" },
+    ),
+    sourceMessage(
+      { text: "buy now" },
+      { "routecraft.mail.uid": 2, "routecraft.mail.from": "spam@x.com", "routecraft.mail.subject": "URGENT BUY NOW" },
+    ),
   ],
   // Destination role: stands in for every .to(mail(...)) and .enrich(mail(...))
   // call in the route. Use `args` (what was passed to mail()) to discriminate.

--- a/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
@@ -117,8 +117,12 @@ it("moves spam and replies to friends", async () => {
 
   expect(mailMock.calls.source).toHaveLength(1);
   expect(mailMock.calls.send).toHaveLength(2);
-  expect(mailMock.calls.send[0].args[0]).toMatchObject({ action: "move" });
-  expect(mailMock.calls.send[1].exchange.body.to).toBe("friend@co.com");
+  // Fixtures are dispatched concurrently, so assert by content, not by the
+  // order the sends happened to land in.
+  const moved = mailMock.calls.send.find((c) => c.args[0]?.action === "move");
+  const replied = mailMock.calls.send.find((c) => c.args[0]?.action !== "move");
+  expect(moved).toBeDefined(); // spam was archived
+  expect(replied?.exchange.body.to).toBe("friend@co.com"); // friend got a reply
 });
 ```
 

--- a/apps/routecraft.dev/src/app/docs/migrating/0.5-to-0.6/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.5-to-0.6/page.md
@@ -4,11 +4,12 @@ title: Migrating from 0.5.x to 0.6.0
 
 What changed between Routecraft 0.5.0 and 0.6.0, and how to update. {% .lead %}
 
-Three consumer-visible changes:
+Four consumer-visible changes:
 
 1. **`skills` is replaced by a unified `blocks` record.** Skills, memory, identity, instructions, and any future system-prompt contribution are now one primitive.
 2. **Tag selectors on `tools()` are removed.** Programmatic `tools((catalog) => [...])` is the new escape hatch for "give me all read-only tools" style selection.
 3. **The `http()` destination option type is renamed.** `HttpOptions<T>` becomes `HttpClientOptions<T>` now that `http()` is a two-sided adapter (the new HTTP source uses `HttpServerOptions`). Type-only change; runtime behaviour and the `http({...})` call sites are unchanged.
+4. **The mail source moves the envelope from `body` to `routecraft.mail.*` headers.** `.from(mail(...))` now delivers the message content on `exchange.body` and the envelope (from, subject, recipients, ...) on headers, matching the HTTP source.
 
 Every other consumer-visible part of the public API is unchanged.
 
@@ -351,7 +352,89 @@ If you never imported `HttpOptions` by name (the common case, since `http({...})
 
 ---
 
-## 4. What is new in 0.6.0
+## 4. Mail: envelope moves from `body` to `routecraft.mail.*` headers {% #mail-envelope-headers %}
+
+The mail **source** (`.from(mail(folder, options))`) used to deliver one fat object on `exchange.body` that mixed the message content (`body.text`, `body.html`, `attachments`) with the envelope (`from`, `to`, `subject`, `date`, `cc`, `bcc`, `replyTo`, `messageId`, `flags`, `sender`, `rawHeaders`). It now follows the same payload-on-`body`, envelope-on-`headers` convention as the HTTP source:
+
+- **`exchange.body`** is a `MailBody`: just `{ text?, html?, attachments? }`. Attachments are message content, so they stay on the body.
+- **`exchange.headers`** carries the envelope under the `routecraft.mail.*` namespace. The keys are declaration-merged into `RoutecraftHeaders` for autocomplete and exported as named constants (`HEADER_MAIL_FROM`, `HEADER_MAIL_SUBJECT`, ...).
+
+Two things this unlocks: `.input({ body })` on a mail route now validates against the message content alone (no need to model envelope fields), and `mail -> transform -> http` collapses to one mental model.
+
+Only the streaming **source** changes. The fetch destination (`.enrich(mail(...))`) still returns `MailMessage[]` with the whole envelope on each element, because a batch fetch cannot split N envelopes across single-valued headers. The send destination input (`MailSendPayload`) is unchanged.
+
+### 4.1 Reading the envelope
+
+**Before (0.5.x):**
+
+```ts
+craft()
+  .from(mail("INBOX", { unseen: true }))
+  .transform((msg) => ({
+    to: "team@example.com",
+    subject: `Fwd: ${msg.subject}`,
+    text: msg.body.text ?? "",
+  }))
+  .to(mail());
+```
+
+**After (0.6.0):**
+
+```ts
+craft()
+  .from(mail("INBOX", { unseen: true }))
+  // The transformer's second argument is the exchange; read the envelope
+  // off its headers. The first argument (the body) is now the MailBody.
+  .transform((body, ex) => ({
+    to: "team@example.com",
+    subject: `Fwd: ${ex.headers["routecraft.mail.subject"]}`,
+    text: body.text ?? "",
+  }))
+  .to(mail());
+```
+
+The field-to-header mapping:
+
+| Before (`ex.body.*`) | After (`ex.headers[...]`)        |
+| -------------------- | -------------------------------- |
+| `body.from`          | `routecraft.mail.from`           |
+| `body.to`            | `routecraft.mail.to` (array)     |
+| `body.cc`            | `routecraft.mail.cc` (array)     |
+| `body.bcc`           | `routecraft.mail.bcc` (array)    |
+| `body.subject`       | `routecraft.mail.subject`        |
+| `body.date`          | `routecraft.mail.date`           |
+| `body.messageId`     | `routecraft.mail.messageId`      |
+| `body.replyTo`       | `routecraft.mail.replyTo`        |
+| `body.flags`         | `routecraft.mail.flags`          |
+| `body.sender`        | `routecraft.mail.sender`         |
+| `body.rawHeaders`    | `routecraft.mail.rawHeaders`     |
+| `body.uid`           | `routecraft.mail.uid` (already)  |
+| `body.folder`        | `routecraft.mail.folder` (already) |
+| `body.text`          | `body.text` (unchanged)          |
+| `body.html`          | `body.html` (unchanged)          |
+| `body.attachments`   | `body.attachments` (unchanged)   |
+
+### 4.2 Filtering on the effective sender
+
+**Before (0.5.x):**
+
+```ts
+.filter((ex) => ex.body.sender?.trust === "verified")
+```
+
+**After (0.6.0):**
+
+```ts
+.filter((ex) => ex.headers["routecraft.mail.sender"]?.trust === "verified")
+```
+
+### 4.3 Downstream IMAP operations are unaffected
+
+`.to(mail({ action: "move", ... }))` and the other IMAP operations already resolved their target from the `routecraft.mail.uid` / `routecraft.mail.folder` headers (or a custom `target` extractor), so chains like `mail source -> filter -> mail move` keep working without change.
+
+---
+
+## 5. What is new in 0.6.0
 
 For context, no migration required:
 

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/http/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/http/page.md
@@ -104,7 +104,7 @@ export const home = craft()
 - `routecraft.http.url` -- raw request URL (path + query).
 - `routecraft.http.params` -- `Record<string, string>` of URL-decoded path params.
 - `routecraft.http.query` -- `Record<string, string>` of query params.
-- `routecraft.http.headers` -- `Record<string, string>` of request headers, lower-cased.
+- `routecraft.http.rawHeaders` -- `Record<string, string>` of the raw request headers, lower-cased. This is the open-ended pass-through wire-header remainder (the parsed envelope above is promoted to its own keys); it mirrors `routecraft.mail.rawHeaders`.
 - `routecraft.auth.principal` -- the authenticated `Principal` (when auth is configured). `ex.principal` is sugar over this header.
 
 ### Request body parsing (driven by `Content-Type`)

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/mail/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/mail/page.md
@@ -5,7 +5,7 @@ title: mail
 [← All adapters](/docs/reference/adapters) {% .lead %}
 
 ```ts
-mail(folder: string, options: Partial<MailServerOptions>): Source<MailMessage>
+mail(folder: string, options: Partial<MailServerOptions>): Source<MailBody>
 mail(folder: string): Destination<unknown, MailFetchResult>
 mail(options: Partial<MailServerOptions>): Destination<unknown, MailFetchResult>
 mail(action: MailAction): Destination<unknown, void>
@@ -16,10 +16,20 @@ Read email via IMAP, send via SMTP, or perform IMAP operations. The adapter has 
 
 **Source mode (IMAP push):** Pass a folder and options to receive new messages via IMAP IDLE or polling. Each new email becomes a separate exchange.
 
+The source follows the payload-on-`body`, envelope-on-`headers` convention shared with the HTTP source: the parsed message content (`text`, `html`, `attachments`) lands on `exchange.body` (a [`MailBody`](#mailbody-source-exchange-body)), and the envelope (from, to, subject, date, flags, sender, ...) lands on [`routecraft.mail.*` headers](#source-headers). This means `.input({ body })` validates against the message content alone, and the same `.transform()` / `.filter()` operators compose whether the payload arrived over mail or HTTP.
+
 ```ts
 craft()
   .id('inbox-watcher')
   .from(mail('INBOX', { markSeen: true }))
+  .to(log())
+
+// Read the envelope off headers, the content off the body.
+craft()
+  .id('inbox-router')
+  .from(mail('INBOX', { markSeen: true }))
+  .filter((ex) => ex.headers['routecraft.mail.from']?.endsWith('@acme.test') ?? false)
+  .transform((body) => body.text ?? '')
   .to(log())
 ```
 
@@ -68,14 +78,15 @@ craft()
 **Combined read and send:**
 
 ```ts
-// Forward unread mail to a different address
+// Forward unread mail to a different address. The incoming subject is on
+// headers (envelope); the text content is on the body (payload).
 craft()
   .id('mail-forwarder')
   .from(mail('INBOX', { unseen: true, markSeen: true }))
-  .transform((msg) => ({
+  .transform((body, ex) => ({
     to: 'team@example.com',
-    subject: `Fwd: ${msg.subject}`,
-    text: msg.body.text ?? '',
+    subject: `Fwd: ${ex.headers['routecraft.mail.subject']}`,
+    text: body.text ?? '',
   }))
   .to(mail())
 ```
@@ -180,7 +191,41 @@ When multiple accounts are configured, select one per adapter call with the `acc
 | `bcc` | `string \| string[]` | | Default BCC recipients |
 | `account` | `string` | | Named account from context config (uses default if omitted) |
 
-**`MailMessage` (exchange body in source/fetch modes):**
+**`MailBody` (source exchange body):** {% #mailbody-source-exchange-body %}
+
+In source mode (`.from(mail(...))`) the exchange **body** is just the parsed message content. The envelope lives on [headers](#source-headers).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `text` | `string?` | Plain text body, when the message included a `text/plain` part. |
+| `html` | `string?` | HTML body, when the message included a `text/html` part. |
+| `attachments` | `MailAttachment[]?` | File attachments. Attachments are message content (not envelope), so they stay on the body alongside `text`/`html`, mirroring how the HTTP source keeps multipart files on the body. |
+
+**Source headers (`routecraft.mail.*`):** {% #source-headers %}
+
+In source mode the envelope is attached to `exchange.headers` under the `routecraft.mail.*` namespace. The keys are declaration-merged into `RoutecraftHeaders` (so you get autocomplete) and exported as named constants (`HEADER_MAIL_FROM`, `HEADER_MAIL_SUBJECT`, ...).
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `routecraft.mail.uid` | `number` | IMAP UID |
+| `routecraft.mail.folder` | `string` | The IMAP folder this message was fetched from |
+| `routecraft.mail.messageId` | `string` | Message-ID header |
+| `routecraft.mail.from` | `string` | Literal `From:` header. For mailing-list forwards this is the rewritten list address; use `routecraft.mail.sender` for the real sender. |
+| `routecraft.mail.to` | `string[]` | Recipient address(es), always normalised to an array |
+| `routecraft.mail.cc` | `string[]?` | CC recipients (absent when none) |
+| `routecraft.mail.bcc` | `string[]?` | BCC recipients (absent when none) |
+| `routecraft.mail.subject` | `string` | Subject line |
+| `routecraft.mail.date` | `Date` | Date sent |
+| `routecraft.mail.replyTo` | `string?` | Reply-to address |
+| `routecraft.mail.flags` | `ReadonlySet<string>` | IMAP flags (e.g. `\Seen`, `\Flagged`) |
+| `routecraft.mail.sender` | `MailSender?` | Computed effective sender and forward chain (see below). Absent when `verify: 'off'`. |
+| `routecraft.mail.rawHeaders` | `Record<string, string \| string[]>?` | Raw email headers (when `includeHeaders` is set) |
+
+> Migrating from the old envelope-on-body shape? See the [0.5.x to 0.6.0 migration guide](/docs/migrating/0.5-to-0.6#mail-envelope-headers).
+
+**`MailMessage` (fetch destination result):**
+
+In fetch mode (`.enrich(mail(...))`) the result body is a `MailMessage[]`. Because a batch fetch returns many messages, each one keeps its whole envelope together in a single object rather than splitting across single-valued headers.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -200,7 +245,7 @@ When multiple accounts are configured, select one per adapter call with the `acc
 | `folder` | `string` | The IMAP folder this message was fetched from |
 | `sender` | `MailSender?` | Computed effective sender and forward chain (see below). Omitted when `verify: 'off'`. |
 
-**`MailSender` (on `MailMessage.sender`):**
+**`MailSender` (on `routecraft.mail.sender` / `MailMessage.sender`):**
 
 Resolves the *real* sender of mailing-list and auto-forwarded messages, so apps can gate on origin without re-parsing headers. For a Google Groups forward, `sender.address` is the original sender and `from` is the rewritten list address.
 
@@ -222,7 +267,7 @@ Resolves the *real* sender of mailing-list and auto-forwarded messages, so apps 
 craft()
   .from(mail('INBOX'))
   .filter((ex) => {
-    const s = ex.body.sender;
+    const s = ex.headers['routecraft.mail.sender'];
     if (s?.address === 'alice@allowed.com' && s.trust === 'verified') {
       return true;
     }
@@ -254,6 +299,6 @@ craft()
 | `rejected` | `string[]` | Rejected recipient addresses |
 | `response` | `string` | SMTP server response string |
 
-**Exported types:** `MailAuth`, `MailServerOptions`, `MailClientOptions`, `MailOptions`, `MailMessage`, `MailAttachment`, `MailSendPayload`, `MailSendResult`, `MailFetchResult`, `MailContextConfig`, `MailAccountConfig`, `MailAction`, `MailSender`, `EmailAddress`, `ForwardHop`, `ForwardType`, `TrustLevel`, `MailClientManager`, `MAIL_CLIENT_MANAGER`. Helpers: `analyzeHeaders`, `parseAuthResults`.
+**Exported types:** `MailAuth`, `MailServerOptions`, `MailClientOptions`, `MailOptions`, `MailBody`, `MailMessage`, `MailAttachment`, `MailSendPayload`, `MailSendResult`, `MailFetchResult`, `MailContextConfig`, `MailAccountConfig`, `MailAction`, `MailSender`, `EmailAddress`, `ForwardHop`, `ForwardType`, `TrustLevel`, `MailClientManager`, `MAIL_CLIENT_MANAGER`. Header key constants: `HEADER_MAIL_UID`, `HEADER_MAIL_FOLDER`, `HEADER_MAIL_MESSAGE_ID`, `HEADER_MAIL_FROM`, `HEADER_MAIL_TO`, `HEADER_MAIL_CC`, `HEADER_MAIL_BCC`, `HEADER_MAIL_SUBJECT`, `HEADER_MAIL_DATE`, `HEADER_MAIL_REPLY_TO`, `HEADER_MAIL_FLAGS`, `HEADER_MAIL_SENDER`, `HEADER_MAIL_RAW_HEADERS`. Helpers: `analyzeHeaders`, `parseAuthResults`.
 
 ---

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/mail/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/mail/page.md
@@ -221,8 +221,6 @@ In source mode the envelope is attached to `exchange.headers` under the `routecr
 | `routecraft.mail.sender` | `MailSender?` | Computed effective sender and forward chain (see below). Absent when `verify: 'off'`. |
 | `routecraft.mail.rawHeaders` | `Record<string, string \| string[]>?` | Raw email headers (when `includeHeaders` is set) |
 
-> Migrating from the old envelope-on-body shape? See the [0.5.x to 0.6.0 migration guide](/docs/migrating/0.5-to-0.6#mail-envelope-headers).
-
 **`MailMessage` (fetch destination result):**
 
 In fetch mode (`.enrich(mail(...))`) the result body is a `MailMessage[]`. Because a batch fetch returns many messages, each one keeps its whole envelope together in a single object rather than splitting across single-valued headers.

--- a/apps/routecraft.dev/src/app/docs/reference/operations/authenticate/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/authenticate/page.md
@@ -19,14 +19,21 @@ Only `subject` is required; `kind` defaults to `"custom"` and `scheme` to `"cust
 craft()
   .from(mail('INBOX'))
   .filter(verifiedSenders)
-  .authenticate((ex) => ({
-    scheme: 'email',
-    subject: ex.body.sender.address,
-    roles: ex.body.sender.address.endsWith('@acme.com') ? ['internal'] : [],
-  }))
+  .authenticate((ex) => {
+    // The mail source attaches the computed sender to a header.
+    const sender = ex.headers['routecraft.mail.sender']
+    return {
+      scheme: 'email',
+      subject: sender.address,
+      roles: sender.address.endsWith('@acme.com') ? ['internal'] : [],
+    }
+  })
   .authorize({ roles: ['internal'] })
   .to(dest)
 
 // Return undefined to stay anonymous
-.authenticate((ex) => (ex.body.sender ? { subject: ex.body.sender.address } : undefined))
+.authenticate((ex) => {
+  const sender = ex.headers['routecraft.mail.sender']
+  return sender ? { subject: sender.address } : undefined
+})
 ```

--- a/apps/routecraft.dev/src/app/docs/reference/operations/authorize/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/authorize/page.md
@@ -63,13 +63,17 @@ craft()
 import { authorize } from '@routecraft/routecraft'
 
 craft()
-  .from(mail({ /* ... */ }))
-  .authenticate((ex) => ({
-    scheme: 'email',
-    subject: ex.body.from?.address ?? 'anonymous',
-    email: ex.body.from?.address,
-    claims: { tenant: deriveTenant(ex.body.from?.address) },
-  }))
+  .from(mail('INBOX', { /* ... */ }))
+  .authenticate((ex) => {
+    // The mail source puts the sender on a header, not the body.
+    const from = ex.headers['routecraft.mail.from']
+    return {
+      scheme: 'email',
+      subject: from ?? 'anonymous',
+      email: from,
+      claims: { tenant: deriveTenant(from) },
+    }
+  })
   .validate(authorize({
     predicate: (p) => p.email?.endsWith('@yourcompany.com') === true,
   }))

--- a/examples/src/mail-noreply-notify.ts
+++ b/examples/src/mail-noreply-notify.ts
@@ -18,16 +18,25 @@ export default craft()
       header: { "Reply-To": ["noreply", "no-reply"] },
     }),
   )
-  .tap(log(({ body }) => `No-reply from ${body.from}: "${body.subject}"`))
-  .transform((body) => ({
+  .tap(
+    log(
+      (ex) =>
+        `No-reply from ${ex.headers["routecraft.mail.from"]}: ` +
+        `"${ex.headers["routecraft.mail.subject"]}"`,
+    ),
+  )
+  // The mail source puts the message payload on `body` and the envelope
+  // (from, subject, date, ...) on `routecraft.mail.*` headers, so read the
+  // envelope off the exchange rather than the body.
+  .transform((_body, ex) => ({
     to: process.env["NOTIFY_TO"] ?? process.env["MAIL_USER"] ?? "",
     subject: "Routecraft: processed a no-reply email",
     text: [
       "Hey! Routecraft just found a no-reply email and marked it as read.",
       "",
-      `From: ${body.from}`,
-      `Subject: ${body.subject}`,
-      `Date: ${body.date}`,
+      `From: ${ex.headers["routecraft.mail.from"]}`,
+      `Subject: ${ex.headers["routecraft.mail.subject"]}`,
+      `Date: ${ex.headers["routecraft.mail.date"]?.toISOString()}`,
       "",
       "This message was sent by the mail-noreply-notify example.",
     ].join("\n"),

--- a/examples/test/mail-noreply-notify.bun.test.ts
+++ b/examples/test/mail-noreply-notify.bun.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach, beforeEach } from "bun:test";
-import { mail, type MailMessage } from "@routecraft/routecraft";
+import { mail, type MailBody } from "@routecraft/routecraft";
 import {
   mockAdapter,
+  sourceMessage,
   testContext,
   type TestContext,
 } from "@routecraft/testing";
@@ -36,17 +37,19 @@ describe("mail-noreply-notify", () => {
    * @expectedResult The send handler is invoked exactly once with the expected subject and a text body that includes the original sender
    */
   it("fans an IMAP fixture through to an SMTP send", async () => {
-    const incoming: MailMessage = {
-      uid: 42,
-      messageId: "<msg42@noreply.test>",
-      from: "noreply@acme.test",
-      to: "me@work.test",
-      subject: "Your order has shipped",
-      date: new Date("2026-04-15T10:00:00Z"),
-      flags: new Set(),
-      folder: "INBOX",
-      body: { text: "Tracking: ABC123" },
-    };
+    // The mail source delivers the payload on `body` and the envelope on
+    // `routecraft.mail.*` headers; `sourceMessage` reproduces that split so
+    // the route (which reads the envelope off headers) can be exercised.
+    const incomingBody: MailBody = { text: "Tracking: ABC123" };
+    const incoming = sourceMessage(incomingBody, {
+      "routecraft.mail.uid": 42,
+      "routecraft.mail.folder": "INBOX",
+      "routecraft.mail.messageId": "<msg42@noreply.test>",
+      "routecraft.mail.from": "noreply@acme.test",
+      "routecraft.mail.to": ["me@work.test"],
+      "routecraft.mail.subject": "Your order has shipped",
+      "routecraft.mail.date": new Date("2026-04-15T10:00:00Z"),
+    });
 
     const mailMock = mockAdapter(mail, {
       // Source role: .from(mail("INBOX", ...)) receives this fixture array.
@@ -99,17 +102,15 @@ describe("mail-noreply-notify", () => {
    * @expectedResult The context records an error via context:error; the send handler was still invoked
    */
   it("surfaces send failures as route errors", async () => {
-    const incoming: MailMessage = {
-      uid: 1,
-      messageId: "<m1@test>",
-      from: "noreply@x.test",
-      to: "me@work.test",
-      subject: "x",
-      date: new Date(),
-      flags: new Set(),
-      folder: "INBOX",
-      body: {},
-    };
+    const incoming = sourceMessage({} as MailBody, {
+      "routecraft.mail.uid": 1,
+      "routecraft.mail.folder": "INBOX",
+      "routecraft.mail.messageId": "<m1@test>",
+      "routecraft.mail.from": "noreply@x.test",
+      "routecraft.mail.to": ["me@work.test"],
+      "routecraft.mail.subject": "x",
+      "routecraft.mail.date": new Date(),
+    });
 
     const mailMock = mockAdapter(mail, {
       source: [incoming],

--- a/packages/routecraft/src/adapters/http/types.ts
+++ b/packages/routecraft/src/adapters/http/types.ts
@@ -309,8 +309,13 @@ declare module "@routecraft/routecraft" {
     "routecraft.http.params"?: Readonly<Record<string, string>>;
     /** Query string parameters as a flat object. Repeated keys keep the last value. */
     "routecraft.http.query"?: Readonly<Record<string, string>>;
-    /** Request headers as a flat lower-cased object. */
-    "routecraft.http.headers"?: Readonly<Record<string, string>>;
+    /**
+     * Raw request headers as a flat lower-cased map. This is the open-ended,
+     * pass-through wire-header remainder (mirrors `routecraft.mail.rawHeaders`);
+     * the parsed request envelope (method, path, query, params) is promoted to
+     * its own keys above.
+     */
+    "routecraft.http.rawHeaders"?: Readonly<Record<string, string>>;
     /** Override the response status code. */
     "routecraft.http.response.status"?: number;
     /** Override the response Content-Type. */

--- a/packages/routecraft/src/adapters/mail/index.ts
+++ b/packages/routecraft/src/adapters/mail/index.ts
@@ -8,7 +8,7 @@ import { MailOperationDestinationAdapter } from "./operation-destination.ts";
 import type {
   MailServerOptions,
   MailClientOptions,
-  MailMessage,
+  MailBody,
   MailFetchResult,
   MailSendPayload,
   MailSendResult,
@@ -68,7 +68,7 @@ import type {
 export function mail(
   folder: string,
   options: MailServerOptions,
-): Source<MailMessage>;
+): Source<MailBody>;
 export function mail(folder: string): Destination<unknown, MailFetchResult>;
 export function mail(
   options: MailServerOptions,
@@ -81,7 +81,7 @@ export function mail(
   folderOrOptions?: string | MailServerOptions | MailClientOptions | MailAction,
   options?: MailServerOptions,
 ):
-  | Source<MailMessage>
+  | Source<MailBody>
   | Destination<unknown, MailFetchResult>
   | Destination<MailSendPayload, MailSendResult>
   | Destination<unknown, void> {
@@ -90,7 +90,7 @@ export function mail(
   // 2 args: string + object -> Source (matches direct(endpoint, options) pattern)
   if (typeof folderOrOptions === "string" && options !== undefined) {
     const adapter = new MailSourceAdapter(folderOrOptions, options);
-    return tagAdapter(adapter, mail, args) as Source<MailMessage>;
+    return tagAdapter(adapter, mail, args) as Source<MailBody>;
   }
 
   // 1 arg string -> Fetch Destination (folder shorthand for .enrich())
@@ -159,6 +159,7 @@ export type {
   MailServerOptions,
   MailClientOptions,
   MailOptions,
+  MailBody,
   MailMessage,
   MailAttachment,
   MailSendPayload,
@@ -181,6 +182,25 @@ export type {
 // Re-export store key and client manager
 export { MAIL_CLIENT_MANAGER } from "./shared.ts";
 export { MailClientManager } from "./client-manager.ts";
+
+// Re-export the `routecraft.mail.*` header key constants so consumers reading
+// envelope metadata off the source exchange get named constants and type-safe
+// autocomplete (the keys are also declaration-merged into `RoutecraftHeaders`).
+export {
+  HEADER_MAIL_UID,
+  HEADER_MAIL_FOLDER,
+  HEADER_MAIL_MESSAGE_ID,
+  HEADER_MAIL_FROM,
+  HEADER_MAIL_TO,
+  HEADER_MAIL_CC,
+  HEADER_MAIL_BCC,
+  HEADER_MAIL_SUBJECT,
+  HEADER_MAIL_DATE,
+  HEADER_MAIL_REPLY_TO,
+  HEADER_MAIL_FLAGS,
+  HEADER_MAIL_SENDER,
+  HEADER_MAIL_RAW_HEADERS,
+} from "./shared.ts";
 
 // Sender analysis
 export type {

--- a/packages/routecraft/src/adapters/mail/shared.ts
+++ b/packages/routecraft/src/adapters/mail/shared.ts
@@ -1,7 +1,8 @@
 import type { CraftContext } from "../../context.ts";
-import type { Exchange } from "../../exchange.ts";
+import type { Exchange, ExchangeHeaders } from "../../exchange.ts";
 import { rcError } from "../../error.ts";
 import type {
+  MailBody,
   MailMessage,
   MailServerOptions,
   MailClientOptions,
@@ -43,6 +44,39 @@ export const HEADER_MAIL_UID = "routecraft.mail.uid";
 
 /** Header key for the IMAP folder of the source message. */
 export const HEADER_MAIL_FOLDER = "routecraft.mail.folder";
+
+/** Header key for the `Message-ID` of the source message. */
+export const HEADER_MAIL_MESSAGE_ID = "routecraft.mail.messageId";
+
+/** Header key for the literal `From:` address. */
+export const HEADER_MAIL_FROM = "routecraft.mail.from";
+
+/** Header key for the recipient address(es) (always an array). */
+export const HEADER_MAIL_TO = "routecraft.mail.to";
+
+/** Header key for the CC recipient address(es). */
+export const HEADER_MAIL_CC = "routecraft.mail.cc";
+
+/** Header key for the BCC recipient address(es). */
+export const HEADER_MAIL_BCC = "routecraft.mail.bcc";
+
+/** Header key for the subject line. */
+export const HEADER_MAIL_SUBJECT = "routecraft.mail.subject";
+
+/** Header key for the date the message was sent. */
+export const HEADER_MAIL_DATE = "routecraft.mail.date";
+
+/** Header key for the Reply-To address. */
+export const HEADER_MAIL_REPLY_TO = "routecraft.mail.replyTo";
+
+/** Header key for the IMAP flags. */
+export const HEADER_MAIL_FLAGS = "routecraft.mail.flags";
+
+/** Header key for the computed effective sender (when `verify !== "off"`). */
+export const HEADER_MAIL_SENDER = "routecraft.mail.sender";
+
+/** Header key for the raw email headers (requested via `includeHeaders`). */
+export const HEADER_MAIL_RAW_HEADERS = "routecraft.mail.rawHeaders";
 
 // ---------------------------------------------------------------------------
 // Client manager access
@@ -141,6 +175,61 @@ export function resolveMailTarget(
  */
 export function toArray(value: string | string[]): string[] {
   return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Split a fetched {@link MailMessage} into the shape the streaming source
+ * delivers: message content on `body` (a {@link MailBody}) and envelope
+ * metadata on `routecraft.mail.*` headers.
+ *
+ * This mirrors the HTTP source convention (payload on `body`, envelope on
+ * `headers`) so the same `.transform()` / `.filter()` operators compose across
+ * adapters. Attachments are message content, not envelope, so they stay on the
+ * body alongside `text`/`html`. IMAP routing identity (`uid`/`folder`) and the
+ * rest of the envelope move to headers.
+ *
+ * @param message - A message produced by {@link fetchMessages}
+ * @returns The `body`/`headers` pair to hand to the source's exchange handler
+ */
+export function splitMailMessage(message: MailMessage): {
+  body: MailBody;
+  headers: ExchangeHeaders;
+} {
+  const body: MailBody = {};
+  if (message.body.text !== undefined) body.text = message.body.text;
+  if (message.body.html !== undefined) body.html = message.body.html;
+  if (message.attachments !== undefined) body.attachments = message.attachments;
+
+  // `ExchangeHeaders` is `Readonly`, so build the map in one literal (with
+  // conditional spreads for the optional envelope fields) rather than
+  // post-assigning. Empty cc/bcc arrays are omitted to keep headers clean.
+  const headers: ExchangeHeaders = {
+    [HEADER_MAIL_UID]: message.uid,
+    [HEADER_MAIL_FOLDER]: message.folder,
+    [HEADER_MAIL_MESSAGE_ID]: message.messageId,
+    [HEADER_MAIL_FROM]: message.from,
+    [HEADER_MAIL_TO]: toArray(message.to),
+    [HEADER_MAIL_SUBJECT]: message.subject,
+    [HEADER_MAIL_DATE]: message.date,
+    [HEADER_MAIL_FLAGS]: message.flags,
+    ...(message.cc !== undefined && message.cc.length > 0
+      ? { [HEADER_MAIL_CC]: message.cc }
+      : {}),
+    ...(message.bcc !== undefined && message.bcc.length > 0
+      ? { [HEADER_MAIL_BCC]: message.bcc }
+      : {}),
+    ...(message.replyTo !== undefined
+      ? { [HEADER_MAIL_REPLY_TO]: message.replyTo }
+      : {}),
+    ...(message.rawHeaders !== undefined
+      ? { [HEADER_MAIL_RAW_HEADERS]: message.rawHeaders }
+      : {}),
+    ...(message.sender !== undefined
+      ? { [HEADER_MAIL_SENDER]: message.sender }
+      : {}),
+  };
+
+  return { body, headers };
 }
 
 /**

--- a/packages/routecraft/src/adapters/mail/source.ts
+++ b/packages/routecraft/src/adapters/mail/source.ts
@@ -2,7 +2,7 @@ import type { CraftContext } from "../../context.ts";
 import type { Source } from "../../operations/from.ts";
 import type { Exchange, ExchangeHeaders } from "../../exchange.ts";
 import { rcError } from "../../error.ts";
-import type { MailMessage, MailServerOptions } from "./types.ts";
+import type { MailBody, MailMessage, MailServerOptions } from "./types.ts";
 import type { MailClientManager } from "./client-manager.ts";
 import { DEFAULT_ON_PARSE_ERROR, type OnParseError } from "../shared/parse.ts";
 import {
@@ -12,8 +12,7 @@ import {
   markMessagesSeen,
   isMailAuthError,
   throwMailConnectionError,
-  HEADER_MAIL_UID,
-  HEADER_MAIL_FOLDER,
+  splitMailMessage,
   MAIL_PARSE_ERRORS,
   type MailFetchLogger,
 } from "./shared.ts";
@@ -34,9 +33,13 @@ const MAIL_RECONNECT_MAX_MS = 60_000;
  * When a MailClientManager is available (via context mail config), uses pooled
  * connections. Otherwise falls back to standalone connections.
  *
- * Sets `routecraft.mail.uid` and `routecraft.mail.folder` headers on each
- * exchange so downstream operations can resolve the target message even after
- * body transforms.
+ * Splits each message into a {@link MailBody} payload on `exchange.body`
+ * (`text`, `html`, and `attachments`) and the envelope on `routecraft.mail.*`
+ * headers (`uid`, `folder`, `from`, `to`, `cc`, `bcc`, `subject`, `date`,
+ * `messageId`, `replyTo`, `flags`, `sender`, `rawHeaders`). This mirrors the
+ * HTTP source convention so the same `.transform()` / `.filter()` operators
+ * compose across adapters, and downstream IMAP operations can resolve the
+ * target message from headers even after body transforms.
  *
  * ## IDLE vs poll
  *
@@ -70,7 +73,7 @@ const MAIL_RECONNECT_MAX_MS = 60_000;
  *   .to(mail({ action: 'move', folder: 'Archive' }))
  * ```
  */
-export class MailSourceAdapter implements Source<MailMessage> {
+export class MailSourceAdapter implements Source<MailBody> {
   readonly adapterId = "routecraft.adapter.mail";
   private readonly adapterOptions: MailServerOptions;
   private readonly folder: string;
@@ -83,7 +86,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
   async subscribe(
     context: CraftContext,
     handler: (
-      message: MailMessage,
+      message: MailBody,
       headers?: ExchangeHeaders,
       parse?: (raw: unknown) => unknown | Promise<unknown>,
       parseFailureMode?: OnParseError,
@@ -156,10 +159,10 @@ export class MailSourceAdapter implements Source<MailMessage> {
     const parseFailureMode = resolved.onParseError ?? DEFAULT_ON_PARSE_ERROR;
 
     const handlerWithHeaders = (message: MailMessage) => {
-      const headers: ExchangeHeaders = {
-        [HEADER_MAIL_UID]: message.uid,
-        [HEADER_MAIL_FOLDER]: message.folder,
-      };
+      // Split the fetched message into payload (body) and envelope (headers)
+      // so the route sees the same payload-on-body / envelope-on-headers shape
+      // as the HTTP source.
+      const { body, headers } = splitMailMessage(message);
       // When the message had a MIME parse failure during fetch, surface
       // the captured error from the synthetic parse step so the route
       // observes it via the configured failure mode. See #187.
@@ -167,7 +170,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
       if (parseError) {
         MAIL_PARSE_ERRORS.delete(message);
         return handler(
-          message,
+          body,
           headers,
           () => {
             throw parseError;
@@ -175,7 +178,7 @@ export class MailSourceAdapter implements Source<MailMessage> {
           parseFailureMode,
         );
       }
-      return handler(message, headers);
+      return handler(body, headers);
     };
 
     try {

--- a/packages/routecraft/src/adapters/mail/types.ts
+++ b/packages/routecraft/src/adapters/mail/types.ts
@@ -336,7 +336,35 @@ export type MailAction =
 // ---------------------------------------------------------------------------
 
 /**
- * A parsed email message returned by the mail adapter source/fetch.
+ * The payload an email message carries, delivered on `exchange.body` by the
+ * mail source. This is the content a route operates on with `.transform()`,
+ * `.filter()`, and friends. Envelope metadata (from, subject, recipients, ...)
+ * travels on `routecraft.mail.*` headers instead. See
+ * {@link MailMessage} for the full object returned by the fetch destination.
+ *
+ * `text` and `html` are two representations of the same content; either, both,
+ * or neither may be populated depending on what the sender composed
+ * (`multipart/alternative` vs a single-part message). Attachments are message
+ * content (not envelope), so they stay on the body alongside `text`/`html`.
+ */
+export interface MailBody {
+  /** Plain text body, when the message included a `text/plain` part. */
+  text?: string;
+  /** HTML body, when the message included a `text/html` part. */
+  html?: string;
+  /** File attachments carried by the message. */
+  attachments?: MailAttachment[];
+}
+
+/**
+ * A parsed email message returned by the mail adapter fetch destination
+ * (`.enrich(mail(...))`), as an array element of {@link MailFetchResult}.
+ *
+ * The streaming source (`.from(mail(...))`) does not deliver this shape; it
+ * splits the message into a {@link MailBody} on `exchange.body` and
+ * `routecraft.mail.*` headers. This object keeps the whole message together
+ * because a batch fetch returns many messages and single-valued headers cannot
+ * hold N envelopes.
  */
 export interface MailMessage {
   /** IMAP UID */
@@ -457,3 +485,56 @@ export interface MailSendResult {
  * Result returned by the fetch destination (array of messages).
  */
 export type MailFetchResult = MailMessage[];
+
+// --------------------------------------------------------------------------
+// Header keys registry augmentation
+// --------------------------------------------------------------------------
+
+// The mail source puts the message payload on `body` and the envelope on
+// `routecraft.mail.*` headers, mirroring the HTTP source convention. These
+// declarations give consumers autocomplete and type-safety when reading those
+// headers. The string constants live in `./shared.ts` (HEADER_MAIL_*).
+//
+// See .standards/type-safety-and-schemas.md#module-augmentation for why this
+// targets the package specifier and not a relative path.
+declare module "@routecraft/routecraft" {
+  interface RoutecraftHeaders {
+    /** IMAP UID of the source message. */
+    "routecraft.mail.uid"?: number;
+    /** IMAP folder the message was fetched from. */
+    "routecraft.mail.folder"?: string;
+    /** `Message-ID` header of the source message. */
+    "routecraft.mail.messageId"?: string;
+    /**
+     * Literal `From:` header. For mailing-list forwards this is the rewritten
+     * list address; use {@link MailSender} on `routecraft.mail.sender` for the
+     * real sender when `verify !== "off"`.
+     */
+    "routecraft.mail.from"?: string;
+    /** Recipient address(es), always normalised to an array. */
+    "routecraft.mail.to"?: string[];
+    /** CC recipient address(es). Absent when the message had none. */
+    "routecraft.mail.cc"?: string[];
+    /** BCC recipient address(es). Absent when the message had none. */
+    "routecraft.mail.bcc"?: string[];
+    /** Subject line. */
+    "routecraft.mail.subject"?: string;
+    /** Date the message was sent. */
+    "routecraft.mail.date"?: Date;
+    /** Reply-To address, when present. */
+    "routecraft.mail.replyTo"?: string;
+    /** IMAP flags (e.g. `\Seen`, `\Flagged`). */
+    "routecraft.mail.flags"?: ReadonlySet<string>;
+    /**
+     * Computed effective sender with forward-chain and authentication
+     * evidence. Absent when the source is configured with `verify: "off"`.
+     */
+    "routecraft.mail.sender"?: MailSender;
+    /**
+     * Raw email headers requested via the `includeHeaders` option. Keys are
+     * lowercased header names; values are strings or arrays for multi-value
+     * headers (e.g. multiple `Received` lines).
+     */
+    "routecraft.mail.rawHeaders"?: Readonly<Record<string, string | string[]>>;
+  }
+}

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -192,11 +192,15 @@ export { shutdownHandler } from "./shutdown.ts";
 
 export {
   RC_ADAPTER_OVERRIDES,
+  SOURCE_FIXTURE,
+  isSourceFixture,
   type AdapterOverride,
   type AdapterSendCall,
   type AdapterSourceCall,
   type SendOverrideHandler,
   type SourceOverrideBehavior,
+  type SourceFixture,
+  type SourceMessage,
 } from "./testing-hooks.ts";
 
 export { tagAdapter, factoryArgs } from "./adapters/shared/factory-tag.ts";
@@ -312,6 +316,7 @@ export {
   type MailServerOptions,
   type MailClientOptions,
   type MailOptions,
+  type MailBody,
   type MailMessage,
   type MailAttachment,
   type MailSendPayload,
@@ -338,4 +343,17 @@ export {
   parseAuthResults,
   ANALYSIS_HEADER_NAMES,
   MailClientManager,
+  HEADER_MAIL_UID,
+  HEADER_MAIL_FOLDER,
+  HEADER_MAIL_MESSAGE_ID,
+  HEADER_MAIL_FROM,
+  HEADER_MAIL_TO,
+  HEADER_MAIL_CC,
+  HEADER_MAIL_BCC,
+  HEADER_MAIL_SUBJECT,
+  HEADER_MAIL_DATE,
+  HEADER_MAIL_REPLY_TO,
+  HEADER_MAIL_FLAGS,
+  HEADER_MAIL_SENDER,
+  HEADER_MAIL_RAW_HEADERS,
 } from "./adapters/mail/index.ts";

--- a/packages/routecraft/src/plugins/http/dispatcher.ts
+++ b/packages/routecraft/src/plugins/http/dispatcher.ts
@@ -254,9 +254,10 @@ export function createDispatcher(
       return response;
     }
 
-    // 5. Build the headers passed to the runtime handler. Standard request
-    //    metadata uses dotted keys (path, method, url, headers) plus typed
-    //    nested objects for params and query.
+    // 5. Build the headers passed to the runtime handler. The parsed request
+    //    envelope (method, path, url) is promoted to its own dotted keys, with
+    //    typed nested maps for params and query; the open-ended pass-through
+    //    wire headers go into the single `routecraft.http.rawHeaders` map.
     const queryObject: Record<string, string> = {};
     for (const [k, v] of url.searchParams) queryObject[k] = v;
     const reqHeaders: Record<string, string> = {};
@@ -270,7 +271,7 @@ export function createDispatcher(
       "routecraft.http.url": req.url,
       "routecraft.http.params": params,
       "routecraft.http.query": Object.freeze(queryObject),
-      "routecraft.http.headers": Object.freeze(reqHeaders),
+      "routecraft.http.rawHeaders": Object.freeze(reqHeaders),
       ...(principal !== undefined
         ? { [HeadersKeys.AUTH_PRINCIPAL]: principal }
         : {}),

--- a/packages/routecraft/src/step-builder-base.ts
+++ b/packages/routecraft/src/step-builder-base.ts
@@ -368,11 +368,15 @@ export abstract class StepBuilderBase<Current = unknown> {
    * craft()
    *   .from(mail("INBOX"))
    *   .filter(verifiedSenders)
-   *   .authenticate((ex) => ({
-   *     scheme: "email",
-   *     subject: ex.body.sender.address,
-   *     roles: ex.body.sender.address.endsWith("@acme.com") ? ["internal"] : [],
-   *   }))
+   *   .authenticate((ex) => {
+   *     // The mail source attaches the computed sender to a header.
+   *     const sender = ex.headers["routecraft.mail.sender"];
+   *     return {
+   *       scheme: "email",
+   *       subject: sender.address,
+   *       roles: sender.address.endsWith("@acme.com") ? ["internal"] : [],
+   *     };
+   *   })
    *   .authorize({ roles: ["internal"] })
    *   .to(dest)
    * ```

--- a/packages/routecraft/src/testing-hooks.ts
+++ b/packages/routecraft/src/testing-hooks.ts
@@ -48,16 +48,70 @@ export interface AdapterSourceCall {
 }
 
 /**
+ * Brand marking a source fixture that carries explicit headers alongside its
+ * body. Lets a source-role mock reproduce the body/headers split that real
+ * envelope-carrying sources (http, mail) perform, so a route that reads
+ * `routecraft.<adapter>.*` headers can be exercised through `mockAdapter`.
+ *
+ * Use the `sourceMessage()` helper from `@routecraft/testing` to construct
+ * these rather than building the branded object by hand.
+ * @internal
+ */
+export const SOURCE_FIXTURE: unique symbol = Symbol.for(
+  "routecraft.testing.source-fixture",
+);
+
+/**
+ * A source fixture pairing a message body with the headers a real source would
+ * have attached. Recognised by {@link wrapSourceWithOverride}.
+ * @internal
+ */
+export interface SourceFixture<M = unknown> {
+  readonly [SOURCE_FIXTURE]: true;
+  /** The body the source would deliver on the exchange. */
+  readonly body: M;
+  /** Headers the source would attach (e.g. `routecraft.mail.*`). */
+  readonly headers?: ExchangeHeaders;
+}
+
+/**
+ * Type guard for {@link SourceFixture}. A plain message is delivered as the
+ * body with no headers; a branded fixture is unwrapped into `(body, headers)`.
+ * @internal
+ */
+export function isSourceFixture(value: unknown): value is SourceFixture {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { [SOURCE_FIXTURE]?: unknown })[SOURCE_FIXTURE] === true
+  );
+}
+
+/**
+ * A source-role fixture: either a plain message (delivered as the body with no
+ * headers) or a {@link SourceFixture} carrying body + headers.
+ * @internal
+ */
+export type SourceMessage<M = unknown> = M | SourceFixture<M>;
+
+/**
  * Handler shape for a source-role mock. May be a plain array of fixtures,
  * an async iterable, or a callable that returns either (receiving the
- * construction args so it can vary by call site).
+ * construction args so it can vary by call site). Each fixture may be a plain
+ * message or a {@link SourceFixture} (via `sourceMessage()`) to also attach
+ * headers.
  * @internal
  */
 export type SourceOverrideBehavior<M = unknown> =
-  | readonly M[]
-  | AsyncIterable<M>
-  | Iterable<M>
-  | ((args: unknown[]) => readonly M[] | Iterable<M> | AsyncIterable<M>);
+  | readonly SourceMessage<M>[]
+  | AsyncIterable<SourceMessage<M>>
+  | Iterable<SourceMessage<M>>
+  | ((
+      args: unknown[],
+    ) =>
+      | readonly SourceMessage<M>[]
+      | Iterable<SourceMessage<M>>
+      | AsyncIterable<SourceMessage<M>>);
 
 /**
  * Handler shape for a destination-role mock. Receives the exchange (as
@@ -184,8 +238,12 @@ export function wrapSourceWithOverride<M = unknown>(
     const pending: Promise<void>[] = [];
     const dispatch = (message: unknown): void => {
       if (abortController.signal.aborted) return;
+      // A branded fixture carries its own headers (mirroring an
+      // envelope-carrying source); a plain fixture is delivered as the body.
+      const body = (isSourceFixture(message) ? message.body : message) as M;
+      const headers = isSourceFixture(message) ? message.headers : undefined;
       pending.push(
-        handler(message as M).then(() => {
+        handler(body, headers).then(() => {
           record.yielded++;
         }),
       );

--- a/packages/routecraft/test/http-source.bun.test.ts
+++ b/packages/routecraft/test/http-source.bun.test.ts
@@ -1181,9 +1181,9 @@ describe("HTTP Source Adapter -- request/response coverage", () => {
   });
 
   /**
-   * @case Request headers land on exchange under routecraft.http.headers (lower-cased)
+   * @case Request headers land on exchange under routecraft.http.rawHeaders (lower-cased)
    * @preconditions Client sends a custom X-Trace header
-   * @expectedResult routecraft.http.headers["x-trace"] === "abc"
+   * @expectedResult routecraft.http.rawHeaders["x-trace"] === "abc"
    */
   test("request headers land on exchange headers (lower-cased)", async () => {
     const bound = await bootHttp({
@@ -1191,7 +1191,7 @@ describe("HTTP Source Adapter -- request/response coverage", () => {
         .id("h")
         .from(http({ path: "/h", method: "GET" }))
         .process(async (ex) => {
-          const h = ex.headers["routecraft.http.headers"] as Record<
+          const h = ex.headers["routecraft.http.rawHeaders"] as Record<
             string,
             string
           >;

--- a/packages/routecraft/test/mail.bun.test.ts
+++ b/packages/routecraft/test/mail.bun.test.ts
@@ -1051,7 +1051,13 @@ describe("Mail Adapter", () => {
 
       expect(mockMailboxOpen).toHaveBeenCalledWith("INBOX");
       expect(s.received.length).toBeGreaterThanOrEqual(1);
-      expect((s.received[0].body as any).subject).toBe("Poll message");
+      // The source puts the envelope on `routecraft.mail.*` headers and the
+      // payload on `body`; subject is now a header.
+      expect(
+        (s.received[0].headers as Record<string, unknown>)[
+          "routecraft.mail.subject"
+        ],
+      ).toBe("Poll message");
     });
 
     /**
@@ -1119,6 +1125,100 @@ describe("Mail Adapter", () => {
       const headers = s.received[0].headers as Record<string, unknown>;
       expect(headers["routecraft.mail.uid"]).toBe(42);
       expect(headers["routecraft.mail.folder"]).toBe("INBOX");
+    });
+
+    /**
+     * @case Source splits the message into payload-on-body and envelope-on-headers
+     * @preconditions Source delivers one message with a full envelope and a text body via poll mode
+     * @expectedResult `body` holds only the parsed payload (`text`); the envelope (from, to, cc, subject, date, messageId, replyTo) lives on `routecraft.mail.*` headers
+     */
+    test("puts payload on body and envelope on headers", async () => {
+      let callCount = 0;
+      mockFetch.mockImplementation(() => ({
+        async *[Symbol.asyncIterator]() {
+          if (callCount === 0) {
+            callCount++;
+            yield {
+              uid: 7,
+              flags: new Set(["\\Seen"]),
+              envelope: {
+                messageId: "<split@test.com>",
+                from: [{ address: "sender@acme.test" }],
+                to: [{ address: "a@dest.test" }, { address: "b@dest.test" }],
+                cc: [{ address: "c@dest.test" }],
+                replyTo: [{ address: "reply@acme.test" }],
+                subject: "Split me",
+                date: new Date("2026-05-01T09:00:00Z"),
+              },
+              source: Buffer.from("raw mime"),
+            };
+          }
+        },
+      }));
+
+      const s = spy();
+
+      t = await testContext()
+        .with({
+          mail: {
+            accounts: {
+              default: {
+                imap: {
+                  host: "imap.test.com",
+                  auth: { user: "u", pass: "p" },
+                },
+              },
+            },
+          },
+        })
+        .routes(
+          craft()
+            .id("test-source-split")
+            .from(
+              mail("INBOX", {
+                markSeen: false,
+                unseen: true,
+                pollIntervalMs: 5,
+                verify: "off",
+              }),
+            )
+            .to(s),
+        )
+        .build();
+
+      const startPromise = t.ctx.start();
+      await new Promise((r) => setTimeout(r, 20));
+      await t.ctx.stop();
+      await startPromise.catch(() => {});
+
+      expect(s.received.length).toBeGreaterThanOrEqual(1);
+      const exchange = s.received[0];
+
+      // Payload on body: only the parsed content (from the mocked parser),
+      // no envelope fields.
+      const body = exchange.body as Record<string, unknown>;
+      expect(body["text"]).toBe("Hello world");
+      expect(body["html"]).toBe("<p>Hello world</p>");
+      expect(body["from"]).toBeUndefined();
+      expect(body["subject"]).toBeUndefined();
+
+      // Envelope on headers.
+      const headers = exchange.headers as Record<string, unknown>;
+      expect(headers["routecraft.mail.uid"]).toBe(7);
+      expect(headers["routecraft.mail.folder"]).toBe("INBOX");
+      expect(headers["routecraft.mail.messageId"]).toBe("<split@test.com>");
+      expect(headers["routecraft.mail.from"]).toBe("sender@acme.test");
+      expect(headers["routecraft.mail.to"]).toEqual([
+        "a@dest.test",
+        "b@dest.test",
+      ]);
+      expect(headers["routecraft.mail.cc"]).toEqual(["c@dest.test"]);
+      expect(headers["routecraft.mail.replyTo"]).toBe("reply@acme.test");
+      expect(headers["routecraft.mail.subject"]).toBe("Split me");
+      expect(headers["routecraft.mail.date"]).toEqual(
+        new Date("2026-05-01T09:00:00Z"),
+      );
+      expect(headers["routecraft.mail.flags"]).toEqual(new Set(["\\Seen"]));
     });
 
     /**

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -34,6 +34,10 @@ export {
   type MockAdapterBehavior,
 } from "./mock-adapter";
 
+// Source fixture helper: attach headers to a source-role mock fixture so
+// routes that read `routecraft.<adapter>.*` headers can be exercised.
+export { sourceMessage } from "./source-message";
+
 // Test helper for fn-like specs (schema + handler). Used to exercise
 // fns registered in `@routecraft/ai`'s agentPlugin without depending on
 // any non-public dispatcher.

--- a/packages/testing/src/source-message.ts
+++ b/packages/testing/src/source-message.ts
@@ -1,0 +1,43 @@
+import {
+  SOURCE_FIXTURE,
+  type ExchangeHeaders,
+  type SourceFixture,
+} from "@routecraft/routecraft";
+
+/**
+ * Wrap a message body with the headers a real source would have attached, for
+ * use as a `mockAdapter(..., { source: [...] })` fixture.
+ *
+ * Envelope-carrying sources (mail, http) split each incoming message into a
+ * payload on `exchange.body` and metadata on `routecraft.<adapter>.*` headers.
+ * A bare fixture array only sets the body, so a route that reads those headers
+ * cannot be exercised through the mock. `sourceMessage(body, headers)` lets the
+ * mock reproduce that split.
+ *
+ * @example
+ * ```typescript
+ * const mailMock = mockAdapter(mail, {
+ *   source: [
+ *     sourceMessage(
+ *       { text: "Tracking: ABC123" },
+ *       {
+ *         "routecraft.mail.from": "noreply@acme.test",
+ *         "routecraft.mail.subject": "Your order has shipped",
+ *       },
+ *     ),
+ *   ],
+ * });
+ * ```
+ *
+ * @param body - The body the source would deliver on the exchange
+ * @param headers - Headers the source would attach (omit for a body-only fixture)
+ * @returns A branded fixture recognised by the source-mock dispatcher
+ */
+export function sourceMessage<M>(
+  body: M,
+  headers?: ExchangeHeaders,
+): SourceFixture<M> {
+  return headers === undefined
+    ? { [SOURCE_FIXTURE]: true, body }
+    : { [SOURCE_FIXTURE]: true, body, headers };
+}

--- a/packages/testing/test/mock-adapter.bun.test.ts
+++ b/packages/testing/test/mock-adapter.bun.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@routecraft/routecraft";
 import {
   mockAdapter,
+  sourceMessage,
   testContext,
   spy,
   type AdapterMock,
@@ -290,6 +291,42 @@ describe("mockAdapter", () => {
       }
       const { received } = await runWithSource<string>(gen());
       expect(received).toEqual(["a", "b"]);
+    });
+
+    /**
+     * @case sourceMessage fixtures deliver headers alongside the body
+     * @preconditions Source mixes a sourceMessage(body, headers) fixture with a plain fixture
+     * @expectedResult The wrapped fixture's body and headers both reach the route; the plain fixture arrives as the body with no extra headers
+     */
+    test("sourceMessage attaches headers to a fixture", async () => {
+      const received: Array<{ body: unknown; headers: ExchangeHeaders }> = [];
+      const mock = mockAdapter<typeof PlainSource, { text: string }>(
+        PlainSource,
+        {
+          source: [
+            sourceMessage(
+              { text: "wrapped" },
+              { "routecraft.mail.from": "a@b.test" },
+            ),
+            { text: "plain" },
+          ],
+        },
+      );
+      const route = craft()
+        .from(plainSource<{ text: string }>("src"))
+        .to(async (ex: Exchange<{ text: string }>) => {
+          received.push({ body: ex.body, headers: ex.headers });
+        });
+      t = await testContext().override(mock).routes(route).build();
+      await t.test();
+
+      expect(received).toHaveLength(2);
+      expect(received[0].body).toEqual({ text: "wrapped" });
+      expect(received[0].headers["routecraft.mail.from"]).toBe("a@b.test");
+      // The plain fixture arrives as the body and carries no envelope header.
+      expect(received[1].body).toEqual({ text: "plain" });
+      expect(received[1].headers["routecraft.mail.from"]).toBeUndefined();
+      expect(mock.calls.source[0].yielded).toBe(2);
     });
   });
 


### PR DESCRIPTION
Align the mail source with the payload-on-`body`, envelope-on-`headers`
convention the HTTP source already follows (.standards/exchange-state-model.md).

`.from(mail(...))` now delivers a `MailBody` (`{ text?, html?, attachments? }`)
on `exchange.body` and the envelope (`from`, `to`, `cc`, `bcc`, `subject`,
`date`, `messageId`, `replyTo`, `flags`, `sender`, `rawHeaders`) on
`routecraft.mail.*` headers. Attachments stay on the body as message content,
matching how the HTTP source keeps multipart files on the body. The new header
keys are declaration-merged into `RoutecraftHeaders` for autocomplete and
exported as `HEADER_MAIL_*` constants. `.input({ body })` on a mail route now
validates against the message content alone.

Only the streaming source changes. The fetch destination (`.enrich(mail(...))`)
still returns `MailMessage[]` with the whole envelope on each element, since a
batch cannot split N envelopes across single-valued headers. The send
destination input (`MailSendPayload`) is unchanged.

Testing: add `sourceMessage(body, headers)` to `@routecraft/testing` so
source-role mocks can reproduce the body/headers split (the mock dispatcher
otherwise delivers a fixture as the body with no headers). This also closes the
same gap for the HTTP source.

BREAKING CHANGE: the mail source exchange shape changed. Routes that read
`ex.body.from` / `ex.body.subject` / `ex.body.sender` etc. must read
`ex.headers["routecraft.mail.*"]` instead; `ex.body` now holds only the parsed
message content. See the 0.5.x to 0.6.0 migration guide.

Closes #391

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves mail envelope fields from the body to `routecraft.mail.*` headers so `exchange.body` carries only `MailBody` (`text`, `html`, `attachments`). Also renames the HTTP request header map to `routecraft.http.rawHeaders`, adds a `sourceMessage()` testing helper, and updates mock examples to assert order-independently. Closes #391.

- **Refactors**
  - `.from(mail(...))` now emits `MailBody` on `exchange.body`; envelope (`from`, `to`, `cc`, `bcc`, `subject`, `date`, `messageId`, `replyTo`, `flags`, `sender`, `rawHeaders`) is on `routecraft.mail.*` headers. Header keys are declaration-merged into `RoutecraftHeaders` and exported as `HEADER_MAIL_*`; `MailBody` is exported.
  - `.enrich(mail(...))` still returns `MailMessage[]`; send input unchanged.
  - HTTP source: `routecraft.http.headers` renamed to `routecraft.http.rawHeaders` (request headers).
  - Testing: `@routecraft/testing` adds `sourceMessage(body, headers)` so source-role mocks can attach headers; examples assert by content, not index, since mock dispatch is concurrent.

- **Migration**
  - Replace reads like `ex.body.from` / `ex.body.subject` / `ex.body.sender` with `ex.headers["routecraft.mail.from"]` / `["routecraft.mail.subject"]` / `["routecraft.mail.sender"]`. `ex.body` now holds only `text`/`html`/`attachments`.
  - Update any `.input({ body: ... })` schemas on mail routes to validate message content only.
  - Tests using `mockAdapter`: wrap fixtures with `sourceMessage(body, headers)` from `@routecraft/testing`, and assert by content rather than positional order.
  - If you referenced `routecraft.http.headers`, switch to `routecraft.http.rawHeaders`.

<sup>Written for commit 9e255214240a828d9bed5bc534ef47e99e2837ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

