### PR TITLE
refactor(framework): promote pre-from filter chain to first-class data (#395)

### DIFF
--- a/.standards/pre-from-filter-chain.md
+++ b/.standards/pre-from-filter-chain.md
@@ -200,33 +200,48 @@ write.
 
 ## 6. Implementation status
 
-Today (as of #112 / 0.6.0):
+Today (as of #112 / #395 / 0.6.0):
 
 - Filters 1-4 and 9-10 are implemented; the chain runs in the
   order documented above.
-- The chain is implicit in `runSteps` (the cache check / store
-  are inserted into `initialSteps` at known positions; authorize
-  steps are peeled from the head of `userSteps` via
-  `RouteDefinition.authorizerCount`).
+- The chain is **first-class data** on `RouteDefinition`:
+  - `preParseFilters: Step<Adapter>[]` -- authorize steps in
+    declaration order (chain position #2).
+  - `postParseFilters: Step<Adapter>[]` -- route-scope cache-check
+    filter (chain position #9). Future resilience wrappers
+    (`throttle`, `circuitBreaker`, `retry`, `timeout`) slot in
+    here between input and cacheCheck once they land.
+  - `postFromFilters: Step<Adapter>[]` -- route-scope cache-store
+    filter (chain position #10).
+  - `errorHandler?: ErrorHandler` -- the `.error()` route-scope
+    catch (chain position #1; implemented as the queue loop's
+    try/catch boundary rather than a step).
+- Parse (chain position #3) is **dynamic per exchange** (set on
+  exchange internals by the source adapter), so `runSteps`
+  interleaves it at runtime between `preParseFilters` and
+  `postParseFilters`.
+- The cache key flows from `cache-check` to `cache-store` via
+  `internals.cacheKey` on the exchange (per-invocation, no shared
+  closure).
+- The builder assembles all three arrays in the chain order
+  regardless of which `.authorize()` / `.cache()` / `.error()`
+  methods were called first on the builder.
 
-Planned (next refactor PR):
+Eager input validation (chain position #4 conceptually) still
+runs in `Route.buildConsumerHandler()` rather than as a chain
+step. This is **a deliberate scoping choice** for the v1
+refactor: moving it into the chain alters when `context:error`
+fires for cross-route validation failures (the consumer route's
+chain fires `context:error` from the runSteps catch instead of
+the eager throw-and-propagate path). Folding it in is tracked
+as a follow-up; until then, parse-attached sources still stash
+the validator on `internals.applyValidation` and the parse step
+runs it.
 
-- Promote the chain to a first-class data model: `RouteDefinition`
-  gains explicit `preFromFilters: Step<Adapter>[]` and
-  `postFromFilters: Step<Adapter>[]`. `authorizerCount` goes
-  away. `cacheConfig` is folded into the relevant filters'
-  closures.
-- `runSteps` collapses to a single chain loop:
-  `[...preFromFilters, ...steps, ...postFromFilters]` wrapped in
-  the `error` catch boundary.
-- Eager input validation (currently in `start()`, outside
-  `runSteps`) moves into the chain as the `input` filter. One code
-  path for parse and non-parse sources.
-
-Filters 5-8 will be added by their respective issues
-(`.throttle()`, `.circuitBreaker()` (#139), `.retry()`,
-`.timeout()`) into the slots reserved above. Each adds ~one
-filter implementation, not ~100 lines of inlined `runSteps`
+Filters 5-8 (`throttle`, `circuitBreaker`, `retry`, `timeout`)
+will be added by their respective issues into the
+`postParseFilters` slot at the documented positions. Each adds
+~one filter implementation, not ~100 lines of inlined `runSteps`
 logic.
 
 ---

--- a/.standards/resilience-wrappers.md
+++ b/.standards/resilience-wrappers.md
@@ -226,9 +226,13 @@ accordingly.
   immediately-next step via `CacheWrapperStep`. Route-scope (called
   BEFORE `.from()`) caches the route's terminal body keyed by the
   source-emitted message and skips the whole pipeline on a hit;
-  wired into `RouteDefinition.cacheConfig` and applied in `runSteps`.
-  Routes containing `.split()` reject route-scope cache at build time
-  (`RC5003`) until split-then-aggregate semantics are decided.
+  wired into `RouteDefinition.postParseFilters` (the `cache-check`
+  filter at chain position #9) and `RouteDefinition.postFromFilters`
+  (the `cache-store` filter at position #10); see
+  [Pre-from Filter Chain](./pre-from-filter-chain.md) for the full
+  composition contract. Routes containing `.split()` reject
+  route-scope cache at build time (`RC5003`) until split-then-aggregate
+  semantics are decided.
 - [Pre-from Filter Chain](./pre-from-filter-chain.md): the
   route-scope counterpart of this contract. Documents the fixed
   ordered chain (`error` -> `authorize` -> `parse` -> `input` ->

--- a/apps/routecraft.dev/src/app/docs/advanced/filter-chain/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/filter-chain/page.md
@@ -23,7 +23,7 @@ Outside in (position 1 wraps everything below):
 | 1 | `error` | shipped | `.error(handler)` | catches throws from everything below |
 | 2 | `authorize` (stacks) | shipped | `.authorize({ roles, scopes, predicate })` | principal on `exchange.headers` |
 | 3 | `parse` | shipped | source adapter (HTTP, mail, CSV, ...) | raw body bytes → typed body |
-| 4 | `input` | shipped | `.input(schema)` | typed body / headers |
+| 4 | `input` | shipped (eager) | `.input(schema)` | typed body / headers |
 | 5 | `throttle` | planned | `.throttle({...})` | rate limit on the route |
 | 6 | `circuitBreaker` | planned ([#139](https://github.com/routecraftjs/routecraft/issues/139)) | `.circuitBreaker({...})` | failure stats; fast-fails when open |
 | 7 | `retry` | planned | `.retry({...})` | re-runs everything below on failure |
@@ -31,6 +31,10 @@ Outside in (position 1 wraps everything below):
 | 9 | `cacheCheck` | shipped | `.cache({...})` | validated body → cache key |
 | - | **your pipeline** | - | `.transform()`, `.to()`, `.process()`, ... | the work |
 | 10 | `cacheStore` | shipped | `.cache({...})` | terminal body, written best-effort |
+
+{% callout type="note" title="Position #4 (`input`) runs eagerly today" %}
+`.input()` schema validation runs in the framework's consumer handler **before** `runSteps`, not as a step in the chain. It still happens at conceptual position #4 (after auth + parse), and an invalid body still gets rejected before `cacheCheck` or any user step runs. The behavioural difference: an `.input()` failure does NOT flow through `.error()` the way a step throw does -- it emits `exchange:dropped` and propagates to the source's caller directly. Folding it into the chain is tracked as a follow-up to the filter chain refactor.
+{% /callout %}
 
 ## What this means in practice
 

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -8,6 +8,8 @@ import {
   type RouteDiscovery,
   type RouteSchemas,
   type Tag,
+  buildCacheCheckStep,
+  buildCacheStoreStep,
 } from "./route.ts";
 import {
   CraftContext,
@@ -762,15 +764,36 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       "Creating route definition",
     );
 
-    // Staged `.authorize()` calls become the route's first steps so they
-    // run before any pipeline operation. They apply uniformly to every
-    // ingress. Multiple authorizers stack in declaration order; the first
-    // failure short-circuits the rest. Per-channel auth (e.g. an unauthored
-    // internal direct ingress alongside a scoped mcp ingress) is expressed
-    // as separate single-source routes, not here.
+    // Assemble the route's pre-from filter chain. Order is fixed by
+    // `.standards/pre-from-filter-chain.md`:
+    //
+    //   preParseFilters   -> .authorize() (#2)
+    //   parse              (#3; dynamic, source-attached, inserted at runtime)
+    //   .input()           (#4; CURRENTLY EAGER -- runs in `Route.buildConsumerHandler()`
+    //                       outside the chain, not in postParseFilters. See
+    //                       `.standards/pre-from-filter-chain.md` for the
+    //                       scoping note: folding it in changes cross-route
+    //                       context:error semantics and is tracked separately.)
+    //   postParseFilters  -> .cache() check (#9); reserved slots for future
+    //                        .throttle() / .circuitBreaker() / .retry() /
+    //                        .timeout() (positions 5-8)
+    //   userSteps         -> declaration order, unchanged
+    //   postFromFilters   -> .cache() store (#10)
+    //
+    // The user does NOT control this order: `.authorize().cache()`
+    // and `.cache().authorize()` produce identical chains.
     const authorizerSteps = authorizers.map(
       (opts) => new ValidateStep(authorize(opts)),
     );
+    const preParseFilters: Step<Adapter>[] = authorizerSteps;
+
+    const postParseFilters: Step<Adapter>[] = cacheConfig
+      ? [buildCacheCheckStep(cacheConfig)]
+      : [];
+
+    const postFromFilters: Step<Adapter>[] = cacheConfig
+      ? [buildCacheStoreStep(cacheConfig)]
+      : [];
 
     const normalizedSources: Source<T>[] = sources.map((source) =>
       typeof source === "function" ? { subscribe: source } : source,
@@ -779,16 +802,15 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     this.currentRoute = {
       id,
       sources: normalizedSources,
-      steps: authorizerSteps,
+      steps: [],
+      preParseFilters,
+      postParseFilters,
+      postFromFilters,
       consumer: {
         type: consumer.type,
         options: consumer.options ?? undefined,
       },
       ...(errorHandler ? { errorHandler } : {}),
-      ...(cacheConfig ? { cacheConfig } : {}),
-      ...(authorizerSteps.length > 0
-        ? { authorizerCount: authorizerSteps.length }
-        : {}),
       ...(discovery ? { discovery } : {}),
     };
     setBrand(this.currentRoute, BRAND.RouteDefinition);
@@ -842,10 +864,10 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
     // breaks the "one cached value per source message" contract.
     // Reject loud rather than silently mis-cache. Step-scope `.cache()`
     // is still usable around the expensive step inside such a route.
-    if (
-      route.cacheConfig !== undefined &&
-      wrapped.operation === OperationType.SPLIT
-    ) {
+    const hasRouteScopeCache = route.postParseFilters.some(
+      (f) => f.label === "cache-check",
+    );
+    if (hasRouteScopeCache && wrapped.operation === OperationType.SPLIT) {
       throw rcError("RC5003", undefined, {
         message:
           `Route-scope .cache() does not support routes containing .split(). ` +

--- a/packages/routecraft/src/exchange.ts
+++ b/packages/routecraft/src/exchange.ts
@@ -366,6 +366,17 @@ type ExchangeInternals = {
    */
   applyValidation?: (exchange: Exchange) => Promise<Exchange>;
   /**
+   * Route-scope cache key captured by the `cache-check` filter and
+   * read back by the `cache-store` filter at the tail of the chain.
+   * Lives on internals so the filters can be constructed once at
+   * builder time (rather than per-`runSteps` closures); each exchange
+   * carries its own key via this slot. Unset when the route has no
+   * `.cache()` configured. See `.standards/pre-from-filter-chain.md`.
+   *
+   * @internal
+   */
+  cacheKey?: string;
+  /**
    * When the engine first encounters an exchange in the step loop it
    * records the start timestamp here, used later to compute duration
    * for `exchange:completed`. Stored on internals (rather than headers)

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -264,19 +264,18 @@ function buildParseStep(
 }
 
 /**
- * Synthetic adapter used as the carrier for the route-scope cache
- * synthetic steps. Has no behaviour; the steps' `execute` does the work.
+ * Synthetic adapter carriers for the route-scope cache filter steps.
+ * Distinct adapter ids per filter so telemetry / event subscribers
+ * correlating by `adapter` can tell read failures (`cache.check`) from
+ * write failures (`cache.store`) without parsing the step label.
+ * Neither carrier has behaviour; the steps' `execute` does the work.
  */
-const CACHE_STEP_ADAPTER: Adapter = { adapterId: "routecraft.cache" };
-
-/**
- * Mutable holder shared between the cache-check and cache-store steps
- * within a single `runSteps` invocation. The check derives the key and
- * stores it here; the store reads it back after the user steps run.
- * Lives only for one `runSteps` call so concurrent exchanges don't
- * cross-contaminate.
- */
-type CacheKeyHolder = { key?: string };
+const CACHE_CHECK_STEP_ADAPTER: Adapter = {
+  adapterId: "routecraft.cache.check",
+};
+const CACHE_STORE_STEP_ADAPTER: Adapter = {
+  adapterId: "routecraft.cache.store",
+};
 
 /**
  * Build the route-scope cache HIT-CHECK synthetic step. Inserted into
@@ -292,15 +291,18 @@ type CacheKeyHolder = { key?: string };
  * `cache:failed` plus `exchange:restored` on a hit. `skipStepEvents:
  * true` keeps `runSteps` from emitting generic `step:started` /
  * `step:completed` for this internal step.
+ *
+ * @internal Exported only so `RouteBuilder.from()` can assemble it into
+ * `RouteDefinition.postParseFilters`. Not part of the public API; the
+ * signature may change without notice.
  */
-function buildCacheCheckStep(
+export function buildCacheCheckStep(
   cacheConfig: import("./operations/cache-wrapper.ts").ResolvedCacheOptions,
-  keyHolder: CacheKeyHolder,
 ): Step<Adapter> {
   return {
     operation: OperationType.PROCESS,
     label: "cache-check",
-    adapter: CACHE_STEP_ADAPTER,
+    adapter: CACHE_CHECK_STEP_ADAPTER,
     skipStepEvents: true,
     async execute(exchange, remainingSteps, queue) {
       const internals = EXCHANGE_INTERNALS.get(exchange);
@@ -332,7 +334,18 @@ function buildCacheCheckStep(
               message: `Route-scope .cache({ key }) for "${routeId}" threw while deriving the cache key`,
             });
       }
-      keyHolder.key = key;
+      // Hand the key off to the matching cache-store filter via
+      // exchange internals. Internals is the framework's per-exchange
+      // state bag set at construction time; absence here means the
+      // caller built an exchange outside `DefaultExchange.rewrap`,
+      // which violates the contract. Fail loudly rather than silently
+      // skip the cache write at the tail of the pipeline.
+      if (!internals) {
+        throw rcError("RC5028", undefined, {
+          message: `Route-scope .cache() for "${routeId}" ran on an exchange without framework internals; cache key cannot be propagated to the store step. This indicates an adapter or step constructed an Exchange outside DefaultExchange.rewrap.`,
+        });
+      }
+      internals.cacheKey = key;
 
       let cached: unknown;
       try {
@@ -409,15 +422,18 @@ function buildCacheCheckStep(
  *
  * `skipStepEvents: true` keeps `runSteps` from emitting generic
  * lifecycle events for this internal step.
+ *
+ * @internal Exported only so `RouteBuilder.from()` can assemble it into
+ * `RouteDefinition.postFromFilters`. Not part of the public API; the
+ * signature may change without notice.
  */
-function buildCacheStoreStep(
+export function buildCacheStoreStep(
   cacheConfig: import("./operations/cache-wrapper.ts").ResolvedCacheOptions,
-  keyHolder: CacheKeyHolder,
 ): Step<Adapter> {
   return {
     operation: OperationType.PROCESS,
     label: "cache-store",
-    adapter: CACHE_STEP_ADAPTER,
+    adapter: CACHE_STORE_STEP_ADAPTER,
     skipStepEvents: true,
     async execute(exchange, remainingSteps, queue) {
       const internals = EXCHANGE_INTERNALS.get(exchange);
@@ -429,7 +445,7 @@ function buildCacheStoreStep(
       const correlationId = exchange.headers[
         HeadersKeys.CORRELATION_ID
       ] as string;
-      const key = keyHolder.key;
+      const key = internals?.cacheKey;
 
       // Only cache successful runs whose terminal body is not
       // `undefined`. `null` is cached (envelope handles it). Dropped
@@ -519,28 +535,36 @@ export type RouteDefinition<T = unknown> = {
   readonly errorHandler?: ErrorHandler;
 
   /**
-   * Optional route-scope `.cache()` configuration. When present, the
-   * route looks up its cache provider before any pipeline step runs;
-   * on a hit, the wrapped step list is skipped entirely and the
-   * cached body is returned to the source. On a miss, the pipeline
-   * runs and the terminal exchange's body is stored for future hits.
-   *
-   * Set by `RouteBuilder.cache()` when called BEFORE `.from()`. See
-   * `.standards/resilience-wrappers.md` for the dual-mode pattern.
-   *
-   * @experimental
-   */
-  readonly cacheConfig?: import("./operations/cache-wrapper.ts").ResolvedCacheOptions;
-
-  /**
-   * Number of leading entries in `steps` that came from `.authorize()`
-   * calls staged before `.from()`. The runtime peels these off and runs
-   * them BEFORE the route-scope cache hit-check so an unauthorized
-   * caller never receives a cached response. Defaults to 0.
+   * Framework-managed filters that run BEFORE the source-attached
+   * parse step (and therefore before everything else). Today: the
+   * `.authorize()` ValidateSteps in declaration order. This is chain
+   * position #2 in `.standards/pre-from-filter-chain.md`.
    *
    * @internal
    */
-  readonly authorizerCount?: number;
+  readonly preParseFilters: Step<Adapter>[];
+
+  /**
+   * Framework-managed filters that run AFTER the source-attached parse
+   * step but BEFORE the user pipeline. Today: the route-scope
+   * `cache-check` filter (chain position #9). Future resilience
+   * wrappers (`throttle`, `circuitBreaker`, `retry`, `timeout` at
+   * positions #5-#8) slot in between input and cacheCheck once they
+   * land.
+   *
+   * @internal
+   */
+  readonly postParseFilters: Step<Adapter>[];
+
+  /**
+   * Framework-managed filters that run AFTER the user pipeline.
+   * Today: the route-scope `cache-store` filter (chain position #10)
+   * when `.cache()` is configured. Reached only on miss-success; the
+   * cache-check filter pushes `steps: []` on a hit to short-circuit.
+   *
+   * @internal
+   */
+  readonly postFromFilters: Step<Adapter>[];
 
   /**
    * Optional route-level discovery bundle: title, description, and input /
@@ -1366,54 +1390,36 @@ export class DefaultRoute implements Route {
       delete internals.applyValidation;
     }
 
-    // Route-scope `.cache()`: wired in as a pair of synthetic steps so
-    // it composes naturally with parse / input validation / authorize.
-    // The check step is inserted AFTER `buildParseStep` (so parse +
-    // `applyValidation` have already produced a validated body) and
-    // BEFORE the user steps. On a hit it pushes the rewrapped exchange
-    // with `steps: []` to short-circuit everything including the
-    // matching store step. The store step runs only on the miss path,
-    // after the user pipeline, and writes the terminal body using the
-    // key captured by the check step.
+    // The route's pre-from filter chain (assembled at builder time in
+    // the framework-fixed order documented at
+    // `.standards/pre-from-filter-chain.md`). Parse is dynamic per
+    // exchange (source-attached) and is interleaved between the two
+    // pre-from arrays:
     //
-    // Stampede protection is NOT applied at route scope in this
-    // release; concurrent callers with the same key all run the
-    // pipeline. Tracked as a follow-up. See `.standards/resilience-wrappers.md`.
+    //   preParseFilters    -> .authorize()
+    //   (parse if present) -> source-attached
+    //   postParseFilters   -> .cache() check, future
+    //                         .throttle() / .circuitBreaker() / .retry() /
+    //                         .timeout() (positions 5-8 in the chain doc)
+    //   userSteps          -> declaration order, unchanged
+    //   postFromFilters    -> .cache() store
     //
-    // Auth note: route-scope `.authorize()` steps live at the head of
-    // `userSteps`, so the cache check (which precedes user steps but
-    // follows parse + input validation) runs BEFORE authorize. If your
-    // route combines `.cache()` with `.authorize()`, the cache key MUST
-    // partition by every fact authorize depends on (subject / roles /
-    // scopes); otherwise a cached response written by an authorized
-    // caller can be served to a caller who would have failed
-    // authorization. The default body-hash key does NOT include the
-    // principal; supply a custom `key` that does, e.g.
-    // `key: e => sha(JSON.stringify({ b: e.body, sub: e.principal?.subject }))`.
-    const cacheConfig = this.definition.cacheConfig;
-    const cacheKeyHolder: CacheKeyHolder = {};
-
-    // `.authorize()` steps were pushed to the front of `steps` by the
-    // builder and tracked via `authorizerCount`. Peel them off here so
-    // they run BEFORE the route-scope cache check: an unauthorized
-    // caller must not receive a cached response.
-    const allSteps = [...this.definition.steps];
-    const authorizerCount = this.definition.authorizerCount ?? 0;
-    const authorizeSteps = allSteps.slice(0, authorizerCount);
-    const businessSteps = allSteps.slice(authorizerCount);
-
+    // The route's `.error()` handler wraps the queue loop (filter
+    // position #1 in the chain doc); it is implemented as a try/catch
+    // around the user pipeline, not a step that calls `next()`.
+    //
+    // The cache key flows from cache-check to cache-store via
+    // `internals.cacheKey` on the exchange -- per-invocation, no
+    // shared closure -- so the filter steps can be constructed once
+    // at builder time.
     const initialSteps: Step<Adapter>[] = [
+      ...this.definition.preParseFilters,
       ...(sourceParse
         ? [buildParseStep(sourceParse, sourceFailureMode, sourceValidate)]
         : []),
-      ...authorizeSteps,
-      ...(cacheConfig
-        ? [buildCacheCheckStep(cacheConfig, cacheKeyHolder)]
-        : []),
-      ...businessSteps,
-      ...(cacheConfig
-        ? [buildCacheStoreStep(cacheConfig, cacheKeyHolder)]
-        : []),
+      ...this.definition.postParseFilters,
+      ...this.definition.steps,
+      ...this.definition.postFromFilters,
     ];
 
     const queue: { exchange: Exchange; steps: Step<Adapter>[] }[] = [

--- a/packages/routecraft/test/batch.bun.test.ts
+++ b/packages/routecraft/test/batch.bun.test.ts
@@ -12,6 +12,9 @@ function createRouteDefinition(id: string): RouteDefinition {
     id,
     sources: [{ subscribe: async () => {} }],
     steps: [],
+    preParseFilters: [],
+    postParseFilters: [],
+    postFromFilters: [],
     consumer: { type: BatchConsumer as never, options: {} },
   } as RouteDefinition;
 }

--- a/packages/routecraft/test/filter-chain.bun.test.ts
+++ b/packages/routecraft/test/filter-chain.bun.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { testContext, type TestContext } from "@routecraft/testing";
+import {
+  craft,
+  direct,
+  MemoryCacheProvider,
+  simple,
+  noop,
+} from "@routecraft/routecraft";
+
+describe("pre-from filter chain assembly", () => {
+  /**
+   * @case Builder call order does NOT change the runtime chain order
+   * @preconditions Two routes declared with different builder orders; both have .authorize(), .cache(), .error()
+   * @expectedResult Both routes produce identical preParseFilters / postParseFilters / postFromFilters arrays
+   */
+  test("builder declaration order does not affect chain assembly", () => {
+    const [a] = craft()
+      .id("a")
+      .authorize()
+      .error(() => "recovered")
+      .cache({ ttl: 1000 })
+      .from(simple("x"))
+      .to(noop())
+      .build();
+
+    const [b] = craft()
+      .id("b")
+      .cache({ ttl: 1000 })
+      .error(() => "recovered")
+      .authorize()
+      .from(simple("x"))
+      .to(noop())
+      .build();
+
+    expect(a!.preParseFilters.map((f) => f.label)).toEqual(
+      b!.preParseFilters.map((f) => f.label),
+    );
+    expect(a!.postParseFilters.map((f) => f.label)).toEqual(
+      b!.postParseFilters.map((f) => f.label),
+    );
+    expect(a!.postFromFilters.map((f) => f.label)).toEqual(
+      b!.postFromFilters.map((f) => f.label),
+    );
+  });
+
+  /**
+   * @case Authorize sits in preParseFilters, cache-check in postParseFilters, cache-store in postFromFilters
+   * @preconditions Route declares .authorize().cache().from()
+   * @expectedResult Each filter lands in the documented slot per .standards/pre-from-filter-chain.md
+   */
+  test("filters land in the documented chain positions", () => {
+    const [route] = craft()
+      .id("chain-positions")
+      .authorize({ roles: ["admin"] })
+      .cache({ ttl: 60_000 })
+      .from(simple("x"))
+      .to(noop())
+      .build();
+
+    expect(route!.preParseFilters).toHaveLength(1);
+    expect(route!.preParseFilters[0]!.operation).toBe("validate");
+
+    expect(route!.postParseFilters.map((f) => f.label)).toEqual([
+      "cache-check",
+    ]);
+
+    expect(route!.postFromFilters.map((f) => f.label)).toEqual(["cache-store"]);
+  });
+
+  /**
+   * @case Multiple .authorize() calls stack in declaration order in preParseFilters
+   * @preconditions Route declares two .authorize() calls
+   * @expectedResult preParseFilters has two ValidateSteps in the order declared
+   */
+  test("stacked .authorize() calls populate preParseFilters in declaration order", () => {
+    const [route] = craft()
+      .id("stacked-authorize")
+      .authorize({ roles: ["admin"] })
+      .authorize({ scopes: ["billing:write"] })
+      .from(simple("x"))
+      .to(noop())
+      .build();
+
+    expect(route!.preParseFilters).toHaveLength(2);
+    expect(route!.preParseFilters[0]!.operation).toBe("validate");
+    expect(route!.preParseFilters[1]!.operation).toBe("validate");
+  });
+
+  /**
+   * @case Routes with neither .authorize() nor .cache() have empty filter arrays
+   * @preconditions Bare route with just a source and destination
+   * @expectedResult All three filter arrays are empty
+   */
+  test("routes with no chain features have empty filter arrays", () => {
+    const [route] = craft().id("bare").from(simple("x")).to(noop()).build();
+
+    expect(route!.preParseFilters).toEqual([]);
+    expect(route!.postParseFilters).toEqual([]);
+    expect(route!.postFromFilters).toEqual([]);
+  });
+});
+
+describe("pre-from filter chain runtime", () => {
+  let t: TestContext | undefined;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Cache key set by `cache-check` survives user-step body rewrites and is read by `cache-store`
+   * @preconditions Route-scope cache + a transform that rewrites the body (forcing a rewrap between check and store)
+   * @expectedResult First call misses (transform runs, cache writes); second call hits (transform skipped). Verifies internals.cacheKey persists across rewrap.
+   */
+  test("internals.cacheKey persists across user-step rewraps from cache-check to cache-store", async () => {
+    const provider = new MemoryCacheProvider();
+    let transformRuns = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cache-key-rewrap")
+          .cache({ provider, key: (e) => String(e.body) })
+          .from(direct())
+          .transform((b) => {
+            transformRuns++;
+            // Body mutation forces a rewrap; the new exchange must
+            // still carry internals.cacheKey from the cache-check step
+            // for cache-store to find it at the tail.
+            return `transformed:${b}`;
+          })
+          .to(noop()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    const first = await t.client.send("cache-key-rewrap", "hello");
+    const second = await t.client.send("cache-key-rewrap", "hello");
+
+    expect(transformRuns).toBe(1);
+    expect(first).toBe("transformed:hello");
+    expect(second).toBe("transformed:hello");
+    expect(provider.size).toBe(1);
+  });
+});


### PR DESCRIPTION
`RouteDefinition` now carries the chain as three explicit, typed
arrays in framework-fixed order:

  preParseFilters   -> authorize ValidateSteps in declaration order
                       (chain position #2)
  postParseFilters  -> route-scope cache-check filter
                       (chain position #9; reserved slots for future
                       throttle / circuitBreaker / retry / timeout at
                       positions #5-#8)
  postFromFilters   -> route-scope cache-store filter
                       (chain position #10)

Removes:
- RouteDefinition.authorizerCount (the implicit "leading N entries in
  steps are authorizers" invariant that the cache check relied on).
- RouteDefinition.cacheConfig (folded into the cache-check / cache-
  store filter closures captured at builder time).

Runtime:
- runSteps now reads the chain off the route definition and
  concatenates `[...preParseFilters, parse?, ...postParseFilters,
  ...steps, ...postFromFilters]`. The previous ~60-line splice that
  re-derived the chain from authorizerCount + cacheConfig is gone.
- Cache key flows from cache-check to cache-store via
  `internals.cacheKey` on the exchange (per-invocation), not a
  per-runSteps closure -- so the filter steps can be constructed once
  at builder time.
- Parse (chain position #3) stays dynamic per exchange (set on
  internals by the source); runSteps interleaves it between the two
  pre-from arrays.

Builder:
- RouteBuilder.from() assembles all three arrays in the documented
  order. The user's call order for .authorize() / .cache() / .error()
  does not change the runtime order -- verified by a new test.
- The split + route-scope cache build-time guard in pushStep no
  longer reads cacheConfig; it detects the cache-check filter by
  label.

Eager input validation (chain position #4) is intentionally NOT
moved into the chain in this PR. Doing so changes when
`context:error` fires for cross-route validation failures (the
consumer route's chain emits context:error from runSteps' catch
instead of the eager throw-propagate path), which breaks the
direct-validation test suite's "t.errors.length === 1" assertions.
The standards doc records this as a scoped follow-up.

Tests:
- Existing cache / authorize / error tests pass unchanged (809/809
  routecraft suite green).
- New `filter-chain.bun.test.ts` asserts: builder call order does
  not affect chain shape; filters land in the documented slots;
  stacked authorize calls populate preParseFilters in declaration
  order; bare routes have empty filter arrays.

Standards:
- `.standards/pre-from-filter-chain.md` updated to mark filters
  1-4 / 9-10 shipped under #112 + #395, document the data model
  promotion, and call out the eager-input scoping decision as a
  remaining follow-up.

Closes #395.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the pre-from filter chain to first-class data on `RouteDefinition` with `preParseFilters`, `postParseFilters`, and `postFromFilters`, simplifying runtime assembly and making auth/cache order explicit. Prepares fixed slots for future resilience wrappers.

- **Refactors**
  - `RouteDefinition` now has `preParseFilters` (authorize), `postParseFilters` (cache-check; future wrappers), and `postFromFilters` (cache-store); removes `authorizerCount` and inlined `cacheConfig` (now captured in filter closures).
  - `runSteps` builds the chain as `[...preParseFilters, parse?, ...postParseFilters, ...steps, ...postFromFilters]`; parse remains dynamic per exchange.
  - Cache key flows via `internals.cacheKey` from `cache-check` to `cache-store`, allowing filter steps to be built once at builder time; distinct adapter ids differentiate check vs store for telemetry.
  - Builder assembles filters in the documented order regardless of call order; `.split()` + route-scope cache guard now detects the `cache-check` filter by label.
  - Input validation stays eager (position #4) for now; behavior unchanged and follow-up documented.
  - Added `filter-chain.bun.test.ts` (also verifies `internals.cacheKey` survives rewraps); standards and docs updated.

- **Migration**
  - No changes to public route builder APIs.
  - If you reference `RouteDefinition` directly, read filters from `preParseFilters`/`postParseFilters`/`postFromFilters` and stop using `authorizerCount`/`cacheConfig`.

<sup>Written for commit 539e59518ba52369168387479a3821975c2f878e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

