### PR TITLE
feat(operations): allow route-scope .cache() on balanced split+aggregate (#394)

### DIFF
--- a/.standards/resilience-wrappers.md
+++ b/.standards/resilience-wrappers.md
@@ -230,9 +230,10 @@ accordingly.
   filter at chain position #9) and `RouteDefinition.postFromFilters`
   (the `cache-store` filter at position #10); see
   [Pre-from Filter Chain](./pre-from-filter-chain.md) for the full
-  composition contract. Routes containing `.split()` reject
-  route-scope cache at build time (`RC5003`) until split-then-aggregate
-  semantics are decided.
+  composition contract. Routes with an unbalanced `.split()` (no
+  matching `.aggregate()`) reject route-scope cache at build time
+  (`RC5003`); balanced `split + aggregate` is supported and caches
+  the aggregated terminal body.
 - [Pre-from Filter Chain](./pre-from-filter-chain.md): the
   route-scope counterpart of this contract. Documents the fixed
   ordered chain (`error` -> `authorize` -> `parse` -> `input` ->

--- a/apps/routecraft.dev/src/app/docs/reference/operations/cache/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/cache/page.md
@@ -89,7 +89,7 @@ On a hit, **the whole pipeline is skipped** (no `.enrich`, no `.transform`, no `
 
 **Side effects do not replay on a hit.** This is a much larger surface than step-scope: every `.to()`, `.tap()`, and `.header()` in the route is bypassed. If the route has destinations whose side effects must run on every input, use step-scope `.cache()` to wrap the expensive step instead.
 
-**Routes containing `.split()` are rejected at build time** with `RC5003`. The pipeline produces multiple terminal exchanges when split is unbalanced by aggregate, which has no single "result" to cache. Use step-scope `.cache()` to wrap the expensive step inside such a route. Split-followed-by-aggregate routes will be revisited in a follow-up.
+**Routes with an unbalanced `.split()` are rejected at build time** with `RC5003`. A bare split produces multiple terminal exchanges with no single "result" to cache. A `.split()` balanced by a matching `.aggregate()` folds the children back into one terminal body and is fully supported: the aggregated value is what gets cached. Use step-scope `.cache()` to wrap the expensive step when you do want a fire-and-forget split.
 
 **`.cache()` slots into the framework's pre-from filter chain at a fixed position.** Auth runs first (unauthenticated callers never see cached responses); parse and `.input()` validation run before the cache check (so stale-schema entries can't slip through); the cache hit-check sits just above the user pipeline; the cache write sits just below. See [Filter Chain](/docs/advanced/filter-chain) for the full chain, including reserved slots for `.throttle()`, `.circuitBreaker()`, `.retry()`, `.timeout()`.
 

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -349,6 +349,53 @@ export type RouteOptions = Partial<Pick<RouteDefinition, "consumer">> & {
  *   .to(log())
  * ```
  */
+
+/**
+ * @internal
+ *
+ * Verifies a finalised route honours the route-scope `.cache()` contract.
+ *
+ * Route-scope `.cache()` caches a single terminal body per source message.
+ * A bare `.split()` produces N terminal exchanges with no fold-back, so
+ * there is no single value to cache. A `.split()` that is balanced by a
+ * matching `.aggregate()` collapses the children back into one terminal
+ * body, which is cacheable.
+ *
+ * The check counts nesting depth across the step list: every `split`
+ * increments, every `aggregate` decrements. A non-zero depth at the end
+ * of the route means at least one `split` was not aggregated, so the
+ * route is rejected with `RC5003`.
+ *
+ * Step-scope `.cache()` is unaffected; it wraps a single inner step and
+ * never participates in this check.
+ */
+function assertRouteScopeCacheCompatibility(route: RouteDefinition): void {
+  const hasRouteScopeCache = route.postParseFilters.some(
+    (f) => f.label === "cache-check",
+  );
+  if (!hasRouteScopeCache) return;
+
+  let depth = 0;
+  for (const step of route.steps) {
+    if (step.operation === OperationType.SPLIT) {
+      depth++;
+    } else if (step.operation === OperationType.AGGREGATE && depth > 0) {
+      depth--;
+    }
+  }
+
+  if (depth > 0) {
+    throw rcError("RC5003", undefined, {
+      message:
+        `Route "${route.id}" has route-scope .cache() and an unbalanced .split() ` +
+        `(no matching .aggregate()). A fire-and-forget split produces multiple ` +
+        `terminal exchanges, so there is no single body to cache. ` +
+        `Add an .aggregate() to fold the children back into one terminal ` +
+        `value, or use step-scope .cache() to wrap the expensive operation.`,
+    });
+  }
+}
+
 export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   protected currentRoute?: RouteDefinition;
   protected routes: RouteDefinition[] = [];
@@ -858,23 +905,15 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
   protected override pushStep<T extends Adapter>(step: Step<T>): void {
     const route = this.requireSource();
     const wrapped = this.applyPendingWrappers(step);
-    // Route-scope `.cache()` skips the entire pipeline on a hit and
-    // caches a single terminal body on a miss. `split` produces N
-    // terminal exchanges (with no aggregate to fold them back), which
-    // breaks the "one cached value per source message" contract.
-    // Reject loud rather than silently mis-cache. Step-scope `.cache()`
-    // is still usable around the expensive step inside such a route.
-    const hasRouteScopeCache = route.postParseFilters.some(
-      (f) => f.label === "cache-check",
-    );
-    if (hasRouteScopeCache && wrapped.operation === OperationType.SPLIT) {
-      throw rcError("RC5003", undefined, {
-        message:
-          `Route-scope .cache() does not support routes containing .split(). ` +
-          `The pipeline produces multiple terminal exchanges, so there is no single body to cache. ` +
-          `Use step-scope .cache() to wrap the expensive operation, or remove the route-scope .cache().`,
-      });
-    }
+    // Route-scope `.cache()` + `.split()` compatibility is checked at
+    // build time: a balanced `split + aggregate` route is cacheable
+    // (the aggregated body is the single terminal value), but a
+    // fire-and-forget split has no single result to cache. See
+    // {@link assertRouteScopeCacheCompatibility} -- it walks each
+    // finalised route in `build()` and throws `RC5003` for unbalanced
+    // shapes. Per-step rejection at push time would refuse the
+    // balanced case before the user gets a chance to add the matching
+    // aggregate.
     logger.trace(
       { operation: wrapped.operation, route: route.id },
       "Adding step to route",
@@ -1051,6 +1090,9 @@ export class RouteBuilder<Current = unknown> extends StepBuilderBase<Current> {
       });
     }
     this.assertNoPendingWrappers("build");
+    for (const route of this.routes) {
+      assertRouteScopeCacheCompatibility(route);
+    }
     logger.trace({ routeCount: this.routes.length }, "Building routes");
     return this.routes;
   }

--- a/packages/routecraft/test/cache.bun.test.ts
+++ b/packages/routecraft/test/cache.bun.test.ts
@@ -994,19 +994,108 @@ describe(".cache() route scope: dual-mode wrapper", () => {
   });
 
   /**
-   * @case Routes containing .split() are rejected at build time
-   * @preconditions craft().cache().from().split().to() at build time
-   * @expectedResult RC5003 thrown synchronously with a clear pointer to step-scope cache
+   * @case Unbalanced .split() (no matching .aggregate()) is rejected at build()
+   * @preconditions craft().cache().from().split().to() with no aggregate
+   * @expectedResult RC5003 thrown at .build() pointing to the missing aggregate
    */
-  test("routes containing .split() reject route-scope cache at build time", () => {
+  test("unbalanced .split() rejects route-scope cache at build time", () => {
     expect(() => {
       craft()
-        .id("route-cache-split")
+        .id("route-cache-split-unbalanced")
         .cache({ ttl: 1000 })
         .from<number[]>(simple([1, 2, 3]))
         .split()
-        .to(noop());
-    }).toThrow(/does not support routes containing \.split\(\)/);
+        .to(noop())
+        .build();
+    }).toThrow(/unbalanced \.split\(\)/);
+  });
+
+  /**
+   * @case Balanced .split() + .aggregate() is allowed at build time
+   * @preconditions craft().cache().from().split()...aggregate()...to()
+   * @expectedResult Build succeeds; the route definition is returned
+   */
+  test("balanced .split() + .aggregate() is accepted at build time", () => {
+    expect(() => {
+      craft()
+        .id("route-cache-split-balanced")
+        .cache({ ttl: 1000 })
+        .from<number[]>(simple([1, 2, 3]))
+        .split()
+        .transform((n: number) => n * 2)
+        .aggregate()
+        .to(noop())
+        .build();
+    }).not.toThrow();
+  });
+
+  /**
+   * @case Nested balanced split/aggregate is allowed
+   * @preconditions Two nested split/aggregate pairs around the cache
+   * @expectedResult Build succeeds; nesting collapses depth back to zero
+   */
+  test("nested balanced split/aggregate is accepted at build time", () => {
+    expect(() => {
+      craft()
+        .id("route-cache-split-nested")
+        .cache({ ttl: 1000 })
+        .from<number[][]>(
+          simple([
+            [1, 2],
+            [3, 4],
+          ]),
+        )
+        .split()
+        .split()
+        .transform((n: number) => n + 1)
+        .aggregate()
+        .aggregate()
+        .to(noop())
+        .build();
+    }).not.toThrow();
+  });
+
+  /**
+   * @case Balanced split+aggregate produces one cache write per source body
+   * @preconditions Route with cache, split, transform, aggregate; same input twice
+   * @expectedResult First call computes and caches the aggregated body;
+   *                 second call hits the cache and skips the pipeline.
+   */
+  test("balanced split+aggregate caches the aggregated body", async () => {
+    const provider = new MemoryCacheProvider();
+    let transformRuns = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("route-cache-split-balanced-runtime")
+          .cache({ provider, key: (e) => JSON.stringify(e.body) })
+          .from(direct())
+          .split()
+          .transform((n: number) => {
+            transformRuns++;
+            return n * 2;
+          })
+          .aggregate()
+          .to(noop()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+
+    const first = await t.client.send(
+      "route-cache-split-balanced-runtime",
+      [1, 2, 3],
+    );
+    const second = await t.client.send(
+      "route-cache-split-balanced-runtime",
+      [1, 2, 3],
+    );
+
+    expect(transformRuns).toBe(3);
+    expect(first).toEqual([2, 4, 6]);
+    expect(second).toEqual([2, 4, 6]);
+    expect(provider.size).toBe(1);
   });
 
   /**


### PR DESCRIPTION
A `.split()` followed by a matching `.aggregate()` folds the children
back into one terminal body, which is exactly what route-scope cache
needs: a single value per source message. The previous build-time
rejection refused all split routes, including this balanced shape.

Move the check from `pushStep` (which fired as soon as `.split()` was
called, before the user could add the aggregate) to a final pass in
`build()` that walks the finished step list and counts nesting depth.
A non-zero depth at the end means at least one split was not
aggregated, which still throws `RC5003`. Balanced and nested-balanced
shapes are accepted.

Step-scope `.cache()` is unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable route-scope `.cache()` for routes that use a balanced `.split()` + `.aggregate()`, caching the aggregated result. Unbalanced splits still fail at build time with `RC5003`.

- **New Features**
  - Support balanced `.split()` + `.aggregate()` with route-scope `.cache()`; caches the aggregated body.
  - Move split-check to `build()` and reject only unbalanced shapes with `RC5003`; balanced and nested-balanced are accepted.
  - Step-scope `.cache()` unchanged. Docs updated; tests cover unbalanced rejection, balanced/nested success, and caching behavior.

<sup>Written for commit b0717c7ee0c7a7267ac3d1c52be5692a4877e295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

