### PR TITLE
feat(docs): add 'Copy page URL' option to docs copy menu

### DIFF
--- a/apps/routecraft.dev/src/components/CopyDocsButton.tsx
+++ b/apps/routecraft.dev/src/components/CopyDocsButton.tsx
@@ -5,7 +5,11 @@ import { usePathname } from 'next/navigation'
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
 import clsx from 'clsx'
 
-import { getPageMarkdown, getAllDocsRawUrl } from '@/markdoc/docs-markdown.mjs'
+import {
+  getPageMarkdown,
+  getPageRawUrl,
+  getAllDocsRawUrl,
+} from '@/markdoc/docs-markdown.mjs'
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
 
@@ -76,7 +80,7 @@ function OpenAIIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   )
 }
 
-type CopiedState = null | 'page' | 'allDocsUrl'
+type CopiedState = null | 'page' | 'pageUrl' | 'allDocsUrl'
 
 export function CopyDocsButton() {
   const pathname = usePathname()
@@ -105,6 +109,11 @@ export function CopyDocsButton() {
     return `${window.location.origin}${rawUrl}`
   }
 
+  function getPageFullUrl() {
+    const rawUrl = getPageRawUrl(pathname, basePath)
+    return `${window.location.origin}${rawUrl}`
+  }
+
   function handleOpenInClaude() {
     const docsUrl = getAllDocsFullUrl()
     const prompt = `I'd like to discuss the content from ${docsUrl}`
@@ -128,6 +137,10 @@ export function CopyDocsButton() {
   function handleCopyPage() {
     const md = getPageMarkdown(pathname)
     if (md) copyToClipboard(md, 'page')
+  }
+
+  function handleCopyPageUrl() {
+    copyToClipboard(getPageFullUrl(), 'pageUrl')
   }
 
   function handleCopyAllDocsUrl() {
@@ -205,6 +218,22 @@ export function CopyDocsButton() {
             >
               <CopyIcon className="h-3.5 w-3.5 shrink-0 text-ink/55" />
               <span>{copied === 'page' ? 'Copied' : 'Copy page'}</span>
+            </button>
+          )}
+        </MenuItem>
+
+        <MenuItem>
+          {({ focus }) => (
+            <button
+              type="button"
+              onClick={handleCopyPageUrl}
+              className={clsx(
+                'flex w-full items-center gap-3 px-3 py-2 font-mono text-[0.7rem] tracking-[0.18em] uppercase transition',
+                focus ? 'bg-paper-deep text-ink' : 'text-ink/70',
+              )}
+            >
+              <LinkIcon className="h-3.5 w-3.5 shrink-0 text-ink/55" />
+              <span>{copied === 'pageUrl' ? 'Copied' : 'Copy page URL'}</span>
             </button>
           )}
         </MenuItem>


### PR DESCRIPTION
Adds a per-page raw markdown URL action alongside the existing
'Copy raw docs URL' (which points at the full combined docs). This
copies a link to the single current page's raw markdown rather than
its full content, reusing the existing getPageRawUrl helper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Copy page URL” option to the docs copy menu that copies a link to the current page’s raw markdown. This complements “Copy raw docs URL” (full combined docs) and uses `getPageRawUrl` to build the per-page link.

<sup>Written for commit b807308cd3991ed395f95503193b9a23ec50582d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

