### PR TITLE
feat(tooling): add prettier-plugin-routecraft for compact DSL formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Type-safe integration and automation framework. Monorepo with Bun workspaces (>=
 - Test: `bun run test`
 - Lint: `bun run lint`
 - Typecheck: `bun run typecheck`
-- Format: `bun run format`
+- Format: `bun run format` (uses `@routecraft/prettier-plugin-routecraft` for compact DSL chains)
 - Run examples: `bun run craft run ./examples/dist/hello-world.js`
 - Run docs site: `bun run docs`
 - All-in-one pre-PR check: `bun run all`
@@ -58,6 +58,7 @@ See [DEFINITION_OF_DONE.md](DEFINITION_OF_DONE.md) for what must be satisfied be
 | `@routecraft/cli` | `packages/cli` | CLI (`craft`) to run routes and contexts |
 | `@routecraft/testing` | `packages/testing` | Test utilities (spy logger, testContext, pseudo, fixtures) |
 | `@routecraft/eslint-plugin-routecraft` | `packages/eslint-plugin-routecraft` | ESLint plugin |
+| `@routecraft/prettier-plugin-routecraft` | `packages/prettier-plugin-routecraft` | Prettier plugin (compact DSL formatting) |
 | `create-routecraft` | `packages/create-routecraft` | Project scaffolder |
 
 ## Agent Skills

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Claude discovers your tool and uses it automatically. ✨
 - `packages/cli` – `craft` CLI to run capabilities and start contexts (Bun >= 1.1.0)
 - `packages/create-routecraft` – Project scaffolder (`bunx create-routecraft`)
 - `packages/eslint-plugin-routecraft` – ESLint rules for capability authoring
+- `packages/prettier-plugin-routecraft` – Prettier plugin for compact DSL formatting
 - `packages/os` – System-native adapters (shell, etc.) – placeholder, in development
 - `packages/testing` – Test utilities (`testContext`, spy logger, `mockAdapter`, fixtures)
 - `skills/` – Agent Skills for authoring Routecraft (Claude Code, Cursor, Codex, Windsurf, Cline, Continue, Copilot, ...; `bunx skills add routecraftjs/routecraft`). See [skills/README.md](./skills/README.md)

--- a/apps/routecraft.dev/src/app/docs/advanced/formatting/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/formatting/page.md
@@ -1,0 +1,117 @@
+---
+title: Formatting
+---
+
+Keep Routecraft DSL chains compact with the Prettier plugin. {% .lead %}
+
+Prettier's defaults push fluent sub-route closures onto their own line and add a
+level of indentation for every nested `.choice()`, `.when()`, and `.otherwise()`.
+A small route can end up five or six levels deep. The
+`@routecraft/prettier-plugin-routecraft` plugin overrides Prettier's printer for
+those closures so the threaded parameter stays on the arrow line and the chain
+keeps a single indent level.
+
+## Before and after
+
+```ts
+// Prettier default
+.choice((c) =>
+  c
+    .when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) =>
+      b
+        .enrich(agent('zoe'), only((r) => r, 'agent'))
+        .to(mail({ action: 'move' })),
+    )
+    .otherwise((b) => b),
+)
+
+// With the plugin
+.choice((c) => c
+  .when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) => b
+    .enrich(agent('zoe'), only((r) => r, 'agent'))
+    .to(mail({ action: 'move' })))
+  .otherwise((b) => b))
+```
+
+## Installation
+
+{% code-tabs %}
+{% code-tab label="bun" language="bash" %}
+```bash
+bun add -d prettier @routecraft/prettier-plugin-routecraft
+```
+{% /code-tab %}
+
+{% code-tab label="npm" language="bash" %}
+```bash
+npm install -D prettier @routecraft/prettier-plugin-routecraft
+```
+{% /code-tab %}
+
+{% code-tab label="pnpm" language="bash" %}
+```bash
+pnpm add -D prettier @routecraft/prettier-plugin-routecraft
+```
+{% /code-tab %}
+
+{% code-tab label="yarn" language="bash" %}
+```bash
+yarn add -D prettier @routecraft/prettier-plugin-routecraft
+```
+{% /code-tab %}
+
+{% /code-tabs %}
+
+## Configuration
+
+Add the plugin to your Prettier config. Prettier loads plugins from the
+`plugins` array; no other options are required.
+
+```js
+// prettier.config.mjs
+export default {
+  plugins: ['@routecraft/prettier-plugin-routecraft'],
+}
+```
+
+Or in `.prettierrc`:
+
+```json
+{
+  "plugins": ["@routecraft/prettier-plugin-routecraft"]
+}
+```
+
+Then format as usual:
+
+```bash
+bunx prettier --write .
+```
+
+## What the plugin touches
+
+The plugin only changes single-parameter arrow closures whose body threads that
+parameter straight into a fluent chain rooted at `craft()`, for example
+`(c) => c.when(...).otherwise(...)` or `(b) => b.enrich(...).to(...)`. This is
+what scopes it to the Routecraft DSL.
+
+Everything else is left to Prettier's defaults, including:
+
+- Ordinary fluent chains such as `arr.map((x) => x.foo().bar())`
+- Callbacks whose body does not start from the parameter, such as
+  `(ex) => direct(...).send(...)`
+- Async arrows and arrows with explicit return types or type parameters, so no
+  type information is ever dropped
+
+The result is roundtrip stable: running Prettier twice produces no further
+changes.
+
+## Related
+
+{% quick-links %}
+
+{% quick-link title="Operations reference" icon="presets" href="/docs/reference/operations" description="The choice, split, and aggregate operations the plugin formats." /%}
+
+{% quick-link title="Linting" icon="presets" href="/docs/advanced/linting" description="Enforce Routecraft authoring best practices with ESLint." /%}
+
+{% /quick-links %}

--- a/apps/routecraft.dev/src/app/docs/advanced/formatting/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/formatting/page.md
@@ -91,16 +91,21 @@ bunx prettier --write .
 ## What the plugin touches
 
 The plugin only changes single-parameter arrow closures whose body is a fluent
-chain and that appear inside a `craft()` chain. This covers builder closures
-such as `(c) => c.when(...).otherwise(...)` and `(b) => b.enrich(...).to(...)`,
-and factory-rooted callbacks such as `(ex) => direct(...).send(...)`. In every
-case the parameter stays on the arrow line. Being inside a `craft()` chain is
-what scopes it to the Routecraft DSL.
+chain and that are passed directly as a call argument inside a `craft()` chain.
+Being a direct argument inside a `craft()` chain is what scopes it to the
+Routecraft DSL. There are two layouts:
+
+- Parameter-threaded builders such as `(c) => c.when(...).otherwise(...)` and
+  `(b) => b.enrich(...).to(...)` keep the parameter on the arrow line.
+- Factory-rooted callbacks such as `(ex) => direct(...).send(...)` keep the
+  parameter on the arrow line but break the body onto the next line.
 
 Everything else is left to Prettier's defaults, including:
 
 - Ordinary fluent chains such as `arr.map((x) => x.foo().bar())` (no `craft()`
   root)
+- Arrows used as object or array values, such as adapter option callbacks
+  (`path: (ex) => path.join(...)`)
 - Non-chain bodies such as template literals or object literals
 - Async arrows and arrows with explicit return types or type parameters, so no
   type information is ever dropped

--- a/apps/routecraft.dev/src/app/docs/advanced/formatting/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/formatting/page.md
@@ -90,16 +90,18 @@ bunx prettier --write .
 
 ## What the plugin touches
 
-The plugin only changes single-parameter arrow closures whose body threads that
-parameter straight into a fluent chain rooted at `craft()`, for example
-`(c) => c.when(...).otherwise(...)` or `(b) => b.enrich(...).to(...)`. This is
+The plugin only changes single-parameter arrow closures whose body is a fluent
+chain and that appear inside a `craft()` chain. This covers builder closures
+such as `(c) => c.when(...).otherwise(...)` and `(b) => b.enrich(...).to(...)`,
+and factory-rooted callbacks such as `(ex) => direct(...).send(...)`. In every
+case the parameter stays on the arrow line. Being inside a `craft()` chain is
 what scopes it to the Routecraft DSL.
 
 Everything else is left to Prettier's defaults, including:
 
-- Ordinary fluent chains such as `arr.map((x) => x.foo().bar())`
-- Callbacks whose body does not start from the parameter, such as
-  `(ex) => direct(...).send(...)`
+- Ordinary fluent chains such as `arr.map((x) => x.foo().bar())` (no `craft()`
+  root)
+- Non-chain bodies such as template literals or object literals
 - Async arrows and arrows with explicit return types or type parameters, so no
   type information is ever dropped
 

--- a/apps/routecraft.dev/src/app/docs/advanced/formatting/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/formatting/page.md
@@ -4,32 +4,14 @@ title: Formatting
 
 Keep Routecraft DSL chains compact with the Prettier plugin. {% .lead %}
 
-Prettier's defaults push fluent sub-route closures onto their own line and add a
-level of indentation for every nested `.choice()`, `.when()`, and `.otherwise()`.
-A small route can end up five or six levels deep. The
-`@routecraft/prettier-plugin-routecraft` plugin overrides Prettier's printer for
-those closures so the threaded parameter stays on the arrow line and the chain
-keeps a single indent level.
-
-## Before and after
+Routecraft recommends formatting projects with
+`@routecraft/prettier-plugin-routecraft`. It overrides Prettier's layout for
+fluent builder closures so nested `.choice()`, `.when()`, and `.otherwise()`
+chains stay shallow instead of indenting a level for every closure:
 
 ```ts
-// Prettier default
-.choice((c) =>
-  c
-    .when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) =>
-      b
-        .enrich(agent('zoe'), only((r) => r, 'agent'))
-        .to(mail({ action: 'move' })),
-    )
-    .otherwise((b) => b),
-)
-
-// With the plugin
 .choice((c) => c
-  .when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) => b
-    .enrich(agent('zoe'), only((r) => r, 'agent'))
-    .to(mail({ action: 'move' })))
+  .when(isUrgent, (b) => b.to(urgent))
   .otherwise((b) => b))
 ```
 
@@ -64,8 +46,7 @@ yarn add -D prettier @routecraft/prettier-plugin-routecraft
 
 ## Configuration
 
-Add the plugin to your Prettier config. Prettier loads plugins from the
-`plugins` array; no other options are required.
+Add the plugin to your Prettier config:
 
 ```js
 // prettier.config.mjs
@@ -88,37 +69,15 @@ Then format as usual:
 bunx prettier --write .
 ```
 
-## What the plugin touches
-
-The plugin only changes single-parameter arrow closures whose body is a fluent
-chain and that are passed directly as a call argument inside a `craft()` chain.
-Being a direct argument inside a `craft()` chain is what scopes it to the
-Routecraft DSL. There are two layouts:
-
-- Parameter-threaded builders such as `(c) => c.when(...).otherwise(...)` and
-  `(b) => b.enrich(...).to(...)` keep the parameter on the arrow line.
-- Factory-rooted callbacks such as `(ex) => direct(...).send(...)` keep the
-  parameter on the arrow line but break the body onto the next line.
-
-Everything else is left to Prettier's defaults, including:
-
-- Ordinary fluent chains such as `arr.map((x) => x.foo().bar())` (no `craft()`
-  root)
-- Arrows used as object or array values, such as adapter option callbacks
-  (`path: (ex) => path.join(...)`)
-- Non-chain bodies such as template literals or object literals
-- Async arrows and arrows with explicit return types or type parameters, so no
-  type information is ever dropped
-
-The result is roundtrip stable: running Prettier twice produces no further
-changes.
+The plugin only adjusts Routecraft builder closures; everything else is left to
+Prettier's defaults.
 
 ## Related
 
 {% quick-links %}
 
-{% quick-link title="Operations reference" icon="presets" href="/docs/reference/operations" description="The choice, split, and aggregate operations the plugin formats." /%}
-
 {% quick-link title="Linting" icon="presets" href="/docs/advanced/linting" description="Enforce Routecraft authoring best practices with ESLint." /%}
+
+{% quick-link title="Operations reference" icon="presets" href="/docs/reference/operations" description="The choice, split, and aggregate operations the plugin formats." /%}
 
 {% /quick-links %}

--- a/apps/routecraft.dev/src/lib/navigation.ts
+++ b/apps/routecraft.dev/src/lib/navigation.ts
@@ -51,6 +51,7 @@ export const navigation = [
         href: '/docs/advanced/securing-capabilities',
       },
       { title: 'Linting', href: '/docs/advanced/linting' },
+      { title: 'Formatting', href: '/docs/advanced/formatting' },
     ],
   },
   {

--- a/bun.lock
+++ b/bun.lock
@@ -231,6 +231,19 @@
         "@routecraft/routecraft": ">=0.5.0",
       },
     },
+    "packages/prettier-plugin-routecraft": {
+      "name": "@routecraft/prettier-plugin-routecraft",
+      "version": "0.6.0",
+      "devDependencies": {
+        "prettier": "^3.8.3",
+        "tsup": "^8.5.1",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.5",
+      },
+      "peerDependencies": {
+        "prettier": ">=3",
+      },
+    },
     "packages/routecraft": {
       "name": "@routecraft/routecraft",
       "version": "0.6.0",
@@ -824,6 +837,8 @@
     "@routecraft/eslint-plugin-routecraft": ["@routecraft/eslint-plugin-routecraft@workspace:packages/eslint-plugin-routecraft"],
 
     "@routecraft/os": ["@routecraft/os@workspace:packages/os"],
+
+    "@routecraft/prettier-plugin-routecraft": ["@routecraft/prettier-plugin-routecraft@workspace:packages/prettier-plugin-routecraft"],
 
     "@routecraft/routecraft": ["@routecraft/routecraft@workspace:packages/routecraft"],
 

--- a/packages/prettier-plugin-routecraft/README.md
+++ b/packages/prettier-plugin-routecraft/README.md
@@ -73,12 +73,16 @@ bunx prettier --write .
 
 ## What it touches
 
-The plugin only changes single-parameter arrow closures whose body threads that
-parameter straight into a fluent chain rooted at `craft()`, for example
-`(c) => c.when(...).otherwise(...)` or `(b) => b.enrich(...).to(...)`. Everything
-else (including ordinary `arr.map((x) => x.foo())` chains) is left to Prettier's
-defaults. Async arrows and arrows with explicit return types or type parameters
-are also left untouched so no type information is ever dropped.
+The plugin only changes single-parameter arrow closures whose body is a fluent
+chain and that appear inside a `craft()` chain. That covers builder closures
+such as `(c) => c.when(...).otherwise(...)` and `(b) => b.enrich(...).to(...)`,
+as well as factory-rooted callbacks such as `(ex) => direct(...).send(...)`: in
+every case the parameter stays on the arrow line.
+
+Everything else is left to Prettier's defaults, including ordinary
+`arr.map((x) => x.foo())` chains (no `craft()` root), non-chain bodies such as
+template literals or object literals, and async arrows or arrows with explicit
+return types or type parameters (so no type information is ever dropped).
 
 ## Documentation
 

--- a/packages/prettier-plugin-routecraft/README.md
+++ b/packages/prettier-plugin-routecraft/README.md
@@ -74,15 +74,28 @@ bunx prettier --write .
 ## What it touches
 
 The plugin only changes single-parameter arrow closures whose body is a fluent
-chain and that appear inside a `craft()` chain. That covers builder closures
-such as `(c) => c.when(...).otherwise(...)` and `(b) => b.enrich(...).to(...)`,
-as well as factory-rooted callbacks such as `(ex) => direct(...).send(...)`: in
-every case the parameter stays on the arrow line.
+chain and that are passed directly as a call argument inside a `craft()` chain.
+There are two layouts:
+
+- Parameter-threaded builders such as `(c) => c.when(...).otherwise(...)` and
+  `(b) => b.enrich(...).to(...)` keep the parameter on the arrow line.
+- Factory-rooted callbacks such as `(ex) => direct(...).send(...)` keep the
+  parameter on the arrow line but break the body onto the next line:
+
+  ```ts
+  .enrich(
+    (ex) =>
+      direct(...).send(...),
+    only((r) => r, "agent"),
+  )
+  ```
 
 Everything else is left to Prettier's defaults, including ordinary
-`arr.map((x) => x.foo())` chains (no `craft()` root), non-chain bodies such as
-template literals or object literals, and async arrows or arrows with explicit
-return types or type parameters (so no type information is ever dropped).
+`arr.map((x) => x.foo())` chains (no `craft()` root), arrows used as object or
+array values such as adapter option callbacks (`path: (ex) => path.join(...)`),
+non-chain bodies such as template literals or object literals, and async arrows
+or arrows with explicit return types or type parameters (so no type information
+is ever dropped).
 
 ## Documentation
 

--- a/packages/prettier-plugin-routecraft/README.md
+++ b/packages/prettier-plugin-routecraft/README.md
@@ -1,0 +1,95 @@
+# @routecraft/prettier-plugin-routecraft
+
+Prettier plugin that keeps Routecraft DSL chains compact and readable.
+
+Prettier's defaults push fluent sub-route closures onto their own line and add
+an extra level of indentation for every nested `.choice()`, `.when()`, and
+`.otherwise()`. This plugin overrides Prettier's printer for those closures so
+the threaded parameter stays on the arrow line and the chain keeps a single
+indent level.
+
+## Before and after
+
+```ts
+// Prettier default
+.choice((c) =>
+  c
+    .when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) =>
+      b
+        .enrich(agent("zoe"), only((r) => r, "agent"))
+        .to(mail({ action: "move" })),
+    )
+    .otherwise((b) => b),
+)
+
+// With @routecraft/prettier-plugin-routecraft
+.choice((c) => c
+  .when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) => b
+    .enrich(agent("zoe"), only((r) => r, "agent"))
+    .to(mail({ action: "move" })))
+  .otherwise((b) => b))
+```
+
+## Installation
+
+```bash
+# Bun (recommended)
+bun add -D @routecraft/prettier-plugin-routecraft prettier
+
+# npm / pnpm / yarn
+npm install --save-dev @routecraft/prettier-plugin-routecraft prettier
+pnpm add -D @routecraft/prettier-plugin-routecraft prettier
+yarn add -D @routecraft/prettier-plugin-routecraft prettier
+```
+
+## Requirements
+
+- Prettier >= 3
+
+## Usage
+
+Add the plugin to your Prettier configuration:
+
+```js
+// prettier.config.mjs
+export default {
+  plugins: ["@routecraft/prettier-plugin-routecraft"],
+};
+```
+
+Or in `.prettierrc`:
+
+```json
+{
+  "plugins": ["@routecraft/prettier-plugin-routecraft"]
+}
+```
+
+Then format as usual:
+
+```bash
+bunx prettier --write .
+```
+
+## What it touches
+
+The plugin only changes single-parameter arrow closures whose body threads that
+parameter straight into a fluent chain rooted at `craft()`, for example
+`(c) => c.when(...).otherwise(...)` or `(b) => b.enrich(...).to(...)`. Everything
+else (including ordinary `arr.map((x) => x.foo())` chains) is left to Prettier's
+defaults. Async arrows and arrows with explicit return types or type parameters
+are also left untouched so no type information is ever dropped.
+
+## Documentation
+
+For more information about Routecraft, visit [routecraft.dev](https://routecraft.dev).
+
+## License
+
+Apache-2.0
+
+## Links
+
+- [Documentation](https://routecraft.dev)
+- [GitHub Repository](https://github.com/routecraftjs/routecraft)
+- [Issue Tracker](https://github.com/routecraftjs/routecraft/issues)

--- a/packages/prettier-plugin-routecraft/README.md
+++ b/packages/prettier-plugin-routecraft/README.md
@@ -73,29 +73,19 @@ bunx prettier --write .
 
 ## What it touches
 
-The plugin only changes single-parameter arrow closures whose body is a fluent
-chain and that are passed directly as a call argument inside a `craft()` chain.
-There are two layouts:
+The plugin only changes parameter-threaded builders: single-parameter arrow
+closures whose body is a fluent chain rooted in that parameter, passed directly
+as a call argument inside a `craft()` chain. Arrows such as
+`(c) => c.when(...).otherwise(...)` and `(b) => b.enrich(...).to(...)` keep the
+parameter on the arrow line instead of breaking the body onto its own line.
 
-- Parameter-threaded builders such as `(c) => c.when(...).otherwise(...)` and
-  `(b) => b.enrich(...).to(...)` keep the parameter on the arrow line.
-- Factory-rooted callbacks such as `(ex) => direct(...).send(...)` keep the
-  parameter on the arrow line but break the body onto the next line:
-
-  ```ts
-  .enrich(
-    (ex) =>
-      direct(...).send(...),
-    only((r) => r, "agent"),
-  )
-  ```
-
-Everything else is left to Prettier's defaults, including ordinary
-`arr.map((x) => x.foo())` chains (no `craft()` root), arrows used as object or
-array values such as adapter option callbacks (`path: (ex) => path.join(...)`),
-non-chain bodies such as template literals or object literals, and async arrows
-or arrows with explicit return types or type parameters (so no type information
-is ever dropped).
+Everything else is left to Prettier's defaults, including factory-rooted
+callbacks such as `(ex) => direct(...).send(...)` (whose chain is rooted in a
+call, not the parameter), ordinary `arr.map((x) => x.foo())` chains (no
+`craft()` root), arrows used as object or array values such as adapter option
+callbacks (`path: (ex) => path.join(...)`), non-chain bodies such as template
+literals or object literals, and async arrows or arrows with explicit return
+types or type parameters (so no type information is ever dropped).
 
 ## Documentation
 

--- a/packages/prettier-plugin-routecraft/package.json
+++ b/packages/prettier-plugin-routecraft/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@routecraft/prettier-plugin-routecraft",
+  "version": "0.6.0",
+  "description": "Prettier plugin for compact Routecraft DSL formatting",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "prepublishOnly": "bun run build",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "prettier": ">=3"
+  },
+  "devDependencies": {
+    "prettier": "^3.8.3",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "https://github.com/routecraftjs/routecraft",
+  "keywords": [
+    "prettier",
+    "prettier-plugin",
+    "routecraft",
+    "formatting",
+    "typescript"
+  ],
+  "author": "routecraftjs",
+  "license": "Apache-2.0",
+  "homepage": "https://routecraft.dev"
+}

--- a/packages/prettier-plugin-routecraft/src/index.ts
+++ b/packages/prettier-plugin-routecraft/src/index.ts
@@ -144,6 +144,11 @@ function isDslArrow(node: DslNode, path: AstPath): boolean {
   const param = params[0];
   if (!param || param.type !== "Identifier" || !param.name) return false;
 
+  // Bail when the parameter is typed. Forcing the arrow inline can make Prettier
+  // break the type annotation across lines to fit, which is uglier than its
+  // default layout (which breaks after `=>` and keeps the annotation intact).
+  if (param.typeAnnotation) return false;
+
   const body = node.body;
   if (!body || body.type === "BlockStatement") return false;
   if (chainHeadName(body) !== param.name) return false;

--- a/packages/prettier-plugin-routecraft/src/index.ts
+++ b/packages/prettier-plugin-routecraft/src/index.ts
@@ -34,26 +34,33 @@ interface DslNode {
 }
 
 /**
- * Whether an arrow body is a fluent chain (or the bare parameter) worth keeping
- * on the arrow line. This covers both parameter-threaded builders such as
- * `(c) => c.when(...)` and callbacks whose chain starts from a factory such as
- * `(ex) => direct(...).send(...)`. Bodies that are not chains (template
- * literals, conditionals, object literals, ...) are left to Prettier.
+ * Walk to the head of a fluent member/call chain and return its identifier
+ * name, or `null` when the chain does not bottom out at a bare identifier. Used
+ * to tell parameter-threaded builders (`(c) => c.when(...)`, head is the param)
+ * from factory-rooted callbacks (`(ex) => direct(...).send(...)`, head is a
+ * call), which are laid out differently.
  */
-function isChainBody(body: DslNode, paramName: string): boolean {
-  switch (body.type) {
-    case "CallExpression":
-    case "OptionalCallExpression":
-    case "MemberExpression":
-    case "OptionalMemberExpression":
-    case "ChainExpression":
-    case "TSNonNullExpression":
-      return true;
-    case "Identifier":
-      return body.name === paramName;
-    default:
-      return false;
+function chainHeadName(node: DslNode): string | null {
+  let cur: DslNode | undefined = node;
+  while (cur) {
+    switch (cur.type) {
+      case "CallExpression":
+      case "OptionalCallExpression":
+        cur = cur.callee;
+        break;
+      case "MemberExpression":
+      case "OptionalMemberExpression":
+        cur = cur.object;
+        break;
+      case "ChainExpression":
+      case "TSNonNullExpression":
+        cur = cur.expression;
+        break;
+      default:
+        return cur.type === "Identifier" ? (cur.name ?? null) : null;
+    }
   }
+  return null;
 }
 
 /**
@@ -111,15 +118,19 @@ function isInsideCraftChain(path: AstPath): boolean {
 }
 
 /**
- * A "DSL arrow" is a single-parameter arrow whose body is a fluent chain, that
- * is passed directly as a call argument inside a `craft()` chain. This covers
- * parameter-threaded builders such as `(c) => c.when(...).otherwise(...)`, the
- * trivial `(b) => b`, and factory-rooted callbacks such as
- * `(ex) => direct(...).send(...)`. These are the closures Prettier breaks
- * across too many lines. Async arrows and arrows with explicit return types or
- * type parameters are left untouched so we never drop a type annotation;
- * non-chain bodies and arrows used as object or array values (such as adapter
- * option callbacks) fall through to Prettier.
+ * A "DSL arrow" is a single-parameter arrow that threads its parameter straight
+ * into a fluent chain (`(c) => c.when(...).otherwise(...)`, or the trivial
+ * `(b) => b`), passed directly as a call argument inside a `craft()` chain.
+ * These are the sub-route builder closures Prettier breaks across too many
+ * lines, so we keep the parameter on the arrow line.
+ *
+ * Everything else falls through to Prettier: factory-rooted callbacks such as
+ * `(ex) => direct(...).send(...)` (whose head is a call, not the parameter) get
+ * Prettier's natural arrow layout, which keeps short bodies inline and breaks
+ * long ones onto the next line. Async arrows and arrows with explicit return
+ * types or type parameters are left untouched so we never drop a type
+ * annotation, as are arrows used as object or array values (adapter option
+ * callbacks) and non-chain bodies (template literals, conditionals, ...).
  */
 function isDslArrow(node: DslNode, path: AstPath): boolean {
   if (node.type !== "ArrowFunctionExpression") return false;
@@ -134,7 +145,7 @@ function isDslArrow(node: DslNode, path: AstPath): boolean {
 
   const body = node.body;
   if (!body || body.type === "BlockStatement") return false;
-  if (!isChainBody(body, param.name)) return false;
+  if (chainHeadName(body) !== param.name) return false;
 
   return isDirectCallArgument(node, path) && isInsideCraftChain(path);
 }
@@ -142,11 +153,12 @@ function isDslArrow(node: DslNode, path: AstPath): boolean {
 const estreePrinter = estreePrinters.estree;
 
 /**
- * Our printer wraps the built-in estree printer. For DSL arrows it keeps the
- * threaded parameter on the same line as the arrow (`(c) => c`) and lets the
- * body's own member-chain layout supply the indentation, which collapses the
- * extra "body on its own line" break and one level of indentation that
- * Prettier would otherwise add. Every other node falls through unchanged.
+ * Our printer wraps the built-in estree printer. For parameter-threaded DSL
+ * builders (`(c) => c.when(...)`) it keeps the parameter on the arrow line and
+ * lets the body's own member-chain layout supply the indentation, collapsing
+ * the extra "body on its own line" break and one level of indentation Prettier
+ * would otherwise add. Every other node falls through to the built-in printer
+ * unchanged.
  */
 const routecraftPrinter: Printer = {
   ...estreePrinter,

--- a/packages/prettier-plugin-routecraft/src/index.ts
+++ b/packages/prettier-plugin-routecraft/src/index.ts
@@ -28,9 +28,15 @@ interface DslNode {
   body?: DslNode;
   params?: DslNode[];
   arguments?: DslNode[];
+  comments?: unknown[];
   typeAnnotation?: unknown;
   returnType?: unknown;
   typeParameters?: unknown;
+}
+
+/** Whether Prettier attached any comments directly to this node. */
+function hasComments(node: DslNode): boolean {
+  return Array.isArray(node.comments) && node.comments.length > 0;
 }
 
 /**
@@ -146,6 +152,13 @@ function isDslArrow(node: DslNode, path: AstPath): boolean {
   const body = node.body;
   if (!body || body.type === "BlockStatement") return false;
   if (chainHeadName(body) !== param.name) return false;
+
+  // Bail to Prettier's default printer when the arrow or its immediate body
+  // carries comments. Our hand-built doc does not reproduce the default arrow
+  // printer's comment placement, and a comment between `=>` and the body would
+  // otherwise produce non-idempotent output. Comments deeper in the chain
+  // attach to other nodes and are printed correctly via recursion.
+  if (hasComments(node) || hasComments(body)) return false;
 
   return isDirectCallArgument(node, path) && isInsideCraftChain(path);
 }

--- a/packages/prettier-plugin-routecraft/src/index.ts
+++ b/packages/prettier-plugin-routecraft/src/index.ts
@@ -27,37 +27,33 @@ interface DslNode {
   expression?: DslNode;
   body?: DslNode;
   params?: DslNode[];
+  arguments?: DslNode[];
   typeAnnotation?: unknown;
   returnType?: unknown;
   typeParameters?: unknown;
 }
 
 /**
- * Walk to the head of a fluent member/call chain and return its identifier
- * name, or `null` when the chain does not bottom out at a bare identifier
- * (for example `direct(...).send(...)`, whose head is a call, not a name).
+ * Whether an arrow body is a fluent chain (or the bare parameter) worth keeping
+ * on the arrow line. This covers both parameter-threaded builders such as
+ * `(c) => c.when(...)` and callbacks whose chain starts from a factory such as
+ * `(ex) => direct(...).send(...)`. Bodies that are not chains (template
+ * literals, conditionals, object literals, ...) are left to Prettier.
  */
-function chainHeadName(node: DslNode): string | null {
-  let cur: DslNode | undefined = node;
-  while (cur) {
-    switch (cur.type) {
-      case "CallExpression":
-      case "OptionalCallExpression":
-        cur = cur.callee;
-        break;
-      case "MemberExpression":
-      case "OptionalMemberExpression":
-        cur = cur.object;
-        break;
-      case "ChainExpression":
-      case "TSNonNullExpression":
-        cur = cur.expression;
-        break;
-      default:
-        return cur.type === "Identifier" ? (cur.name ?? null) : null;
-    }
+function isChainBody(body: DslNode, paramName: string): boolean {
+  switch (body.type) {
+    case "CallExpression":
+    case "OptionalCallExpression":
+    case "MemberExpression":
+    case "OptionalMemberExpression":
+    case "ChainExpression":
+    case "TSNonNullExpression":
+      return true;
+    case "Identifier":
+      return body.name === paramName;
+    default:
+      return false;
   }
-  return null;
 }
 
 /**
@@ -88,6 +84,18 @@ function rootsAtCraft(node: DslNode): boolean {
   return false;
 }
 
+/**
+ * Whether the node sits directly in a call's argument list, for example the
+ * closure in `.enrich((ex) => ..., only(...))`. This keeps the plugin to DSL
+ * callback arguments and leaves arrows that are object or array values (such as
+ * `path: (ex) => path.join(...)` inside an adapter's options) to Prettier.
+ */
+function isDirectCallArgument(node: DslNode, path: AstPath): boolean {
+  const parent = path.getParentNode(0) as DslNode | null;
+  if (!parent || parent.type !== "CallExpression") return false;
+  return Array.isArray(parent.arguments) && parent.arguments.includes(node);
+}
+
 /** Whether any ancestor call expression is part of a `craft()` chain. */
 function isInsideCraftChain(path: AstPath): boolean {
   let depth = 0;
@@ -103,13 +111,15 @@ function isInsideCraftChain(path: AstPath): boolean {
 }
 
 /**
- * A "DSL arrow" is a single-parameter arrow whose body threads that parameter
- * straight into a fluent chain, for example `(c) => c.when(...).otherwise(...)`
- * or the trivial `(b) => b`. These are the sub-route builder closures that
- * Prettier breaks across too many lines. Async arrows, arrows with explicit
- * return types or type parameters, and closures whose body does not start from
- * the parameter are left untouched so we never drop a type annotation or
- * fight Prettier on shapes we do not own.
+ * A "DSL arrow" is a single-parameter arrow whose body is a fluent chain, that
+ * is passed directly as a call argument inside a `craft()` chain. This covers
+ * parameter-threaded builders such as `(c) => c.when(...).otherwise(...)`, the
+ * trivial `(b) => b`, and factory-rooted callbacks such as
+ * `(ex) => direct(...).send(...)`. These are the closures Prettier breaks
+ * across too many lines. Async arrows and arrows with explicit return types or
+ * type parameters are left untouched so we never drop a type annotation;
+ * non-chain bodies and arrows used as object or array values (such as adapter
+ * option callbacks) fall through to Prettier.
  */
 function isDslArrow(node: DslNode, path: AstPath): boolean {
   if (node.type !== "ArrowFunctionExpression") return false;
@@ -124,9 +134,9 @@ function isDslArrow(node: DslNode, path: AstPath): boolean {
 
   const body = node.body;
   if (!body || body.type === "BlockStatement") return false;
-  if (chainHeadName(body) !== param.name) return false;
+  if (!isChainBody(body, param.name)) return false;
 
-  return isInsideCraftChain(path);
+  return isDirectCallArgument(node, path) && isInsideCraftChain(path);
 }
 
 const estreePrinter = estreePrinters.estree;

--- a/packages/prettier-plugin-routecraft/src/index.ts
+++ b/packages/prettier-plugin-routecraft/src/index.ts
@@ -1,0 +1,176 @@
+import type { AstPath, Doc, Parser, Plugin, Printer } from "prettier";
+import { printers as estreePrinters } from "prettier/plugins/estree";
+import { parsers as typescriptParsers } from "prettier/plugins/typescript";
+import { parsers as babelParsers } from "prettier/plugins/babel";
+
+/**
+ * Name of the AST format this plugin registers. The wrapped parsers point
+ * their `astFormat` here so Prettier dispatches every node to our printer,
+ * which delegates back to the built-in estree printer for everything that is
+ * not a Routecraft DSL closure.
+ */
+const AST_FORMAT = "routecraft-estree";
+
+/**
+ * Minimal structural view of the estree-like nodes this plugin inspects.
+ * Prettier does not export estree node types, so we model only the fields we
+ * read while walking fluent chains. Optional fields cover the variations the
+ * TypeScript and Babel parsers can emit (optional chaining, non-null
+ * assertions, type annotations).
+ */
+interface DslNode {
+  type: string;
+  name?: string;
+  async?: boolean;
+  object?: DslNode;
+  callee?: DslNode;
+  expression?: DslNode;
+  body?: DslNode;
+  params?: DslNode[];
+  typeAnnotation?: unknown;
+  returnType?: unknown;
+  typeParameters?: unknown;
+}
+
+/**
+ * Walk to the head of a fluent member/call chain and return its identifier
+ * name, or `null` when the chain does not bottom out at a bare identifier
+ * (for example `direct(...).send(...)`, whose head is a call, not a name).
+ */
+function chainHeadName(node: DslNode): string | null {
+  let cur: DslNode | undefined = node;
+  while (cur) {
+    switch (cur.type) {
+      case "CallExpression":
+      case "OptionalCallExpression":
+        cur = cur.callee;
+        break;
+      case "MemberExpression":
+      case "OptionalMemberExpression":
+        cur = cur.object;
+        break;
+      case "ChainExpression":
+      case "TSNonNullExpression":
+        cur = cur.expression;
+        break;
+      default:
+        return cur.type === "Identifier" ? (cur.name ?? null) : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Whether a chain ultimately roots at a `craft()` call. This is what scopes
+ * the plugin to the Routecraft DSL: arbitrary fluent chains such as
+ * `arr.map(...)` are left to Prettier's defaults.
+ */
+function rootsAtCraft(node: DslNode): boolean {
+  let cur: DslNode | undefined = node;
+  while (cur) {
+    switch (cur.type) {
+      case "CallExpression":
+      case "OptionalCallExpression":
+        cur = cur.callee;
+        break;
+      case "MemberExpression":
+      case "OptionalMemberExpression":
+        cur = cur.object;
+        break;
+      case "ChainExpression":
+      case "TSNonNullExpression":
+        cur = cur.expression;
+        break;
+      default:
+        return cur.type === "Identifier" && cur.name === "craft";
+    }
+  }
+  return false;
+}
+
+/** Whether any ancestor call expression is part of a `craft()` chain. */
+function isInsideCraftChain(path: AstPath): boolean {
+  let depth = 0;
+  let parent = path.getParentNode(depth) as DslNode | null;
+  while (parent) {
+    if (parent.type === "CallExpression" && rootsAtCraft(parent)) {
+      return true;
+    }
+    depth += 1;
+    parent = path.getParentNode(depth) as DslNode | null;
+  }
+  return false;
+}
+
+/**
+ * A "DSL arrow" is a single-parameter arrow whose body threads that parameter
+ * straight into a fluent chain, for example `(c) => c.when(...).otherwise(...)`
+ * or the trivial `(b) => b`. These are the sub-route builder closures that
+ * Prettier breaks across too many lines. Async arrows, arrows with explicit
+ * return types or type parameters, and closures whose body does not start from
+ * the parameter are left untouched so we never drop a type annotation or
+ * fight Prettier on shapes we do not own.
+ */
+function isDslArrow(node: DslNode, path: AstPath): boolean {
+  if (node.type !== "ArrowFunctionExpression") return false;
+  if (node.async) return false;
+  if (node.returnType || node.typeParameters) return false;
+
+  const params = node.params;
+  if (!params || params.length !== 1) return false;
+
+  const param = params[0];
+  if (!param || param.type !== "Identifier" || !param.name) return false;
+
+  const body = node.body;
+  if (!body || body.type === "BlockStatement") return false;
+  if (chainHeadName(body) !== param.name) return false;
+
+  return isInsideCraftChain(path);
+}
+
+const estreePrinter = estreePrinters.estree;
+
+/**
+ * Our printer wraps the built-in estree printer. For DSL arrows it keeps the
+ * threaded parameter on the same line as the arrow (`(c) => c`) and lets the
+ * body's own member-chain layout supply the indentation, which collapses the
+ * extra "body on its own line" break and one level of indentation that
+ * Prettier would otherwise add. Every other node falls through unchanged.
+ */
+const routecraftPrinter: Printer = {
+  ...estreePrinter,
+  print(path, options, print, args): Doc {
+    const node = path.node as DslNode;
+    if (node && isDslArrow(node, path)) {
+      const param = node.params?.[0];
+      const arrowParens = options.arrowParens ?? "always";
+      const omitParens = arrowParens === "avoid" && !param?.typeAnnotation;
+      const paramDoc = path.call(print, "params", 0);
+      const bodyDoc = path.call(print, "body");
+      const open = omitParens ? "" : "(";
+      const close = omitParens ? "" : ")";
+      return [open, paramDoc, close, " => ", bodyDoc];
+    }
+    return estreePrinter.print(path, options, print, args);
+  },
+};
+
+/** Wrap a built-in parser so it dispatches to our printer. */
+function withRoutecraftPrinter(parser: Parser): Parser {
+  return { ...parser, astFormat: AST_FORMAT };
+}
+
+export const parsers: Record<string, Parser> = {
+  typescript: withRoutecraftPrinter(typescriptParsers.typescript),
+  babel: withRoutecraftPrinter(babelParsers.babel),
+  "babel-ts": withRoutecraftPrinter(babelParsers["babel-ts"]),
+};
+
+export const printers: Record<string, Printer> = {
+  [AST_FORMAT]: routecraftPrinter,
+};
+
+const plugin: Plugin = { parsers, printers };
+
+export default plugin;

--- a/packages/prettier-plugin-routecraft/src/index.ts
+++ b/packages/prettier-plugin-routecraft/src/index.ts
@@ -40,33 +40,47 @@ function hasComments(node: DslNode): boolean {
 }
 
 /**
- * Walk to the head of a fluent member/call chain and return its identifier
- * name, or `null` when the chain does not bottom out at a bare identifier. Used
- * to tell parameter-threaded builders (`(c) => c.when(...)`, head is the param)
- * from factory-rooted callbacks (`(ex) => direct(...).send(...)`, head is a
- * call), which are laid out differently.
+ * Walk to the head of a fluent member/call chain and return the terminal node
+ * (the first node that is not a chain link). For `c.when(...).otherwise(...)`
+ * this is the identifier `c`; for `direct(...).send(...)` it is the `direct`
+ * identifier reached through the leading call. Callers inspect the result to
+ * distinguish parameter-threaded builders from factory-rooted callbacks and to
+ * detect `craft()`-rooted chains.
  */
-function chainHeadName(node: DslNode): string | null {
-  let cur: DslNode | undefined = node;
-  while (cur) {
+function chainHead(node: DslNode): DslNode {
+  let cur: DslNode = node;
+  while (true) {
+    let next: DslNode | undefined;
     switch (cur.type) {
       case "CallExpression":
       case "OptionalCallExpression":
-        cur = cur.callee;
+        next = cur.callee;
         break;
       case "MemberExpression":
       case "OptionalMemberExpression":
-        cur = cur.object;
+        next = cur.object;
         break;
       case "ChainExpression":
       case "TSNonNullExpression":
-        cur = cur.expression;
+        next = cur.expression;
         break;
       default:
-        return cur.type === "Identifier" ? (cur.name ?? null) : null;
+        return cur;
     }
+    if (!next) return cur;
+    cur = next;
   }
-  return null;
+}
+
+/**
+ * The identifier name at the head of a chain, or `null` when it does not bottom
+ * out at a bare identifier. Used to tell parameter-threaded builders
+ * (`(c) => c.when(...)`, head is the param) from factory-rooted callbacks
+ * (`(ex) => direct(...).send(...)`, head is a call).
+ */
+function chainHeadName(node: DslNode): string | null {
+  const head = chainHead(node);
+  return head.type === "Identifier" ? (head.name ?? null) : null;
 }
 
 /**
@@ -75,26 +89,7 @@ function chainHeadName(node: DslNode): string | null {
  * `arr.map(...)` are left to Prettier's defaults.
  */
 function rootsAtCraft(node: DslNode): boolean {
-  let cur: DslNode | undefined = node;
-  while (cur) {
-    switch (cur.type) {
-      case "CallExpression":
-      case "OptionalCallExpression":
-        cur = cur.callee;
-        break;
-      case "MemberExpression":
-      case "OptionalMemberExpression":
-        cur = cur.object;
-        break;
-      case "ChainExpression":
-      case "TSNonNullExpression":
-        cur = cur.expression;
-        break;
-      default:
-        return cur.type === "Identifier" && cur.name === "craft";
-    }
-  }
-  return false;
+  return chainHeadName(node) === "craft";
 }
 
 /**

--- a/packages/prettier-plugin-routecraft/test/format.bun.test.ts
+++ b/packages/prettier-plugin-routecraft/test/format.bun.test.ts
@@ -108,19 +108,22 @@ describe("prettier-plugin-routecraft", () => {
 
   /**
    * @case The full mail-routing example from the issue formats to the documented compact shape
-   * @preconditions The choice/when/otherwise example with a non-threaded enrich callback and a log template literal
-   * @expectedResult The DSL arrows compact while the non-DSL enrich callback (head is direct(...), not the parameter) is left to Prettier
+   * @preconditions The choice/when/otherwise example with a factory-rooted enrich callback and a log template literal
+   * @expectedResult Every chain-bodied arrow keeps its parameter on the arrow line (including the factory-rooted (ex) => direct(...).send(...)), while the template-literal log callback is left to Prettier
    */
-  test("issue example compacts DSL arrows but leaves non-DSL callbacks alone", async () => {
+  test("issue example compacts every chain-bodied arrow", async () => {
     const out = await format(
-      `export const route = craft().id("mail").from(mail({ action: "watch" })).choice((c) => c.when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) => b.enrich((ex) => direct<{ name: string; body: MailMessage }, AgentResult>("agent").send(DefaultExchange.rewrap(ex, { body: { name: "zoe", body: ex.body } })), only((r) => r, "agent")).to(mail({ action: "move", folder: "[Gmail]/All Mail" })).log((ex) => \`Processed: \${ex.body.from}\`)).otherwise((b) => b));`,
+      `export const route = craft().id("mail").from(mail({ action: "watch" })).choice((c) => c.when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) => b.enrich((ex) => direct<{ name: string; body: MailMessage }, AgentResult>("agent").send(DefaultExchange.rewrap(ex, { body: { name: "zoe", body: ex.body } })), only((r) => r, "agent")).to(mail({ action: "move", folder: "[Gmail]/All Mail" })).log((ex) => \`Processed: \${ex.body.from} [\${ex.body.sender?.address}] - \${ex.body.subject}\`)).otherwise((b) => b));`,
     );
-    // DSL arrows compacted: parameter stays on the arrow line.
+    // Builder arrows compacted: parameter stays on the arrow line.
     expect(out).toContain("(c) => c\n");
     expect(out).toContain("(b) => b\n");
-    // Non-DSL callback whose chain head is direct(...) keeps Prettier's default
-    // layout: its parameter is not threaded, so the arrow body breaks normally.
-    expect(out).toMatch(/\(ex\) =>\s*\n\s*direct</);
+    // Factory-rooted callback: the parameter and the chain head stay together
+    // on the arrow line instead of `(ex) =>` breaking onto its own line.
+    expect(out).toContain("(ex) => direct<");
+    expect(out).not.toMatch(/\(ex\) =>\s*\n\s*direct</);
+    // A non-chain body (template literal) is still left to Prettier.
+    expect(out).toMatch(/\(ex\) =>\s*\n\s*`Processed:/);
     expect(await format(out)).toBe(out);
   });
 

--- a/packages/prettier-plugin-routecraft/test/format.bun.test.ts
+++ b/packages/prettier-plugin-routecraft/test/format.bun.test.ts
@@ -180,4 +180,16 @@ describe("prettier-plugin-routecraft", () => {
     expect(out).toContain("// everything else");
     expect(await format(out)).toBe(out);
   });
+
+  /**
+   * @case An arrow with a typed parameter is left to Prettier (the type annotation is never broken to fit)
+   * @preconditions A craft chain whose .enrich() projection uses a callback with a wide inline object type, e.g. only((r: { output?: { links: string[] } }) => r.output?.links, "links")
+   * @expectedResult Output matches stock Prettier byte-for-byte and is roundtrip stable, so the type annotation stays intact
+   */
+  test("typed-parameter arrows are left to Prettier", async () => {
+    const src = `export const r = craft().id("x").from(s()).enrich(enricher, only((r: { output?: { links: string[] } }) => r.output?.links, "links")).to(out());`;
+    const out = await format(src);
+    expect(out).toBe(await formatStock(src));
+    expect(await format(out)).toBe(out);
+  });
 });

--- a/packages/prettier-plugin-routecraft/test/format.bun.test.ts
+++ b/packages/prettier-plugin-routecraft/test/format.bun.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import prettier from "prettier";
+import plugin from "../src/index.ts";
+
+/** Format a TypeScript snippet with the Routecraft plugin enabled. */
+async function format(source: string): Promise<string> {
+  return prettier.format(source, {
+    parser: "typescript",
+    plugins: [plugin],
+  });
+}
+
+/** Format the same snippet with stock Prettier (no plugin). */
+async function formatStock(source: string): Promise<string> {
+  return prettier.format(source, { parser: "typescript" });
+}
+
+describe("prettier-plugin-routecraft", () => {
+  /**
+   * @case A choice with a single when branch keeps the threaded parameter inline
+   * @preconditions A craft() chain containing .choice((c) => c.when(...))
+   * @expectedResult The arrow head stays on the choice line (`(c) => c`) rather than breaking onto its own line
+   */
+  test("single when branch stays compact", async () => {
+    const out = await format(
+      `export const r = craft().id("c").from(src()).choice((c) => c.when(isAllowed(env.X), (b) => b.enrich(agent("zoe")).to(out())));`,
+    );
+    // Single short link keeps `c.when(...)` inline; the key win is that the
+    // parameter is never pushed onto its own line after the arrow.
+    expect(out).not.toMatch(/\(c\) =>\s*\n\s*c\b/);
+    expect(out).toContain("(b) => b\n");
+  });
+
+  /**
+   * @case A choice with two when branches keeps both branches one indent level below choice
+   * @preconditions A craft() chain with .choice((c) => c.when(...).when(...).otherwise(...))
+   * @expectedResult Each branch stays compact and the chain remains roundtrip stable
+   */
+  test("two when branches stay compact", async () => {
+    const out = await format(
+      `export const r = craft().id("c").from(src()).choice((c) => c.when(isA(), (b) => b.to(a())).when(isB(), (b) => b.to(b())).otherwise((b) => b));`,
+    );
+    expect(out).toContain("(c) => c\n");
+    expect(out).toContain(".when(isA(), (b) => b.to(a()))");
+    expect(out).toContain(".when(isB(), (b) => b.to(b()))");
+    expect(out).toContain(".otherwise((b) => b)");
+    expect(await format(out)).toBe(out);
+  });
+
+  /**
+   * @case A choice with three or more when branches remains readable and compact
+   * @preconditions A craft() chain with three .when() branches and an .otherwise()
+   * @expectedResult The arrow head stays inline and no branch is buried under an extra indent level
+   */
+  test("three when branches stay compact", async () => {
+    const out = await format(
+      `export const r = craft().id("c").from(src()).choice((c) => c.when(isA(), (b) => b.to(a())).when(isB(), (b) => b.to(b())).when(isC(), (b) => b.to(c())).otherwise((b) => b));`,
+    );
+    expect(out).toContain("(c) => c\n");
+    expect(out).not.toMatch(/\(c\) =>\s*\n\s*c\b/);
+    for (const branch of ["isA()", "isB()", "isC()"]) {
+      expect(out).toContain(branch);
+    }
+    expect(await format(out)).toBe(out);
+  });
+
+  /**
+   * @case A choice without an otherwise branch is still formatted compactly
+   * @preconditions A craft() chain with .choice((c) => c.when(...)) and no .otherwise()
+   * @expectedResult The threaded parameter stays inline and output is roundtrip stable
+   */
+  test("choice without otherwise stays compact", async () => {
+    const src = `export const r = craft().id("c").from(src()).choice((c) => c.when(isA(), (b) => b.to(a())));`;
+    const out = await format(src);
+    expect(out).toContain(".choice((c) => c.when(isA(), (b) => b.to(a())));");
+    expect(await format(out)).toBe(out);
+  });
+
+  /**
+   * @case split and aggregate sub-builder closures are formatted compactly
+   * @preconditions A craft() chain using .split((s) => ...) and .aggregate((a) => ...)
+   * @expectedResult The threaded parameters stay inline with their arrows and output is roundtrip stable
+   */
+  test("split and aggregate chains stay compact", async () => {
+    const out = await format(
+      `export const r = craft().id("s").from(src()).split((s) => s.body.items).to(log()).aggregate((a) => a.size(10)).to(out());`,
+    );
+    expect(out).toContain(".split((s) => s.body.items)");
+    expect(out).toContain(".aggregate((a) => a.size(10))");
+    expect(await format(out)).toBe(out);
+  });
+
+  /**
+   * @case A choice nested inside another choice keeps each level compact
+   * @preconditions A craft() chain with .choice() whose when branch contains another .choice()
+   * @expectedResult Both the outer and inner choice arrows keep their parameters inline and output is stable
+   */
+  test("deeply nested choice stays compact", async () => {
+    const out = await format(
+      `export const r = craft().id("n").from(src()).choice((c) => c.when(isA(), (b) => b.choice((c2) => c2.when(isB(), (b2) => b2.to(x())).otherwise((b2) => b2))).otherwise((b) => b));`,
+    );
+    expect(out).toContain("(c) => c\n");
+    expect(out).toContain("(c2) => c2\n");
+    expect(out).not.toMatch(/\(c\) =>\s*\n\s*c\b/);
+    expect(out).not.toMatch(/\(c2\) =>\s*\n\s*c2\b/);
+    expect(await format(out)).toBe(out);
+  });
+
+  /**
+   * @case The full mail-routing example from the issue formats to the documented compact shape
+   * @preconditions The choice/when/otherwise example with a non-threaded enrich callback and a log template literal
+   * @expectedResult The DSL arrows compact while the non-DSL enrich callback (head is direct(...), not the parameter) is left to Prettier
+   */
+  test("issue example compacts DSL arrows but leaves non-DSL callbacks alone", async () => {
+    const out = await format(
+      `export const route = craft().id("mail").from(mail({ action: "watch" })).choice((c) => c.when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) => b.enrich((ex) => direct<{ name: string; body: MailMessage }, AgentResult>("agent").send(DefaultExchange.rewrap(ex, { body: { name: "zoe", body: ex.body } })), only((r) => r, "agent")).to(mail({ action: "move", folder: "[Gmail]/All Mail" })).log((ex) => \`Processed: \${ex.body.from}\`)).otherwise((b) => b));`,
+    );
+    // DSL arrows compacted: parameter stays on the arrow line.
+    expect(out).toContain("(c) => c\n");
+    expect(out).toContain("(b) => b\n");
+    // Non-DSL callback whose chain head is direct(...) keeps Prettier's default
+    // layout: its parameter is not threaded, so the arrow body breaks normally.
+    expect(out).toMatch(/\(ex\) =>\s*\n\s*direct</);
+    expect(await format(out)).toBe(out);
+  });
+
+  /**
+   * @case A non-Routecraft fluent chain is left exactly as stock Prettier would format it
+   * @preconditions An arr.map((x) => x.foo().bar().baz()) chain with no craft() root, both short and long
+   * @expectedResult Output is byte-for-byte identical to stock Prettier (plugin does not touch non-DSL chains)
+   */
+  test("non-DSL chains are untouched", async () => {
+    const shortSrc = `const notDsl = arr.map((x) => x.foo().bar().baz());`;
+    const longSrc = `const notDsl = someReallyLongCollectionName.map((item) => item.transformOne().transformTwo().transformThree().transformFour().transformFive());`;
+    expect(await format(shortSrc)).toBe(await formatStock(shortSrc));
+    expect(await format(longSrc)).toBe(await formatStock(longSrc));
+  });
+});

--- a/packages/prettier-plugin-routecraft/test/format.bun.test.ts
+++ b/packages/prettier-plugin-routecraft/test/format.bun.test.ts
@@ -151,4 +151,33 @@ describe("prettier-plugin-routecraft", () => {
     expect(await format(shortSrc)).toBe(await formatStock(shortSrc));
     expect(await format(longSrc)).toBe(await formatStock(longSrc));
   });
+
+  /**
+   * @case An arrow whose body carries a leading comment is left to Prettier and stays idempotent
+   * @preconditions A choice arrow with a comment between => and the body: (c) => / comment / c.when(...)
+   * @expectedResult Output is roundtrip stable and matches stock Prettier (the plugin bails to the default printer for comment-bearing arrows)
+   */
+  test("arrow with a comment before its body is stable and left to Prettier", async () => {
+    const src = `export const r = craft().id("x").from(s()).choice((c) =>\n  // pick a branch\n  c.when(isA(), (b) => b.to(a())).otherwise((b) => b));`;
+    const once = await format(src);
+    // Idempotent: formatting the result again is a no-op.
+    expect(await format(once)).toBe(once);
+    // Comment-bearing arrow falls through to stock Prettier's layout.
+    expect(once).toBe(await formatStock(src));
+  });
+
+  /**
+   * @case Comments on branches inside the chain keep the compact layout
+   * @preconditions A choice whose .when()/.otherwise() branches are preceded by line comments
+   * @expectedResult The chain stays compact (parameter on the arrow line) and output is roundtrip stable
+   */
+  test("branch comments keep the compact layout", async () => {
+    const out = await format(
+      `export const r = craft().id("x").from(s()).choice((c) => c\n  // urgent\n  .when(isUrgent, (b) => b.to(urgent))\n  // everything else\n  .otherwise((b) => b));`,
+    );
+    expect(out).toContain("(c) => c\n");
+    expect(out).toContain("// urgent");
+    expect(out).toContain("// everything else");
+    expect(await format(out)).toBe(out);
+  });
 });

--- a/packages/prettier-plugin-routecraft/test/format.bun.test.ts
+++ b/packages/prettier-plugin-routecraft/test/format.bun.test.ts
@@ -109,21 +109,34 @@ describe("prettier-plugin-routecraft", () => {
   /**
    * @case The full mail-routing example from the issue formats to the documented compact shape
    * @preconditions The choice/when/otherwise example with a factory-rooted enrich callback and a log template literal
-   * @expectedResult Every chain-bodied arrow keeps its parameter on the arrow line (including the factory-rooted (ex) => direct(...).send(...)), while the template-literal log callback is left to Prettier
+   * @expectedResult Parameter-threaded builders stay inline, while the factory-rooted (ex) => direct(...).send(...) breaks its body onto a new line
    */
-  test("issue example compacts every chain-bodied arrow", async () => {
+  test("issue example compacts builders and breaks factory-rooted callbacks", async () => {
     const out = await format(
       `export const route = craft().id("mail").from(mail({ action: "watch" })).choice((c) => c.when(senderInAllowlist(env.MAIL_ALLOWED_INBOUND), (b) => b.enrich((ex) => direct<{ name: string; body: MailMessage }, AgentResult>("agent").send(DefaultExchange.rewrap(ex, { body: { name: "zoe", body: ex.body } })), only((r) => r, "agent")).to(mail({ action: "move", folder: "[Gmail]/All Mail" })).log((ex) => \`Processed: \${ex.body.from} [\${ex.body.sender?.address}] - \${ex.body.subject}\`)).otherwise((b) => b));`,
     );
-    // Builder arrows compacted: parameter stays on the arrow line.
+    // Parameter-threaded builders stay inline: parameter on the arrow line.
     expect(out).toContain("(c) => c\n");
     expect(out).toContain("(b) => b\n");
-    // Factory-rooted callback: the parameter and the chain head stay together
-    // on the arrow line instead of `(ex) =>` breaking onto its own line.
-    expect(out).toContain("(ex) => direct<");
-    expect(out).not.toMatch(/\(ex\) =>\s*\n\s*direct</);
+    // Factory-rooted callback: the body breaks onto its own indented line so the
+    // parameter and the factory chain do not crowd together.
+    expect(out).toMatch(/\(ex\) =>\s*\n\s*direct</);
+    expect(out).not.toContain("(ex) => direct<");
     // A non-chain body (template literal) is still left to Prettier.
     expect(out).toMatch(/\(ex\) =>\s*\n\s*`Processed:/);
+    expect(await format(out)).toBe(out);
+  });
+
+  /**
+   * @case A factory-rooted callback that is the sole argument of a DSL call hugs the call line
+   * @preconditions A single-argument .enrich((ex) => direct(...).send(...)) inside a craft() chain
+   * @expectedResult The parameter stays on the enrich line and the factory chain breaks onto the next line
+   */
+  test("single-arg factory-rooted callback hugs the call line", async () => {
+    const out = await format(
+      `export const route = craft().id("m").from(src()).choice((c) => c.when(isA(), (b) => b.enrich((ex) => direct<{ name: string; body: MailMessage }, AgentResult>("agent").send(DefaultExchange.rewrap(ex, { body: { name: "zoe", body: ex.body } })))).otherwise((b) => b));`,
+    );
+    expect(out).toMatch(/\.enrich\(\(ex\) =>\s*\n\s*direct</);
     expect(await format(out)).toBe(out);
   });
 

--- a/packages/prettier-plugin-routecraft/tsup.config.mjs
+++ b/packages/prettier-plugin-routecraft/tsup.config.mjs
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  clean: true,
+  dts: true,
+  format: ["esm"],
+  outDir: "dist",
+  sourcemap: true,
+  minify: true,
+  splitting: false,
+  treeshake: true,
+  target: "node20",
+  platform: "node",
+  external: ["prettier"],
+});

--- a/packages/prettier-plugin-routecraft/vitest.config.mjs
+++ b/packages/prettier-plugin-routecraft/vitest.config.mjs
@@ -1,0 +1,16 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["lcov", "text"],
+    },
+    environment: "node",
+    exclude: [
+      ...configDefaults.exclude,
+      "**/*.bun.test.ts",
+      "**/*.bun.test.tsx",
+    ],
+  },
+});

--- a/packages/routecraft/test/choice.bun.test.ts
+++ b/packages/routecraft/test/choice.bun.test.ts
@@ -50,18 +50,16 @@ describe("choice operation", () => {
         craft()
           .id("choice-basic")
           .from(items(inputs))
-          .choice((c) =>
-            c
-              .when(
-                (ex) => ex.body.priority === "urgent",
-                (b) => b.to(urgent),
-              )
-              .when(
-                (ex) => ex.body.amount > 1000,
-                (b) => b.to(big),
-              )
-              .otherwise((b) => b.to(fallback)),
-          )
+          .choice((c) => c
+            .when(
+              (ex) => ex.body.priority === "urgent",
+              (b) => b.to(urgent),
+            )
+            .when(
+              (ex) => ex.body.amount > 1000,
+              (b) => b.to(big),
+            )
+            .otherwise((b) => b.to(fallback)))
           .to(shared),
       )
       .build();
@@ -94,12 +92,10 @@ describe("choice operation", () => {
         craft()
           .id("choice-unmatched")
           .from(items<Order>([{ priority: "normal", amount: 10 }]))
-          .choice((c) =>
-            c.when(
-              (ex) => ex.body.priority === "urgent",
-              (b) => b.to(matched),
-            ),
-          )
+          .choice((c) => c.when(
+            (ex) => ex.body.priority === "urgent",
+            (b) => b.to(matched),
+          ))
           .to(shared),
       )
       .build();
@@ -131,14 +127,12 @@ describe("choice operation", () => {
         craft()
           .id("choice-halt")
           .from(items(inputs))
-          .choice((c) =>
-            c
-              .when(
-                (ex) => ex.body.priority === "urgent",
-                (b) => b.to(urgent),
-              )
-              .otherwise((b) => b.to(errorSink).halt()),
-          )
+          .choice((c) => c
+            .when(
+              (ex) => ex.body.priority === "urgent",
+              (b) => b.to(urgent),
+            )
+            .otherwise((b) => b.to(errorSink).halt()))
           .to(shared),
       )
       .build();
@@ -173,12 +167,10 @@ describe("choice operation", () => {
         craft()
           .id("choice-events-match")
           .from(items<Order>([{ priority: "urgent", amount: 10 }]))
-          .choice((c) =>
-            c.when(
-              (ex) => ex.body.priority === "urgent",
-              (b) => b.to(sink),
-            ),
-          ),
+          .choice((c) => c.when(
+            (ex) => ex.body.priority === "urgent",
+            (b) => b.to(sink),
+          )),
       )
       .on(
         "route:operation:choice:matched",
@@ -216,12 +208,10 @@ describe("choice operation", () => {
         craft()
           .id("choice-events-unmatch")
           .from(items<Order>([{ priority: "normal", amount: 10 }]))
-          .choice((c) =>
-            c.when(
-              (ex) => ex.body.priority === "urgent",
-              (b) => b.to(sink),
-            ),
-          ),
+          .choice((c) => c.when(
+            (ex) => ex.body.priority === "urgent",
+            (b) => b.to(sink),
+          )),
       )
       .on(
         "route:operation:choice:unmatched",
@@ -249,9 +239,9 @@ describe("choice operation", () => {
       craft()
         .id("choice-dup-otherwise")
         .from(items<Order>([]))
-        .choice((c) =>
-          c.otherwise((b) => b.to(spy())).otherwise((b) => b.to(spy())),
-        )
+        .choice((c) => c
+          .otherwise((b) => b.to(spy()))
+          .otherwise((b) => b.to(spy())))
         .build(),
     ).toThrow(/otherwise/);
   });
@@ -270,14 +260,12 @@ describe("choice operation", () => {
         craft()
           .id("choice-otherwise-order")
           .from(items<Order>([{ priority: "urgent", amount: 1 }]))
-          .choice((c) =>
-            c
-              .otherwise((b) => b.to(otherwiseSink))
-              .when(
-                (ex) => ex.body.priority === "urgent",
-                (b) => b.to(whenSink),
-              ),
-          ),
+          .choice((c) => c
+            .otherwise((b) => b.to(otherwiseSink))
+            .when(
+              (ex) => ex.body.priority === "urgent",
+              (b) => b.to(whenSink),
+            )),
       )
       .build();
 
@@ -306,16 +294,12 @@ describe("choice operation", () => {
         craft()
           .id("choice-transform-converge")
           .from(items(inputs))
-          .choice((c) =>
-            c
-              .when(
-                (ex) => ex.body.priority === "urgent",
-                (b) => b.transform((body) => ({ ...body, amount: 999 })),
-              )
-              .otherwise((b) =>
-                b.transform((body) => ({ ...body, amount: 0 })),
-              ),
-          )
+          .choice((c) => c
+            .when(
+              (ex) => ex.body.priority === "urgent",
+              (b) => b.transform((body) => ({ ...body, amount: 999 })),
+            )
+            .otherwise((b) => b.transform((body) => ({ ...body, amount: 0 }))))
           .to(shared),
       )
       .build();
@@ -343,14 +327,10 @@ describe("choice operation", () => {
         craft()
           .id("choice-transform-chain")
           .from(items<Order>([{ priority: "normal", amount: 1 }]))
-          .choice((c) =>
-            c.otherwise((b) =>
-              b
-                .transform((body) => ({ ...body, amount: body.amount + 100 }))
-                .to(sink)
-                .halt(),
-            ),
-          )
+          .choice((c) => c.otherwise((b) => b
+            .transform((body) => ({ ...body, amount: body.amount + 100 }))
+            .to(sink)
+            .halt()))
           .to(downstream),
       )
       .build();
@@ -381,14 +361,12 @@ describe("choice operation", () => {
         craft()
           .id("choice-transform-type-change")
           .from(items(inputs))
-          .choice<string>((c) =>
-            c
-              .when(
-                (ex) => ex.body.priority === "urgent",
-                (b) => b.transform((body) => `URGENT:${body.amount}`),
-              )
-              .otherwise((b) => b.transform((body) => `normal:${body.amount}`)),
-          )
+          .choice<string>((c) => c
+            .when(
+              (ex) => ex.body.priority === "urgent",
+              (b) => b.transform((body) => `URGENT:${body.amount}`),
+            )
+            .otherwise((b) => b.transform((body) => `normal:${body.amount}`)))
           .to(downstream),
       )
       .build();
@@ -412,16 +390,12 @@ describe("choice operation", () => {
         craft()
           .id("choice-transform-async")
           .from(items<Order>([{ priority: "normal", amount: 1 }]))
-          .choice((c) =>
-            c.otherwise((b) =>
-              b
-                .transform(async (body) => {
-                  await new Promise((r) => setTimeout(r, 1));
-                  return { ...body, amount: body.amount + 1 };
-                })
-                .to(sink),
-            ),
-          ),
+          .choice((c) => c.otherwise((b) => b
+            .transform(async (body) => {
+              await new Promise((r) => setTimeout(r, 1));
+              return { ...body, amount: body.amount + 1 };
+            })
+            .to(sink))),
       )
       .build();
 
@@ -458,13 +432,9 @@ describe("choice operation", () => {
         craft()
           .id("choice-transform-throws")
           .from(items<Order>([{ priority: "normal", amount: 1 }]))
-          .choice((c) =>
-            c.otherwise((b) =>
-              b.transform(() => {
-                throw new Error("branch transform blew up");
-              }),
-            ),
-          )
+          .choice((c) => c.otherwise((b) => b.transform(() => {
+            throw new Error("branch transform blew up");
+          })))
           .to(downstream),
       )
       .build();
@@ -503,11 +473,9 @@ describe("choice operation", () => {
         craft()
           .id("choice-enrich-merge")
           .from(items<Order>([{ priority: "normal", amount: 5000 }]))
-          .choice((c) =>
-            c.otherwise((b) =>
-              b.enrich(() => ({ reviewReason: "high-value" })),
-            ),
-          )
+          .choice((c) => c.otherwise((b) => b.enrich(() => ({
+            reviewReason: "high-value",
+          }))))
           .to(shared),
       )
       .build();
@@ -536,16 +504,12 @@ describe("choice operation", () => {
         craft()
           .id("choice-enrich-async")
           .from(items<Order>([{ priority: "urgent", amount: 1 }]))
-          .choice((c) =>
-            c.otherwise((b) =>
-              b
-                .enrich(async () => {
-                  await new Promise((r) => setTimeout(r, 1));
-                  return { fetched: 42 };
-                })
-                .to(sink),
-            ),
-          ),
+          .choice((c) => c.otherwise((b) => b
+            .enrich(async () => {
+              await new Promise((r) => setTimeout(r, 1));
+              return { fetched: 42 };
+            })
+            .to(sink))),
       )
       .build();
 
@@ -586,13 +550,9 @@ describe("choice operation", () => {
         craft()
           .id("choice-enrich-throws")
           .from(items<Order>([{ priority: "normal", amount: 1 }]))
-          .choice((c) =>
-            c.otherwise((b) =>
-              b.enrich(() => {
-                throw new Error("enrich fetch blew up");
-              }),
-            ),
-          )
+          .choice((c) => c.otherwise((b) => b.enrich(() => {
+            throw new Error("enrich fetch blew up");
+          })))
           .to(downstream),
       )
       .build();
@@ -637,9 +597,9 @@ describe("choice operation", () => {
         craft()
           .id("choice-filter-branch")
           .from(items(inputs))
-          .choice((c) =>
-            c.otherwise((b) => b.filter((ex) => ex.body.amount >= 100)),
-          )
+          .choice((c) => c.otherwise((b) => b.filter(
+            (ex) => ex.body.amount >= 100,
+          )))
           .to(downstream),
       )
       .build();
@@ -719,14 +679,12 @@ describe("choice operation", () => {
         craft()
           .id("choice-process-branch")
           .from(items<Order>([{ priority: "urgent", amount: 1 }]))
-          .choice<{ tag: string }>((c) =>
-            c.otherwise((b) =>
-              b.process<{ tag: string }>((ex) => ({
-                ...ex,
-                body: { tag: `${ex.body.priority}:${ex.body.amount}` },
-              })),
-            ),
-          )
+          .choice<{ tag: string }>((c) => c.otherwise((b) => b.process<{
+            tag: string;
+          }>((ex) => ({
+            ...ex,
+            body: { tag: `${ex.body.priority}:${ex.body.amount}` },
+          }))))
           .to(downstream),
       )
       .build();
@@ -758,13 +716,9 @@ describe("choice operation", () => {
         craft()
           .id("choice-validate-branch")
           .from(items<Order>([{ priority: "urgent", amount: 1 }]))
-          .choice((c) =>
-            c.otherwise((b) =>
-              b.validate(() => {
-                throw new Error("validation failed");
-              }),
-            ),
-          )
+          .choice((c) => c.otherwise((b) => b.validate(() => {
+            throw new Error("validation failed");
+          })))
           .to(downstream),
       )
       .build();
@@ -790,13 +744,11 @@ describe("choice operation", () => {
         craft()
           .id("choice-sugar-branch")
           .from(items<Order>([{ priority: "normal", amount: 99 }]))
-          .choice<{ label: string }>((c) =>
-            c.otherwise((b) =>
-              b.log().map<{ label: string }>({
-                label: (src) => `${src.priority}-${src.amount}`,
-              }),
-            ),
-          )
+          .choice<{ label: string }>((c) => c.otherwise((b) => b
+            .log()
+            .map<{ label: string }>({
+              label: (src) => `${src.priority}-${src.amount}`,
+            })))
           .to(downstream),
       )
       .build();
@@ -864,9 +816,9 @@ describe("choice operation", () => {
         craft()
           .id("choice-sugar-schema-branch")
           .from(items<Order>([{ priority: "normal", amount: 5 }]))
-          .choice<{ priority: string; amount: number }>((c) =>
-            c.otherwise((b) => b.schema(orderSchema)),
-          )
+          .choice<{ priority: string; amount: number }>((c) => c.otherwise(
+            (b) => b.schema(orderSchema),
+          ))
           .to(downstream),
       )
       .build();

--- a/packages/routecraft/test/pseudo.bun.test.ts
+++ b/packages/routecraft/test/pseudo.bun.test.ts
@@ -127,15 +127,13 @@ describe("Pseudo adapter", () => {
       const route = craft()
         .from(src<{ account: string }>({ poll: 1000 }))
         .enrich(mcp<{ messages: string[] }>({ server: "gmail", tool: "list" }))
-        .split<string>((ex) =>
-          ex.body.messages.map(
-            (body) =>
-              new DefaultExchange(getExchangeContext(ex)!, {
-                body,
-                headers: ex.headers,
-              }),
-          ),
-        )
+        .split<string>((ex) => ex.body.messages.map(
+          (body) =>
+            new DefaultExchange(getExchangeContext(ex)!, {
+              body,
+              headers: ex.headers,
+            }),
+        ))
         .to(db<{ id: string }>({ table: "emails" }));
       expectTypeOf(route).toEqualTypeOf<RouteBuilder<{ id: string }>>();
     });
@@ -299,15 +297,13 @@ describe("Pseudo adapter", () => {
         .id("pseudo-integration")
         .from(src<{ account: string }>({ poll: 1000 }))
         .enrich(mcp<{ messages: string[] }>({ server: "gmail", tool: "list" }))
-        .split<string>((ex) =>
-          ex.body.messages.map(
-            (body) =>
-              new DefaultExchange(getExchangeContext(ex)!, {
-                body,
-                headers: ex.headers,
-              }),
-          ),
-        )
+        .split<string>((ex) => ex.body.messages.map(
+          (body) =>
+            new DefaultExchange(getExchangeContext(ex)!, {
+              body,
+              headers: ex.headers,
+            }),
+        ))
         .tap(log())
         .build();
 

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,11 @@
+/**
+ * Root Prettier config for the Routecraft monorepo.
+ *
+ * The Routecraft plugin is loaded straight from TypeScript source (the same
+ * way eslint.config.mjs loads the ESLint plugin) so `bun run format` works on
+ * a fresh checkout without a build step. Format scripts run under the Bun
+ * runtime, which transpiles the `.ts` entry on import.
+ */
+export default {
+  plugins: ["./packages/prettier-plugin-routecraft/src/index.ts"],
+};


### PR DESCRIPTION
## Summary

Adds `prettier-plugin-routecraft`, a Prettier plugin that keeps Routecraft DSL chains compact:

- Keeps factory-rooted callback arrows inline where Prettier would otherwise explode them across lines, while bailing back to Prettier for comment-bearing and typed-parameter arrows so nothing is ever formatted unsafely.
- Shares one chain walker across the printer logic.
- Adds a root `prettier.config.mjs` wiring the plugin into the repo itself, and a slimmed `advanced/formatting` docs page matching the linting guide's structure.

This branch was developed previously and is opened as its own PR so the upcoming release-engineering PR (changesets, independent versioning) can include the package in the fixed version group without carrying these 7 commits in its diff.

## Verification

- `bun run all` green on the branch (build, lint, typecheck, tests).
- Plugin has its own test suite under `packages/prettier-plugin-routecraft`.

https://claude.ai/code/session_01H1s3hSMQEJNk867foNazHv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1s3hSMQEJNk867foNazHv)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@routecraft/prettier-plugin-routecraft` to keep Routecraft DSL chains compact and readable, wired via `prettier.config.mjs`. Reduces noisy indentation in `.choice()`, `.when()`, and `.otherwise()` closures without affecting non-DSL code.

- New Features
  - New `packages/prettier-plugin-routecraft` Prettier plugin that keeps parameter-threaded builder arrows inline inside `craft()` chains.
  - Leaves factory-rooted callbacks, async/typed arrows, non-chain bodies, and non-Routecraft chains to Prettier; preserves comments.
  - Enabled repo-wide via root `prettier.config.mjs`; added tests and a docs page at `/docs/advanced/formatting` (clarifies factory-rooted callbacks use Prettier defaults).

<sup>Written for commit bfea1f721639e85c43a45cda31f85ec4f11c1e31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

