### PR TITLE
fix(release): pass GITHUB_TOKEN to the canary version step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,11 @@ jobs:
 
       - name: Version snapshot
         if: steps.snapshot.outputs.publish == 'true'
+        env:
+          # @changesets/changelog-github resolves PR and author links via the
+          # GitHub API while versioning, snapshots included; without a token
+          # it aborts the whole version step.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bunx changeset version --snapshot canary
 
       # Tokenless npm auth: same Trusted Publishing config as the release job


### PR DESCRIPTION
## Summary

The first canary run after #419 failed in `changeset version --snapshot`: the `@changesets/changelog-github` generator resolves PR and author links via the GitHub API even for snapshot versions, and it hard-aborts when no `GITHUB_TOKEN` env var is present. The release job receives the token from the changesets action; the snapshot step in `publish-canary` did not. This passes the same default token to that step.

## Verification

Run [#1 of the Release workflow](https://github.com/routecraftjs/routecraft/actions/runs/27361188278): `release` and `build-and-deploy-docs` succeeded; `publish-canary` failed with `Error: Please create a GitHub personal access token ... and add it as the GITHUB_TOKEN environment variable` from `@changesets/get-github-info` during `bunx changeset version --snapshot canary`.

## After merging

The merge itself touches only `.github/workflows/`, so the changed-package detection will report no public package and skip the canary publish for this push. The pending 0.6.0 changesets remain, so the next push that touches any package will canary the core train plus ai and browser, which will also be the first live test of the `release.yml` trusted publishers on npmjs.

https://claude.ai/code/session_01H1s3hSMQEJNk867foNazHv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1s3hSMQEJNk867foNazHv)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass `GITHUB_TOKEN` to the "Version snapshot" step in `.github/workflows/release.yml` to fix failing canary snapshot versioning. This lets `@changesets/changelog-github` resolve PR and author links during `changeset version --snapshot` instead of aborting.

<sup>Written for commit ad2a20d14e8e96e4a7defb102eb5c995e3bc2cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

