### PR TITLE
docs(standards): codify package boundaries (PR D of the v1 architecture plan)

### DIFF
--- a/.standards/README.md
+++ b/.standards/README.md
@@ -16,7 +16,9 @@ Internal development standards for Routecraft contributors (human and AI). These
 | [Type Safety Registries](./type-safety-registries.md) | Declaration-merging registries for typed adapters and endpoints; codegen direction |
 | [Testing](./testing.md) | Runner conventions, JSDoc-on-every-test, helpers from `@routecraft/testing`, lifecycle pattern, assertion patterns |
 | [CI/CD](./ci-cd.md) | PR gates, hook policy, peer-dependency rules, optional peer dependencies, release flow |
+| [Package Boundaries](./package-boundaries.md) | Standards-in-core vs vendors-grouped-by-ecosystem, the bounded package count, core dependency policy (minimal-dependency ambition with pragmatic exceptions), packages created on first adapter |
 | [Resilience Wrappers](./resilience-wrappers.md) | Dual-mode wrapper pattern (`.error()` and future `.retry()`/`.timeout()`/`.cache()`/...), authoring contract, stacking + cascade rules |
+| [Pre-from Filter Chain](./pre-from-filter-chain.md) | Fixed ordered chain at route scope (`error` / `authorize` / `parse` / `input` / `throttle` / `circuitBreaker` / `retry` / `timeout` / `cacheCheck` / pipeline / `cacheStore`); framework picks the order, future wrappers slot into reserved positions |
 | [Security](./security.md) | JWT / JWKS verification rules, principal propagation across the exchange, bearer-token handling, OAuth `userinfo` enrichment, RFC 9728 metadata, `authorize()` semantics |
 | [API Stability](./api-stability.md) | The v0 policy: the whole public API is unstable, so we tag only `@internal` (non-public) and `@deprecated`; per-symbol `@experimental` / `@beta` / `@stable` tiers arrive at v1 |
 | [Content and Docs](./content-and-docs.md) | Where content belongs across the docs site and blog (the five surfaces), the depth axis between introduction and advanced, code-lives-once, nav-matches-folders, the `route.ts` public-surface decision, and the static-export redirect constraint |

--- a/.standards/package-boundaries.md
+++ b/.standards/package-boundaries.md
@@ -1,0 +1,53 @@
+# Package Boundaries
+
+Where code lives across the `@routecraft/*` packages and what dependencies each kind of package may carry. Decided 2026-06-12; this codifies the package-boundary decision so contributors and review bots can check changes against it.
+
+The goal is a bounded package count: roughly 8 to 12 packages long term, regardless of how many integrations exist.
+
+---
+
+## 1. Standards live in core; vendors group by ecosystem
+
+The boundary question for any new adapter is: **is this a protocol standard or a vendor product?**
+
+- **Protocol standards stay in core** (`@routecraft/routecraft`): HTTP, mail (SMTP/IMAP), CardDAV, cron, files, CSV, JSONL. A standard outlives any vendor, and its SDK cost is contained by the optional-peer mechanism (section 3).
+- **Vendor products group into one package per logical domain**, never one package per integration:
+
+| Package | Contents |
+|---------|----------|
+| `@routecraft/auth` | Vendor auth providers that do not justify their own package: `clerk()`, `workos()`, and peers. Accepted trade-off: a WorkOS change ships a Clerk update too; it is one package. |
+| `@routecraft/google` | Google ecosystem: a `gmail` adapter (mail-the-protocol stays in core), Sheets, Docs, PubSub. |
+| `@routecraft/messaging` (future) | Slack, Teams, and similar, when needed. |
+
+Rules that follow:
+
+- A new integration **within** an existing domain goes into that domain's package. It never creates a new package.
+- A new **logical domain** creates exactly one new package, following the checklist in [`ci-cd.md` section 4](./ci-cd.md#4-adding-a-new-package-the-checklist).
+- Packages are created **when their first adapter lands**, not speculatively. An empty package is release-train weight with no user.
+
+## 2. Auth: protocol in core, vendors in `@routecraft/auth`
+
+JWT, JWKS, API keys, OAuth flows, and the principal object are protocol-level standards and stay in core (see [`security.md`](./security.md)). Vendor products on top of them (Clerk, WorkOS) belong in `@routecraft/auth`.
+
+`@routecraft/auth` factories must be **transport-agnostic**: they return the common auth interface consumed by both the MCP transport and the HTTP transport. The same `workos()` call works on either; the transport does not care how auth works internally.
+
+## 3. Dependency policy for core
+
+Zero third-party runtime dependencies in core is the **ambition, not a hard rule**. Exceptions are allowed when the library is popular, well maintained, and makes the effort significantly easier than inlining or reimplementing. Adding a hard dependency to core is a reviewed decision, not a default.
+
+- **Accepted core dependencies** (the current exception list): `pino`, `lru-cache`, `@opentelemetry/api`, `@standard-schema/spec`. The latter two are interface standards with no meaningful runtime of their own.
+- **Bun-native APIs** (Redis, S3) are always fine: no external SDK is introduced.
+- **Vendor and protocol SDKs for adapters are never hard dependencies.** They are optional peers loaded through `loadOptionalPeer` with an `RC5017` install hint, per [`ci-cd.md` section 6](./ci-cd.md#6-optional-peer-dependencies-provider-sdks). Installing core must never pull a vendor SDK transitively.
+
+Ecosystem packages are not bound by the core ambition. `@routecraft/ai` depends on the Vercel AI SDK and that is accepted: `@routecraft/ai` is **not core**, and docs must not present it as such. Ecosystem packages still follow the `@routecraft/*` peer-dependency shape in [`ci-cd.md` section 5](./ci-cd.md#5-dependency-policy-on-routecraft).
+
+## 4. What this supersedes
+
+An earlier note (March 2026) proposed moving `mail()` out of core into `@routecraft/email`. That is superseded: mail is a protocol standard and stays in core. Vendor mail products (Gmail-specific APIs) go to `@routecraft/google` when built.
+
+## Related
+
+- [CI/CD](./ci-cd.md) -- adding a package, dependency shapes, optional peers
+- [Adapter Architecture](./adapter-architecture.md) -- how to build the adapter once its home is decided
+- [Naming Policy](./naming-policy.md) -- what to call it
+- [Security](./security.md) -- the protocol-level auth that stays in core

--- a/.standards/package-boundaries.md
+++ b/.standards/package-boundaries.md
@@ -36,7 +36,7 @@ JWT, JWKS, API keys, OAuth flows, and the principal object are protocol-level st
 Zero third-party runtime dependencies in core is the **ambition, not a hard rule**. Exceptions are allowed when the library is popular, well maintained, and makes the effort significantly easier than inlining or reimplementing. Adding a hard dependency to core is a reviewed decision, not a default.
 
 - **Accepted core dependencies** (the current exception list): `pino`, `lru-cache`, `@opentelemetry/api`, `@standard-schema/spec`. The latter two are interface standards with no meaningful runtime of their own.
-- **Bun-native APIs** (Redis, S3) are always fine: no external SDK is introduced.
+- **Bun-native APIs** (`Bun.redis`, `Bun.s3`, `bun:sqlite`) do not count against the dependency budget: no external SDK is introduced. They are not a blanket license, though: core targets Node 22+ as well as Bun, so any Bun-native usage needs a Node-equivalent code path (a `node:` builtin or an optional peer such as `@aws-sdk/client-s3`), proven by cross-runtime tests in both arms per [`ci-cd.md` section 2](./ci-cd.md#2-the-pr-gates).
 - **Vendor and protocol SDKs for adapters are never hard dependencies.** They are optional peers loaded through `loadOptionalPeer` with an `RC5017` install hint, per [`ci-cd.md` section 6](./ci-cd.md#6-optional-peer-dependencies-provider-sdks). Installing core must never pull a vendor SDK transitively.
 
 Ecosystem packages are not bound by the core ambition. `@routecraft/ai` depends on the Vercel AI SDK and that is accepted: `@routecraft/ai` is **not core**, and docs must not present it as such. Ecosystem packages still follow the `@routecraft/*` peer-dependency shape in [`ci-cd.md` section 5](./ci-cd.md#5-dependency-policy-on-routecraft).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Detailed coding standards for contributors live in `.standards/`:
 - [Type Safety Registries](.standards/type-safety-registries.md) -- declaration-merging registries for typed adapters and endpoints
 - [Testing](.standards/testing.md) -- runner conventions, JSDoc-on-every-test, helpers, lifecycle, assertion patterns
 - [CI/CD](.standards/ci-cd.md) -- PR gates, hook policy, peer-dependency rules, release flow
+- [Package Boundaries](.standards/package-boundaries.md) -- standards-in-core vs vendors-grouped-by-ecosystem, bounded package count, core dependency policy (minimal-dependency ambition with pragmatic exceptions), packages created on first adapter
 - [Resilience Wrappers](.standards/resilience-wrappers.md) -- dual-mode wrapper pattern (`.error()` and future resilience ops), authoring contract
 - [Pre-from Filter Chain](.standards/pre-from-filter-chain.md) -- fixed ordered chain at route scope (`error` / `authorize` / `parse` / `input` / `throttle` / `circuitBreaker` / `retry` / `timeout` / `cacheCheck` / pipeline / `cacheStore`); framework picks the order, future wrappers slot into reserved positions
 - [Security](.standards/security.md) -- JWT / JWKS verification, principal propagation, bearer-token handling, `userinfo` enrichment, RFC 9728 metadata, `authorize()` semantics


### PR DESCRIPTION
PR D of the v1 architecture plan (A: #418 prettier plugin, B: #419 release engineering, C: #431 core API future-proofing). The original packaging scope was decided down to documentation: the package-boundary decision was amended on 2026-06-12 (zero-dependency core is an ambition with pragmatic exceptions; mail stays in core as a protocol standard), which removes all code work from this PR. What remains is codifying the rules so contributors and review bots check changes against them.

## What

- **New `.standards/package-boundaries.md`** recording the approved rules:
  - Protocol standards (HTTP, mail, CardDAV, cron, files, CSV, JSONL) stay in core; vendor products group into one package per ecosystem domain (`@routecraft/auth` for Clerk/WorkOS/peers, `@routecraft/google` for Gmail/Sheets/Docs/PubSub, future `@routecraft/messaging`). New integrations within a domain never create packages; packages are created when their first adapter lands, not speculatively. Target: 8 to 12 packages long term.
  - `@routecraft/auth` factories are transport-agnostic; protocol-level auth (JWT, JWKS, API keys, OAuth, principal) stays in core per `.standards/security.md`.
  - Core dependency policy: zero third-party runtime deps is the ambition, not a hard rule; popular libraries that significantly ease effort are allowed as reviewed exceptions (current list: `pino`, `lru-cache`, `@opentelemetry/api`, `@standard-schema/spec`). Vendor SDKs are never hard deps; always optional peers via `loadOptionalPeer`/RC5017.
  - Supersedes the March 2026 note about moving `mail()` to `@routecraft/email`.
- **Indexes** the new standard in `.standards/README.md` and `CLAUDE.md`.
- **Drive-by fix**: adds the Pre-from Filter Chain row that was missing from the `.standards/README.md` table (CLAUDE.md already listed it).

## Notes

- Docs-only, non-breaking, no changeset (standards are not published).
- This closes out the v1 architecture PR train. The "Version Packages" PR #427 is not waiting on anything after this; merging it cuts 0.6.0.

https://claude.ai/code/session_01H1s3hSMQEJNk867foNazHv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1s3hSMQEJNk867foNazHv)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codifies package boundaries for v1: protocol standards stay in core, and vendor integrations group into ecosystem packages like `@routecraft/auth` and `@routecraft/google` (created on first adapter).
Documents the core dependency policy (zero-dep ambition with exceptions: `pino`, `lru-cache`, `@opentelemetry/api`, `@standard-schema/spec`), requires Node-equivalent fallbacks with cross-runtime tests for Bun-native APIs, keeps auth protocol in core with vendors in `@routecraft/auth`, supersedes moving `mail()` to `@routecraft/email`, and indexes the new standard with a small README fix.

<sup>Written for commit be5df3b7f3413f7ead7bd145f45f741896d637ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

