### PR TITLE
Centralize exchange drop logic with emitExchangeDropped helper

### DIFF
--- a/packages/routecraft/src/exchange.ts
+++ b/packages/routecraft/src/exchange.ts
@@ -305,8 +305,9 @@ type ExchangeInternals = {
    */
   startedAt?: number;
   /**
-   * Set by filter, choice (halt + unmatched), and the synthetic parse
-   * step when an exchange is dropped. The runtime engine reads this
+   * Set when an exchange is dropped (filter, choice halt / unmatched,
+   * parse drop, input-validation drop, `recovery.drop()` directives; see
+   * {@link emitExchangeDropped}). The runtime engine reads this
    * after `runPipeline` completes to skip `exchange:completed` emission.
    * Stored on internals so the flag survives `rewrap`: the engine
    * rewraps an exchange before each step (to update the operation
@@ -364,8 +365,11 @@ export function getExchangeRoute(exchange: Exchange): Route | undefined {
 }
 
 /**
- * Mark an exchange as dropped. Idempotent. Used by filter, choice, halt,
- * and the synthetic parse step's drop branch.
+ * Mark an exchange as dropped. Idempotent. Drop sites that also emit
+ * `route:exchange:dropped` go through {@link emitExchangeDropped}, which
+ * wraps this; call this directly only when there is no emission to pair
+ * with (e.g. the cache wrapper's loader-drop path, or marking ahead of an
+ * earlier event that carries the exchange).
  *
  * The drop flag lives on the exchange's internals object (which is shared
  * by reference across `rewrap`) rather than a per-instance WeakSet, so a
@@ -381,6 +385,45 @@ export function markDropped(exchange: Exchange): void {
       INTERNALS_KEY
     ] ?? EXCHANGE_INTERNALS.get(exchange);
   if (internals) internals.dropped = true;
+}
+
+/**
+ * Drop an exchange: mark it dropped, then emit `route:exchange:dropped`.
+ *
+ * This is the single sanctioned way to drop an exchange from a step or
+ * pipeline site. The mark MUST precede the emission so a subscriber that
+ * calls `isDropped(event.details.exchange)` observes the correct state;
+ * the runtime engine reads the flag after `runPipeline` to skip
+ * `exchange:completed` (see `pipeline/executor.ts`). The mark is
+ * unconditional ({@link markDropped} is idempotent); the emission is
+ * skipped when no context is bound, which keeps the drop flag correct
+ * for synthetic exchanges in unit tests.
+ *
+ * Sites that emit additional events before the drop (`step:completed`,
+ * `step:failed`, `operation:choice:unmatched`, error-handler events)
+ * keep those emissions local and call this helper last, so
+ * `route:exchange:dropped` stays the final event for the exchange.
+ *
+ * @internal
+ */
+export function emitExchangeDropped(
+  context: CraftContext | undefined,
+  details: {
+    routeId: string;
+    correlationId: string;
+    reason: string;
+    exchange: Exchange;
+  },
+): void {
+  const { routeId, correlationId, reason, exchange } = details;
+  markDropped(exchange);
+  context?.emit("route:exchange:dropped", {
+    routeId,
+    exchangeId: exchange.id,
+    correlationId,
+    reason,
+    exchange,
+  });
 }
 
 /**

--- a/packages/routecraft/src/operations/choice.ts
+++ b/packages/routecraft/src/operations/choice.ts
@@ -5,7 +5,7 @@ import {
   HeadersKeys,
   getExchangeContext,
   getExchangeRoute,
-  markDropped,
+  emitExchangeDropped,
 } from "../exchange.ts";
 import { rcError } from "../error.ts";
 import { COLLECT_STEPS } from "../dsl-symbol.ts";
@@ -70,19 +70,12 @@ export class HaltStep implements Step<HaltAdapter> {
       HeadersKeys.CORRELATION_ID
     ] as string;
 
-    // Mark before emit so subscribers calling `isDropped(event.details.exchange)`
-    // observe the correct state.
-    markDropped(exchange);
-
-    if (context) {
-      context.emit("route:exchange:dropped", {
-        routeId,
-        exchangeId: exchange.id,
-        correlationId,
-        reason: "halted",
-        exchange,
-      });
-    }
+    emitExchangeDropped(context, {
+      routeId,
+      correlationId,
+      reason: "halted",
+      exchange,
+    });
 
     return { kind: "drop" };
   }
@@ -300,9 +293,6 @@ export class ChoiceStep<In = unknown> implements Step<ChoiceAdapter> {
     }
 
     if (!matchedBranch) {
-      // Mark before emit so subscribers calling
-      // `isDropped(event.details.exchange)` observe the correct state.
-      markDropped(exchange);
       if (context) {
         context.emit("route:step:completed", {
           routeId,
@@ -317,14 +307,13 @@ export class ChoiceStep<In = unknown> implements Step<ChoiceAdapter> {
           exchangeId: exchange.id,
           correlationId,
         });
-        context.emit("route:exchange:dropped", {
-          routeId,
-          exchangeId: exchange.id,
-          correlationId,
-          reason: "unmatched",
-          exchange,
-        });
       }
+      emitExchangeDropped(context, {
+        routeId,
+        correlationId,
+        reason: "unmatched",
+        exchange,
+      });
       return { kind: "drop" };
     }
 

--- a/packages/routecraft/src/operations/filter.ts
+++ b/packages/routecraft/src/operations/filter.ts
@@ -10,7 +10,7 @@ import {
   HeadersKeys,
   getExchangeContext,
   getExchangeRoute,
-  markDropped,
+  emitExchangeDropped,
 } from "../exchange.ts";
 import { rcError } from "../error.ts";
 
@@ -109,33 +109,22 @@ export class FilterStep<T = unknown> implements Step<Filter<T>> {
           "Filter rejected exchange",
         );
 
-        // Mark the exchange as dropped before emitting `exchange:dropped`
-        // so a subscriber that calls `isDropped(event.details.exchange)`
-        // observes the correct state. The drop flag lives on the
-        // exchange's shared internals object (see `markDropped` /
-        // `isDropped` in `exchange.ts`); the route engine reads it
-        // after `runPipeline` to skip `exchange:completed`.
-        markDropped(exchange);
+        // Emit step:completed first, then exchange:dropped
+        context?.emit("route:step:completed", {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          operation: stepLabel,
+          ...(adapterLabel ? { adapter: adapterLabel } : {}),
+          duration: Date.now() - stepStart,
+        });
 
-        if (context) {
-          // Emit step:completed first, then exchange:dropped
-          context.emit("route:step:completed", {
-            routeId,
-            exchangeId: exchange.id,
-            correlationId,
-            operation: stepLabel,
-            ...(adapterLabel ? { adapter: adapterLabel } : {}),
-            duration: Date.now() - stepStart,
-          });
-
-          context.emit("route:exchange:dropped", {
-            routeId,
-            exchangeId: exchange.id,
-            correlationId,
-            reason: dropReason,
-            exchange,
-          });
-        }
+        emitExchangeDropped(context, {
+          routeId,
+          correlationId,
+          reason: dropReason,
+          exchange,
+        });
         return { kind: "drop" };
       }
     } catch (error: unknown) {

--- a/packages/routecraft/src/pipeline/synthetic-steps.ts
+++ b/packages/routecraft/src/pipeline/synthetic-steps.ts
@@ -4,7 +4,7 @@ import {
   OperationType,
   DefaultExchange,
   EXCHANGE_INTERNALS,
-  markDropped,
+  emitExchangeDropped,
 } from "../exchange.ts";
 import { rcError } from "../error.ts";
 import { isRoutecraftError } from "../brand.ts";
@@ -119,14 +119,8 @@ export function buildParseStep(
           // counting parse failures see step:failed; subscribers
           // tracking drop policy see exchange:dropped.
           emitStepFailed(cause);
-          // Mark dropped before `exchange:dropped` fires so subscribers
-          // calling `isDropped(event.details.exchange)` observe the
-          // correct state. The route engine reads it after `runPipeline`
-          // to skip `exchange:completed`.
-          markDropped(exchange);
-          context?.emit("route:exchange:dropped", {
+          emitExchangeDropped(context, {
             routeId,
-            exchangeId: exchange.id,
             correlationId,
             reason: PARSE_DROPPED_REASON,
             exchange,

--- a/packages/routecraft/src/pipeline/validation.ts
+++ b/packages/routecraft/src/pipeline/validation.ts
@@ -5,6 +5,7 @@ import {
   type ExchangeHeaders,
   HeadersKeys,
   DefaultExchange,
+  emitExchangeDropped,
 } from "../exchange.ts";
 import { rcError, RoutecraftError, formatSchemaIssues } from "../error.ts";
 import type { ErrorHandler, ForwardFn, Route } from "../route.ts";
@@ -161,9 +162,8 @@ export function emitInputValidationFailure(
     exchangeId: exchange.id,
     correlationId,
   });
-  deps.context.emit("route:exchange:dropped", {
+  emitExchangeDropped(deps.context, {
     routeId,
-    exchangeId: exchange.id,
     correlationId,
     reason: `input validation failed: ${message}`,
     exchange,

--- a/packages/routecraft/src/recovery.ts
+++ b/packages/routecraft/src/recovery.ts
@@ -1,4 +1,4 @@
-import { markDropped, type Exchange } from "./exchange.ts";
+import { markDropped, emitExchangeDropped, type Exchange } from "./exchange.ts";
 import { BRAND, isBranded } from "./brand.ts";
 import type { CraftContext } from "./context.ts";
 import type { Route } from "./route.ts";
@@ -137,6 +137,9 @@ export function applyDropDirective(args: {
     stepLabel,
   } = args;
 
+  // Mark eagerly (ahead of the final mark-and-emit below) so subscribers
+  // to `route:error:caught`, whose payload carries the exchange, already
+  // observe `isDropped(exchange) === true`.
   markDropped(exchange);
 
   if (scope === "route" && route) {
@@ -160,9 +163,8 @@ export function applyDropDirective(args: {
     ...(stepLabel !== undefined ? { stepLabel } : {}),
   });
 
-  context.emit("route:exchange:dropped", {
+  emitExchangeDropped(context, {
     routeId,
-    exchangeId: exchange.id,
     correlationId,
     reason,
     exchange,


### PR DESCRIPTION
## Summary

Introduces `emitExchangeDropped()` helper to consolidate the mark-then-emit pattern used across all exchange drop sites. This ensures consistent ordering (mark before emit) and reduces duplication while clarifying the contract for when to use `markDropped()` directly vs. the new helper.

## Changes

- **New `emitExchangeDropped()` helper** (`exchange.ts`): Encapsulates the required pattern of marking an exchange dropped before emitting `route:exchange:dropped`. Includes comprehensive JSDoc explaining the ordering requirement (subscribers calling `isDropped()` on the event details must observe the correct state) and when to call `markDropped()` directly instead.

- **Updated drop sites to use the helper**:
  - `FilterStep`: Replaced inline mark-and-emit with `emitExchangeDropped()` call
  - `HaltStep` and `ChoiceStep` (unmatched branch): Replaced inline mark-and-emit with `emitExchangeDropped()` call
  - Synthetic parse step: Replaced inline mark-and-emit with `emitExchangeDropped()` call
  - Input validation failure handler: Replaced inline mark-and-emit with `emitExchangeDropped()` call
  - Recovery drop directive: Added early `markDropped()` call (ahead of error event emission) so subscribers to `route:error:caught` observe the correct drop state, then uses `emitExchangeDropped()` for the final mark-and-emit

- **Updated JSDoc**: Clarified `markDropped()` contract to distinguish it from the new helper, noting it should be called directly only when there is no paired emission (e.g., cache wrapper loader-drop path, or marking ahead of an earlier event).

## Implementation Details

The helper maintains the critical invariant that `markDropped()` is called before `route:exchange:dropped` emission, ensuring subscribers that inspect `isDropped(event.details.exchange)` in their handlers observe the correct state. The mark is unconditional (idempotent); emission is skipped when no context is bound, preserving correctness for synthetic exchanges in unit tests.

Drop sites that emit additional events before the drop (e.g., `step:completed`, `step:failed`, `operation:choice:unmatched`) keep those emissions local and call `emitExchangeDropped()` last, ensuring `route:exchange:dropped` remains the final event for the exchange.

https://claude.ai/code/session_01DzpWdADXRwDebBYP68vZnE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes exchange drop handling with a new `emitExchangeDropped` helper that marks an exchange as dropped and then emits `route:exchange:dropped`. This unifies behavior across steps and fixes inconsistent state during input validation drops.

- **Refactors**
  - Added `emitExchangeDropped` (wraps `markDropped` and emits), keeping `markDropped` for no-emission or early-mark cases.
  - Migrated all drop sites to the helper: Filter, Choice halt/unmatched, synthetic parse, input validation, and recovery (keeps early mark for `route:error:caught`, then uses the helper).
  - Ensures `route:exchange:dropped` is the final event for an exchange.

- **Bug Fixes**
  - Input validation now marks before emitting the drop event, so subscribers always observe `isDropped(exchange) === true`.

<sup>Written for commit 829067a34056b80f24a37d5120615d0f63bd7d26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

