### PR TITLE
feat(mail)!: require folder to discriminate object-form fetch from send

### DIFF
--- a/.standards/naming-policy.md
+++ b/.standards/naming-policy.md
@@ -41,6 +41,22 @@ export type MailOptions = MailServerOptions | MailClientOptions;
 
 Do not invent an empty `XxxBaseOptions` to make the structure look uniform; the union is what matters and an empty parent only adds friction. The decision rule is "would I write the same field on both Server and Client?" -- if yes for two or more fields, factor; otherwise, declare independently.
 
+### Discriminating the two sides
+
+Every call shape of a multiplexed factory must be distinguishable by a **required, side-unique key** (or by argument kind: string vs object vs function). At most one side per facade may offer an all-optional "bare default" form; that slot goes to the most common zero-config use.
+
+| Facade | Discrimination |
+|--------|----------------|
+| `http` | `path` (server) vs `url` (client), both required |
+| `mcp` | bare object (source) vs required `url` / `serverId` (client) |
+| `carddav` | bare object (read) vs required `action` (write) |
+| `direct` | bare/options object (source) vs endpoint string/function (destination) |
+| `mail` | bare object (send) vs required `folder` (fetch) vs required `action` (operations) |
+
+Key-sniffing heuristics over *optional* keys are forbidden. TypeScript resolves overloads from arguments only (never from the `.to()` / `.enrich()` context), so when two sides are both all-optional the compiler silently picks the first structurally matching overload while the runtime guesses from whichever keys happen to be present -- the two drift apart and the types lie (issue #433 is the case study; the mail adapter's old `hasServerKeys()` shipped four keys out of sync). Optional phantom/brand fields do not fix this: they do not affect assignability of object literals.
+
+When an ambiguous shape can still reach the factory at runtime (plain JS), throw `RC5003` naming the conflicting keys; never guess a side.
+
 ## Single-role adapters
 
 Adapters that only act as source or only as destination (timer, simple, log, noop) use a single options type: **XxxOptions** (e.g., `TimerOptions`, `LogOptions`). Do not use Server/Client in their option names.

--- a/apps/routecraft.dev/src/app/cheat-sheet/page.tsx
+++ b/apps/routecraft.dev/src/app/cheat-sheet/page.tsx
@@ -221,12 +221,13 @@ await ctx.stop()`}</CheatCode>
 .to(jsonl({ file: './out.jsonl' }))
 .to(csv({ file: './out.csv' }))
 
-// Send email via SMTP
-.to(mail({
-  to: ex => ex.body.email,
+// Send email via SMTP (payload from the exchange body)
+.transform(body => ({
+  to: body.email,
   subject: 'Hello',
-  text: ex => ex.body.text,
-}))`}</CheatCode>
+  text: body.text,
+}))
+.to(mail())`}</CheatCode>
           </CheatSection>
 
           <CheatSection id="exchanges" eyebrow="Envelope" title="Exchanges">

--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -519,7 +519,7 @@ Stack `.authorize()` calls to AND-combine; the first failure short-circuits.
 import { authorize } from "@routecraft/routecraft"
 
 craft()
-  .from(mail({ /* ... */ }))
+  .from(mail("INBOX", { /* ... */ }))
   .process(attachEmailPrincipal)
   .validate(authorize({ predicate: (p) => p.email?.endsWith("@yourcompany.com") === true }))
   .to(yourDestination)

--- a/apps/routecraft.dev/src/app/docs/migrating/0.5-to-0.6/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.5-to-0.6/page.md
@@ -449,6 +449,26 @@ The field-to-header mapping:
 
 `.to(mail({ action: "move", ... }))` and the other IMAP operations already resolved their target from the `routecraft.mail.uid` / `routecraft.mail.folder` headers (or a custom `target` extractor), so chains like `mail source -> filter -> mail move` keep working without change.
 
+### 4.4 Object-form fetch requires `folder`
+
+`MailServerOptions` (IMAP fetch) and `MailClientOptions` (SMTP send) overlap on `host` / `port` / `secure` / `auth` / `account`, so the old object-form overloads could not tell a fetch from a send: the compiler resolved ambiguous calls to the fetch overload while the runtime key-sniffed its way to the send adapter, and the two regularly disagreed. In 0.6.0 the object-form fetch destination requires `folder`, which is the discriminator: an options object with `folder` is a fetch, one without it is a send. Fetch-only keys without `folder` are a compile error, and plain JS gets `RC5003` at construction instead of a guessed side.
+
+**Before (0.5.x):**
+
+```ts
+.enrich(mail({ unseen: true, limit: 10 }))
+```
+
+**After (0.6.0):**
+
+```ts
+.enrich(mail({ folder: "INBOX", unseen: true, limit: 10 }))
+// or keep the shorthand when defaults suffice
+.enrich(mail("INBOX"))
+```
+
+The `mail("INBOX")` string shorthand, the two-argument source form, `{ action }` operations, and bare `mail()` sends are unchanged. Send options gain real typechecking from this: `.to(mail({ host, auth }))` now resolves to `Destination<MailSendPayload, MailSendResult>` instead of the fetch signature, so payload mistakes surface at compile time and no cast is needed.
+
 ---
 
 ## 5. Events: fixed names, identity in the payload

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/mail/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/mail/page.md
@@ -7,8 +7,8 @@ title: mail
 ```ts
 mail(folder: string, options: Partial<MailServerOptions>): Source<MailBody>
 mail(folder: string): Destination<unknown, MailFetchResult>
-mail(options: Partial<MailServerOptions>): Destination<unknown, MailFetchResult>
 mail(action: MailAction): Destination<unknown, void>
+mail(options: MailServerOptions & { folder: string }): Destination<unknown, MailFetchResult>
 mail(options?: Partial<MailClientOptions>): Destination<MailSendPayload, MailSendResult>
 ```
 
@@ -68,7 +68,7 @@ craft()
   .to(processMessage())
 ```
 
-**Fetch destination (IMAP pull):** Pass a folder string or server options to fetch messages. Use with `.enrich()` to pull mail on demand.
+**Fetch destination (IMAP pull):** Pass a folder string, or server options containing `folder`, to fetch messages. Use with `.enrich()` to pull mail on demand. The `folder` key is required in the object form: it is what distinguishes a fetch from a send, the same way `http` splits on `path` vs `url`.
 
 ```ts
 craft()
@@ -76,9 +76,16 @@ craft()
   .from(cron('0 */5 * * * *'))
   .enrich(mail('INBOX'))
   .to(log())
+
+// Object form: `folder` is required and marks the fetch intent
+craft()
+  .id('check-unread')
+  .from(cron('0 */5 * * * *'))
+  .enrich(mail({ folder: 'INBOX', unseen: true, limit: 10 }))
+  .to(log())
 ```
 
-**Send destination (SMTP):** Call with no arguments or client options to send email. The exchange body must be a `MailSendPayload`.
+**Send destination (SMTP):** Call with no arguments or client options (no `folder`) to send email. The exchange body must be a `MailSendPayload`.
 
 ```ts
 craft()
@@ -173,7 +180,7 @@ When multiple accounts are configured, select one per adapter call with the `acc
 | `port` | `number` | `993` | IMAP port |
 | `secure` | `boolean` | `true` | Use TLS |
 | `auth` | `MailAuth` | | `{ user, pass }` credentials |
-| `folder` | `string` | `'INBOX'` | IMAP mailbox folder |
+| `folder` | `string` | | IMAP mailbox folder. Required in the object-form fetch destination, where it is the fetch/send discriminator; passed positionally in the source form |
 | `markSeen` | `boolean` | `true` | Mark fetched messages as seen |
 | `since` | `Date` | | Only fetch messages since this date |
 | `unseen` | `boolean` | `true` | Only fetch unseen messages |

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
@@ -505,7 +505,7 @@ For programmatic assertions ("the agent must have replied via `replyEmail`, othe
 ```ts
 craft()
   .id("inbox-bot")
-  .from(mail({ account: "support" }))
+  .from(mail("INBOX", { account: "support" }))
   .to(agent({
     system: "Reply to the customer via replyEmail. If you cannot answer, leave it unanswered.",
     tools: tools(["replyEmail"]),

--- a/packages/routecraft/src/adapters/mail/index.ts
+++ b/packages/routecraft/src/adapters/mail/index.ts
@@ -134,24 +134,47 @@ export function mail(
 }
 
 /**
+ * Option keys that exist on {@link MailServerOptions} but not on
+ * {@link MailClientOptions}. Keys shared by both sides (`host`, `port`,
+ * `secure`, `auth`, `account`, `from`) carry no intent and are excluded
+ * by the `Exclude<>` automatically.
+ */
+type ServerOnlyKey = Exclude<keyof MailServerOptions, keyof MailClientOptions>;
+
+/**
+ * Exhaustive map of server-only keys, used by {@link hasServerKeys} to
+ * discriminate fetch intent from send intent at runtime. `Record<ServerOnlyKey,
+ * true>` makes the list exhaustive by construction: adding a field to
+ * MailServerOptions that is absent from MailClientOptions without listing it
+ * here is a compile error, so this runtime heuristic cannot drift from the
+ * option types (it previously had: `verify`, `onParseError`, `description`,
+ * and `keywords` dispatched to the send destination).
+ */
+const SERVER_ONLY_KEYS: Record<ServerOnlyKey, true> = {
+  folder: true,
+  markSeen: true,
+  since: true,
+  unseen: true,
+  to: true,
+  subject: true,
+  body: true,
+  header: true,
+  limit: true,
+  description: true,
+  keywords: true,
+  pollIntervalMs: true,
+  includeHeaders: true,
+  verify: true,
+  onParseError: true,
+  reconnect: true,
+};
+
+/**
  * Check whether options contain server-specific keys that indicate
  * an IMAP fetch/source intent rather than an SMTP send intent.
  */
 function hasServerKeys(opts: object): boolean {
-  return (
-    "folder" in opts ||
-    "markSeen" in opts ||
-    "since" in opts ||
-    "unseen" in opts ||
-    "limit" in opts ||
-    "pollIntervalMs" in opts ||
-    "subject" in opts ||
-    "to" in opts ||
-    "body" in opts ||
-    "header" in opts ||
-    "includeHeaders" in opts ||
-    "reconnect" in opts
-  );
+  return Object.keys(SERVER_ONLY_KEYS).some((key) => key in opts);
 }
 
 // Re-export types for public API

--- a/packages/routecraft/src/adapters/mail/index.ts
+++ b/packages/routecraft/src/adapters/mail/index.ts
@@ -1,5 +1,6 @@
 import type { Source } from "../../operations/from.ts";
 import type { Destination } from "../../operations/to.ts";
+import { rcError } from "../../error.ts";
 import { tagAdapter, factoryArgs } from "../shared/factory-tag.ts";
 import { MailSourceAdapter } from "./source.ts";
 import { MailFetchDestinationAdapter } from "./fetch-destination.ts";
@@ -22,11 +23,14 @@ import type {
  * **Source (for `.from()`):** Call with two arguments: `mail(folder, options)`.
  * Uses IMAP IDLE or polling to push new messages to the route.
  *
- * **Fetch Destination (for `.enrich()`):** Call with a folder string or server options.
- * Fetches messages from IMAP and returns them as the enrichment result.
+ * **Fetch Destination (for `.enrich()`):** Call with a folder string or server
+ * options containing `folder`. The required `folder` key is what distinguishes
+ * a fetch from a send (the object-form counterpart of the `mail('INBOX')`
+ * shorthand, mirroring `http`'s `path` vs `url` split). Fetches messages from
+ * IMAP and returns them as the enrichment result.
  *
- * **Send Destination (for `.to()`):** Call with no arguments or client options.
- * Sends email via SMTP using the exchange body as the payload.
+ * **Send Destination (for `.to()`):** Call with no arguments or client options
+ * (no `folder`). Sends email via SMTP using the exchange body as the payload.
  *
  * **Operation Destination (for `.to()`):** Call with a MailAction object.
  * Performs IMAP operations (move, copy, delete, flag, unflag, append) on messages.
@@ -37,6 +41,12 @@ import type {
  * craft()
  *   .from(cron('0 0/5 * * * *'))
  *   .enrich(mail('INBOX'))
+ *   .to(processMessages())
+ *
+ * // Fetch with options: `folder` is required and marks the fetch intent
+ * craft()
+ *   .from(cron('0 0/5 * * * *'))
+ *   .enrich(mail({ folder: 'INBOX', unseen: true, limit: 10 }))
  *   .to(processMessages())
  *
  * // Source: IMAP IDLE for push-based processing
@@ -70,10 +80,10 @@ export function mail(
   options: MailServerOptions,
 ): Source<MailBody>;
 export function mail(folder: string): Destination<unknown, MailFetchResult>;
-export function mail(
-  options: MailServerOptions,
-): Destination<unknown, MailFetchResult>;
 export function mail(action: MailAction): Destination<unknown, void>;
+export function mail(
+  options: MailServerOptions & { folder: string },
+): Destination<unknown, MailFetchResult>;
 export function mail(
   options?: MailClientOptions,
 ): Destination<MailSendPayload, MailSendResult>;
@@ -104,7 +114,8 @@ export function mail(
     >;
   }
 
-  // Action discriminator -> Operation Destination (checked before hasServerKeys)
+  // Action discriminator -> Operation Destination (checked before `folder`:
+  // move/copy/append actions carry a folder of their own)
   if (folderOrOptions && "action" in folderOrOptions) {
     const adapter = new MailOperationDestinationAdapter(
       folderOrOptions as MailAction,
@@ -112,8 +123,10 @@ export function mail(
     return tagAdapter(adapter, mail, args) as Destination<unknown, void>;
   }
 
-  // Object with server-specific keys -> Fetch Destination
-  if (folderOrOptions && hasServerKeys(folderOrOptions)) {
+  // `folder` is the required fetch discriminator (object-form counterpart of
+  // the mail('INBOX') shorthand). Key presence declares the intent; an
+  // undefined value still resolves through the context-level folder default.
+  if (folderOrOptions && "folder" in folderOrOptions) {
     const adapter = new MailFetchDestinationAdapter(
       folderOrOptions as MailServerOptions,
     );
@@ -121,6 +134,20 @@ export function mail(
       unknown,
       MailFetchResult
     >;
+  }
+
+  // Fetch-only keys without `folder` mean the intent is ambiguous (fetch
+  // options, send dispatch). Refuse rather than guess; only reachable from
+  // untyped JS because the overloads reject this shape at compile time.
+  if (folderOrOptions) {
+    const fetchOnly = serverOnlyKeysIn(folderOrOptions);
+    if (fetchOnly.length > 0) {
+      throw rcError("RC5003", undefined, {
+        message: `mail() options include IMAP fetch keys (${fetchOnly.join(", ")}) but no folder; cannot tell fetch intent from send intent`,
+        suggestion:
+          "Add folder (e.g. mail({ folder: 'INBOX', ... })) or use the mail('INBOX') shorthand to fetch; remove fetch-only keys to send via SMTP",
+      });
+    }
   }
 
   // No args or client-only keys -> Send Destination
@@ -142,13 +169,13 @@ export function mail(
 type ServerOnlyKey = Exclude<keyof MailServerOptions, keyof MailClientOptions>;
 
 /**
- * Exhaustive map of server-only keys, used by {@link hasServerKeys} to
- * discriminate fetch intent from send intent at runtime. `Record<ServerOnlyKey,
- * true>` makes the list exhaustive by construction: adding a field to
- * MailServerOptions that is absent from MailClientOptions without listing it
- * here is a compile error, so this runtime heuristic cannot drift from the
- * option types (it previously had: `verify`, `onParseError`, `description`,
- * and `keywords` dispatched to the send destination).
+ * Exhaustive map of server-only keys, used by {@link serverOnlyKeysIn} to
+ * detect fetch intent on options that lack the `folder` discriminator.
+ * `Record<ServerOnlyKey, true>` makes the list exhaustive by construction:
+ * adding a field to MailServerOptions that is absent from MailClientOptions
+ * without listing it here is a compile error, so the runtime guard cannot
+ * drift from the option types. (`folder` itself never reaches the guard;
+ * it dispatches to the fetch destination earlier.)
  */
 const SERVER_ONLY_KEYS: Record<ServerOnlyKey, true> = {
   folder: true,
@@ -170,11 +197,11 @@ const SERVER_ONLY_KEYS: Record<ServerOnlyKey, true> = {
 };
 
 /**
- * Check whether options contain server-specific keys that indicate
- * an IMAP fetch/source intent rather than an SMTP send intent.
+ * List the server-only (IMAP fetch) keys present on an options object,
+ * for the ambiguity guard's error message.
  */
-function hasServerKeys(opts: object): boolean {
-  return Object.keys(SERVER_ONLY_KEYS).some((key) => key in opts);
+function serverOnlyKeysIn(opts: object): string[] {
+  return Object.keys(SERVER_ONLY_KEYS).filter((key) => key in opts);
 }
 
 // Re-export types for public API

--- a/packages/routecraft/src/adapters/mail/types.ts
+++ b/packages/routecraft/src/adapters/mail/types.ts
@@ -155,7 +155,13 @@ export interface MailServerOptions {
   secure?: boolean;
   /** Authentication credentials */
   auth?: MailAuth;
-  /** IMAP mailbox folder (default 'INBOX') */
+  /**
+   * IMAP mailbox folder. Required in the object-form fetch destination
+   * (`mail({ folder: 'INBOX', ... })`), where it is the key that
+   * distinguishes a fetch from an SMTP send. Optional on this type only
+   * because the source form passes it positionally
+   * (`mail('INBOX', { ... })`).
+   */
   folder?: string;
   /** Mark fetched messages as seen (default true) */
   markSeen?: boolean;
@@ -178,13 +184,13 @@ export interface MailServerOptions {
    * @example
    * ```typescript
    * // Match emails with Reply-To containing "no-reply"
-   * mail({ header: { "Reply-To": "no-reply" } })
+   * mail({ folder: "INBOX", header: { "Reply-To": "no-reply" } })
    *
    * // Match emails with a specific List-Id
-   * mail({ header: { "List-Id": "announcements.example.com" } })
+   * mail({ folder: "INBOX", header: { "List-Id": "announcements.example.com" } })
    *
    * // OR within a header: match "noreply" or "no-reply" in Reply-To
-   * mail({ header: { "Reply-To": ["noreply", "no-reply"] } })
+   * mail({ folder: "INBOX", header: { "Reply-To": ["noreply", "no-reply"] } })
    * ```
    */
   header?: Record<string, string | string[]>;

--- a/packages/routecraft/test/mail.bun.test.ts
+++ b/packages/routecraft/test/mail.bun.test.ts
@@ -17,6 +17,8 @@ import {
   parseAuthResults,
 } from "../src/adapters/mail/analysis.ts";
 import type { MailServerOptions } from "../src/adapters/mail/types.ts";
+import { MailFetchDestinationAdapter } from "../src/adapters/mail/fetch-destination.ts";
+import { MailSendDestinationAdapter } from "../src/adapters/mail/send-destination.ts";
 
 // Mock functions declared at module scope for mock.module hoisting
 const mockFetch = mock();
@@ -199,6 +201,56 @@ describe("Mail Adapter", () => {
     test("mail({ action: 'flag' }) returns an Operation Destination", () => {
       const adapter = mail({ action: "flag", flags: "\\Seen" });
       expect(adapter).toHaveProperty("send");
+    });
+
+    /**
+     * @case every server-only MailServerOptions key dispatches to the Fetch Destination
+     * @preconditions One mail({ [key]: value }) call per key that exists on
+     *   MailServerOptions but not MailClientOptions. Regression: `verify`,
+     *   `onParseError`, `description`, and `keywords` were missing from the
+     *   runtime heuristic and dispatched to the Send Destination.
+     * @expectedResult Each call returns a MailFetchDestinationAdapter
+     */
+    test("each server-only key dispatches to the Fetch Destination", () => {
+      const probes: MailServerOptions[] = [
+        { folder: "INBOX" },
+        { markSeen: true },
+        { since: new Date() },
+        { unseen: true },
+        { to: "ops@example.com" },
+        { subject: "invoice" },
+        { body: "urgent" },
+        { header: { "List-Id": "announcements.example.com" } },
+        { limit: 5 },
+        { description: "incoming invoices" },
+        { keywords: ["invoices"] },
+        { pollIntervalMs: 1000 },
+        { includeHeaders: true },
+        { verify: "headers" },
+        { onParseError: "drop" },
+      ];
+      for (const opts of probes) {
+        expect(mail(opts)).toBeInstanceOf(MailFetchDestinationAdapter);
+      }
+    });
+
+    /**
+     * @case mail({ host, port, secure, auth, account }) returns a Send Destination
+     * @preconditions Object with only keys shared by MailServerOptions and
+     *   MailClientOptions (no server-only key present)
+     * @expectedResult Returns a MailSendDestinationAdapter (current heuristic
+     *   resolves shared-key-only options to send; see issue #433 for the
+     *   type-level ambiguity this leaves open)
+     */
+    test("mail({ shared keys only }) returns a Send Destination", () => {
+      const adapter = mail({
+        host: "smtp.example.com",
+        port: 465,
+        secure: true,
+        auth: { user: "me@example.com", pass: "secret" },
+        account: "support",
+      });
+      expect(adapter).toBeInstanceOf(MailSendDestinationAdapter);
     });
 
     /**

--- a/packages/routecraft/test/mail.bun.test.ts
+++ b/packages/routecraft/test/mail.bun.test.ts
@@ -204,23 +204,53 @@ describe("Mail Adapter", () => {
     });
 
     /**
-     * @case every server-only MailServerOptions key dispatches to the Fetch Destination
-     * @preconditions One mail({ [key]: value }) call per key that exists on
-     *   MailServerOptions but not MailClientOptions. Regression: `verify`,
-     *   `onParseError`, `description`, and `keywords` were missing from the
-     *   runtime heuristic and dispatched to the Send Destination.
+     * @case mail({ folder, ...serverKey }) dispatches to the Fetch Destination for every server-only key
+     * @preconditions One mail({ folder, [key]: value }) call per key that
+     *   exists on MailServerOptions but not MailClientOptions
      * @expectedResult Each call returns a MailFetchDestinationAdapter
      */
-    test("each server-only key dispatches to the Fetch Destination", () => {
-      const probes: MailServerOptions[] = [
+    test("folder plus any server-only key dispatches to the Fetch Destination", () => {
+      const probes: (MailServerOptions & { folder: string })[] = [
         { folder: "INBOX" },
+        { folder: "INBOX", markSeen: true },
+        { folder: "INBOX", since: new Date() },
+        { folder: "INBOX", unseen: true },
+        { folder: "INBOX", to: "ops@example.com" },
+        { folder: "INBOX", subject: "invoice" },
+        { folder: "INBOX", body: "urgent" },
+        { folder: "INBOX", header: { "List-Id": "announce.example.com" } },
+        { folder: "INBOX", limit: 5 },
+        { folder: "INBOX", description: "incoming invoices" },
+        { folder: "INBOX", keywords: ["invoices"] },
+        { folder: "INBOX", pollIntervalMs: 1000 },
+        { folder: "INBOX", includeHeaders: true },
+        { folder: "INBOX", verify: "headers" },
+        { folder: "INBOX", onParseError: "drop" },
+      ];
+      for (const opts of probes) {
+        expect(mail(opts)).toBeInstanceOf(MailFetchDestinationAdapter);
+      }
+    });
+
+    /**
+     * @case mail({ serverKey }) without folder throws RC5003 for every server-only key
+     * @preconditions Untyped call (the overloads reject this shape at compile
+     *   time) with a server-only fetch key and no folder. Regression: the old
+     *   hasServerKeys() heuristic silently dispatched `verify`, `onParseError`,
+     *   `description`, and `keywords` to the Send Destination.
+     * @expectedResult Each call throws RoutecraftError RC5003 naming the
+     *   conflicting key instead of guessing a side
+     */
+    test("server-only keys without folder throw RC5003", () => {
+      const untypedMail = mail as unknown as (opts: unknown) => unknown;
+      const probes: Record<string, unknown>[] = [
         { markSeen: true },
         { since: new Date() },
         { unseen: true },
         { to: "ops@example.com" },
         { subject: "invoice" },
         { body: "urgent" },
-        { header: { "List-Id": "announcements.example.com" } },
+        { header: { "List-Id": "announce.example.com" } },
         { limit: 5 },
         { description: "incoming invoices" },
         { keywords: ["invoices"] },
@@ -230,7 +260,13 @@ describe("Mail Adapter", () => {
         { onParseError: "drop" },
       ];
       for (const opts of probes) {
-        expect(mail(opts)).toBeInstanceOf(MailFetchDestinationAdapter);
+        const key = Object.keys(opts)[0]!;
+        expect(() => untypedMail(opts)).toThrow(key);
+        try {
+          untypedMail(opts);
+        } catch (error) {
+          expect(error).toMatchObject({ rc: "RC5003" });
+        }
       }
     });
 


### PR DESCRIPTION
Closes #433

## Summary

`MailServerOptions` (IMAP fetch) and `MailClientOptions` (SMTP send) overlap on `host` / `port` / `secure` / `auth` / `account`, so the object-form `mail()` overloads could not tell fetch intent from send intent: the compiler resolved ambiguous calls to the fetch overload while the runtime key-sniffed its way to the send adapter via `hasServerKeys()`, and the two regularly disagreed. The worst case actually sent mail, since the send destination forwards email-shaped bodies straight to nodemailer.

Instead of the facade verbs proposed in #433, this adopts the discrimination rule every other two-sided facade already follows (`http` `path`/`url`, `mcp` `url`/`serverId`, `carddav` `action`, `direct` endpoint): **`folder` is the required fetch discriminator**. An options object with `folder` is a fetch, one without it is a send.

```ts
.enrich(mail({ folder: "INBOX", unseen: true }))  // fetch
.to(mail({ host: "smtp.x.com", auth }))           // send, finally typechecks
```

## Changes

- **`mail()` factory**: fetch overload is now `MailServerOptions & { folder: string }`; runtime dispatch is `action` key, then `folder` key, then send. The `hasServerKeys()` heuristic is deleted. Fetch-only keys without `folder` are a compile error; plain JS gets `RC5003` naming the conflicting keys instead of a guessed side, backed by an exhaustive `Record<ServerOnlyKey, true>` map that cannot drift from the option types.
- **Drift fix** (first commit): the old heuristic had already drifted; `verify`, `onParseError`, `description`, and `keywords` were missing, so e.g. `mail({ verify: "headers" })` silently constructed a send destination.
- **Standards**: new "Discriminating the two sides" section in `.standards/naming-policy.md` codifying the required-side-key rule, the one-bare-default-side-per-facade limit, and the RC5003-over-guessing contract, so the next two-sided adapter cannot reintroduce this.
- **Tests**: dispatch probes for every server-only key with and without `folder`, plus shared-keys-only send dispatch.
- **Docs**: mail reference page, 0.5-to-0.6 migration entry with before/after, and fixes for three pre-existing invalid examples (cheat sheet showed a `.to(mail({ to, subject, text }))` extractor API that never existed; two pages called `.from(mail({...}))` with a single object, which matches no source overload).

## Breaking change

Object-form fetch calls must state `folder` (`mail({ folder: "INBOX", ... })`) or use the `mail("INBOX")` shorthand; the implicit INBOX/context-level folder default no longer applies to that form. The string shorthand, two-argument source form, `{ action }` operations, and bare `mail()` sends are unchanged.

Follow-up outside this repo: `craft-harness` can drop the cast in `capabilities/email/send-email.ts` once this releases.

## Verification

`bun run all` (build, test, lint, typecheck across workspaces) passes; the 76-test mail suite passes after the rebase onto main.

https://claude.ai/code/session_01SjDbERraudLNKd6WTmpW6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjDbERraudLNKd6WTmpW6p)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require `folder` to disambiguate object-form `mail()` fetch (IMAP) from send (SMTP), removing ambiguous overloads and preventing accidental sends. Replaces key-sniffing with a typed discriminator and an exhaustive server-only key guard; ambiguous JS shapes now throw `RC5003`, and send options now typecheck.

- **Migration**
  - Object-form fetch must include `folder`: use `mail({ folder: "INBOX", ... })` or the shorthand `mail("INBOX")`.
  - Source form is unchanged: `mail("INBOX", { ... })`.
  - Send is unchanged: `mail()` or `mail({ host, auth, ... })` (no `folder`).
  - Plain JS with fetch-only keys but no `folder` throws `RC5003`.

- **Updates**
  - Standards: naming policy now requires a side-unique key for multiplexed factories; key-sniffing is forbidden.
  - Tests: dispatch coverage for every server-only key; shared-keys-only resolves to send.
  - Docs: fixed invalid `mail()` examples; updated reference and 0.5→0.6 migration guides.

<sup>Written for commit 9c21cd2fcb8738e94f448fcb4324656da0b4ddcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

