### PR TITLE
feat(ai): emit route:agent:usage event with token + cache breakdown

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
       "version": "0.5.0",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "ai": "^6.0.174",
+        "ai": "^6.0.203",
       },
       "devDependencies": {
         "@ai-sdk/anthropic": "^3.0.74",
@@ -329,7 +329,7 @@
   "packages": {
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.82", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-WKKou2wbhGGYV8PSALAPyV2YY4nfCqCPkyBzYtJtDA9yCcIFwsbtkTNgg7bqtLCVzeEsY7wwxRoCWy+EMfrw/A=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.127", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Obmw5hmE5x+ccRrMp/Djx5r0rpFVX87YqE6OY06g5fwYlRI30dA84ARfTzX45ivCvkW4eCnBpOVXVWQ/pjH85w=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.129", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.29", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-KEQpZGJuCksc4iFxYtVHeHHG7yH0izGFzJLmRZlriI0hFIzJF9bT2AzJoaTHUI6minlxtP0WKYh84dP18o/Cuw=="],
 
     "@ai-sdk/google": ["@ai-sdk/google@3.0.80", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg=="],
 
@@ -1125,7 +1125,7 @@
 
     "agent-browser": ["agent-browser@0.17.1", "", { "dependencies": { "node-simctl": "^7.4.0", "playwright-core": "^1.57.0", "webdriverio": "^9.15.0", "ws": "^8.19.0", "zod": "^3.22.4" }, "bin": { "agent-browser": "bin/agent-browser.js" } }, "sha512-KNV+6F3nYStxgTrsdcfMBsxtLdnaUu2NTuQ9EL8CvnYUgAzdoYztYVJzkr1KbconGEyLdSgXZedSsKw0TPiL/g=="],
 
-    "ai": ["ai@6.0.200", "", { "dependencies": { "@ai-sdk/gateway": "3.0.127", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-kme8AWPy7om8s5Isj/uIE0T3hVf8d5QEIpd2WJ/RiAansglud92fIEurCaz/ZYgjW5abcxuyhv55soQnLIWYEA=="],
+    "ai": ["ai@6.0.203", "", { "dependencies": { "@ai-sdk/gateway": "3.0.129", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.29", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2Qi1ZPGF/FnlvnRqntVgRbUYGeA5ZKFYwTtgu8rcUzMmddArM/nLsvCW69Ip99B1cop6XHRHl+GCKk9t9B+GDA=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
@@ -2745,6 +2745,8 @@
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
+    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.29", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA=="],
+
     "@ai-sdk/openai-compatible/@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
 
     "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.25", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA=="],
@@ -2844,6 +2846,8 @@
     "@wdio/utils/@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
     "agent-browser/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.29", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA=="],
 
     "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
-    "ai": "^6.0.174"
+    "ai": "^6.0.203"
   },
   "devDependencies": {
     "@routecraft/routecraft": "workspace:*",

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -312,14 +312,19 @@ export class AgentSession {
     // string. Falls back to "unknown" only when the provider didn't
     // report one.
     const finishReason = result.finishReason ?? "unknown";
-    ctx.emit("route:agent:finished", {
+    const agentName =
+      this.input.agentName !== undefined
+        ? { agentName: this.input.agentName }
+        : {};
+    const identity = {
       routeId: id.routeId,
       exchangeId: id.exchangeId,
       correlationId: id.correlationId,
-      ...(this.input.agentName !== undefined && {
-        agentName: this.input.agentName,
-      }),
+      ...agentName,
       model: this.input.model,
+    };
+    ctx.emit("route:agent:finished", {
+      ...identity,
       finishReason,
       ...(result.usage?.inputTokens !== undefined && {
         inputTokens: result.usage.inputTokens,
@@ -331,6 +336,26 @@ export class AgentSession {
         totalTokens: result.usage.totalTokens,
       }),
     });
+    if (result.usage) {
+      ctx.emit("route:agent:usage", {
+        ...identity,
+        ...(result.usage.inputTokens !== undefined && {
+          inputTokens: result.usage.inputTokens,
+        }),
+        ...(result.usage.outputTokens !== undefined && {
+          outputTokens: result.usage.outputTokens,
+        }),
+        ...(result.usage.totalTokens !== undefined && {
+          totalTokens: result.usage.totalTokens,
+        }),
+        ...(result.usage.cacheReadTokens !== undefined && {
+          cacheReadTokens: result.usage.cacheReadTokens,
+        }),
+        ...(result.usage.cacheWriteTokens !== undefined && {
+          cacheWriteTokens: result.usage.cacheWriteTokens,
+        }),
+      });
+    }
   }
 
   /**

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -336,26 +336,24 @@ export class AgentSession {
         totalTokens: result.usage.totalTokens,
       }),
     });
-    if (result.usage) {
-      ctx.emit("route:agent:usage", {
-        ...identity,
-        ...(result.usage.inputTokens !== undefined && {
-          inputTokens: result.usage.inputTokens,
-        }),
-        ...(result.usage.outputTokens !== undefined && {
-          outputTokens: result.usage.outputTokens,
-        }),
-        ...(result.usage.totalTokens !== undefined && {
-          totalTokens: result.usage.totalTokens,
-        }),
-        ...(result.usage.cacheReadTokens !== undefined && {
-          cacheReadTokens: result.usage.cacheReadTokens,
-        }),
-        ...(result.usage.cacheWriteTokens !== undefined && {
-          cacheWriteTokens: result.usage.cacheWriteTokens,
-        }),
-      });
-    }
+    ctx.emit("route:agent:usage", {
+      ...identity,
+      ...(result.usage?.inputTokens !== undefined && {
+        inputTokens: result.usage.inputTokens,
+      }),
+      ...(result.usage?.outputTokens !== undefined && {
+        outputTokens: result.usage.outputTokens,
+      }),
+      ...(result.usage?.totalTokens !== undefined && {
+        totalTokens: result.usage.totalTokens,
+      }),
+      ...(result.usage?.cacheReadTokens !== undefined && {
+        cacheReadTokens: result.usage.cacheReadTokens,
+      }),
+      ...(result.usage?.cacheWriteTokens !== undefined && {
+        cacheWriteTokens: result.usage.cacheWriteTokens,
+      }),
+    });
   }
 
   /**

--- a/packages/ai/src/llm/providers/llm-utils.ts
+++ b/packages/ai/src/llm/providers/llm-utils.ts
@@ -80,16 +80,28 @@ export function assertLanguageModelShape(
   }
 }
 
-/** Pass through AI SDK usage so LlmUsage matches LanguageModelUsage (inputTokens/outputTokens). */
+/** Pass through AI SDK usage into LlmUsage, including cache token details when present. */
 export function toLlmUsage(u: {
   inputTokens?: number | undefined;
   outputTokens?: number | undefined;
   totalTokens?: number | undefined;
+  inputTokenDetails?:
+    | {
+        cacheReadTokens?: number | undefined;
+        cacheWriteTokens?: number | undefined;
+      }
+    | undefined;
 }): LlmUsage {
   return {
     ...(u.inputTokens !== undefined && { inputTokens: u.inputTokens }),
     ...(u.outputTokens !== undefined && { outputTokens: u.outputTokens }),
     ...(u.totalTokens !== undefined && { totalTokens: u.totalTokens }),
+    ...(u.inputTokenDetails?.cacheReadTokens !== undefined && {
+      cacheReadTokens: u.inputTokenDetails.cacheReadTokens,
+    }),
+    ...(u.inputTokenDetails?.cacheWriteTokens !== undefined && {
+      cacheWriteTokens: u.inputTokenDetails.cacheWriteTokens,
+    }),
   };
 }
 

--- a/packages/ai/src/llm/types.ts
+++ b/packages/ai/src/llm/types.ts
@@ -217,13 +217,22 @@ export type LlmOptionsMerged = Required<
   Omit<LlmOptions, "temperature" | "maxTokens">;
 
 /**
- * Token usage. Matches Vercel AI SDK LanguageModelUsage shape (inputTokens/outputTokens)
- * so result.usage can be used interchangeably with generateText() return value.
+ * Token usage reported by the provider. Mirrors the Vercel AI SDK
+ * `LanguageModelUsage` shape so result.usage can be used interchangeably
+ * with `generateText()` return values.
+ *
+ * Cache fields are populated only when the provider reports them (currently
+ * Anthropic with prompt caching enabled). Absent when the provider does not
+ * support caching or caching was not active for the call.
  */
 export interface LlmUsage {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  /** Cached input tokens read from the provider's cache (e.g. Anthropic prompt caching). */
+  cacheReadTokens?: number;
+  /** Input tokens written to the provider's cache for future calls. */
+  cacheWriteTokens?: number;
 }
 
 /**

--- a/packages/ai/test/agent-bus-events.bun.test.ts
+++ b/packages/ai/test/agent-bus-events.bun.test.ts
@@ -354,11 +354,13 @@ describe("agent context-bus events", () => {
   });
 
   /**
-   * @case agent:usage includes cache token fields when the provider reports them
-   * @preconditions LLM mock returns usage with cacheReadTokens and cacheWriteTokens
+   * @case agent:usage propagates cache token fields from LlmResult.usage to the event
+   * @preconditions LLM mock returns LlmResult with cacheReadTokens and cacheWriteTokens
+   *   already on usage (i.e. the toLlmUsage conversion has already run in the provider
+   *   layer; this test covers session.ts propagation, not the conversion itself)
    * @expectedResult usage event carries cacheReadTokens and cacheWriteTokens
    */
-  test("agent:usage includes cache tokens when provider reports them", async () => {
+  test("agent:usage propagates cache token fields to the event", async () => {
     const { callLlm } = await import("../src/llm/providers/index.ts");
     (callLlm as ReturnType<typeof mock>).mockImplementationOnce(
       async (): Promise<LlmResult> => ({

--- a/packages/ai/test/agent-bus-events.bun.test.ts
+++ b/packages/ai/test/agent-bus-events.bun.test.ts
@@ -313,6 +313,98 @@ describe("agent context-bus events", () => {
   });
 
   /**
+   * @case agent:usage fires after a successful dispatch with token counts and model
+   * @preconditions Agent without tools; happy-path LLM call with usage reported
+   * @expectedResult Subscriber receives one usage event with inputTokens, outputTokens,
+   *   totalTokens, and model; no finishReason (that lives on agent:finished)
+   */
+  test("agent:usage emitted with token counts and model", async () => {
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("usage-agent")
+          .from(simple("hi"))
+          .to(agent({ system: "x", model: "anthropic:claude-opus-4-7" })),
+      )
+      .build();
+
+    const usageEvents: unknown[] = [];
+    t.ctx.on(
+      "route:agent:usage" as never,
+      ({ details }: { details: unknown }) => {
+        usageEvents.push(details);
+      },
+    );
+
+    await t.test();
+
+    expect(usageEvents).toHaveLength(1);
+    const d = usageEvents[0] as Record<string, unknown>;
+    expect(d["routeId"]).toBe("usage-agent");
+    expect(d["model"]).toBe("anthropic:claude-opus-4-7");
+    expect(d["inputTokens"]).toBe(10);
+    expect(d["outputTokens"]).toBe(5);
+    expect(d["totalTokens"]).toBe(15);
+    expect(d["finishReason"]).toBeUndefined();
+  });
+
+  /**
+   * @case agent:usage includes cache token fields when the provider reports them
+   * @preconditions LLM mock returns usage with cacheReadTokens and cacheWriteTokens
+   * @expectedResult usage event carries cacheReadTokens and cacheWriteTokens
+   */
+  test("agent:usage includes cache tokens when provider reports them", async () => {
+    const { callLlm } = await import("../src/llm/providers/index.ts");
+    (callLlm as ReturnType<typeof mock>).mockImplementationOnce(
+      async (): Promise<LlmResult> => ({
+        text: "cached-response",
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          totalTokens: 120,
+          cacheReadTokens: 80,
+          cacheWriteTokens: 20,
+        },
+        finishReason: "stop",
+      }),
+    );
+
+    t = await testContext()
+      .with({
+        plugins: [
+          llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+        ],
+      })
+      .routes(
+        craft()
+          .id("cache-agent")
+          .from(simple("hi"))
+          .to(agent({ system: "x", model: "anthropic:claude-opus-4-7" })),
+      )
+      .build();
+
+    const usageEvents: unknown[] = [];
+    t.ctx.on(
+      "route:agent:usage" as never,
+      ({ details }: { details: unknown }) => {
+        usageEvents.push(details);
+      },
+    );
+
+    await t.test();
+
+    expect(usageEvents).toHaveLength(1);
+    const d = usageEvents[0] as Record<string, unknown>;
+    expect(d["cacheReadTokens"]).toBe(80);
+    expect(d["cacheWriteTokens"]).toBe(20);
+  });
+
+  /**
    * @case agent:started fires at dispatch start with model + tool names
    * @preconditions Inline agent with one tool; mocked callLlm
    * @expectedResult Subscriber receives one started event carrying the

--- a/packages/ai/test/llm-utils.bun.test.ts
+++ b/packages/ai/test/llm-utils.bun.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { toLlmUsage } from "../src/llm/providers/llm-utils.ts";
+
+describe("toLlmUsage", () => {
+  /**
+   * @case basic token fields are passed through unchanged
+   * @preconditions SDK usage object with inputTokens, outputTokens, totalTokens
+   * @expectedResult LlmUsage has the same values; no extra keys
+   */
+  test("passes through basic token counts", () => {
+    const result = toLlmUsage({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+    });
+    expect(result.inputTokens).toBe(100);
+    expect(result.outputTokens).toBe(50);
+    expect(result.totalTokens).toBe(150);
+    expect(result.cacheReadTokens).toBeUndefined();
+    expect(result.cacheWriteTokens).toBeUndefined();
+  });
+
+  /**
+   * @case cache token details from inputTokenDetails are extracted correctly
+   * @preconditions SDK usage with inputTokenDetails.cacheReadTokens and cacheWriteTokens
+   * @expectedResult LlmUsage carries cacheReadTokens and cacheWriteTokens
+   */
+  test("extracts cacheReadTokens and cacheWriteTokens from inputTokenDetails", () => {
+    const result = toLlmUsage({
+      inputTokens: 100,
+      outputTokens: 20,
+      totalTokens: 120,
+      inputTokenDetails: {
+        cacheReadTokens: 80,
+        cacheWriteTokens: 20,
+      },
+    });
+    expect(result.cacheReadTokens).toBe(80);
+    expect(result.cacheWriteTokens).toBe(20);
+  });
+
+  /**
+   * @case partial cache detail -- only cacheReadTokens present
+   * @preconditions inputTokenDetails has cacheReadTokens but not cacheWriteTokens
+   * @expectedResult cacheReadTokens set, cacheWriteTokens absent
+   */
+  test("handles partial inputTokenDetails gracefully", () => {
+    const result = toLlmUsage({
+      inputTokens: 50,
+      outputTokens: 10,
+      totalTokens: 60,
+      inputTokenDetails: { cacheReadTokens: 40 },
+    });
+    expect(result.cacheReadTokens).toBe(40);
+    expect(result.cacheWriteTokens).toBeUndefined();
+  });
+
+  /**
+   * @case undefined fields are omitted, not set to undefined
+   * @preconditions SDK usage with all fields undefined
+   * @expectedResult empty LlmUsage object (no own properties)
+   */
+  test("omits undefined fields entirely", () => {
+    const result = toLlmUsage({});
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -539,6 +539,24 @@ export interface EventDetailsMap {
     outputTokens?: number;
     totalTokens?: number;
   };
+  /**
+   * Emitted after every successful agent dispatch alongside
+   * `route:agent:finished`. Carries the full token breakdown for the
+   * dispatch so consumers can compute cost without subscribing to the
+   * broader lifecycle event.
+   *
+   * Cache fields are present only when the provider reports them (e.g.
+   * Anthropic with prompt caching enabled).
+   */
+  "route:agent:usage": ExchangeScoped & {
+    agentName?: string;
+    model: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
   "route:agent:error": ExchangeScoped & {
     agentName?: string;
     model: string;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a dedicated `route:agent:usage` event emitted alongside `route:agent:finished` after every successful agent dispatch
- Extends `LlmUsage` with `cacheReadTokens` and `cacheWriteTokens` fields (populated from Vercel AI SDK v6 `inputTokenDetails` -- Anthropic prompt caching)
- Updates `toLlmUsage` to read cache token details from the SDK
- Registers the new event type in `EventDetailsMap`
- Two new tests: basic token fields and cache token pass-through

Closes #228 (partial -- cost computation and sub-agent attribution are follow-up items; sub-agents depend on the tools helper + tool loop story)

## Usage

```ts
ctx.on("route:agent:usage", ({ details }) => {
  // details.model, details.inputTokens, details.outputTokens, details.totalTokens
  // details.cacheReadTokens, details.cacheWriteTokens (Anthropic only, when caching active)
});
```

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test packages/ai/test/agent-bus-events.bun.test.ts` -- all 9 tests pass (2 new)
- [x] Full test suite: 505 pass, 0 fail
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbhrtQEjYbnPbJ56GTrHfg)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `route:agent:usage` event that reports full token usage (including cache reads/writes) after each successful agent dispatch, emitted even when the provider omits usage fields. Also surfaces Anthropic prompt caching details via `LlmUsage`; partial progress on #228 (cost math and sub-agent attribution to follow).

- **New Features**
  - Emit `route:agent:usage` alongside `route:agent:finished` for every successful dispatch with `model`, `routeId`, `exchangeId`, `correlationId`, optional `agentName`, `inputTokens`, `outputTokens`, `totalTokens`, and optional `cacheReadTokens`/`cacheWriteTokens`.
  - Extend `LlmUsage` with cache fields; update `toLlmUsage` to read `inputTokenDetails` from the SDK.
  - Register the new event in `EventDetailsMap`.
  - Tests: usage event tokens, cache token propagation, and unit tests for `toLlmUsage` conversion.

- **Dependencies**
  - Bump `ai` to `^6.0.203`.

<sup>Written for commit 9d438658c6dcddd144d36cdf5fd5fc9c0815b538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

