### PR TITLE
refactor(ai): drop redundant StoreRegistry key/value casts

### DIFF
--- a/packages/ai/src/agent/destination.ts
+++ b/packages/ai/src/agent/destination.ts
@@ -22,7 +22,6 @@ import {
 import type { AgentDeltaListener } from "./events.ts";
 import type { ResolvedTool } from "./tools/selection.ts";
 import type {
-  AgentDefaultOptions,
   AgentOptions,
   AgentPrincipalRenderer,
   AgentRegisteredOptions,
@@ -191,9 +190,7 @@ export class AgentDestinationAdapter implements Destination<
           `"${AGENT_REGISTRY_STORE_DESCRIPTION}" store can be read.`,
       });
     }
-    const registry = context.getStore(
-      ADAPTER_AGENT_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-    ) as Map<string, AgentRegisteredOptions> | undefined;
+    const registry = context.getStore(ADAPTER_AGENT_REGISTRY);
     if (!registry) {
       throw rcError("RC5004", undefined, {
         message:
@@ -245,9 +242,7 @@ function mergeWithDefaults(
   base: AgentOptions | AgentRegisteredOptions,
   context: CraftContext | undefined,
 ): AgentOptions | AgentRegisteredOptions {
-  const defaults = context?.getStore(
-    ADAPTER_AGENT_DEFAULT_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
-  ) as AgentDefaultOptions | undefined;
+  const defaults = context?.getStore(ADAPTER_AGENT_DEFAULT_OPTIONS);
   if (!defaults) return base;
   const out = { ...base } as AgentOptions | AgentRegisteredOptions;
   if (out.model === undefined && defaults.model !== undefined) {

--- a/packages/ai/src/agent/plugin.ts
+++ b/packages/ai/src/agent/plugin.ts
@@ -115,9 +115,7 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
     apply(ctx: CraftContext) {
       // Merge into an existing registry when present so multiple
       // `agentPlugin({...})` entries compose instead of overwriting.
-      const existingAgents = ctx.getStore(
-        ADAPTER_AGENT_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-      ) as Map<string, AgentRegisteredOptions> | undefined;
+      const existingAgents = ctx.getStore(ADAPTER_AGENT_REGISTRY);
       const agentMap =
         existingAgents ?? new Map<string, AgentRegisteredOptions>();
       for (const [id, entry] of Object.entries(agents)) {
@@ -145,15 +143,10 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
         agentMap.set(id, entry);
       }
       if (!existingAgents) {
-        ctx.setStore(
-          ADAPTER_AGENT_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-          agentMap,
-        );
+        ctx.setStore(ADAPTER_AGENT_REGISTRY, agentMap);
       }
 
-      const existingFns = ctx.getStore(
-        ADAPTER_FN_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-      ) as Map<string, FnEntry> | undefined;
+      const existingFns = ctx.getStore(ADAPTER_FN_REGISTRY);
       const fnMap = existingFns ?? new Map<string, FnEntry>();
       for (const [id, entry] of Object.entries(functions)) {
         if (id.trim() === "") {
@@ -177,21 +170,13 @@ export function agentPlugin(options: AgentPluginOptions = {}): CraftPlugin {
         fnMap.set(id, entry);
       }
       if (!existingFns) {
-        ctx.setStore(
-          ADAPTER_FN_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-          fnMap,
-        );
+        ctx.setStore(ADAPTER_FN_REGISTRY, fnMap);
       }
 
       if (defaultOptions !== undefined) {
-        const existing = ctx.getStore(
-          ADAPTER_AGENT_DEFAULT_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
-        ) as AgentDefaultOptions | undefined;
+        const existing = ctx.getStore(ADAPTER_AGENT_DEFAULT_OPTIONS);
         const merged = mergePluginDefaults(existing, defaultOptions);
-        ctx.setStore(
-          ADAPTER_AGENT_DEFAULT_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
-          merged,
-        );
+        ctx.setStore(ADAPTER_AGENT_DEFAULT_OPTIONS, merged);
       }
 
       emitRegistrations(ctx, agents, functions);

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -698,10 +698,7 @@ function listKnownMcpClients(registry: McpToolRegistry): string[] {
 
 function listKnownNames(ctx: CraftContext): string[] {
   const fnNames = [
-    ...(
-      (ctx.getStore(ADAPTER_FN_REGISTRY) as Map<string, FnEntry> | undefined) ??
-      new Map()
-    ).keys(),
+    ...(ctx.getStore(ADAPTER_FN_REGISTRY) ?? new Map<string, FnEntry>()).keys(),
   ];
   const routeNames = ctx.capabilities().map((c) => `Direct(${c.endpoint})`);
   return [...fnNames, ...routeNames].sort();

--- a/packages/ai/src/embedding/destination.ts
+++ b/packages/ai/src/embedding/destination.ts
@@ -41,9 +41,7 @@ function resolveProviderAndModel(
       `Embedding adapter: model id "${modelId}" requires a context to resolve. Ensure the exchange has context (e.g. from a route) so embedding providers can be read.`,
     );
   }
-  const store = context.getStore(
-    ADAPTER_EMBEDDING_PROVIDERS as keyof import("@routecraft/routecraft").StoreRegistry,
-  ) as Map<string, EmbeddingModelConfig> | undefined;
+  const store = context.getStore(ADAPTER_EMBEDDING_PROVIDERS);
   if (!store) {
     throw new Error(
       "Embedding provider not found: no providers registered. Add embeddingPlugin({ providers: { huggingface: {} } }) to your config.",
@@ -88,9 +86,7 @@ export class EmbeddingDestinationAdapter<T = unknown>
   public options: Partial<EmbeddingOptions>;
 
   mergedOptions(context: CraftContext): EmbeddingOptions {
-    const store = context.getStore(
-      ADAPTER_EMBEDDING_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
-    ) as Partial<EmbeddingOptions> | undefined;
+    const store = context.getStore(ADAPTER_EMBEDDING_OPTIONS);
     return { ...store, ...this.options } as EmbeddingOptions;
   }
 

--- a/packages/ai/src/embedding/plugin.ts
+++ b/packages/ai/src/embedding/plugin.ts
@@ -37,18 +37,12 @@ export function embeddingPlugin(
           );
         }
       }
-      ctx.setStore(
-        ADAPTER_EMBEDDING_PROVIDERS as keyof import("@routecraft/routecraft").StoreRegistry,
-        map,
-      );
+      ctx.setStore(ADAPTER_EMBEDDING_PROVIDERS, map);
       if (
         options.defaultOptions &&
         Object.keys(options.defaultOptions).length > 0
       ) {
-        ctx.setStore(
-          ADAPTER_EMBEDDING_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
-          options.defaultOptions,
-        );
+        ctx.setStore(ADAPTER_EMBEDDING_OPTIONS, options.defaultOptions);
       }
     },
     async teardown() {

--- a/packages/ai/src/llm/destination.ts
+++ b/packages/ai/src/llm/destination.ts
@@ -91,9 +91,7 @@ export class LlmDestinationAdapter<
   public options: Partial<LlmOptionsMerged>;
 
   mergedOptions(context: CraftContext): LlmOptionsMerged {
-    const store = context.getStore(
-      ADAPTER_LLM_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
-    ) as Partial<LlmOptionsMerged> | undefined;
+    const store = context.getStore(ADAPTER_LLM_OPTIONS);
     return {
       temperature: DEFAULT_TEMPERATURE,
       maxTokens: DEFAULT_MAX_TOKENS,

--- a/packages/ai/src/llm/plugin.ts
+++ b/packages/ai/src/llm/plugin.ts
@@ -51,18 +51,12 @@ export function llmPlugin(
         if (opts !== undefined)
           map.set(providerId, toModelConfig(providerId, opts));
       }
-      ctx.setStore(
-        ADAPTER_LLM_PROVIDERS as keyof import("@routecraft/routecraft").StoreRegistry,
-        map,
-      );
+      ctx.setStore(ADAPTER_LLM_PROVIDERS, map);
       if (
         options.defaultOptions &&
         Object.keys(options.defaultOptions).length > 0
       ) {
-        ctx.setStore(
-          ADAPTER_LLM_OPTIONS as keyof import("@routecraft/routecraft").StoreRegistry,
-          options.defaultOptions,
-        );
+        ctx.setStore(ADAPTER_LLM_OPTIONS, options.defaultOptions);
       }
     },
   };

--- a/packages/ai/src/llm/shared.ts
+++ b/packages/ai/src/llm/shared.ts
@@ -57,9 +57,7 @@ export function resolveModel(
     );
   }
 
-  const store = context.getStore(
-    ADAPTER_LLM_PROVIDERS as keyof import("@routecraft/routecraft").StoreRegistry,
-  ) as Map<string, LlmModelConfig> | undefined;
+  const store = context.getStore(ADAPTER_LLM_PROVIDERS);
   if (!store) {
     throw new Error(
       `LLM provider not found: no providers registered. Add llmPlugin({ providers: { ollama: { provider: "ollama" }, ... } }) to your config.`,

--- a/packages/ai/src/mcp/adapters/mcp/source.ts
+++ b/packages/ai/src/mcp/adapters/mcp/source.ts
@@ -97,24 +97,17 @@ export class McpSourceAdapter implements Source<McpMessage<undefined>> {
       });
     }
 
-    const registered = context.getStore(
-      MCP_PLUGIN_REGISTERED as keyof import("@routecraft/routecraft").StoreRegistry,
-    ) as boolean | undefined;
+    const registered = context.getStore(MCP_PLUGIN_REGISTERED);
     if (registered !== true) {
       throw new Error(
         "MCP plugin required: routes using .from(mcp(...)) require the MCP plugin. Add mcpPlugin() to your config: plugins: [mcpPlugin()].",
       );
     }
 
-    let registry = context.getStore(
-      MCP_LOCAL_TOOL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-    ) as Map<string, McpLocalToolEntry> | undefined;
+    let registry = context.getStore(MCP_LOCAL_TOOL_REGISTRY);
     if (!registry) {
       registry = new Map<string, McpLocalToolEntry>();
-      context.setStore(
-        MCP_LOCAL_TOOL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-        registry,
-      );
+      context.setStore(MCP_LOCAL_TOOL_REGISTRY, registry);
     }
 
     if (registry.has(endpoint)) {
@@ -166,9 +159,7 @@ export class McpSourceAdapter implements Source<McpMessage<undefined>> {
     sub.signal.addEventListener(
       "abort",
       () => {
-        const current = context.getStore(
-          MCP_LOCAL_TOOL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-        ) as Map<string, McpLocalToolEntry> | undefined;
+        const current = context.getStore(MCP_LOCAL_TOOL_REGISTRY);
         current?.delete(endpoint);
       },
       { once: true },

--- a/packages/ai/src/mcp/plugin.ts
+++ b/packages/ai/src/mcp/plugin.ts
@@ -49,21 +49,15 @@ export function mcpPlugin(options: McpPluginOptions = {}): CraftPlugin {
 
   return {
     async apply(ctx: CraftContext) {
-      ctx.setStore(
-        MCP_PLUGIN_REGISTERED as keyof import("@routecraft/routecraft").StoreRegistry,
-        true,
-      );
+      ctx.setStore(MCP_PLUGIN_REGISTERED, true);
 
       // Create and store tool registry
       toolRegistry = new McpToolRegistry();
-      ctx.setStore(
-        MCP_TOOL_REGISTRY as keyof import("@routecraft/routecraft").StoreRegistry,
-        toolRegistry,
-      );
+      ctx.setStore(MCP_TOOL_REGISTRY, toolRegistry);
 
       // Store stdio managers map so destination adapter can call tools on stdio clients
       ctx.setStore(
-        MCP_STDIO_MANAGERS as keyof import("@routecraft/routecraft").StoreRegistry,
+        MCP_STDIO_MANAGERS,
         stdioManagers as unknown as Map<
           string,
           {
@@ -84,10 +78,7 @@ export function mcpPlugin(options: McpPluginOptions = {}): CraftPlugin {
         for (const [k, v] of clientEntries) {
           map.set(k, v);
         }
-        ctx.setStore(
-          ADAPTER_MCP_CLIENT_SERVERS as keyof import("@routecraft/routecraft").StoreRegistry,
-          map,
-        );
+        ctx.setStore(ADAPTER_MCP_CLIENT_SERVERS, map);
 
         // Start stdio clients and list HTTP client tools
         for (const [serverId, config] of clientEntries) {


### PR DESCRIPTION

## Summary

- Removes all `as keyof import("@routecraft/routecraft").StoreRegistry` key casts and their paired trailing `as Map<...>` / `as Partial<...>` re-narrows from `packages/ai/src`
- The declaration-merged `StoreRegistry` already types `getStore`/`setStore` precisely per-symbol; the key cast was actively widening the return type to the full registry union, and the trailing cast was just undoing that damage
- Removes one now-unused `AgentDefaultOptions` import in `agent/destination.ts` uncovered by the cleanup

**Files changed:** `agent/plugin.ts`, `agent/destination.ts`, `agent/tools/selection.ts`, `embedding/plugin.ts`, `embedding/destination.ts`, `llm/plugin.ts`, `llm/destination.ts`, `llm/shared.ts`, `mcp/plugin.ts`, `mcp/adapters/mcp/source.ts`

**One value cast intentionally kept:** `mcp/plugin.ts` retains `stdioManagers as unknown as Map<string, { callTool }>` -- `stdioManagers` is `Map<string, StdioClientManager>` while the store declares the narrower callTool-only shape; Map value invariance requires the bridge. Only the redundant key cast was removed there.

Closes #330

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] AI bun test suite: 503 pass, 0 fail

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuTrzBJE9akmQpeThsqAE5)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant `StoreRegistry` key/value casts across `packages/ai`, letting the declaration-merged registry type `getStore`/`setStore` per symbol. This simplifies code and avoids type widening; one necessary value cast for stdio managers remains, and an unused import is removed.

- **Refactors**
  - Dropped `as keyof import("@routecraft/routecraft").StoreRegistry` and trailing `as Map<...>`/`as Partial<...>` in agent, embedding, llm, and mcp modules.
  - Kept the bridge cast for `stdioManagers` where the store exposes a narrower callTool-only shape.
  - Removed unused `AgentDefaultOptions` import in `agent/destination.ts`.

<sup>Written for commit 79a5b2915560dc4841b11c1b85fb7aa4e2b3fa53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

