### PR TITLE
feat(eslint-plugin): add opt-in capability-boundaries rule

### DIFF
--- a/apps/routecraft.dev/src/app/docs/advanced/linting/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/linting/page.md
@@ -59,7 +59,74 @@ The `recommended` preset enables all rules at their default levels. See the [Lin
 
 ## Presets
 
-The plugin ships two presets: `recommended` (rules at their default levels) and `all` (every rule as an error). Use `recommended` for most projects; use `all` to enforce every rule strictly from the start. See the [Linting reference](/docs/reference/linting#presets) for the full preset and rule catalog.
+The plugin ships two presets: `recommended` (rules at their default levels) and `all` (every rule as an error). Use `recommended` for most projects; use `all` to enforce every rule strictly from the start. Both presets cover the general convention rules; the opt-in `capability-boundaries` rule is excluded from both and must be enabled explicitly (see below). See the [Linting reference](/docs/reference/linting#presets) for the full preset and rule catalog.
+
+## Capability boundaries (opt-in)
+
+`capability-boundaries` enforces Spring-Modulith-style module boundaries between capabilities. A capability is any folder that contains a public-surface file (`route.ts` by default) under a `capabilities/` directory: the route file is the capability's only public surface, and everything else in the folder is internal. From outside a capability, only its public surface may be imported. Share across capabilities via a `direct()` route or a shared package instead.
+
+```
+apps/agent/
+  capabilities/
+    index.ts                 # registry: imports each route.ts (the public surface)
+    employees/               # domain grouping only (no shared code, no route.ts)
+      onboard/
+        route.ts             # PUBLIC SURFACE
+        mapper.ts            # internal
+      offboard/
+        route.ts
+  env.ts
+packages/
+  shared/                    # shared code: bare @scope/* imports, always allowed
+```
+
+```ts
+// from apps/agent/capabilities/employees/onboard/route.ts
+
+// Good
+import other from '../offboard/route.js' // sibling public surface
+import { map } from './mapper.js' // same capability (internal)
+import { util } from '@scope/shared' // shared package
+
+// Bad
+import { map } from '../offboard/mapper.js' // another capability's internal
+```
+
+Because the rule encodes a specific layout, it is not part of any preset. Enable it explicitly and scope it to the part of the repo that follows the convention. In a mixed monorepo where only one app is Routecraft, point `files` at that app:
+
+```js
+// eslint.config.mjs
+import routecraftPlugin from '@routecraft/eslint-plugin-routecraft'
+
+export default [
+  // ... other configs
+  {
+    files: ['apps/agent/**/*.{ts,tsx}'],
+    plugins: { '@routecraft/routecraft': routecraftPlugin },
+    rules: {
+      '@routecraft/routecraft/capability-boundaries': 'error',
+    },
+  },
+]
+```
+
+The rule is inert for any import that does not reach into a capability's internals, so files outside a `capabilities/` tree are never flagged even without `files` scoping. Two options tune it for a different layout:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `capabilitiesDir` | `"capabilities"` | Directory name that marks the capabilities root. |
+| `publicSurface` | `"route.ts"` | File name that is a capability's public surface. |
+
+```js
+rules: {
+  '@routecraft/routecraft/capability-boundaries': [
+    'error',
+    { capabilitiesDir: 'modules', publicSurface: 'api.ts' },
+  ],
+}
+```
+
+It resolves ESM `.js` specifiers to their `.ts` sources itself, so it needs no `eslint-import-resolver-typescript`. Bare specifiers (`@scope/*`, framework packages, node builtins) are always allowed. Circular-dependency detection (`madge --circular`) is orthogonal and remains a separate check.
 
 ## Customizing severity
 

--- a/apps/routecraft.dev/src/app/docs/reference/linting/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/linting/page.md
@@ -11,13 +11,18 @@ Rule catalog for `@routecraft/eslint-plugin-routecraft`. {% .lead %}
 | `require-named-route` | error | Every `craft()` chain must call `.id(<non-empty string>)` before `.from()` | No |
 | `batch-before-from` | warn | `.batch()` must appear before `.from()` -- using it after has no effect on the current route | No |
 | `single-to-per-route` | warn | Each `craft()` chain should have at most one `.to()`; extra outputs belong in `.tap()` | No |
+| `capability-boundaries` | off (opt-in) | From outside a capability folder, import only its public-surface `route.ts`, never its internals | No |
 
 ## Presets
 
 | Preset | Description |
 |--------|-------------|
-| `routecraftPlugin.configs.recommended` | All rules at their default levels |
-| `routecraftPlugin.configs.all` | All rules as errors |
+| `routecraftPlugin.configs.recommended` | The convention rules at their default levels |
+| `routecraftPlugin.configs.all` | The convention rules as errors |
+
+`capability-boundaries` is **not** in either preset. It encodes a specific repository layout
+(`capabilities/<domain>/<capability>/route.ts`), so it is opt-in only and must be enabled
+explicitly. See [Capability boundaries](/docs/advanced/linting#capability-boundaries-opt-in).
 
 ---
 

--- a/packages/eslint-plugin-routecraft/README.md
+++ b/packages/eslint-plugin-routecraft/README.md
@@ -43,6 +43,8 @@ export default [
 
 - `routecraft/require-named-route`: Enforce `.id(<non-empty string>)` before `.from()` in a `craft()` chain
 - `routecraft/batch-before-from`: Enforce `batch()` is used as a route-level operation before `.from()`
+- `routecraft/single-to-per-route`: Warn when a route uses more than one `.to()`
+- `routecraft/capability-boundaries` (opt-in): Enforce capability module boundaries (Spring Modulith style)
 
 ### routecraft/require-named-route
 
@@ -69,6 +71,90 @@ craft()
   .batch({ size: 50 })
   .to(dest)
 ```
+
+### routecraft/capability-boundaries (opt-in)
+
+Enforces Spring-Modulith-style module boundaries between capabilities. A capability
+is any folder that contains a public-surface file (`route.ts` by default) under a
+`capabilities/` directory. The route file is the capability's only public surface;
+every other file in the folder is internal. From outside a capability, only its
+public surface may be imported. Share across capabilities via a `direct()` route or
+a shared package instead.
+
+```
+apps/agent/
+  capabilities/
+    index.ts                 # registry: imports each route.ts (the public surface)
+    employees/               # domain grouping only (no shared code, no route.ts)
+      onboard/
+        route.ts             # PUBLIC SURFACE
+        mapper.ts            # internal
+      offboard/
+        route.ts
+  env.ts
+packages/
+  shared/                    # shared code: bare @scope/* imports, always allowed
+```
+
+```ts
+// from apps/agent/capabilities/employees/onboard/route.ts
+
+// ✅ Good
+import other from "../offboard/route.js";          // sibling public surface
+import { map } from "./mapper.js";                  // same capability (internal)
+import { util } from "@scope/shared";               // shared package
+
+// ❌ Bad
+import { map } from "../offboard/mapper.js";         // another capability's internal
+```
+
+This rule is **opt-in**: it encodes a specific repository layout and is deliberately
+excluded from both the `recommended` and `all` configs. Enable it explicitly:
+
+```js
+// eslint.config.mjs
+import routecraftPlugin from "@routecraft/eslint-plugin-routecraft";
+
+export default [
+  {
+    // Scope the rule to the part of the repo that follows the layout. In a
+    // mixed monorepo where only one app is Routecraft, point `files` at it.
+    files: ["apps/agent/**/*.{ts,tsx}"],
+    plugins: { routecraft: routecraftPlugin },
+    rules: {
+      "routecraft/capability-boundaries": "error",
+    },
+  },
+];
+```
+
+The rule is inert for any import that does not reach into a capability's internals,
+so files outside a `capabilities/` tree are never flagged even without `files`
+scoping. Two options tune it for a different layout:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `capabilitiesDir` | `"capabilities"` | Directory name that marks the capabilities root. |
+| `publicSurface` | `"route.ts"` | File name that is a capability's public surface. |
+
+```js
+rules: {
+  "routecraft/capability-boundaries": [
+    "error",
+    { capabilitiesDir: "modules", publicSurface: "api.ts" },
+  ],
+}
+```
+
+It resolves ESM `.js` specifiers to their `.ts` sources itself, so it needs no
+`eslint-import-resolver-typescript`. Bare specifiers (`@scope/*`, framework
+packages, node builtins) are always allowed. Circular-dependency detection
+(`madge --circular`) is orthogonal and remains a separate check.
+
+A capability is detected as the nearest ancestor folder that contains the
+public-surface file, so domain grouping folders must not contain one themselves
+(a `route.ts` directly under `employees/` would make `employees/` a capability).
+Keep the public surface at the capability leaf, never at a grouping level.
 
 ## Recommended Configuration
 

--- a/packages/eslint-plugin-routecraft/src/index.ts
+++ b/packages/eslint-plugin-routecraft/src/index.ts
@@ -2,11 +2,15 @@ import type { Rule } from "eslint";
 import requireNamedRouteRule from "./rules/require-named-route.ts";
 import batchBeforeFromRule from "./rules/batch-before-from.ts";
 import singleToPerRouteRule from "./rules/single-to-per-route.ts";
+import capabilityBoundariesRule from "./rules/capability-boundaries.ts";
 
 export const rules: Record<string, Rule.RuleModule> = {
   "require-named-route": requireNamedRouteRule,
   "batch-before-from": batchBeforeFromRule,
   "single-to-per-route": singleToPerRouteRule,
+  // Opt-in only: capability-boundaries encodes a specific repository layout
+  // and is deliberately excluded from the recommended/all configs below.
+  "capability-boundaries": capabilityBoundariesRule,
 };
 
 export const configs = {

--- a/packages/eslint-plugin-routecraft/src/rules/capability-boundaries.ts
+++ b/packages/eslint-plugin-routecraft/src/rules/capability-boundaries.ts
@@ -1,0 +1,267 @@
+import type { Rule } from "eslint";
+import { existsSync, statSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
+
+/**
+ * Spring-Modulith-style capability boundary rule.
+ *
+ * A "capability" is a folder that contains the public-surface file (`route.ts`
+ * by default) somewhere under a `capabilities/` directory. The capability's
+ * route file is its only public surface; every other file in the folder is
+ * internal. From outside a capability, only its public surface may be imported.
+ *
+ * The rule resolves relative specifiers itself (it never needs
+ * `eslint-import-resolver-typescript`) and compares basenames without
+ * extensions, so an ESM `./mapper.js` specifier resolves to its `./mapper.ts`
+ * source. Bare specifiers (`@scope/*`, framework packages, node builtins) are
+ * always allowed, so cross-package sharing keeps working.
+ */
+
+// Extensions we treat as interchangeable when comparing a specifier against the
+// public-surface file name. An ESM build emits `.js` specifiers that map to
+// `.ts` sources, so `route.js` and `route.ts` are the same public surface.
+const MODULE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+];
+
+function stripModuleExtension(name: string): string {
+  for (const ext of MODULE_EXTENSIONS) {
+    if (name.endsWith(ext)) {
+      return name.slice(0, -ext.length);
+    }
+  }
+  return name;
+}
+
+interface CapabilityBoundariesOptions {
+  capabilitiesDir: string;
+  publicSurface: string;
+}
+
+const DEFAULT_OPTIONS: CapabilityBoundariesOptions = {
+  capabilitiesDir: "capabilities",
+  publicSurface: "route.ts",
+};
+
+/**
+ * Does `dir` directly contain the public-surface file?
+ *
+ * Detection is extension-agnostic so it stays consistent with the public-surface
+ * comparison in the rule body: pointing the rule at a source tree (`route.ts`)
+ * or an emitted tree (`route.js`) both work, and configuring
+ * `publicSurface: "route.js"` does not silently disable the rule.
+ */
+function hasPublicSurface(
+  dir: string,
+  options: CapabilityBoundariesOptions,
+): boolean {
+  if (existsSync(join(dir, options.publicSurface))) {
+    return true;
+  }
+  const stem = stripModuleExtension(options.publicSurface);
+  // Only probe extension variants when publicSurface actually carries a module
+  // extension; a bare name like "PUBLIC" should match literally, nothing else.
+  if (stem !== options.publicSurface) {
+    for (const ext of MODULE_EXTENSIONS) {
+      if (existsSync(join(dir, stem + ext))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Find the capability directory that owns `startDir`, or null when `startDir`
+ * is not inside a capability.
+ *
+ * A capability directory is the nearest ancestor of `startDir` (inclusive) that
+ * (a) lives under a `capabilitiesDir` segment and (b) directly contains the
+ * public-surface file. Domain grouping folders (which hold no `route.ts`) and
+ * the `capabilitiesDir` itself are never capabilities.
+ */
+function findCapabilityDir(
+  startDir: string,
+  options: CapabilityBoundariesOptions,
+): string | null {
+  // Cheap guard: a capability can only exist under the capabilities root.
+  if (!startDir.split(sep).includes(options.capabilitiesDir)) {
+    return null;
+  }
+
+  let dir = startDir;
+  while (true) {
+    // Reaching the capabilities root means we never found an owning capability.
+    if (basename(dir) === options.capabilitiesDir) {
+      return null;
+    }
+    if (hasPublicSurface(dir, options)) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      // Filesystem root; stop walking.
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * The `source` of an import/export-from declaration is a string Literal node.
+ * We type it structurally to avoid an `@types/estree` dependency (matching the
+ * other rules in this plugin, which type-guard ESTree shapes locally).
+ */
+interface SourceLiteral {
+  value: unknown;
+}
+
+function getSourceLiteral(node: unknown): SourceLiteral | null {
+  if (typeof node !== "object" || node === null || !("source" in node)) {
+    return null;
+  }
+  const source = (node as { source?: unknown }).source;
+  if (
+    typeof source === "object" &&
+    source !== null &&
+    "value" in source &&
+    "type" in source
+  ) {
+    return source as SourceLiteral;
+  }
+  return null;
+}
+
+interface ResolvedTarget {
+  /** Directory the specifier resolves into. */
+  dir: string;
+  /** File basename, or null when the specifier resolves to a directory. */
+  base: string | null;
+}
+
+/**
+ * Resolve a relative specifier to the directory it lands in plus the imported
+ * file basename. Directory specifiers (which resolve to an `index` barrel, not
+ * the public surface) report a null basename so they are never mistaken for the
+ * public surface.
+ */
+function resolveTarget(fromDir: string, specifier: string): ResolvedTarget {
+  const resolved = resolve(fromDir, specifier);
+  if (existsSync(resolved) && statSync(resolved).isDirectory()) {
+    return { dir: resolved, base: null };
+  }
+  return { dir: dirname(resolved), base: basename(resolved) };
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce capability module boundaries: from outside a capability folder, import only its public-surface route file, never its internals.",
+      // Opt-in only. This encodes a specific repository layout
+      // (`capabilities/<domain>/<capability>/route.ts`) and must not be turned
+      // on by the plugin's recommended or all configs.
+      recommended: false,
+    },
+    messages: {
+      crossCapabilityInternalImport:
+        "capability-boundaries: '{{specifier}}' reaches into capability '{{capability}}' internals. From outside a capability, import only its public surface ('{{surface}}'); share via a direct() route or a shared package instead.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          capabilitiesDir: {
+            type: "string",
+            description:
+              "Directory name that marks the capabilities root. Defaults to 'capabilities'.",
+          },
+          publicSurface: {
+            type: "string",
+            description:
+              "File name that is a capability's public surface. Defaults to 'route.ts'.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const rawOptions = (context.options[0] ??
+      {}) as Partial<CapabilityBoundariesOptions>;
+    const options: CapabilityBoundariesOptions = {
+      capabilitiesDir:
+        rawOptions.capabilitiesDir ?? DEFAULT_OPTIONS.capabilitiesDir,
+      publicSurface: rawOptions.publicSurface ?? DEFAULT_OPTIONS.publicSurface,
+    };
+
+    const filename = context.physicalFilename ?? context.filename;
+    // RuleTester and some processors hand back virtual names like "<input>";
+    // path logic needs a real absolute path to resolve against.
+    if (!filename || !isAbsolute(filename)) {
+      return {};
+    }
+
+    const currentDir = dirname(filename);
+    const sourceCapDir = findCapabilityDir(currentDir, options);
+    const publicSurfaceStem = stripModuleExtension(options.publicSurface);
+
+    function checkSource(node: unknown): void {
+      const source = getSourceLiteral(node);
+      if (!source) return;
+      const specifier = source.value;
+      if (typeof specifier !== "string") return;
+      // Only relative specifiers can cross a capability boundary in-tree.
+      // Bare specifiers (packages, framework, node builtins) are always allowed.
+      if (!specifier.startsWith(".")) return;
+
+      const target = resolveTarget(currentDir, specifier);
+      const targetCapDir = findCapabilityDir(target.dir, options);
+
+      // Target is not inside any capability: shared/non-capability code, allowed.
+      if (!targetCapDir) return;
+
+      // Intra-capability import: unrestricted.
+      if (targetCapDir === sourceCapDir) return;
+
+      // The capability's public surface is the one cross-boundary file allowed.
+      const isPublicSurface =
+        target.base !== null &&
+        stripModuleExtension(target.base) === publicSurfaceStem &&
+        target.dir === targetCapDir;
+      if (isPublicSurface) return;
+
+      context.report({
+        node: source as unknown as Rule.Node,
+        messageId: "crossCapabilityInternalImport",
+        data: {
+          specifier,
+          capability: basename(targetCapDir),
+          surface: options.publicSurface,
+        },
+      });
+    }
+
+    return {
+      ImportDeclaration(node) {
+        checkSource(node);
+      },
+      ExportNamedDeclaration(node) {
+        checkSource(node);
+      },
+      ExportAllDeclaration(node) {
+        checkSource(node);
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries-custom/modules/alpha/api.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries-custom/modules/alpha/api.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries-custom/modules/alpha/internal.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries-custom/modules/alpha/internal.ts
@@ -1,0 +1,1 @@
+export const internal = 1;

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries-custom/modules/beta/api.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries-custom/modules/beta/api.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries-custom/modules/beta/internal.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries-custom/modules/beta/internal.ts
@@ -1,0 +1,1 @@
+export const internal = 2;

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/built/internal.js
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/built/internal.js
@@ -1,0 +1,1 @@
+export const internal = 1;

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/built/route.js
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/built/route.js
@@ -1,0 +1,1 @@
+export const surface = 1;

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/comms/notify/lib.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/comms/notify/lib.ts
@@ -1,0 +1,1 @@
+export const send = 1;

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/comms/notify/route.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/comms/notify/route.ts
@@ -1,0 +1,2 @@
+// public surface placeholder
+export default {};

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/offboard/mapper.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/offboard/mapper.ts
@@ -1,0 +1,1 @@
+export const map = 1;

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/offboard/route.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/offboard/route.ts
@@ -1,0 +1,2 @@
+// public surface placeholder
+export default {};

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/onboard/__fixtures__/sample.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/onboard/__fixtures__/sample.ts
@@ -1,0 +1,1 @@
+export const fixture = {};

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/onboard/lib.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/onboard/lib.ts
@@ -1,0 +1,1 @@
+export const lib = 1;

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/onboard/mapper.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/onboard/mapper.ts
@@ -1,0 +1,1 @@
+export const map = 1;

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/onboard/route.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/employees/onboard/route.ts
@@ -1,0 +1,2 @@
+// public surface placeholder
+export default {};

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/index.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/index.ts
@@ -1,0 +1,1 @@
+export const registry = {};

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/standalone/route.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/capabilities/standalone/route.ts
@@ -1,0 +1,2 @@
+// public surface placeholder
+export default {};

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/env.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/apps/agent/env.ts
@@ -1,0 +1,1 @@
+export const env = {};

--- a/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/packages/shared/index.ts
+++ b/packages/eslint-plugin-routecraft/test/__fixtures__/capability-boundaries/packages/shared/index.ts
@@ -1,0 +1,1 @@
+export const util = () => {};

--- a/packages/eslint-plugin-routecraft/test/capability-boundaries.bun.test.ts
+++ b/packages/eslint-plugin-routecraft/test/capability-boundaries.bun.test.ts
@@ -1,0 +1,258 @@
+import { describe, test } from "bun:test";
+import { RuleTester } from "eslint";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import capabilityBoundariesRule from "../src/rules/capability-boundaries";
+
+// ESLint's RuleTester registers describe/it blocks dynamically when
+// `.run(...)` is called. Bun:test does not allow new test registrations
+// from inside a running test() callback, so `.run(...)` must happen at
+// module top-level. See .standards/testing.md § 2 for why RuleTester
+// files use describe-level JSDoc instead of per-test JSDoc.
+(
+  RuleTester as unknown as { describe: typeof describe; it: typeof test }
+).describe = describe;
+(RuleTester as unknown as { describe: typeof describe; it: typeof test }).it =
+  test;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+// The rule resolves specifiers against the real filesystem to find the owning
+// capability (a folder containing route.ts), so tests point `filename` at a
+// real fixture tree. RuleTester lints the `code` string; the fixture files only
+// need to exist so capability detection can locate their route.ts.
+const fixturesRoot = fileURLToPath(
+  new URL("./__fixtures__/capability-boundaries", import.meta.url),
+);
+const cap = (...segments: string[]): string => join(fixturesRoot, ...segments);
+
+/**
+ * @case capability-boundaries rule on the default `capabilities/route.ts` layout: intra-capability, public-surface, bare, and shared imports pass; reaching into another capability's internals is flagged
+ * @preconditions A real fixture tree under capabilities/ with domain folders, nested capabilities, a registry index.ts, an app env.ts, and a shared package; imports exercised from inside and outside capabilities, including ESM .js specifiers, type imports, export-from, and a directory (barrel) import
+ * @expectedResult Valid partition reports nothing; each invalid case reports exactly one crossCapabilityInternalImport naming the target capability
+ */
+ruleTester.run("capability-boundaries", capabilityBoundariesRule, {
+  valid: [
+    // Intra-capability: route.ts -> ./mapper.js (same folder) is unrestricted.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import { map } from "./mapper.js";`,
+    },
+    // Intra-capability from a nested subfolder back up to the capability files.
+    {
+      filename: cap(
+        "apps/agent/capabilities/employees/onboard/__fixtures__/sample.ts",
+      ),
+      code: `import { map } from "../mapper.js";`,
+    },
+    // Cross-capability via the public surface (sibling capability route.ts).
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import other from "../offboard/route.js";`,
+    },
+    // Cross-capability import from another domain's public surface. The rule is
+    // import-kind agnostic, so a value import covers the type-import path too.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import { Output } from "../../comms/notify/route.js";`,
+    },
+    // Bare specifiers (framework, shared packages) are always allowed.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import { craft } from "@routecraft/routecraft";`,
+    },
+    // Relative import into a shared package outside the capabilities tree.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import { util } from "../../../../packages/shared/index.js";`,
+    },
+    // The registry imports each capability's public surface; allowed.
+    {
+      filename: cap("apps/agent/capabilities/index.ts"),
+      code: `import onboard from "./employees/onboard/route.js";`,
+    },
+    // A capability directly under capabilities/ importing a sibling's surface.
+    {
+      filename: cap("apps/agent/capabilities/standalone/route.ts"),
+      code: `import notify from "../comms/notify/route.js";`,
+    },
+    // Re-export of a sibling capability's public surface (contract types).
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `export { Output } from "../offboard/route.js";`,
+    },
+    // Importing a node builtin is a bare specifier; allowed.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import { join } from "node:path";`,
+    },
+    // Detection is extension-agnostic: a capability whose on-disk public
+    // surface is route.js (an emitted tree) is still recognised, and importing
+    // its surface is allowed even though the default publicSurface is route.ts.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import built from "../../built/route.js";`,
+    },
+  ],
+  invalid: [
+    // Reaching into a route.js-surfaced capability's internal: detected and flagged.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import { internal } from "../../built/internal.js";`,
+      errors: [
+        {
+          messageId: "crossCapabilityInternalImport",
+          data: {
+            specifier: "../../built/internal.js",
+            capability: "built",
+            surface: "route.ts",
+          },
+        },
+      ],
+    },
+    // Reaching into a sibling capability's internal mapper.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import { map } from "../offboard/mapper.js";`,
+      errors: [
+        {
+          messageId: "crossCapabilityInternalImport",
+          data: {
+            specifier: "../offboard/mapper.js",
+            capability: "offboard",
+            surface: "route.ts",
+          },
+        },
+      ],
+    },
+    // Reaching into a capability's internal in another domain.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import { send } from "../../comms/notify/lib.js";`,
+      errors: [
+        {
+          messageId: "crossCapabilityInternalImport",
+          data: {
+            specifier: "../../comms/notify/lib.js",
+            capability: "notify",
+            surface: "route.ts",
+          },
+        },
+      ],
+    },
+    // A file outside any capability (app env) reaching into capability internals.
+    {
+      filename: cap("apps/agent/env.ts"),
+      code: `import { map } from "./capabilities/employees/onboard/mapper.js";`,
+      errors: [
+        {
+          messageId: "crossCapabilityInternalImport",
+          data: {
+            specifier: "./capabilities/employees/onboard/mapper.js",
+            capability: "onboard",
+            surface: "route.ts",
+          },
+        },
+      ],
+    },
+    // The registry reaching into an internal instead of the public surface.
+    {
+      filename: cap("apps/agent/capabilities/index.ts"),
+      code: `import { map } from "./employees/onboard/mapper.js";`,
+      errors: [
+        {
+          messageId: "crossCapabilityInternalImport",
+          data: {
+            specifier: "./employees/onboard/mapper.js",
+            capability: "onboard",
+            surface: "route.ts",
+          },
+        },
+      ],
+    },
+    // export * from another capability's internal.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `export * from "../offboard/mapper.js";`,
+      errors: [
+        {
+          messageId: "crossCapabilityInternalImport",
+          data: {
+            specifier: "../offboard/mapper.js",
+            capability: "offboard",
+            surface: "route.ts",
+          },
+        },
+      ],
+    },
+    // Directory (barrel) import of another capability resolves to its index,
+    // not its public surface, so it is a boundary violation.
+    {
+      filename: cap("apps/agent/capabilities/employees/onboard/route.ts"),
+      code: `import everything from "../offboard";`,
+      errors: [
+        {
+          messageId: "crossCapabilityInternalImport",
+          data: {
+            specifier: "../offboard",
+            capability: "offboard",
+            surface: "route.ts",
+          },
+        },
+      ],
+    },
+  ],
+});
+
+// Custom layout: capabilities root named `modules` and public surface `api.ts`.
+const customRoot = fileURLToPath(
+  new URL("./__fixtures__/capability-boundaries-custom", import.meta.url),
+);
+const mod = (...segments: string[]): string => join(customRoot, ...segments);
+const customOptions = [{ capabilitiesDir: "modules", publicSurface: "api.ts" }];
+
+/**
+ * @case capability-boundaries rule honours the capabilitiesDir and publicSurface options for repos that use a different layout
+ * @preconditions A fixture tree under modules/ where api.ts is the public surface; the rule is configured with { capabilitiesDir: "modules", publicSurface: "api.ts" }
+ * @expectedResult Importing a sibling module's api.ts passes; importing its internal.ts reports one crossCapabilityInternalImport naming the surface as api.ts
+ */
+ruleTester.run(
+  "capability-boundaries (custom options)",
+  capabilityBoundariesRule,
+  {
+    valid: [
+      {
+        filename: mod("modules/alpha/api.ts"),
+        code: `import beta from "../beta/api.js";`,
+        options: customOptions,
+      },
+      {
+        filename: mod("modules/alpha/api.ts"),
+        code: `import { internal } from "./internal.js";`,
+        options: customOptions,
+      },
+    ],
+    invalid: [
+      {
+        filename: mod("modules/alpha/api.ts"),
+        code: `import { internal } from "../beta/internal.js";`,
+        options: customOptions,
+        errors: [
+          {
+            messageId: "crossCapabilityInternalImport",
+            data: {
+              specifier: "../beta/internal.js",
+              capability: "beta",
+              surface: "api.ts",
+            },
+          },
+        ],
+      },
+    ],
+  },
+);


### PR DESCRIPTION
Closes #364.

## What

Adds a Spring-Modulith-style import boundary rule, `capability-boundaries`, to `@routecraft/eslint-plugin-routecraft`. A capability is any folder containing a public-surface file (`route.ts` by default) under a `capabilities/` directory. The route file is the capability's only public surface; everything else is internal. From outside a capability, only its public surface may be imported, so capabilities stay self-contained and regenerable.

## Behaviour

- **Detection by `route.ts` presence, not a fixed depth**, so capabilities directly under `capabilities/` and nested under domain folders both resolve.
- **Cross-boundary check applies to every file** (another capability, the registry `index.ts`, `env.ts`), matching the issue's "from outside a capability, only its route.ts may be imported."
- **Allowed:** intra-capability imports, bare specifiers (`@scope/*`, framework, node builtins), and the sanctioned cross edge (importing a callee `route.ts`).
- **Self-contained resolution:** resolves ESM `.js` specifiers to `.ts` sources itself, so no `eslint-import-resolver-typescript`. Detection is extension-agnostic, so it works on both source and emitted trees and `publicSurface: "route.js"` does not silently disable the rule.
- **Options:** `capabilitiesDir` (default `"capabilities"`) and `publicSurface` (default `"route.ts"`) for alternative layouts.

## Opt-in, as the issue requires

Deliberately excluded from **both** the `recommended` and `all` presets: it encodes a specific repository convention, so auto-enabling it via `all` would false-positive in non-conforming repos. It is also inert for any import that does not reach into a capability's internals, so files outside a `capabilities/` tree are never flagged even without `files` scoping. This covers the configurability raised in the issue comment (mixed monorepos where only one app is Routecraft): scope via flat-config `files`, or rely on the inert default.

## Tests and docs

- RuleTester suite (53 cases across the plugin) against a real on-disk fixture tree: default `capabilities/route.ts` layout, a custom `modules`/`api.ts` layout, and an emitted `route.js` capability. Covers intra-capability, public-surface, bare, shared, registry, barrel-import, and `export ... from` cases.
- Updated the plugin README and the docs reference/advanced linting pages, including a caveat that grouping folders must not contain the public-surface file.

## Verification

`format`, `lint`, `typecheck`, and the full bun suite pass. A self-review (correctness pass) flagged a detection-vs-comparison extension asymmetry, which is fixed in this PR (extension-agnostic detection plus a regression test). Circular-dependency detection (`madge --circular`) is left as the orthogonal separate check, as noted in the issue.

https://claude.ai/code/session_012FsznQxGw2QgsrQDHkrpr6

---
_Generated by [Claude Code](https://claude.ai/code/session_012FsznQxGw2QgsrQDHkrpr6)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `capability-boundaries` rule to `@routecraft/eslint-plugin-routecraft` to enforce Spring‑Modulith‑style capability boundaries and prevent cross-capability internal imports; closes #364.

- **New Features**
  - Enforces: from outside a capability, only its public surface (`route.ts` by default) can be imported; everything else is internal.
  - Detects capabilities by `route.ts` presence under `capabilities/` (not fixed depth); handles nested folders and emitted `route.js`.
  - Resolves ESM `.js` specifiers to `.ts` sources internally; no `eslint-import-resolver-typescript` needed.
  - Allows intra-capability imports and bare specifiers (e.g., `@scope/*`, framework, Node builtins); checks apply to any file (including registry `index.ts` and `env.ts`).
  - Options: `capabilitiesDir` (default `"capabilities"`), `publicSurface` (default `"route.ts"`) for custom layouts.
  - Opt-in only: excluded from `recommended` and `all`; inert outside capability trees and easy to scope via flat-config `files`.
  - Added tests across real fixture trees and updated docs (reference + advanced linting).

<sup>Written for commit c0ca14606bf9541060f547bd5acf343d51677bcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

