### PR TITLE
feat(docs): blog lightbox, post filtering, and related posts

### DIFF
--- a/apps/routecraft.dev/src/app/blog/page.tsx
+++ b/apps/routecraft.dev/src/app/blog/page.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
 
-import { BlogCard } from '@/components/BlogCard'
+import { BlogIndex } from '@/components/BlogIndex'
 import { FeaturedBlogCard } from '@/components/FeaturedBlogCard'
+import { SectionLabel } from '@/components/SectionLabel'
 import { getAllBlogPosts } from '@/lib/blog'
 
 export const metadata: Metadata = {
@@ -64,33 +65,12 @@ export default function BlogIndexPage() {
             </section>
           )}
 
-          {rest.length > 0 && (
-            <section className="mt-24">
-              <SectionLabel label="Recent posts" />
-              <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                {rest.map((post) => (
-                  <BlogCard key={post.slug} post={post} />
-                ))}
-              </div>
-            </section>
-          )}
+          {rest.length > 0 && <BlogIndex posts={rest} />}
 
           <SubscribeCallout />
         </>
       )}
     </main>
-  )
-}
-
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <div className="flex items-center gap-4">
-      <span aria-hidden="true" className="h-1.5 w-1.5 bg-cobalt-500" />
-      <span className="font-mono text-[0.65rem] tracking-[0.22em] text-ink/55 uppercase">
-        {label}
-      </span>
-      <span className="h-px flex-1 bg-ink/15" />
-    </div>
   )
 }
 

--- a/apps/routecraft.dev/src/components/BlogCard.tsx
+++ b/apps/routecraft.dev/src/components/BlogCard.tsx
@@ -21,7 +21,7 @@ export function BlogCard({
     >
       <Link
         href={post.href}
-        className="flex h-full flex-col focus:outline-none"
+        className="flex h-full flex-col focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cobalt-500"
       >
         <div
           className="relative w-full overflow-hidden border-b border-ink/15"

--- a/apps/routecraft.dev/src/components/BlogIndex.tsx
+++ b/apps/routecraft.dev/src/components/BlogIndex.tsx
@@ -11,6 +11,11 @@ import { SectionLabel } from '@/components/SectionLabel'
 // the DOM bounded no matter how many posts the archive grows to.
 const BATCH = 9
 
+// Cap the inline tag chips so the filter bar stays a tidy row or two however
+// large the tag vocabulary grows. The rest fold behind a "+N more" toggle and
+// stay findable via the search box.
+const MAX_VISIBLE_TAGS = 8
+
 /**
  * The filterable, incrementally-loaded post grid below the featured section.
  * Filtering and pagination run in the browser because the site is a static
@@ -22,6 +27,7 @@ export function BlogIndex({ posts }: { posts: BlogPostMeta[] }) {
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [query, setQuery] = useState('')
   const [visible, setVisible] = useState(BATCH)
+  const [tagsExpanded, setTagsExpanded] = useState(false)
 
   // Tags ordered by how often they appear, so the most useful filters lead.
   const allTags = useMemo(() => {
@@ -35,6 +41,17 @@ export function BlogIndex({ posts }: { posts: BlogPostMeta[] }) {
       .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
       .map(([tag]) => tag)
   }, [posts])
+
+  // Collapsed, show the top tags plus any selected tag that would otherwise be
+  // hidden, so an active filter never disappears off the end of the list.
+  const visibleTags = useMemo(() => {
+    if (tagsExpanded) return allTags
+    const top = allTags.slice(0, MAX_VISIBLE_TAGS)
+    const pinned = selectedTags.filter((tag) => !top.includes(tag))
+    return [...top, ...pinned]
+  }, [allTags, tagsExpanded, selectedTags])
+
+  const hiddenTagCount = allTags.length - visibleTags.length
 
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase()
@@ -97,7 +114,7 @@ export function BlogIndex({ posts }: { posts: BlogPostMeta[] }) {
             >
               All
             </button>
-            {allTags.map((tag) => (
+            {visibleTags.map((tag) => (
               <button
                 key={tag}
                 type="button"
@@ -108,6 +125,24 @@ export function BlogIndex({ posts }: { posts: BlogPostMeta[] }) {
                 {tag}
               </button>
             ))}
+            {!tagsExpanded && hiddenTagCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setTagsExpanded(true)}
+                className="px-2 py-1.5 font-mono text-[0.65rem] tracking-[0.2em] text-cobalt-500 uppercase transition hover:text-cobalt-600"
+              >
+                +{hiddenTagCount} more
+              </button>
+            )}
+            {tagsExpanded && allTags.length > MAX_VISIBLE_TAGS && (
+              <button
+                type="button"
+                onClick={() => setTagsExpanded(false)}
+                className="px-2 py-1.5 font-mono text-[0.65rem] tracking-[0.2em] text-cobalt-500 uppercase transition hover:text-cobalt-600"
+              >
+                Show less
+              </button>
+            )}
           </div>
         )}
 

--- a/apps/routecraft.dev/src/components/BlogIndex.tsx
+++ b/apps/routecraft.dev/src/components/BlogIndex.tsx
@@ -110,6 +110,7 @@ export function BlogIndex({ posts }: { posts: BlogPostMeta[] }) {
                 setSelectedTags([])
                 setVisible(BATCH)
               }}
+              aria-pressed={selectedTags.length === 0}
               className={chipClass(selectedTags.length === 0)}
             >
               All

--- a/apps/routecraft.dev/src/components/BlogIndex.tsx
+++ b/apps/routecraft.dev/src/components/BlogIndex.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import clsx from 'clsx'
+
+import type { BlogPostMeta } from '@/lib/blog'
+import { BlogCard } from '@/components/BlogCard'
+import { SectionLabel } from '@/components/SectionLabel'
+
+// How many posts to reveal per "Load more" click. Keeps the initial paint and
+// the DOM bounded no matter how many posts the archive grows to.
+const BATCH = 9
+
+/**
+ * The filterable, incrementally-loaded post grid below the featured section.
+ * Filtering and pagination run in the browser because the site is a static
+ * export: the full (lightweight) post metadata is already shipped, so there is
+ * no request to make. Selecting tags narrows to posts matching ANY selected tag;
+ * the search box matches title, description, and tags.
+ */
+export function BlogIndex({ posts }: { posts: BlogPostMeta[] }) {
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [query, setQuery] = useState('')
+  const [visible, setVisible] = useState(BATCH)
+
+  // Tags ordered by how often they appear, so the most useful filters lead.
+  const allTags = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const post of posts) {
+      for (const tag of post.tags ?? []) {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1)
+      }
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([tag]) => tag)
+  }, [posts])
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return posts.filter((post) => {
+      const matchesTags =
+        selectedTags.length === 0 ||
+        (post.tags ?? []).some((tag) => selectedTags.includes(tag))
+      if (!matchesTags) return false
+      if (!needle) return true
+      const haystack = [
+        post.title,
+        post.description ?? '',
+        ...(post.tags ?? []),
+      ]
+        .join(' ')
+        .toLowerCase()
+      return haystack.includes(needle)
+    })
+  }, [posts, selectedTags, query])
+
+  const shown = filtered.slice(0, visible)
+  const hasFilters = selectedTags.length > 0 || query.trim().length > 0
+
+  // Changing a filter is a user action, so the window resets to the first batch
+  // right here in the handler rather than in an effect.
+  function toggleTag(tag: string) {
+    setSelectedTags((current) =>
+      current.includes(tag)
+        ? current.filter((t) => t !== tag)
+        : [...current, tag],
+    )
+    setVisible(BATCH)
+  }
+
+  function changeQuery(value: string) {
+    setQuery(value)
+    setVisible(BATCH)
+  }
+
+  function clearFilters() {
+    setSelectedTags([])
+    setQuery('')
+    setVisible(BATCH)
+  }
+
+  return (
+    <section className="mt-24">
+      <SectionLabel label="All posts" />
+
+      <div className="mt-8 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        {allTags.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedTags([])
+                setVisible(BATCH)
+              }}
+              className={chipClass(selectedTags.length === 0)}
+            >
+              All
+            </button>
+            {allTags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleTag(tag)}
+                aria-pressed={selectedTags.includes(tag)}
+                className={chipClass(selectedTags.includes(tag))}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <label className="relative block shrink-0 lg:w-64">
+          <span className="sr-only">Search posts</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => changeQuery(event.target.value)}
+            placeholder="Search posts"
+            className="w-full border border-ink/20 bg-transparent px-3 py-2 font-mono text-[0.7rem] tracking-[0.12em] text-ink uppercase transition placeholder:text-ink/40 focus:border-cobalt-500 focus:outline-none"
+          />
+        </label>
+      </div>
+
+      <div className="mt-5 flex items-center gap-4">
+        <span className="font-mono text-[0.65rem] tracking-[0.2em] text-ink/45 uppercase">
+          {filtered.length} {filtered.length === 1 ? 'post' : 'posts'}
+        </span>
+        {hasFilters && (
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="font-mono text-[0.65rem] tracking-[0.2em] text-cobalt-500 uppercase transition hover:text-cobalt-600"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="mt-10 border border-dashed border-ink/30 p-12 text-center">
+          <p className="font-editorial text-[1.25rem] tracking-[-0.01em] text-ink italic">
+            No posts match those filters.
+          </p>
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="mt-4 font-mono text-[0.65rem] tracking-[0.2em] text-cobalt-500 uppercase transition hover:text-cobalt-600"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {shown.map((post) => (
+              <BlogCard key={post.slug} post={post} />
+            ))}
+          </div>
+
+          {filtered.length > visible && (
+            <div className="mt-12 flex justify-center">
+              <button
+                type="button"
+                onClick={() => setVisible((v) => v + BATCH)}
+                className="group inline-flex items-center gap-2 border border-ink/30 px-5 py-3 font-mono text-[0.7rem] tracking-[0.22em] text-ink uppercase transition hover:border-cobalt-500 hover:text-cobalt-500"
+              >
+                <span>Load more ({filtered.length - visible} more)</span>
+                <span
+                  aria-hidden="true"
+                  className="transition group-hover:translate-y-0.5"
+                >
+                  ↓
+                </span>
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+function chipClass(active: boolean): string {
+  return clsx(
+    'border px-3 py-1.5 font-mono text-[0.65rem] tracking-[0.2em] uppercase transition',
+    active
+      ? 'border-cobalt-500 bg-cobalt-500 text-paper'
+      : 'border-ink/20 text-ink/55 hover:border-cobalt-500 hover:text-cobalt-500',
+  )
+}

--- a/apps/routecraft.dev/src/components/BlogMeta.tsx
+++ b/apps/routecraft.dev/src/components/BlogMeta.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 
-import { formatBlogDate } from '@/lib/blog'
+import { formatBlogDate } from '@/lib/blog-date'
 
 export function BlogMeta({
   date,

--- a/apps/routecraft.dev/src/components/BlogPostLayout.tsx
+++ b/apps/routecraft.dev/src/components/BlogPostLayout.tsx
@@ -5,8 +5,10 @@ import { Prose } from '@/components/Prose'
 import { TableOfContents } from '@/components/TableOfContents'
 import { BlogMeta } from '@/components/BlogMeta'
 import { BlogCoverInline } from '@/components/BlogCover'
+import { LightboxImage } from '@/components/Lightbox'
+import { RelatedPosts } from '@/components/RelatedPosts'
 import { collectSections } from '@/lib/sections'
-import { formatBlogDate, getAllBlogPosts } from '@/lib/blog'
+import { formatBlogDate, getAllBlogPosts, getRelatedPosts } from '@/lib/blog'
 
 interface BlogPostFrontmatter {
   title?: string
@@ -22,6 +24,7 @@ interface BlogPostFrontmatter {
   coverGlyph?: string
   readingTime?: number
   draft?: boolean
+  related?: string[]
   slug?: string
 }
 
@@ -54,6 +57,10 @@ export function BlogPostLayout({
   const tableOfContents = collectSections(nodes)
   const date = typeof frontmatter.date === 'string' ? frontmatter.date : ''
   const { slug, figureNumber } = resolveSlugAndFigure(frontmatter)
+
+  const allPosts = getAllBlogPosts()
+  const current = allPosts.find((post) => post.slug === slug)
+  const related = current ? getRelatedPosts(current, 2, allPosts) : []
 
   return (
     <>
@@ -116,11 +123,10 @@ export function BlogPostLayout({
 
           {frontmatter.image ? (
             <figure className="mt-12 border border-ink/15">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
+              <LightboxImage
                 src={frontmatter.image}
                 alt={frontmatter.imageAlt ?? frontmatter.title}
-                className="w-full"
+                caption={frontmatter.imageAlt}
               />
             </figure>
           ) : (
@@ -139,6 +145,8 @@ export function BlogPostLayout({
           <div className="mt-12">
             <Prose>{children}</Prose>
           </div>
+
+          <RelatedPosts posts={related} />
 
           <footer className="mt-20 border-t border-ink/15 pt-8">
             <p className="font-editorial text-[1rem] text-ink/70 italic">

--- a/apps/routecraft.dev/src/components/FeaturedBlogCard.tsx
+++ b/apps/routecraft.dev/src/components/FeaturedBlogCard.tsx
@@ -10,7 +10,7 @@ export function FeaturedBlogCard({ post }: { post: BlogPostMeta }) {
     <article className="group relative flex flex-col border border-ink/15 transition hover:border-cobalt-500/50">
       <Link
         href={post.href}
-        className="flex h-full flex-col p-8 focus:outline-none lg:p-10"
+        className="flex h-full flex-col p-8 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cobalt-500 lg:p-10"
       >
         <div className="flex items-center gap-3 font-mono text-[0.65rem] tracking-[0.22em] uppercase">
           <span className="flex items-center gap-2 text-cobalt-500">

--- a/apps/routecraft.dev/src/components/Lightbox.tsx
+++ b/apps/routecraft.dev/src/components/Lightbox.tsx
@@ -82,9 +82,9 @@ export function LightboxImage({
               className="max-h-[82vh] w-auto max-w-full cursor-zoom-out border border-paper/15 object-contain"
             />
             {overlayCaption && (
-              <figcaption className="max-w-2xl text-center font-mono text-[0.65rem] tracking-[0.2em] text-paper/55 uppercase">
+              <p className="max-w-2xl text-center font-mono text-[0.65rem] tracking-[0.2em] text-paper/55 uppercase">
                 {overlayCaption}
-              </figcaption>
+              </p>
             )}
           </DialogPanel>
         </div>

--- a/apps/routecraft.dev/src/components/Lightbox.tsx
+++ b/apps/routecraft.dev/src/components/Lightbox.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState } from 'react'
+import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react'
+import clsx from 'clsx'
+
+/**
+ * A content image that expands into a full-screen lightbox on click. Used for
+ * every image inside a post: the hero, standalone markdown images, and figures.
+ * The overlay shows the image at full resolution (the site ships unoptimized
+ * images, so the same `src` is the high-quality original).
+ */
+export function LightboxImage({
+  src,
+  alt = '',
+  caption,
+  title,
+  className,
+}: {
+  src?: string
+  alt?: string
+  caption?: string
+  /** Markdown image title (`![alt](src "title")`); used as the overlay caption. */
+  title?: string
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+  if (!src) return null
+
+  const overlayCaption = caption ?? title
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={alt ? `Expand image: ${alt}` : 'Expand image'}
+        className={clsx(
+          'group/lightbox block w-full cursor-zoom-in border-0 bg-transparent p-0',
+          className,
+        )}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={src}
+          alt={alt}
+          className="w-full transition duration-500 group-hover/lightbox:opacity-90"
+        />
+      </button>
+
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        className="relative z-[60]"
+      >
+        <DialogBackdrop
+          transition
+          className="fixed inset-0 bg-ink/90 backdrop-blur-sm transition duration-300 ease-out data-[closed]:opacity-0"
+        />
+
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="fixed top-5 right-5 z-10 inline-flex items-center gap-2 font-mono text-[0.65rem] tracking-[0.22em] text-paper/70 uppercase transition hover:text-paper sm:top-7 sm:right-7"
+        >
+          <span>Close</span>
+          <span aria-hidden="true" className="text-[0.9rem] leading-none">
+            ✕
+          </span>
+        </button>
+
+        <div className="fixed inset-0 flex items-center justify-center p-4 sm:p-10">
+          <DialogPanel
+            transition
+            className="relative flex max-h-full flex-col items-center gap-4 transition duration-300 ease-out data-[closed]:scale-[0.97] data-[closed]:opacity-0"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={src}
+              alt={alt}
+              onClick={() => setOpen(false)}
+              className="max-h-[82vh] w-auto max-w-full cursor-zoom-out border border-paper/15 object-contain"
+            />
+            {overlayCaption && (
+              <figcaption className="max-w-2xl text-center font-mono text-[0.65rem] tracking-[0.2em] text-paper/55 uppercase">
+                {overlayCaption}
+              </figcaption>
+            )}
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/routecraft.dev/src/components/RelatedPosts.tsx
+++ b/apps/routecraft.dev/src/components/RelatedPosts.tsx
@@ -21,7 +21,7 @@ export function RelatedPosts({ posts }: { posts: BlogPostMeta[] }) {
           >
             <Link
               href={post.href}
-              className="flex h-full flex-col p-6 focus:outline-none"
+              className="flex h-full flex-col p-6 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cobalt-500"
             >
               {post.tags && post.tags.length > 0 && (
                 <div className="mb-4 flex flex-wrap items-center gap-2 font-mono text-[0.65rem] tracking-[0.22em] text-ink/55 uppercase">

--- a/apps/routecraft.dev/src/components/RelatedPosts.tsx
+++ b/apps/routecraft.dev/src/components/RelatedPosts.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link'
+
+import type { BlogPostMeta } from '@/lib/blog'
+import { BlogMeta } from '@/components/BlogMeta'
+import { SectionLabel } from '@/components/SectionLabel'
+
+// Text-forward "keep reading" cards shown at the foot of a post. Deliberately
+// lighter than the index grid: no cover art, just the tags, title, and meta, so
+// the suggestion reads as a quiet nudge rather than a second hero.
+export function RelatedPosts({ posts }: { posts: BlogPostMeta[] }) {
+  if (posts.length === 0) return null
+
+  return (
+    <section className="mt-20 border-t border-ink/15 pt-10">
+      <SectionLabel label="Keep reading" />
+      <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2">
+        {posts.map((post) => (
+          <article
+            key={post.slug}
+            className="group relative flex flex-col border border-ink/15 bg-paper-deep/30 transition hover:border-cobalt-500/50"
+          >
+            <Link
+              href={post.href}
+              className="flex h-full flex-col p-6 focus:outline-none"
+            >
+              {post.tags && post.tags.length > 0 && (
+                <div className="mb-4 flex flex-wrap items-center gap-2 font-mono text-[0.65rem] tracking-[0.22em] text-ink/55 uppercase">
+                  {post.tags.slice(0, 3).map((tag, i) => (
+                    <span key={tag} className="inline-flex items-center gap-2">
+                      {i > 0 && (
+                        <span aria-hidden="true" className="text-ink/25">
+                          ·
+                        </span>
+                      )}
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+              <h3 className="font-editorial text-[1.3rem] leading-[1.2] tracking-[-0.015em] text-ink transition group-hover:text-cobalt-500">
+                {post.title}
+              </h3>
+              {post.description && (
+                <p className="mt-3 line-clamp-2 text-sm leading-[1.6] text-ink/65">
+                  {post.description}
+                </p>
+              )}
+              <div className="mt-auto pt-5">
+                <BlogMeta date={post.date} readingTime={post.readingTime} />
+              </div>
+            </Link>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/routecraft.dev/src/components/RelatedPosts.tsx
+++ b/apps/routecraft.dev/src/components/RelatedPosts.tsx
@@ -11,7 +11,7 @@ export function RelatedPosts({ posts }: { posts: BlogPostMeta[] }) {
   if (posts.length === 0) return null
 
   return (
-    <section className="mt-20 border-t border-ink/15 pt-10">
+    <section className="mt-20">
       <SectionLabel label="Keep reading" />
       <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2">
         {posts.map((post) => (

--- a/apps/routecraft.dev/src/components/SectionLabel.tsx
+++ b/apps/routecraft.dev/src/components/SectionLabel.tsx
@@ -1,0 +1,13 @@
+// The hairline-rule section heading used across the blog: a cobalt tick, a mono
+// uppercase label, and a rule that fills the remaining width.
+export function SectionLabel({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-4">
+      <span aria-hidden="true" className="h-1.5 w-1.5 bg-cobalt-500" />
+      <span className="font-mono text-[0.65rem] tracking-[0.22em] text-ink/55 uppercase">
+        {label}
+      </span>
+      <span className="h-px flex-1 bg-ink/15" />
+    </div>
+  )
+}

--- a/apps/routecraft.dev/src/lib/blog-date.ts
+++ b/apps/routecraft.dev/src/lib/blog-date.ts
@@ -1,0 +1,13 @@
+// Pure date formatting for posts, kept free of Node built-ins (`fs`/`path`) so
+// it can be imported from client components like BlogMeta without dragging the
+// filesystem-backed `blog.ts` into the browser bundle.
+export function formatBlogDate(value: string): string {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}

--- a/apps/routecraft.dev/src/lib/blog.ts
+++ b/apps/routecraft.dev/src/lib/blog.ts
@@ -130,7 +130,9 @@ export function getRelatedPosts(
   const candidates = posts.filter((p) => !p.draft && p.slug !== current.slug)
 
   if (current.related && current.related.length > 0) {
-    return current.related
+    // Dedupe slugs first (Set preserves insertion order) so a repeated slug in
+    // frontmatter cannot render the same post twice.
+    return [...new Set(current.related)]
       .map((slug) => candidates.find((p) => p.slug === slug))
       .filter((p): p is BlogPostMeta => Boolean(p))
       .slice(0, limit)

--- a/apps/routecraft.dev/src/lib/blog.ts
+++ b/apps/routecraft.dev/src/lib/blog.ts
@@ -2,6 +2,10 @@ import fs from 'fs'
 import path from 'path'
 
 import { parseFrontmatter } from '@/lib/frontmatter'
+import { formatBlogDate } from '@/lib/blog-date'
+
+// Re-exported so existing server-side importers of `@/lib/blog` keep working.
+export { formatBlogDate }
 
 export interface BlogPostMeta {
   slug: string
@@ -20,6 +24,8 @@ export interface BlogPostMeta {
   imageAlt?: string
   /** Override the auto-picked cover glyph. First character only. */
   coverGlyph?: string
+  /** Explicit follow-up posts (slugs); overrides the tag-based suggestions. */
+  related?: string[]
   readingTime: number
   href: string
 }
@@ -69,6 +75,7 @@ function readPost(blogDir: string, slug: string): BlogPostMeta | undefined {
     imageAlt: typeof data.imageAlt === 'string' ? data.imageAlt : undefined,
     coverGlyph:
       typeof data.coverGlyph === 'string' ? data.coverGlyph : undefined,
+    related: Array.isArray(data.related) ? data.related.map(String) : undefined,
     readingTime:
       typeof data.readingTime === 'number'
         ? data.readingTime
@@ -109,18 +116,45 @@ export function getFeaturedPost(
   )
 }
 
+/**
+ * Suggested follow-up posts for a given post. An explicit `related` list in the
+ * post's frontmatter wins (author's order, unknown slugs dropped); otherwise the
+ * posts sharing the most tags are returned, most recent breaking ties. Drafts
+ * and the post itself are never suggested.
+ */
+export function getRelatedPosts(
+  current: BlogPostMeta,
+  limit = 2,
+  posts: BlogPostMeta[] = getAllBlogPosts(),
+): BlogPostMeta[] {
+  const candidates = posts.filter((p) => !p.draft && p.slug !== current.slug)
+
+  if (current.related && current.related.length > 0) {
+    return current.related
+      .map((slug) => candidates.find((p) => p.slug === slug))
+      .filter((p): p is BlogPostMeta => Boolean(p))
+      .slice(0, limit)
+  }
+
+  const tags = new Set(current.tags ?? [])
+  if (tags.size === 0) return []
+
+  return candidates
+    .map((post) => ({
+      post,
+      shared: (post.tags ?? []).filter((tag) => tags.has(tag)).length,
+    }))
+    .filter((entry) => entry.shared > 0)
+    .sort(
+      (a, b) =>
+        b.shared - a.shared ||
+        (b.post.date || '').localeCompare(a.post.date || ''),
+    )
+    .slice(0, limit)
+    .map((entry) => entry.post)
+}
+
 export function getBlogPostBySlug(slug: string): BlogPostMeta | undefined {
   const blogDir = path.join(process.cwd(), 'src', 'app', 'blog')
   return readPost(blogDir, slug)
-}
-
-export function formatBlogDate(value: string): string {
-  if (!value) return ''
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return value
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
 }

--- a/apps/routecraft.dev/src/markdoc/nodes.js
+++ b/apps/routecraft.dev/src/markdoc/nodes.js
@@ -6,6 +6,7 @@ import Markdoc from '@markdoc/markdoc'
 import { PageLayout } from '@/components/PageLayout'
 import { Fence } from '@/components/Fence'
 import { InlineCode } from '@/components/InlineCode'
+import { LightboxImage } from '@/components/Lightbox'
 
 let documentSlugifyMap = new Map()
 
@@ -132,6 +133,12 @@ const nodes = {
         type: String,
       },
     },
+  },
+  // Standard markdown images (`![alt](src "title")`) open in a lightbox so
+  // readers can inspect diagrams and screenshots at full resolution.
+  image: {
+    ...defaultNodes.image,
+    render: LightboxImage,
   },
 }
 

--- a/apps/routecraft.dev/src/markdoc/tags.js
+++ b/apps/routecraft.dev/src/markdoc/tags.js
@@ -1,4 +1,5 @@
 import { Callout } from '@/components/Callout'
+import { LightboxImage } from '@/components/Lightbox'
 import { Badge } from '@/components/Badge'
 import { QuickLink, QuickLinks } from '@/components/QuickLinks'
 import { CodeTabs, CodeTab } from '@/components/CodeTabs'
@@ -31,9 +32,8 @@ const tags = {
     },
     render: ({ src, alt = '', caption }) => (
       <figure>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={src} alt={alt} />
-        <figcaption>{caption}</figcaption>
+        <LightboxImage src={src} alt={alt} caption={caption} />
+        {caption ? <figcaption>{caption}</figcaption> : null}
       </figure>
     ),
   },


### PR DESCRIPTION
## What

Three reading-experience improvements to the blog, plus the supporting refactors. Everything renders server-side for SEO and hydrates for interactivity, and matches the existing editorial aesthetic (Fraunces, cobalt accent, ink/paper tokens, mono micro-labels, hairline borders).

### Image lightbox
Every post image (the hero, standard markdown `[](...)`, and `{% figure %}`) opens full-screen on click via a new client `LightboxImage` (Headless UI `Dialog`, no new dependency). Markdown image titles surface as the overlay caption. Wired through the Markdoc `image` node and `figure` tag, so it covers all current and future posts.

### Index filtering and pagination
The flat grid becomes a filterable archive (`BlogIndex`):
- Clickable tag chips ordered by frequency; selecting tags narrows to posts matching any selected tag.
- A search box matching title, description, and tags.
- A "Load more" button revealing posts in batches of 9, so the page and DOM stay bounded as the archive grows.
- The tag bar caps at the 8 most-used tags with a "+N more" / "Show less" toggle; any active-but-hidden tag stays pinned visible, and rarer tags remain reachable via search.

Filtering runs in the browser because the site is a static export.

### Related posts
Each post ends with a "Keep reading" section suggesting up to two follow-ups, chosen by shared-tag overlap (most recent breaking ties), with an optional `related: [slug]` frontmatter override. Logic lives in `getRelatedPosts`.

### Supporting refactors
- Extract the shared `SectionLabel`.
- Split the pure `formatBlogDate` into `blog-date.ts` so client components can format dates without pulling the filesystem-backed `blog.ts` into the browser bundle.

## Notes
- Only one published post currently exists on `main`, so the index grid and related sections stay hidden until more posts are published (drafts are excluded by design). Verified by temporarily publishing posts during a local build: the index, filters, "Load more", tag toggle, and related section all render server-side.
- No new dependencies; typecheck, lint, and a full `next build` static export pass.

https://claude.ai/code/session_01B2wXbsCsSomNG3k1VshpW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2wXbsCsSomNG3k1VshpW7)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full-screen image lightbox, tag/search filtering with “Load more,” and related post suggestions to improve the blog reading experience. Now wired into the blog index and updated for better accessibility and valid markup; pages render server-side and hydrate for interactivity.

- **New Features**
  - Full-screen lightbox for all post images via `LightboxImage` (Markdown titles shown as captions; wired into Markdoc image node and `figure` tag; built with `@headlessui/react` `Dialog`).
  - Filterable blog index (`BlogIndex`): tag chips ordered by frequency with a “+N more” toggle, search across title/description/tags, and “Load more” in batches of 9.
  - Related posts (“Keep reading”): up to two suggestions by shared-tag overlap, with optional `related: [slug]` frontmatter override.

- **Bug Fixes**
  - Accessibility and HTML: focus-visible outlines on card links; aria-pressed on “All” filter; lightbox caption rendered as a paragraph instead of `figcaption`.
  - Related posts: dedupe explicit `related` slugs to prevent duplicate suggestions.

<sup>Written for commit 24fd08bbfc3d2349059e11949a1c1dfdc776d8f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

