### PR TITLE
feat(operations): implement circuit breaker operation (route + step scope)

### DIFF
--- a/.standards/pre-from-filter-chain.md
+++ b/.standards/pre-from-filter-chain.md
@@ -8,9 +8,8 @@ called on the builder. Builder order is for ergonomics; runtime
 order is the framework's call.
 
 This document is the single source of truth for that order. The
-resilience wrappers (`.throttle()`, `.retry()`, `.timeout()`) slot into
-the positions named below; the future `.circuitBreaker()` reserves
-position #6.
+resilience wrappers (`.throttle()`, `.circuitBreaker()`, `.retry()`,
+`.timeout()`) slot into the positions named below.
 
 Inspiration: Spring's `FilterChainProxy` / `WebSecurityConfigurerAdapter`
 and Resilience4J's wrapper composition. The framework picks the
@@ -30,7 +29,7 @@ below).
 | 3 | `parse` | shipped (source-attached) | yes (`RC5016`) | raw bytes → typed body; deterministic, not retried |
 | 4 | `input` | shipped | yes (`RC5002`) | schema validation; deterministic, not retried |
 | 5 | `throttle` | shipped (#151) | `mode: 'reject'` only (`RC5013`); default `'delay'` paces | rate limit valid requests (not pre-auth; that's source-layer DoS protection). Delay paces; reject fails fast with `RC5013` |
-| 6 | `circuitBreaker` | planned (#139) | yes (new RC code, fast-fail when open) | counts inner failures; trips after threshold |
+| 6 | `circuitBreaker` | shipped (#139) | yes (`RC5025`, fast-fail when open) | counts inner failures; trips after threshold, fast-fails (fallback or `RC5025`) until cooldown, then probes |
 | 7 | `retry` | shipped (#148) | yes (final attempt's throw) | re-runs everything below on failure |
 | 8 | `timeout` | shipped (#147) | yes (`RC5011`) | per-attempt deadline |
 | 9 | `cacheCheck` | shipped (#112) | yes (`RC5028` / `RC5029`) | hit → short-circuit pipeline |
@@ -208,18 +207,24 @@ write.
 
 Today (as of #112 / #395 / 0.6.0):
 
-- Filters 1-5 and 7-10 are implemented (only #6
-  `circuitBreaker` remains); the chain runs in the order documented
-  above.
+- All filters 1-10 are implemented; the chain runs in the order
+  documented above.
 - The chain is **first-class data** on `RouteDefinition`:
   - `preParseFilters: Step<Adapter>[]` -- authorize steps in
     declaration order (chain position #2).
   - `postParseFilters: Step<Adapter>[]` -- route-scope cache-check
-    filter (chain position #9). The future `circuitBreaker` (#6)
-    slots in here once it lands. Route-scope `throttle` (#5) is a
+    filter (chain position #9). Route-scope `throttle` (#5) is a
     one-shot gate but must sit OUTSIDE the retry / timeout segments,
     which wrap this array, so it rides on its own field (below)
     rather than here.
+  - `circuitBreaker?: CircuitBreakerController` -- route-scope
+    `.circuitBreaker()` (#6). Unlike the cache filters it is not a
+    flat step: it scopes OVER the tail (when open it skips the tail;
+    when closed it runs it and observes the outcome) and holds
+    persistent per-Route state (the failure window + open/half-open
+    machine), so the builder stores the live controller here once and
+    the executor wraps the tail in a breaker segment around it,
+    OUTSIDE the retry (#7) / timeout (#8) segments.
   - `postFromFilters: Step<Adapter>[]` -- route-scope cache-store
     filter (chain position #10).
   - `errorHandler?: ErrorHandler` -- the `.error()` route-scope
@@ -272,9 +277,18 @@ wrap). See `buildThrottleCheckStep` in
 `deps.definition.throttle` placement in
 `packages/routecraft/src/pipeline/executor.ts`.
 
-Filter 6 (`circuitBreaker`) will be added by its issue at the
-documented position, following the segment pattern where it needs
-scope over the tail.
+Filter 6 (`circuitBreaker` #139) is shipped. Like retry / timeout it
+scopes OVER the tail (it conditionally runs and observes it), so it is
+a segment, not a flat `postParseFilters` entry. Unlike them it also
+holds persistent per-Route state, so its live `CircuitBreakerController`
+rides on the `circuitBreaker` field of `RouteDefinition` (built once per
+route) and the executor wraps the tail in a breaker segment around it,
+OUTSIDE the retry (#7) / timeout (#8) segments and INSIDE the throttle
+(#5) gate. See `buildCircuitBreakerSegmentStep` in
+`packages/routecraft/src/pipeline/executor.ts`. The route-scope breaker
+fast-fails (fallback or `RC5025`) when open but does NOT yet pause the
+source consumer during cooldown; true source backpressure is a tracked
+follow-up (see `.standards/resilience-wrappers.md` section 7).
 
 ---
 

--- a/.standards/pre-from-filter-chain.md
+++ b/.standards/pre-from-filter-chain.md
@@ -104,7 +104,7 @@ The handler decides what to recover:
   if (['RC5012', 'RC5015', 'RC5002', 'RC5016'].includes(err.rc)) throw err
 
   // Throttle / breaker: re-throw to surface backpressure to the caller.
-  if (['RC5013'].includes(err.rc)) throw err
+  if (['RC5013', 'RC5025'].includes(err.rc)) throw err
 
   // Operational failures: recover with a fallback.
   if (err.rc === 'RC5011') return { fallback: 'timeout' }
@@ -301,7 +301,7 @@ follow-up (see `.standards/resilience-wrappers.md` section 7).
 - #119 -- route-level `.error()` (filter 1 shipped here).
 - #140 -- dual-mode wrapper pattern (closed; the contract this
   chain inherits at the route-scope side).
-- #139 -- circuit breaker (filter 6 will land here).
+- #139 -- circuit breaker (filter 6, shipped here).
 - Spring Security `FilterChainProxy`: similar pattern at a
   different scale.
 - Resilience4J wrapper composition: the resilience-tier ordering

--- a/.standards/resilience-wrappers.md
+++ b/.standards/resilience-wrappers.md
@@ -2,7 +2,7 @@
 
 Authoring contract for "dual-mode wrapper" operations: a single builder
 method (`.error()`, `.cache()`, `.retry()`, `.timeout()`,
-`.throttle()`, future `.circuitBreaker()`) that applies at either route scope
+`.throttle()`, `.circuitBreaker()`) that applies at either route scope
 (when staged before `.from()`) or step scope (when chained after
 `.from()`). `.delay()` follows the step-scope half of this contract but
 is deliberately step-scope only: a route-scope delay is equivalent to a
@@ -21,7 +21,7 @@ Three categories cover every operation in the framework:
 | Category | Position | Examples |
 |----------|----------|----------|
 | Route-only | Before `.from()` only. Configures the route. | `.id()`, `.batch()`, `.title()`, `.description()`, `.input()`, `.output()` |
-| Dual-mode wrapper | Same method, position decides scope. | `.error()`, `.cache()`, `.retry()`, `.timeout()`, `.throttle()`, future `.circuitBreaker()` |
+| Dual-mode wrapper | Same method, position decides scope. | `.error()`, `.cache()`, `.retry()`, `.timeout()`, `.throttle()`, `.circuitBreaker()` |
 | Step-only wrapper | After `.from()` only; wraps the next step. | `.delay()` (no route-scope form by design) |
 | Pipeline | After `.from()` only. Already enforced by the builder type system. | `.transform()`, `.to()`, `.process()`, `.enrich()`, `.split()`, `.aggregate()`, `.tap()`, `.filter()`, `.validate()`, `.choice()`, `.header()` |
 
@@ -195,12 +195,19 @@ step wrapping cannot provide:
 | Route-level `.circuitBreaker()` | NOT well-served by a wrapper alone. | Pausing the source consumer (HTTP / queue / cron) during cooldown so backpressure flows back to the caller / queue. |
 | Route-level `.throttle()` (rate limit on the route) | Pacing exchanges through a shared token bucket so downstream calls stay within the rate (shipped as a flat gate at chain position #5). | Pausing the source consumer so it stops PULLING; the shipped gate paces in-flight exchanges instead, so under high concurrency they queue in memory. |
 
-The circuit-breaker rows still need a paired `Consumer` integration (a
-consumer that observes breaker state and pauses pulling). Throttle
-shipped its wrapper / gate half (#151); the consumer-pausing half (true
-source backpressure, plus the `maxQueueSize` bound on in-flight
-exchanges) is a tracked follow-up. Track this kind of constraint in the
-new operation's issue and scope its acceptance criteria accordingly.
+The circuit breaker (#139) shipped its fast-fail half at both scopes:
+the step-scope wrapper trips on counted failures and fast-fails the
+wrapped step (fallback or `RC5025`), and the route-scope segment does the
+same for the whole pipeline. What it does NOT yet do is pause the source
+consumer during cooldown, so an open route-scope breaker fast-fails each
+exchange (flowing backpressure to the caller) but the consumer keeps
+pulling. That paired `Consumer` integration (a consumer that observes
+breaker state and pauses pulling) is a tracked follow-up, the same shape
+as throttle's: throttle shipped its wrapper / gate half (#151) and its
+consumer-pausing half (true source backpressure, plus the `maxQueueSize`
+bound on in-flight exchanges) remains outstanding. Track this kind of
+constraint in the operation's issue and scope its acceptance criteria
+accordingly.
 
 ## 8. `.standards` checklist for a new wrapper
 

--- a/.standards/resilience-wrappers.md
+++ b/.standards/resilience-wrappers.md
@@ -246,9 +246,10 @@ accordingly.
 - `#187` (source-level parse error recovery): once parsing moves into
   the pipeline, `.error()` wraps the parse step to get "log and skip
   bad rows, continue processing" as a composable pattern.
-- `#139` (Circuit Breaker): see "When a wrapper is not enough"; the
-  step-scope side is a wrapper, the route-scope side needs consumer
-  integration.
+- `#139` (Circuit Breaker): shipped at both scopes (step-scope wrapper +
+  route-scope segment). See "When a wrapper is not enough" for the
+  outstanding consumer-pausing follow-up (pausing the source from pulling
+  during cooldown).
 - `#112` (Cache): dual-mode at both scopes. Step-scope wraps the
   immediately-next step via `CacheWrapperStep`. Route-scope (called
   BEFORE `.from()`) caches the route's terminal body keyed by the
@@ -265,8 +266,8 @@ accordingly.
   route-scope counterpart of this contract. Documents the fixed
   ordered chain (`error` -> `authorize` -> `parse` -> `input` ->
   `throttle` -> `circuitBreaker` -> `retry` -> `timeout` ->
-  `cacheCheck` -> pipeline -> `cacheStore`) and reserves slots for
-  the future resilience wrappers listed in section 1.
+  `cacheCheck` -> pipeline -> `cacheStore`); every position is now filled
+  by a shipped operation (see section 1).
 - `WrapperStep` source: `packages/routecraft/src/operations/wrapper.ts`.
 - `ErrorWrapperStep` source:
   `packages/routecraft/src/operations/error-wrapper.ts`.

--- a/apps/routecraft.dev/src/app/docs/reference/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/events/page.md
@@ -137,6 +137,17 @@ A failure of the wrapped operation *inside* the deadline does not emit a timeout
 
 `scope` is `"route"` for `.throttle()` declared BEFORE `.from()` (the whole pipeline is rate-limited) and `"step"` for the wrapper attached AFTER `.from()`. `stepLabel` is the wrapped step's label, or `"route"` at route scope. An exchange admitted from the burst (no wait) emits only `route:throttle:passed` with `waited: false`; a paced exchange emits `route:throttle:delayed` first, then `route:throttle:passed` with `waited: true`. In the default delay mode throttle only ever delays an exchange and never drops one; in `mode: 'reject'` an over-limit exchange instead emits `route:throttle:rejected` and is failed with `RC5013`. `label` is present when `.throttle({ label })` is set, so stacked gates can be told apart.
 
+### Circuit breaker wrapper operations
+
+| Event | When it fires | Details |
+| --- | --- | --- |
+| `route:circuitBreaker:opened` | The breaker tripped to open (failures reached the threshold while closed, or a probe failed while half-open) | `{ routeId, exchangeId, correlationId, stepLabel, scope: "route" \| "step", failureCount, threshold, cooldownMs, label? }` |
+| `route:circuitBreaker:halfOpen` | The cooldown elapsed and the breaker admitted a probe call to test recovery | `{ routeId, exchangeId, correlationId, stepLabel, scope: "route" \| "step", label? }` |
+| `route:circuitBreaker:closed` | A probe succeeded and the breaker recovered to closed | `{ routeId, exchangeId, correlationId, stepLabel, scope: "route" \| "step", label? }` |
+| `route:circuitBreaker:rejected` | A call was fast-failed because the breaker is open (or half-open at capacity); a `fallback` ran or `RC5025` followed | `{ routeId, exchangeId, correlationId, stepLabel, scope: "route" \| "step", state: "open" \| "half-open", retryAfterMs, label? }` |
+
+`scope` is `"route"` for `.circuitBreaker()` declared BEFORE `.from()` (the whole pipeline is protected) and `"step"` for the wrapper attached AFTER `.from()`. `stepLabel` is the wrapped step's label, or `"route"` at route scope. `retryAfterMs` on a rejection is the time until the breaker would admit a probe (`0` when half-open is at capacity). `label` is present when `.circuitBreaker({ label })` is set. Breaker state is per route, not per exchange, so these events reflect the shared circuit.
+
 ### Choice operations
 
 | Event | When it fires | Details |

--- a/apps/routecraft.dev/src/app/docs/reference/operations/circuitbreaker/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/circuitbreaker/page.md
@@ -60,7 +60,7 @@ Like the other resilience wrappers, position decides scope.
 craft()
   .id('resilient-route')
   .circuitBreaker({ failureThreshold: 10, fallback: () => ({ degraded: true }) })
-  .from(direct('input'))
+  .from(direct())
   .to(http({ url: 'https://flaky.api/endpoint' }))
 ```
 
@@ -69,7 +69,7 @@ craft()
 ```ts
 craft()
   .id('enrich-order')
-  .from(direct('orders'))
+  .from(direct())
   .circuitBreaker({ failureThreshold: 3, windowMs: 30_000 })
   .to(http({ url: 'https://inventory.api/check' })) // protected
   .transform(formatResponse) // NOT protected

--- a/apps/routecraft.dev/src/app/docs/reference/operations/circuitbreaker/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/circuitbreaker/page.md
@@ -1,0 +1,101 @@
+---
+title: circuitBreaker
+---
+
+[← All operations](/docs/reference/operations) {% .lead %}
+
+```ts
+circuitBreaker(options: {
+  failureThreshold: number
+  windowMs?: number
+  cooldownMs?: number
+  halfOpenMax?: number
+  fallback?: (exchange: Exchange) => unknown
+  onStateChange?: (state: 'closed' | 'open' | 'half-open') => void
+  isFailure?: (error: Error) => boolean
+  label?: string
+}): RouteBuilder<Current>
+```
+
+Stop hammering a downstream that is already failing. The breaker counts failures over a sliding window; once they reach `failureThreshold` it trips OPEN and fast-fails subsequent calls (returning a `fallback`, or throwing `RC5025`) without running the protected work. After `cooldownMs` it goes HALF-OPEN and lets a probe through: a success closes it, a failure re-opens it.
+
+```ts
+craft()
+  .id('charge-customer')
+  .from(source)
+  .circuitBreaker({ failureThreshold: 5, cooldownMs: 30_000 })
+  .to(http({ url: 'https://api.stripe.com/charge' })) // protected
+  .transform(formatReceipt) // NOT protected
+```
+
+**Mental model:** A three-state switch.
+
+```
+CLOSED  --[failures >= threshold in window]-->  OPEN
+OPEN    --[cooldownMs elapsed]-------------->   HALF-OPEN
+HALF-OPEN --[probe succeeds]--------------->    CLOSED
+HALF-OPEN --[probe fails]------------------>    OPEN
+```
+
+**Parameters:**
+
+- `failureThreshold` - counted failures within `windowMs` that trip the breaker. A finite integer >= 1.
+- `windowMs` - sliding window over which failures are counted. Failures older than this stop counting. Default `60_000`.
+- `cooldownMs` - how long the breaker stays open before admitting a probe. Default `30_000`.
+- `halfOpenMax` - maximum concurrent probe calls in the half-open state. Default `1`. Values above 1 are best-effort: the first probe to succeed closes the breaker.
+- `fallback` - value returned when a call is rejected (open, or half-open at capacity). When set, the rejected exchange's body becomes `fallback(exchange)` and the pipeline continues; when omitted, the breaker throws `RC5025`.
+- `onStateChange` - side-effect callback fired on every transition (`closed` / `open` / `half-open`). For logging or metrics; it must not throw.
+- `isFailure` - decide whether a failed call counts toward the threshold. Default: count everything except `RoutecraftError`s flagged `retryable: false` (auth `RC5012`, validation `RC5002`, ...), which are deterministic and not evidence the downstream is unhealthy.
+- `label` - tag carried on this breaker's events so sibling breakers can be told apart.
+
+Invalid options are rejected at build time (`RC5003`).
+
+## Dual mode: route scope vs step scope
+
+Like the other resilience wrappers, position decides scope.
+
+**Before `.from()` (route scope):** the breaker protects the whole pipeline (pre-from filter chain position 6). When open, the pipeline is skipped entirely and the `fallback` becomes the body (or `RC5025` is thrown). It sits OUTSIDE `.retry()` and `.timeout()`, so a fully exhausted retry attempt is recorded as a single breaker failure, not one per retry, and when the breaker is open it fast-fails before retry or timeout run.
+
+```ts
+craft()
+  .id('resilient-route')
+  .circuitBreaker({ failureThreshold: 10, fallback: () => ({ degraded: true }) })
+  .from(direct('input'))
+  .to(http({ url: 'https://flaky.api/endpoint' }))
+```
+
+**After `.from()` (step scope):** the breaker wraps only the immediately-next step. Later steps run normally.
+
+```ts
+craft()
+  .id('enrich-order')
+  .from(direct('orders'))
+  .circuitBreaker({ failureThreshold: 3, windowMs: 30_000 })
+  .to(http({ url: 'https://inventory.api/check' })) // protected
+  .transform(formatResponse) // NOT protected
+```
+
+The two compose: a route-scope breaker over the whole pipeline plus a tighter step-scope breaker on one flaky call.
+
+## State is per route
+
+Breaker state (the failure window and the open/half-open machine) is shared across every exchange on the route, not per exchange, so failures accumulate toward the threshold and one tripped breaker fast-fails the whole route. A definition registered into multiple contexts gets an independent circuit per route, so the contexts never trip each other. State is in-memory and per instance; sharing a breaker across instances is a future addition built on the shared-store abstraction.
+
+## Interaction with `.error()` and `.retry()`
+
+`.circuitBreaker()` and `.error()` are complementary: the breaker prevents calls when the target is known to be down (fail fast), while `.error()` recovers unexpected failures that slip through. When the breaker is open and no `fallback` is set, the thrown `RC5025` flows to a route-scope `.error()` handler if one is defined.
+
+`RC5025` is non-retryable, so an enclosing `.retry()` does not burn attempts against an open breaker. Because the breaker sits outside retry, retries happen inside one breaker call: only the final, exhausted outcome counts as a breaker failure.
+
+## Events
+
+The breaker emits the `route:circuitBreaker:*` family. See the [events reference](/docs/reference/events) for payload shapes. `scope` is `"route"` when declared before `.from()` and `"step"` for the wrapper after it.
+
+- `route:circuitBreaker:opened` - the breaker tripped (threshold reached, or a probe failed).
+- `route:circuitBreaker:halfOpen` - cooldown elapsed; a probe call was admitted.
+- `route:circuitBreaker:closed` - a probe succeeded; the breaker recovered.
+- `route:circuitBreaker:rejected` - a call was fast-failed (a `fallback` ran, or `RC5025` was thrown).
+
+## MCP integration
+
+When a route-scope breaker trips on a route sourced from `mcp()`, an MCP server plugin can subscribe to `route:circuitBreaker:opened` and mark the tool unavailable in `listTools` (re-adding it on `route:circuitBreaker:closed`) so the model stops calling a tool that is known to be down.

--- a/apps/routecraft.dev/src/app/docs/reference/operations/circuitbreaker/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/circuitbreaker/page.md
@@ -10,8 +10,7 @@ circuitBreaker(options: {
   windowMs?: number
   cooldownMs?: number
   halfOpenMax?: number
-  fallback?: (exchange: Exchange) => unknown
-  onStateChange?: (state: 'closed' | 'open' | 'half-open') => void
+  fallback?: (exchange: Exchange, forward: ForwardFn) => unknown | Promise<unknown>
   isFailure?: (error: Error) => boolean
   label?: string
 }): RouteBuilder<Current>
@@ -43,8 +42,7 @@ HALF-OPEN --[probe fails]------------------>    OPEN
 - `windowMs` - sliding window over which failures are counted. Failures older than this stop counting. Default `60_000`.
 - `cooldownMs` - how long the breaker stays open before admitting a probe. Default `30_000`.
 - `halfOpenMax` - maximum concurrent probe calls in the half-open state. Default `1`. Values above 1 are best-effort: the first probe to succeed closes the breaker.
-- `fallback` - value returned when a call is rejected (open, or half-open at capacity). When set, the rejected exchange's body becomes `fallback(exchange)` and the pipeline continues; when omitted, the breaker throws `RC5025`.
-- `onStateChange` - side-effect callback fired on every transition (`closed` / `open` / `half-open`). For logging or metrics; it must not throw.
+- `fallback` - produces the body to use when a call is rejected (open, or half-open at capacity). When set, the rejected exchange's body becomes the result of `fallback` and the pipeline continues; when omitted, the breaker throws `RC5025`. The second argument is `forward` (the same direct-route caller `.error()` receives), so the fallback can be dynamic, for example `fallback: (exchange, forward) => forward('recs-fallback', exchange.body)`; it may be async. To observe transitions, subscribe to the events below rather than passing a callback.
 - `isFailure` - decide whether a failed call counts toward the threshold. Default: count everything except `RoutecraftError`s flagged `retryable: false` (auth `RC5012`, validation `RC5002`, ...), which are deterministic and not evidence the downstream is unhealthy.
 - `label` - tag carried on this breaker's events so sibling breakers can be told apart.
 

--- a/apps/routecraft.dev/src/components/OperationsIndex.tsx
+++ b/apps/routecraft.dev/src/components/OperationsIndex.tsx
@@ -108,6 +108,13 @@ const ops: Op[] = [
     signature: '.cache({ key, ttl })',
     description: 'Cache and reuse the result of the next operation.',
   },
+  {
+    name: 'circuitBreaker',
+    category: 'Wrapper',
+    signature: '.circuitBreaker({ failureThreshold })',
+    description:
+      'Trip after repeated failures and fast-fail until the target recovers.',
+  },
 
   // Transform
   {

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -69,6 +69,12 @@ import {
   type ResolvedThrottleOptions,
   resolveThrottleOptions,
 } from "./operations/throttle-wrapper.ts";
+import {
+  type CircuitBreakerOptions,
+  type ResolvedCircuitBreakerOptions,
+  resolveCircuitBreakerOptions,
+  CircuitBreakerController,
+} from "./operations/circuit-breaker-wrapper.ts";
 
 /**
  * Builder for creating a Routecraft context with routes and configuration.
@@ -490,6 +496,12 @@ export interface PreFromStaging<S extends BuilderState = BuilderState> {
    * the post-`.from()` builder. See {@link RouteBuilder.throttle}.
    */
   throttle(options: ThrottleOptions): this;
+  /**
+   * Configure a ROUTE-SCOPE circuit breaker for the next route (protect
+   * the whole pipeline, chain position 6). The step-scope variant lives
+   * on the post-`.from()` builder. See {@link RouteBuilder.circuitBreaker}.
+   */
+  circuitBreaker(options: CircuitBreakerOptions): this;
   /** Declare an authorization requirement on the next route. See {@link RouteBuilder.authorize}. */
   authorize(options?: AuthorizeOptions): this;
   /** Finalize and return the route definition(s). See {@link RouteBuilder.build}. */
@@ -578,6 +590,7 @@ export class RouteBuilder<
         retryConfig?: ResolvedRetryOptions;
         timeoutConfig?: ResolvedTimeoutOptions;
         throttleConfigs?: ResolvedThrottleOptions[];
+        circuitBreakerConfig?: ResolvedCircuitBreakerOptions;
         discovery?: RouteDiscovery;
         authorizers?: AuthorizeOptions[];
       }
@@ -975,6 +988,43 @@ export class RouteBuilder<
   }
 
   /**
+   * Circuit breaker. Dual-mode:
+   *
+   * - **Before `.from()` (route scope):** protects the whole pipeline at
+   *   pre-from filter chain position 6, OUTSIDE `.retry()` (#7) and
+   *   `.timeout()` (#8) and INSIDE `.throttle()` (#5). When the breaker
+   *   is open the pipeline is skipped entirely and the configured
+   *   `fallback` becomes the body (or `RC5025` is thrown when no fallback
+   *   is set, which a route-scope `.error()` handler can catch). Because
+   *   it sits outside retry, one fully exhausted attempt is recorded as a
+   *   single breaker failure rather than one per retry. State is per
+   *   Route, so a definition reused across contexts does not share a
+   *   circuit.
+   *
+   * - **After `.from()` (step scope):** wraps the immediately-next step;
+   *   see {@link StepBuilderBase.circuitBreaker} for the step-scope
+   *   contract.
+   *
+   * Unlike `.throttle()`, circuit breakers do not stack: a single breaker
+   * per route protects the pipeline. A second `.circuitBreaker()` before
+   * `.from()` overwrites the first.
+   */
+  override circuitBreaker(options: CircuitBreakerOptions): this {
+    if (this.currentRoute === undefined || this.pendingOptions !== undefined) {
+      // Route scope: stage the resolved config (validates the options at
+      // staging time) so the next `.from()` builds one controller per
+      // RouteDefinition.
+      this.pendingOptions = {
+        ...(this.pendingOptions ?? {}),
+        circuitBreakerConfig: resolveCircuitBreakerOptions(options),
+      };
+      logger.trace("Staging route-scope circuit breaker config for next route");
+      return this;
+    }
+    return super.circuitBreaker(options);
+  }
+
+  /**
    * Declare an authorization requirement on the next route. **Route-only**:
    * stages the authorizer onto the next-route options and runs at route
    * entry, before any pipeline step. Same staging convention as `.id`,
@@ -1099,6 +1149,7 @@ export class RouteBuilder<
     const retryConfig = this.pendingOptions?.retryConfig;
     const timeoutConfig = this.pendingOptions?.timeoutConfig;
     const throttleConfigs = this.pendingOptions?.throttleConfigs;
+    const circuitBreakerConfig = this.pendingOptions?.circuitBreakerConfig;
     const discovery = this.pendingOptions?.discovery;
     const authorizers = this.pendingOptions?.authorizers ?? [];
 
@@ -1161,6 +1212,18 @@ export class RouteBuilder<
       buildThrottleCheckStep(cfg),
     );
 
+    // Route-scope circuit breaker (#6) holds persistent per-Route state
+    // (the failure window + the open/half-open machine), so unlike retry /
+    // timeout (re-built into a segment per run from a plain config object)
+    // its live controller is built ONCE here and stored on the definition.
+    // The pipeline executor wraps the chain tail in a breaker segment
+    // around this controller, OUTSIDE the retry / timeout segments. The
+    // controller keys its machines by Route, so a definition reused across
+    // contexts gives each Route its own circuit.
+    const circuitBreakerController = circuitBreakerConfig
+      ? new CircuitBreakerController(circuitBreakerConfig)
+      : undefined;
+
     const postFromFilters: Step<Adapter>[] = cacheConfig
       ? [buildCacheStoreStep(cacheConfig)]
       : [];
@@ -1190,6 +1253,11 @@ export class RouteBuilder<
       ...(timeoutConfig ? { timeout: timeoutConfig } : {}),
       ...(throttleGates && throttleGates.length > 0
         ? { throttle: throttleGates }
+        : {}),
+      // Route-scope circuit breaker (#6): segment-wrapped by the executor
+      // around the persistent controller (see above).
+      ...(circuitBreakerController
+        ? { circuitBreaker: circuitBreakerController }
         : {}),
     };
     setBrand(this.currentRoute, BRAND.RouteDefinition);

--- a/packages/routecraft/src/builder.ts
+++ b/packages/routecraft/src/builder.ts
@@ -1296,7 +1296,7 @@ export class RouteBuilder<
         message:
           `Route metadata staged but no .from() called: route-level configuration ` +
           `(.id / .title / .description / .input / .output / .batch / .error / .authorize / ` +
-          `.cache / .retry / .timeout) must be ` +
+          `.cache / .retry / .timeout / .circuitBreaker) must be ` +
           `followed by .from() before pipeline operations on the next route.`,
       });
     }
@@ -1509,7 +1509,7 @@ export class RouteBuilder<
     if (this.pendingStepWrappers.length > 0) {
       throw rcError("RC2001", undefined, {
         message:
-          `Wrapper(s) staged via .error() / .retry() / .timeout() / .cache() / .delay() but no step followed before .${method}(). ` +
+          `Wrapper(s) staged via .error() / .retry() / .timeout() / .circuitBreaker() / .cache() / .delay() but no step followed before .${method}(). ` +
           `A wrapper attaches to the immediately next pipeline step; orphaning one (or letting it leak into the next route) is almost always a mistake.`,
       });
     }

--- a/packages/routecraft/src/error.ts
+++ b/packages/routecraft/src/error.ts
@@ -72,6 +72,7 @@ export interface ErrorCodeRegistry {
   RC5022: RCMeta;
   RC5023: RCMeta;
   RC5024: RCMeta;
+  RC5025: RCMeta;
   RC5028: RCMeta;
   RC5029: RCMeta;
   RC5030: RCMeta;
@@ -288,6 +289,14 @@ export const RC: { [K in CoreErrorCode]: RCMeta } = {
     suggestion:
       "authenticate() (and the .authenticate() operation) require a non-empty `subject` naming the verified identity, e.g. authenticate({ subject: sender.address, roles: [...] }). This is a programming error at the mint call, distinct from RC5023 (a principal that reached authorize() without being established by a trusted origin).",
     docs: `${DOCS_BASE}#rc-5024`,
+    retryable: false,
+  },
+  RC5025: {
+    category: "Runtime",
+    message: "Circuit breaker is open",
+    suggestion:
+      "The route or step exceeded its failure threshold and is failing fast to prevent cascading failures against a downstream that is known to be unhealthy. Wait for the cooldown to elapse (the breaker then probes with a half-open call), configure a `fallback` to return a degraded result instead of throwing, or raise `failureThreshold` / `cooldownMs` if the breaker is too sensitive. Not retryable: an immediate retry would hit the same open breaker.",
+    docs: `${DOCS_BASE}#rc-5025`,
     retryable: false,
   },
   RC5028: {

--- a/packages/routecraft/src/exchange.ts
+++ b/packages/routecraft/src/exchange.ts
@@ -45,6 +45,8 @@ export enum OperationType {
   CHOICE = "choice",
   /** Rate limit an operation, pacing exchanges that exceed the rate */
   THROTTLE = "throttle",
+  /** Fast-fail an operation while a downstream is known to be failing */
+  CIRCUIT_BREAKER = "circuit-breaker",
   /** Short-circuit the pipeline: drop the exchange without further steps */
   HALT = "halt",
 }

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -175,6 +175,12 @@ export {
   type ThrottleTimeUnit,
   type ResolvedThrottleOptions,
 } from "./operations/throttle-wrapper.ts";
+export {
+  CircuitBreakerWrapperStep,
+  type CircuitBreakerOptions,
+  type CircuitBreakerState,
+  type ResolvedCircuitBreakerOptions,
+} from "./operations/circuit-breaker-wrapper.ts";
 
 export {
   ContextBuilder,

--- a/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
+++ b/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
@@ -1,5 +1,6 @@
 import { type Exchange, DefaultExchange } from "../exchange.ts";
 import { rcError } from "../error.ts";
+import { logger } from "../logger.ts";
 import type { CraftContext } from "../context.ts";
 import type { Route } from "../route.ts";
 import type { Adapter, Step, StepContext, StepOutcome } from "../types.ts";
@@ -204,7 +205,19 @@ export class CircuitBreakerMachine {
 
   #toState(to: CircuitBreakerState): void {
     this.#state = to;
-    this.#options.onStateChange?.(to);
+    // `onStateChange` is user code (metrics / logging). The contract says
+    // it must not throw, but isolate it so a throwing callback cannot
+    // corrupt the transition or abort the acquire / record call that
+    // triggered it (which would surface the callback's error instead of
+    // the breaker's RC5025 / fallback).
+    try {
+      this.#options.onStateChange?.(to);
+    } catch (err) {
+      logger.warn(
+        { err },
+        "circuitBreaker onStateChange callback threw; ignoring",
+      );
+    }
   }
 
   #prune(now: number): void {
@@ -275,8 +288,11 @@ export class CircuitBreakerMachine {
     if (this.#state === "half-open") {
       this.#openedAt = now;
       this.#toState("open");
-      this.#prune(now);
-      hooks.onOpened(this.#failures.length);
+      // Exactly one failed probe re-opened the breaker. Report 1 rather
+      // than `#failures.length`, which still holds the original
+      // closed-state trip's timestamps (cleared only on close) and is
+      // therefore a stale, window-dependent number here.
+      hooks.onOpened(1);
       return;
     }
 

--- a/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
+++ b/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
@@ -1,0 +1,522 @@
+import { type Exchange, DefaultExchange } from "../exchange.ts";
+import { rcError } from "../error.ts";
+import type { CraftContext } from "../context.ts";
+import type { Route } from "../route.ts";
+import type { Adapter, Step, StepContext, StepOutcome } from "../types.ts";
+import { WrapperStep } from "./wrapper.ts";
+import { wrapperEventScope } from "./event-scope.ts";
+import { assertDurationMs } from "./cancellable-sleep.ts";
+import { defaultRetryOn } from "./retry-wrapper.ts";
+
+/**
+ * The three states of a circuit breaker.
+ *
+ * - `closed`: calls flow through; failures within the sliding window are
+ *   counted, and the breaker trips to `open` once they reach the
+ *   threshold.
+ * - `open`: calls fast-fail (fallback or `RC5025`) without running the
+ *   protected work, until `cooldownMs` has elapsed.
+ * - `half-open`: a bounded number of probe calls are allowed through to
+ *   test whether the downstream has recovered; one success closes the
+ *   breaker, one failure re-opens it.
+ */
+export type CircuitBreakerState = "closed" | "open" | "half-open";
+
+/**
+ * Options for the `.circuitBreaker()` operation (step scope and route
+ * scope). A breaker tracks failures over a sliding window and short-circuits
+ * execution when the target is known to be failing, so a flaky downstream
+ * does not turn into a pile of slow, doomed calls.
+ */
+export interface CircuitBreakerOptions {
+  /**
+   * Number of failures within `windowMs` that trips the breaker from
+   * `closed` to `open`. Must be a finite integer >= 1.
+   */
+  failureThreshold: number;
+  /**
+   * Sliding window (ms) over which failures are counted. Failures older
+   * than this no longer count toward the threshold. Default `60_000`.
+   */
+  windowMs?: number;
+  /**
+   * How long (ms) the breaker stays `open` before allowing a probe
+   * (transition to `half-open`). Default `30_000`.
+   */
+  cooldownMs?: number;
+  /**
+   * Maximum concurrent probe calls allowed in the `half-open` state.
+   * Default `1`. Values above 1 are best-effort: the first probe to
+   * succeed closes the breaker, so concurrent probes resolving after it
+   * are accounted against the now-closed breaker.
+   */
+  halfOpenMax?: number;
+  /**
+   * Value to return when the breaker rejects a call (open, or half-open
+   * at capacity). When set, the rejected exchange's body becomes
+   * `fallback(exchange)` and the pipeline continues; when omitted, the
+   * breaker throws `RC5025` so a `.error()` handler (or the default
+   * error path) can react.
+   */
+  fallback?: (exchange: Exchange) => unknown;
+  /**
+   * Callback fired on every state transition (`opened` / `halfOpen` /
+   * `closed`). Side-effect hook for logging or metrics; it must not
+   * throw.
+   */
+  onStateChange?: (state: CircuitBreakerState) => void;
+  /**
+   * Decide whether a failed call counts toward the failure threshold.
+   * Default: count everything except `RoutecraftError`s flagged
+   * `retryable: false` (auth `RC5012`, validation `RC5002`, etc.), which
+   * are deterministic and not evidence the downstream is unhealthy. This
+   * mirrors `.retry()`'s `retryOn` default.
+   */
+  isFailure?: (error: Error) => boolean;
+  /**
+   * Optional label carried on this breaker's `route:circuitBreaker:*`
+   * events, so stacked or sibling breakers can be told apart in logs and
+   * metrics. Has no effect on behaviour.
+   */
+  label?: string;
+}
+
+/**
+ * {@link CircuitBreakerOptions} with every behavioural field populated.
+ * This is the shape stored behind {@link CircuitBreakerController} and is
+ * shared by the step-scope wrapper and the route-scope segment.
+ *
+ * @internal
+ */
+export interface ResolvedCircuitBreakerOptions {
+  failureThreshold: number;
+  windowMs: number;
+  cooldownMs: number;
+  halfOpenMax: number;
+  fallback?: (exchange: Exchange) => unknown;
+  onStateChange?: (state: CircuitBreakerState) => void;
+  isFailure: (error: Error) => boolean;
+  label?: string;
+}
+
+/**
+ * Validate user-supplied {@link CircuitBreakerOptions} into a
+ * {@link ResolvedCircuitBreakerOptions}. Rejects at build time (RC5003)
+ * so a typo fails when the route is built rather than at first dispatch.
+ *
+ * @internal
+ */
+export function resolveCircuitBreakerOptions(
+  options: CircuitBreakerOptions,
+): ResolvedCircuitBreakerOptions {
+  const {
+    failureThreshold,
+    windowMs = 60_000,
+    cooldownMs = 30_000,
+    halfOpenMax = 1,
+    fallback,
+    onStateChange,
+    isFailure = defaultRetryOn,
+    label,
+  } = options;
+
+  if (!Number.isInteger(failureThreshold) || failureThreshold < 1) {
+    throw rcError("RC5003", undefined, {
+      message: `circuitBreaker({ failureThreshold }) must be an integer >= 1, got ${String(failureThreshold)}.`,
+    });
+  }
+  assertDurationMs("circuitBreaker({ windowMs })", windowMs, 1);
+  assertDurationMs("circuitBreaker({ cooldownMs })", cooldownMs, 1);
+  if (!Number.isInteger(halfOpenMax) || halfOpenMax < 1) {
+    throw rcError("RC5003", undefined, {
+      message: `circuitBreaker({ halfOpenMax }) must be an integer >= 1, got ${String(halfOpenMax)}.`,
+    });
+  }
+
+  return {
+    failureThreshold,
+    windowMs,
+    cooldownMs,
+    halfOpenMax,
+    isFailure,
+    ...(fallback ? { fallback } : {}),
+    ...(onStateChange ? { onStateChange } : {}),
+    ...(label !== undefined ? { label } : {}),
+  };
+}
+
+/**
+ * Decision returned by {@link CircuitBreakerMachine.acquire}. `probe` is
+ * true when the admitted call is a half-open probe, so the matching
+ * record call knows to release the probe slot and apply half-open
+ * transition semantics.
+ *
+ * @internal
+ */
+export type CircuitBreakerDecision =
+  | { admitted: true; probe: boolean }
+  | { admitted: false; state: "open" | "half-open"; retryAfterMs: number };
+
+/**
+ * Lifecycle hooks the breaker reports transitions to, so the step-scope
+ * wrapper and the route-scope segment emit the same
+ * `route:circuitBreaker:*` events with their own `scope` / `stepLabel`
+ * bindings.
+ *
+ * @internal
+ */
+export interface CircuitBreakerHooks {
+  /** Closed/half-open -> open (the breaker tripped). */
+  onOpened(failureCount: number): void;
+  /** Open -> half-open (cooldown elapsed; a probe is being admitted). */
+  onHalfOpen(): void;
+  /** Half-open -> closed (a probe succeeded; the breaker recovered). */
+  onClosed(): void;
+  /** A call was rejected because the breaker is open or half-open at capacity. */
+  onRejected(state: "open" | "half-open", retryAfterMs: number): void;
+}
+
+/**
+ * The per-route state machine. Holds the sliding window of failure
+ * timestamps (a ring buffer, pruned on access, not a flat counter so the
+ * window genuinely slides), the current state, the open timestamp, and
+ * the in-flight half-open probe count. One instance per Route (see
+ * {@link CircuitBreakerController}), never one per exchange.
+ *
+ * @internal
+ */
+export class CircuitBreakerMachine {
+  #state: CircuitBreakerState = "closed";
+  /** Timestamps of counted failures within the window, oldest first. */
+  readonly #failures: number[] = [];
+  #openedAt = 0;
+  #halfOpenInFlight = 0;
+  readonly #options: ResolvedCircuitBreakerOptions;
+
+  constructor(options: ResolvedCircuitBreakerOptions) {
+    this.#options = options;
+  }
+
+  /** Current breaker state (exposed for diagnostics and tests). */
+  get state(): CircuitBreakerState {
+    return this.#state;
+  }
+
+  #toState(to: CircuitBreakerState): void {
+    this.#state = to;
+    this.#options.onStateChange?.(to);
+  }
+
+  #prune(now: number): void {
+    const cutoff = now - this.#options.windowMs;
+    while (this.#failures.length > 0 && this.#failures[0]! < cutoff) {
+      this.#failures.shift();
+    }
+  }
+
+  /**
+   * Decide whether the calling exchange may proceed. May transition
+   * open -> half-open when the cooldown has elapsed. Emits `halfOpen` /
+   * `rejected` via `hooks`.
+   */
+  acquire(now: number, hooks: CircuitBreakerHooks): CircuitBreakerDecision {
+    if (this.#state === "open") {
+      const elapsed = now - this.#openedAt;
+      if (elapsed >= this.#options.cooldownMs) {
+        this.#halfOpenInFlight = 0;
+        this.#toState("half-open");
+        hooks.onHalfOpen();
+      } else {
+        const retryAfterMs = this.#options.cooldownMs - elapsed;
+        hooks.onRejected("open", retryAfterMs);
+        return { admitted: false, state: "open", retryAfterMs };
+      }
+    }
+
+    if (this.#state === "half-open") {
+      if (this.#halfOpenInFlight < this.#options.halfOpenMax) {
+        this.#halfOpenInFlight += 1;
+        return { admitted: true, probe: true };
+      }
+      hooks.onRejected("half-open", 0);
+      return { admitted: false, state: "half-open", retryAfterMs: 0 };
+    }
+
+    // closed
+    return { admitted: true, probe: false };
+  }
+
+  /** Record a successful call. A successful probe closes the breaker. */
+  recordSuccess(probe: boolean, hooks: CircuitBreakerHooks): void {
+    if (probe && this.#halfOpenInFlight > 0) this.#halfOpenInFlight -= 1;
+    if (this.#state === "half-open") {
+      this.#failures.length = 0;
+      this.#toState("closed");
+      hooks.onClosed();
+    }
+    // In `closed`, a success does not retract windowed failures; the
+    // window expiry does. In `open` a success cannot occur (no call ran).
+  }
+
+  /**
+   * Record a failed call. `counts` is false for deterministic errors that
+   * should not trip the breaker (the probe slot is still released so it
+   * does not leak, but no state transition is applied).
+   */
+  recordFailure(
+    now: number,
+    probe: boolean,
+    counts: boolean,
+    hooks: CircuitBreakerHooks,
+  ): void {
+    if (probe && this.#halfOpenInFlight > 0) this.#halfOpenInFlight -= 1;
+    if (!counts) return;
+
+    if (this.#state === "half-open") {
+      this.#openedAt = now;
+      this.#toState("open");
+      this.#prune(now);
+      hooks.onOpened(this.#failures.length);
+      return;
+    }
+
+    if (this.#state === "closed") {
+      this.#failures.push(now);
+      this.#prune(now);
+      if (this.#failures.length >= this.#options.failureThreshold) {
+        this.#openedAt = now;
+        this.#toState("open");
+        hooks.onOpened(this.#failures.length);
+      }
+    }
+  }
+}
+
+/**
+ * Owns the circuit-breaker state for one `.circuitBreaker()` across every
+ * Route the enclosing step (or segment) runs in. Keyed by Route in a
+ * WeakMap, so a single definition registered into multiple contexts gives
+ * each Route its OWN breaker rather than one shared circuit (which would
+ * let the contexts trip each other). Mirrors {@link ThrottleController}.
+ *
+ * @internal
+ */
+export class CircuitBreakerController {
+  readonly #options: ResolvedCircuitBreakerOptions;
+  readonly #byRoute = new WeakMap<Route, CircuitBreakerMachine>();
+  #routeless?: CircuitBreakerMachine;
+
+  constructor(options: ResolvedCircuitBreakerOptions) {
+    this.#options = options;
+  }
+
+  /** The resolved options (fallback, threshold, cooldown, label, ...). */
+  get options(): ResolvedCircuitBreakerOptions {
+    return this.#options;
+  }
+
+  /** Optional gate label, surfaced on the `route:circuitBreaker:*` events. */
+  get label(): string | undefined {
+    return this.#options.label;
+  }
+
+  #machineFor(route: Route | undefined): CircuitBreakerMachine {
+    if (!route) {
+      this.#routeless ??= new CircuitBreakerMachine(this.#options);
+      return this.#routeless;
+    }
+    let machine = this.#byRoute.get(route);
+    if (!machine) {
+      machine = new CircuitBreakerMachine(this.#options);
+      this.#byRoute.set(route, machine);
+    }
+    return machine;
+  }
+
+  /** Current state for `route` (diagnostics; e.g. MCP tool availability). */
+  stateFor(route: Route | undefined): CircuitBreakerState {
+    return this.#machineFor(route).state;
+  }
+
+  acquire(
+    route: Route | undefined,
+    hooks: CircuitBreakerHooks,
+  ): CircuitBreakerDecision {
+    return this.#machineFor(route).acquire(Date.now(), hooks);
+  }
+
+  recordSuccess(
+    route: Route | undefined,
+    probe: boolean,
+    hooks: CircuitBreakerHooks,
+  ): void {
+    this.#machineFor(route).recordSuccess(probe, hooks);
+  }
+
+  recordFailure(
+    route: Route | undefined,
+    error: Error,
+    probe: boolean,
+    hooks: CircuitBreakerHooks,
+  ): void {
+    const counts = this.#options.isFailure(error);
+    this.#machineFor(route).recordFailure(Date.now(), probe, counts, hooks);
+  }
+}
+
+/** Event-scope bindings shared by the `route:circuitBreaker:*` payloads. */
+export interface CircuitBreakerEventScope {
+  routeId: string;
+  exchangeId: string;
+  correlationId: string;
+  stepLabel: string;
+  scope: "route" | "step";
+  /** Optional breaker label, when configured. */
+  label?: string;
+}
+
+/**
+ * Build the {@link CircuitBreakerHooks} that emit the
+ * `route:circuitBreaker:*` events. Shared by the step-scope wrapper and
+ * the route-scope segment so the payload shape lives in one place (only
+ * the `scoped` descriptor and the `emit` guard differ). `context?.emit`
+ * no-ops when the exchange carries no context.
+ *
+ * @internal
+ */
+export function circuitBreakerEmitHooks(
+  context: CraftContext | undefined,
+  scoped: CircuitBreakerEventScope,
+  emit: boolean,
+  options: ResolvedCircuitBreakerOptions,
+): CircuitBreakerHooks {
+  return {
+    onOpened: (failureCount) => {
+      if (emit) {
+        context?.emit("route:circuitBreaker:opened", {
+          ...scoped,
+          failureCount,
+          threshold: options.failureThreshold,
+          cooldownMs: options.cooldownMs,
+        });
+      }
+    },
+    onHalfOpen: () => {
+      if (emit) context?.emit("route:circuitBreaker:halfOpen", { ...scoped });
+    },
+    onClosed: () => {
+      if (emit) context?.emit("route:circuitBreaker:closed", { ...scoped });
+    },
+    onRejected: (state, retryAfterMs) => {
+      if (emit) {
+        context?.emit("route:circuitBreaker:rejected", {
+          ...scoped,
+          state,
+          retryAfterMs,
+        });
+      }
+    },
+  };
+}
+
+/**
+ * Outcome for a rejected call (breaker open, or half-open at capacity):
+ * substitute the configured `fallback` body and continue, or throw
+ * `RC5025` so the route's `.error()` handler (or the default error path)
+ * decides what to do. Shared by the step-scope wrapper and the
+ * route-scope segment.
+ *
+ * @internal
+ */
+export function circuitOpenOutcome(
+  exchange: Exchange,
+  options: ResolvedCircuitBreakerOptions,
+  scopeDescription: string,
+): StepOutcome {
+  if (options.fallback) {
+    return {
+      kind: "continue",
+      exchange: DefaultExchange.rewrap(exchange, {
+        body: options.fallback(exchange),
+      }),
+    };
+  }
+  throw rcError("RC5025", undefined, {
+    message: `Circuit breaker ${scopeDescription} is open; failing fast (no fallback configured).`,
+  });
+}
+
+/**
+ * Step-scope `.circuitBreaker()` wrapper. Protects the immediately-next
+ * step: counts its failures over a sliding window, trips after the
+ * threshold, then fast-fails subsequent calls (fallback or `RC5025`)
+ * until the cooldown elapses and a probe is allowed through. The breaker
+ * state lives on a {@link CircuitBreakerController} keyed by Route, so
+ * every exchange on a given Route shares one breaker while distinct
+ * Routes (even from the same definition) stay isolated. This is the
+ * deliberate per-ROUTE shared-state exception to the `WrapperStep` rule
+ * (see `.standards/resilience-wrappers.md` section 8).
+ *
+ * Emits the `route:circuitBreaker:opened` / `:halfOpen` / `:closed` /
+ * `:rejected` family with `scope: "step"`.
+ */
+export class CircuitBreakerWrapperStep<
+  T extends Adapter = Adapter,
+> extends WrapperStep<T> {
+  readonly #controller: CircuitBreakerController;
+
+  constructor(inner: Step<T>, options: CircuitBreakerOptions) {
+    super(inner);
+    this.#controller = new CircuitBreakerController(
+      resolveCircuitBreakerOptions(options),
+    );
+  }
+
+  protected override async runInner(
+    exchange: Exchange,
+    ctx: StepContext,
+  ): Promise<StepOutcome> {
+    const { route, context, routeId, stepLabel, correlationId } =
+      wrapperEventScope(exchange, this);
+    const shouldEmit = Boolean(route && context && routeId);
+    const scoped: CircuitBreakerEventScope = {
+      routeId: routeId as string,
+      exchangeId: exchange.id,
+      correlationId,
+      stepLabel,
+      scope: "step",
+      ...(this.#controller.label !== undefined
+        ? { label: this.#controller.label }
+        : {}),
+    };
+    const hooks = circuitBreakerEmitHooks(
+      context,
+      scoped,
+      shouldEmit,
+      this.#controller.options,
+    );
+
+    const decision = this.#controller.acquire(route, hooks);
+    if (!decision.admitted) {
+      return circuitOpenOutcome(
+        exchange,
+        this.#controller.options,
+        `for step "${stepLabel}"`,
+      );
+    }
+
+    try {
+      const outcome = await this.inner.execute(exchange, ctx);
+      this.#controller.recordSuccess(route, decision.probe, hooks);
+      return outcome;
+    } catch (err) {
+      this.#controller.recordFailure(
+        route,
+        err instanceof Error ? err : new Error(String(err)),
+        decision.probe,
+        hooks,
+      );
+      throw err;
+    }
+  }
+}

--- a/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
+++ b/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
@@ -333,11 +333,6 @@ export class CircuitBreakerController {
     return machine;
   }
 
-  /** Current state for `route` (diagnostics; e.g. MCP tool availability). */
-  stateFor(route: Route | undefined): CircuitBreakerState {
-    return this.#machineFor(route).state;
-  }
-
   acquire(
     route: Route | undefined,
     hooks: CircuitBreakerHooks,
@@ -447,6 +442,44 @@ export function circuitOpenOutcome(
 }
 
 /**
+ * Run `run` under the breaker `controller` for `route`, recording the
+ * outcome: a resolve (success, or a drop) records a success, a throw
+ * records a counted failure and re-throws. When the breaker rejects the
+ * call (open, or half-open at capacity) the protected work is skipped and
+ * `onOpen()` produces the substitute outcome (a `fallback` continue, or a
+ * thrown `RC5025`).
+ *
+ * Shared by the step-scope wrapper and the route-scope segment so the
+ * acquire / record protocol lives in one place, mirroring the retry
+ * operation's `executeWithRetry`.
+ *
+ * @internal
+ */
+export async function executeWithCircuitBreaker(
+  controller: CircuitBreakerController,
+  route: Route | undefined,
+  hooks: CircuitBreakerHooks,
+  onOpen: () => StepOutcome,
+  run: () => Promise<StepOutcome>,
+): Promise<StepOutcome> {
+  const decision = controller.acquire(route, hooks);
+  if (!decision.admitted) return onOpen();
+  try {
+    const outcome = await run();
+    controller.recordSuccess(route, decision.probe, hooks);
+    return outcome;
+  } catch (err) {
+    controller.recordFailure(
+      route,
+      err instanceof Error ? err : new Error(String(err)),
+      decision.probe,
+      hooks,
+    );
+    throw err;
+  }
+}
+
+/**
  * Step-scope `.circuitBreaker()` wrapper. Protects the immediately-next
  * step: counts its failures over a sliding window, trips after the
  * threshold, then fast-fails subsequent calls (fallback or `RC5025`)
@@ -496,27 +529,17 @@ export class CircuitBreakerWrapperStep<
       this.#controller.options,
     );
 
-    const decision = this.#controller.acquire(route, hooks);
-    if (!decision.admitted) {
-      return circuitOpenOutcome(
-        exchange,
-        this.#controller.options,
-        `for step "${stepLabel}"`,
-      );
-    }
-
-    try {
-      const outcome = await this.inner.execute(exchange, ctx);
-      this.#controller.recordSuccess(route, decision.probe, hooks);
-      return outcome;
-    } catch (err) {
-      this.#controller.recordFailure(
-        route,
-        err instanceof Error ? err : new Error(String(err)),
-        decision.probe,
-        hooks,
-      );
-      throw err;
-    }
+    return executeWithCircuitBreaker(
+      this.#controller,
+      route,
+      hooks,
+      () =>
+        circuitOpenOutcome(
+          exchange,
+          this.#controller.options,
+          `for step "${stepLabel}"`,
+        ),
+      () => this.inner.execute(exchange, ctx),
+    );
   }
 }

--- a/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
+++ b/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
@@ -262,7 +262,11 @@ export class CircuitBreakerMachine {
   /** Record a successful call. A successful probe closes the breaker. */
   recordSuccess(probe: boolean, hooks: CircuitBreakerHooks): void {
     if (probe && this.#halfOpenInFlight > 0) this.#halfOpenInFlight -= 1;
-    if (this.#state === "half-open") {
+    // Only the probe's outcome decides a half-open breaker. A non-probe
+    // success here is stale work from a call admitted while the breaker
+    // was still closed (long enough to outlive the trip + cooldown); it
+    // must not close the breaker out from under the in-flight probe.
+    if (this.#state === "half-open" && probe) {
       this.#failures.length = 0;
       this.#toState("closed");
       hooks.onClosed();
@@ -286,6 +290,10 @@ export class CircuitBreakerMachine {
     if (!counts) return;
 
     if (this.#state === "half-open") {
+      // Symmetric with recordSuccess: only the probe re-opens a half-open
+      // breaker. A non-probe failure here is stale work from a call
+      // admitted before the trip and must not override the probe's verdict.
+      if (!probe) return;
       this.#openedAt = now;
       this.#toState("open");
       // Exactly one failed probe re-opened the breaker. Report 1 rather
@@ -370,7 +378,19 @@ export class CircuitBreakerController {
     probe: boolean,
     hooks: CircuitBreakerHooks,
   ): void {
-    const counts = this.#options.isFailure(error);
+    // `isFailure` is user code. Isolate it like `onStateChange`: a throwing
+    // predicate must not mask the original step error (re-thrown by the
+    // caller after this returns), skip breaker accounting, or leak the
+    // half-open probe slot. Default to counting the failure on a throw.
+    let counts = true;
+    try {
+      counts = this.#options.isFailure(error);
+    } catch (err) {
+      logger.warn(
+        { err },
+        "circuitBreaker isFailure callback threw; counting the failure",
+      );
+    }
     this.#machineFor(route).recordFailure(Date.now(), probe, counts, hooks);
   }
 }

--- a/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
+++ b/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
@@ -2,7 +2,7 @@ import { type Exchange, DefaultExchange } from "../exchange.ts";
 import { rcError } from "../error.ts";
 import { logger } from "../logger.ts";
 import type { CraftContext } from "../context.ts";
-import type { Route } from "../route.ts";
+import type { ForwardFn, Route } from "../route.ts";
 import type { Adapter, Step, StepContext, StepOutcome } from "../types.ts";
 import { WrapperStep } from "./wrapper.ts";
 import { wrapperEventScope } from "./event-scope.ts";
@@ -53,19 +53,34 @@ export interface CircuitBreakerOptions {
    */
   halfOpenMax?: number;
   /**
-   * Value to return when the breaker rejects a call (open, or half-open
-   * at capacity). When set, the rejected exchange's body becomes
-   * `fallback(exchange)` and the pipeline continues; when omitted, the
-   * breaker throws `RC5025` so a `.error()` handler (or the default
-   * error path) can react.
+   * Produce the value to use when the breaker rejects a call (open, or
+   * half-open at capacity). When set, the rejected exchange's body becomes
+   * the result of `fallback` and the pipeline continues; when omitted, the
+   * breaker throws `RC5025` so a `.error()` handler (or the default error
+   * path) can react.
+   *
+   * The second argument is `forward`, the same direct-route caller the
+   * `.error()` handler receives: `forward(endpoint, payload)` sends to a
+   * direct route and resolves with that route's result, so a fallback can
+   * be dynamic (serve from a cache route, a secondary provider, etc.)
+   * rather than a static value. May be async.
+   *
+   * @example Static fallback
+   * ```ts
+   * .circuitBreaker({ failureThreshold: 5, fallback: () => ({ degraded: true }) })
+   * ```
+   * @example Dynamic fallback via a direct route
+   * ```ts
+   * .circuitBreaker({
+   *   failureThreshold: 5,
+   *   fallback: (exchange, forward) => forward("recs-fallback", exchange.body),
+   * })
+   * ```
    */
-  fallback?: (exchange: Exchange) => unknown;
-  /**
-   * Callback fired on every state transition (`opened` / `halfOpen` /
-   * `closed`). Side-effect hook for logging or metrics; it must not
-   * throw.
-   */
-  onStateChange?: (state: CircuitBreakerState) => void;
+  fallback?: (
+    exchange: Exchange,
+    forward: ForwardFn,
+  ) => unknown | Promise<unknown>;
   /**
    * Decide whether a failed call counts toward the failure threshold.
    * Default: count everything except `RoutecraftError`s flagged
@@ -77,7 +92,10 @@ export interface CircuitBreakerOptions {
   /**
    * Optional label carried on this breaker's `route:circuitBreaker:*`
    * events, so stacked or sibling breakers can be told apart in logs and
-   * metrics. Has no effect on behaviour.
+   * metrics. Has no effect on behaviour. Observe transitions by
+   * subscribing to those events (`route:circuitBreaker:opened` /
+   * `:halfOpen` / `:closed` / `:rejected`); the breaker exposes no
+   * notification callback, consistent with the other operations.
    */
   label?: string;
 }
@@ -94,8 +112,10 @@ export interface ResolvedCircuitBreakerOptions {
   windowMs: number;
   cooldownMs: number;
   halfOpenMax: number;
-  fallback?: (exchange: Exchange) => unknown;
-  onStateChange?: (state: CircuitBreakerState) => void;
+  fallback?: (
+    exchange: Exchange,
+    forward: ForwardFn,
+  ) => unknown | Promise<unknown>;
   isFailure: (error: Error) => boolean;
   label?: string;
 }
@@ -116,7 +136,6 @@ export function resolveCircuitBreakerOptions(
     cooldownMs = 30_000,
     halfOpenMax = 1,
     fallback,
-    onStateChange,
     isFailure = defaultRetryOn,
     label,
   } = options;
@@ -141,7 +160,6 @@ export function resolveCircuitBreakerOptions(
     halfOpenMax,
     isFailure,
     ...(fallback ? { fallback } : {}),
-    ...(onStateChange ? { onStateChange } : {}),
     ...(label !== undefined ? { label } : {}),
   };
 }
@@ -203,23 +221,6 @@ export class CircuitBreakerMachine {
     return this.#state;
   }
 
-  #toState(to: CircuitBreakerState): void {
-    this.#state = to;
-    // `onStateChange` is user code (metrics / logging). The contract says
-    // it must not throw, but isolate it so a throwing callback cannot
-    // corrupt the transition or abort the acquire / record call that
-    // triggered it (which would surface the callback's error instead of
-    // the breaker's RC5025 / fallback).
-    try {
-      this.#options.onStateChange?.(to);
-    } catch (err) {
-      logger.warn(
-        { err },
-        "circuitBreaker onStateChange callback threw; ignoring",
-      );
-    }
-  }
-
   #prune(now: number): void {
     const cutoff = now - this.#options.windowMs;
     while (this.#failures.length > 0 && this.#failures[0]! < cutoff) {
@@ -237,7 +238,7 @@ export class CircuitBreakerMachine {
       const elapsed = now - this.#openedAt;
       if (elapsed >= this.#options.cooldownMs) {
         this.#halfOpenInFlight = 0;
-        this.#toState("half-open");
+        this.#state = "half-open";
         hooks.onHalfOpen();
       } else {
         const retryAfterMs = this.#options.cooldownMs - elapsed;
@@ -268,7 +269,7 @@ export class CircuitBreakerMachine {
     // must not close the breaker out from under the in-flight probe.
     if (this.#state === "half-open" && probe) {
       this.#failures.length = 0;
-      this.#toState("closed");
+      this.#state = "closed";
       hooks.onClosed();
     }
     // In `closed`, a success does not retract windowed failures; the
@@ -295,7 +296,7 @@ export class CircuitBreakerMachine {
       // admitted before the trip and must not override the probe's verdict.
       if (!probe) return;
       this.#openedAt = now;
-      this.#toState("open");
+      this.#state = "open";
       // Exactly one failed probe re-opened the breaker. Report 1 rather
       // than `#failures.length`, which still holds the original
       // closed-state trip's timestamps (cleared only on close) and is
@@ -309,7 +310,7 @@ export class CircuitBreakerMachine {
       this.#prune(now);
       if (this.#failures.length >= this.#options.failureThreshold) {
         this.#openedAt = now;
-        this.#toState("open");
+        this.#state = "open";
         hooks.onOpened(this.#failures.length);
       }
     }
@@ -451,25 +452,46 @@ export function circuitBreakerEmitHooks(
 }
 
 /**
- * Outcome for a rejected call (breaker open, or half-open at capacity):
- * substitute the configured `fallback` body and continue, or throw
- * `RC5025` so the route's `.error()` handler (or the default error path)
- * decides what to do. Shared by the step-scope wrapper and the
- * route-scope segment.
+ * Build the `forward` passed to a `fallback`: the route's direct-route
+ * caller, or (when the step ran without a route binding, e.g. a unit test)
+ * a stub that fails loudly only if the fallback actually calls it, so a
+ * static fallback that ignores `forward` still works. Mirrors the
+ * step-scope `.error()` handler's forward handling.
  *
  * @internal
  */
-export function circuitOpenOutcome(
+export function circuitBreakerForward(route: Route | undefined): ForwardFn {
+  if (route) return route.getForward();
+  return () =>
+    Promise.reject(
+      rcError("RC5001", undefined, {
+        message:
+          "circuitBreaker fallback called forward() but the step ran without a route binding; forward() requires a route.",
+      }),
+    );
+}
+
+/**
+ * Outcome for a rejected call (breaker open, or half-open at capacity):
+ * substitute the configured `fallback` body and continue, or throw
+ * `RC5025` so the route's `.error()` handler (or the default error path)
+ * decides what to do. The `fallback` receives `forward` so it can produce
+ * a dynamic body from a direct route, and may be async. Shared by the
+ * step-scope wrapper and the route-scope segment.
+ *
+ * @internal
+ */
+export async function circuitOpenOutcome(
   exchange: Exchange,
   options: ResolvedCircuitBreakerOptions,
+  forward: ForwardFn,
   scopeDescription: string,
-): StepOutcome {
+): Promise<StepOutcome> {
   if (options.fallback) {
+    const body = await options.fallback(exchange, forward);
     return {
       kind: "continue",
-      exchange: DefaultExchange.rewrap(exchange, {
-        body: options.fallback(exchange),
-      }),
+      exchange: DefaultExchange.rewrap(exchange, { body }),
     };
   }
   throw rcError("RC5025", undefined, {
@@ -495,7 +517,7 @@ export async function executeWithCircuitBreaker(
   controller: CircuitBreakerController,
   route: Route | undefined,
   hooks: CircuitBreakerHooks,
-  onOpen: () => StepOutcome,
+  onOpen: () => Promise<StepOutcome>,
   run: () => Promise<StepOutcome>,
 ): Promise<StepOutcome> {
   const decision = controller.acquire(route, hooks);
@@ -565,6 +587,8 @@ export class CircuitBreakerWrapperStep<
       this.#controller.options,
     );
 
+    const forward = circuitBreakerForward(route);
+
     return executeWithCircuitBreaker(
       this.#controller,
       route,
@@ -573,6 +597,7 @@ export class CircuitBreakerWrapperStep<
         circuitOpenOutcome(
           exchange,
           this.#controller.options,
+          forward,
           `for step "${stepLabel}"`,
         ),
       () => this.inner.execute(exchange, ctx),

--- a/packages/routecraft/src/pipeline/executor.ts
+++ b/packages/routecraft/src/pipeline/executor.ts
@@ -27,6 +27,12 @@ import {
   executeWithRetry,
   type ResolvedRetryOptions,
 } from "../operations/retry-wrapper.ts";
+import {
+  type CircuitBreakerController,
+  type CircuitBreakerEventScope,
+  circuitBreakerEmitHooks,
+  circuitOpenOutcome,
+} from "../operations/circuit-breaker-wrapper.ts";
 import type { ForwardFn, Route, RouteDefinition } from "../route.ts";
 
 /**
@@ -50,6 +56,7 @@ export interface ExecutorDeps {
     | "retry"
     | "timeout"
     | "throttle"
+    | "circuitBreaker"
   >;
   buildForward(): ForwardFn;
   /**
@@ -157,6 +164,19 @@ export async function runPipeline(
   }
   if (deps.definition.retry) {
     tail = [buildRetrySegmentStep(deps, tail, deps.definition.retry)];
+  }
+  // Route-scope circuit breaker (#6) sits OUTSIDE retry / timeout: when
+  // open it fast-fails before they run, so the breaker records ONE failure
+  // per fully exhausted attempt rather than one per retry. Wrapping it
+  // after the retry segment makes it the outer of the two.
+  if (deps.definition.circuitBreaker) {
+    tail = [
+      buildCircuitBreakerSegmentStep(
+        deps,
+        tail,
+        deps.definition.circuitBreaker,
+      ),
+    ];
   }
   // Route-scope throttle (#5) is the outermost resilience filter: it
   // admits an exchange ONCE, then the retry / timeout segments (and the
@@ -623,6 +643,9 @@ export async function runPipeline(
  */
 const RETRY_SEGMENT_ADAPTER: Adapter = { adapterId: "routecraft.retry" };
 const TIMEOUT_SEGMENT_ADAPTER: Adapter = { adapterId: "routecraft.timeout" };
+const CIRCUIT_BREAKER_SEGMENT_ADAPTER: Adapter = {
+  adapterId: "routecraft.circuitBreaker",
+};
 
 /**
  * Executor deps for a nested segment run: same route identity and
@@ -791,6 +814,92 @@ function buildRetrySegmentStep(
       );
       if (result.dropped) return { kind: "drop" } as const;
       return { kind: "continue", exchange: result.exchange } as const;
+    },
+  };
+}
+
+/**
+ * Build the route-scope `.circuitBreaker()` segment step (pre-from chain
+ * position #6). Wraps the chain tail (the retry / timeout segments, the
+ * cache check, the user pipeline, and the cache store). On each exchange
+ * the breaker decides whether to admit the call:
+ *
+ * - OPEN (cooldown not elapsed) or HALF-OPEN at capacity: fast-fail
+ *   WITHOUT running the tail. With a `fallback` the configured value
+ *   becomes the body and the pipeline completes; without one it throws
+ *   `RC5025` to the route-scope `.error()` handler (or the default error
+ *   path).
+ * - CLOSED, or HALF-OPEN with a free probe slot: run the tail via a
+ *   nested executor invocation (`rethrowUnhandled`, so a failed attempt
+ *   surfaces here). A success closes a half-open breaker; a counted
+ *   failure trips a closed breaker or re-opens a half-open one.
+ *
+ * Because it sits OUTSIDE retry, one fully exhausted attempt (after retry
+ * gives up) is recorded as a single breaker failure, not one per retry.
+ *
+ * The breaker `controller` is built once per route definition (in
+ * `RouteBuilder.from`) and holds the persistent per-Route state, so it is
+ * passed in rather than constructed here. `skipStepEvents: true` keeps
+ * `runPipeline` from emitting generic lifecycle events for this internal
+ * step; the segment emits its own `route:circuitBreaker:*` family with
+ * `scope: "route"`.
+ */
+function buildCircuitBreakerSegmentStep(
+  deps: ExecutorDeps,
+  segment: Step<Adapter>[],
+  controller: CircuitBreakerController,
+): Step<Adapter> {
+  return {
+    operation: OperationType.CIRCUIT_BREAKER,
+    label: "circuitBreaker",
+    adapter: CIRCUIT_BREAKER_SEGMENT_ADAPTER,
+    skipStepEvents: true,
+    async execute(exchange) {
+      const correlationId = exchange.headers[
+        HeadersKeys.CORRELATION_ID
+      ] as string;
+      const scoped: CircuitBreakerEventScope = {
+        routeId: deps.routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        stepLabel: "route",
+        scope: "route",
+        ...(controller.label !== undefined ? { label: controller.label } : {}),
+      };
+      const hooks = circuitBreakerEmitHooks(
+        deps.context,
+        scoped,
+        true,
+        controller.options,
+      );
+
+      const decision = controller.acquire(deps.route, hooks);
+      if (!decision.admitted) {
+        return circuitOpenOutcome(
+          exchange,
+          controller.options,
+          `for route "${deps.routeId}"`,
+        );
+      }
+
+      try {
+        const result = await runPipeline(
+          nestedSegmentDeps(deps, segment),
+          exchange,
+          Date.now(),
+        );
+        controller.recordSuccess(deps.route, decision.probe, hooks);
+        if (result.dropped) return { kind: "drop" } as const;
+        return { kind: "continue", exchange: result.exchange } as const;
+      } catch (err) {
+        controller.recordFailure(
+          deps.route,
+          err instanceof Error ? err : new Error(String(err)),
+          decision.probe,
+          hooks,
+        );
+        throw err;
+      }
     },
   };
 }

--- a/packages/routecraft/src/pipeline/executor.ts
+++ b/packages/routecraft/src/pipeline/executor.ts
@@ -889,6 +889,8 @@ function buildCircuitBreakerSegmentStep(
         controller.options,
       );
 
+      const forward = deps.buildForward();
+
       return executeWithCircuitBreaker(
         controller,
         deps.route,
@@ -897,6 +899,7 @@ function buildCircuitBreakerSegmentStep(
           circuitOpenOutcome(
             exchange,
             controller.options,
+            forward,
             `for route "${deps.routeId}"`,
           ),
         async () =>

--- a/packages/routecraft/src/pipeline/executor.ts
+++ b/packages/routecraft/src/pipeline/executor.ts
@@ -16,6 +16,7 @@ import {
   type Adapter,
   type Step,
   type StepContext,
+  type StepOutcome,
   getAdapterLabel,
 } from "../types.ts";
 import { buildParseStep } from "./synthetic-steps.ts";
@@ -649,6 +650,22 @@ const CIRCUIT_BREAKER_SEGMENT_ADAPTER: Adapter = {
 };
 
 /**
+ * Convert a nested segment run's result into the {@link StepOutcome} the
+ * outer pipeline schedules: a deliberately dropped run resolves as a
+ * drop, every other run continues with the produced exchange. Shared by
+ * the timeout / retry / circuit-breaker segment builders so the mapping
+ * lives in one place.
+ */
+function segmentResultToOutcome(result: {
+  exchange: Exchange;
+  dropped: boolean;
+}): StepOutcome {
+  return result.dropped
+    ? ({ kind: "drop" } as const)
+    : ({ kind: "continue", exchange: result.exchange } as const);
+}
+
+/**
  * Executor deps for a nested segment run: same route identity and
  * capabilities, but the step arrays carry only the wrapped segment and
  * no `errorHandler` / `retry` / `timeout` (the outer invocation owns
@@ -729,8 +746,7 @@ function buildTimeoutSegmentStep(
           ...scoped,
           elapsed: Date.now() - start,
         });
-        if (result.dropped) return { kind: "drop" } as const;
-        return { kind: "continue", exchange: result.exchange } as const;
+        return segmentResultToOutcome(result);
       } catch (err) {
         if (!(err instanceof DeadlineExceededError)) throw err;
         // Stop the abandoned run from scheduling further steps: its
@@ -813,8 +829,7 @@ function buildRetrySegmentStep(
           },
         },
       );
-      if (result.dropped) return { kind: "drop" } as const;
-      return { kind: "continue", exchange: result.exchange } as const;
+      return segmentResultToOutcome(result);
     },
   };
 }
@@ -884,16 +899,14 @@ function buildCircuitBreakerSegmentStep(
             controller.options,
             `for route "${deps.routeId}"`,
           ),
-        async () => {
-          const result = await runPipeline(
-            nestedSegmentDeps(deps, segment),
-            exchange,
-            Date.now(),
-          );
-          return result.dropped
-            ? ({ kind: "drop" } as const)
-            : ({ kind: "continue", exchange: result.exchange } as const);
-        },
+        async () =>
+          segmentResultToOutcome(
+            await runPipeline(
+              nestedSegmentDeps(deps, segment),
+              exchange,
+              Date.now(),
+            ),
+          ),
       );
     },
   };

--- a/packages/routecraft/src/pipeline/executor.ts
+++ b/packages/routecraft/src/pipeline/executor.ts
@@ -32,6 +32,7 @@ import {
   type CircuitBreakerEventScope,
   circuitBreakerEmitHooks,
   circuitOpenOutcome,
+  executeWithCircuitBreaker,
 } from "../operations/circuit-breaker-wrapper.ts";
 import type { ForwardFn, Route, RouteDefinition } from "../route.ts";
 
@@ -873,33 +874,27 @@ function buildCircuitBreakerSegmentStep(
         controller.options,
       );
 
-      const decision = controller.acquire(deps.route, hooks);
-      if (!decision.admitted) {
-        return circuitOpenOutcome(
-          exchange,
-          controller.options,
-          `for route "${deps.routeId}"`,
-        );
-      }
-
-      try {
-        const result = await runPipeline(
-          nestedSegmentDeps(deps, segment),
-          exchange,
-          Date.now(),
-        );
-        controller.recordSuccess(deps.route, decision.probe, hooks);
-        if (result.dropped) return { kind: "drop" } as const;
-        return { kind: "continue", exchange: result.exchange } as const;
-      } catch (err) {
-        controller.recordFailure(
-          deps.route,
-          err instanceof Error ? err : new Error(String(err)),
-          decision.probe,
-          hooks,
-        );
-        throw err;
-      }
+      return executeWithCircuitBreaker(
+        controller,
+        deps.route,
+        hooks,
+        () =>
+          circuitOpenOutcome(
+            exchange,
+            controller.options,
+            `for route "${deps.routeId}"`,
+          ),
+        async () => {
+          const result = await runPipeline(
+            nestedSegmentDeps(deps, segment),
+            exchange,
+            Date.now(),
+          );
+          return result.dropped
+            ? ({ kind: "drop" } as const)
+            : ({ kind: "continue", exchange: result.exchange } as const);
+        },
+      );
     },
   };
 }

--- a/packages/routecraft/src/route.ts
+++ b/packages/routecraft/src/route.ts
@@ -22,6 +22,7 @@ import { logger, childBindings } from "./logger.ts";
 import { type Source, type Subscription } from "./operations/from.ts";
 import { type ResolvedRetryOptions } from "./operations/retry-wrapper.ts";
 import { type ResolvedTimeoutOptions } from "./operations/timeout-wrapper.ts";
+import { type CircuitBreakerController } from "./operations/circuit-breaker-wrapper.ts";
 import {
   type Adapter,
   type Step,
@@ -270,6 +271,23 @@ export type RouteDefinition<T = unknown> = {
    * @internal
    */
   readonly throttle?: Step<Adapter>[];
+
+  /**
+   * Route-scope `.circuitBreaker()` controller (pre-from filter chain
+   * position #6). Unlike retry / timeout (config objects re-built into a
+   * segment per run), the breaker holds persistent per-Route state (the
+   * failure window and the open/half-open machine), so the builder stores
+   * the live {@link CircuitBreakerController} here once at `.from()` time
+   * and the pipeline executor wraps the chain tail in a breaker segment
+   * around it. Sits OUTSIDE the retry (#7) / timeout (#8) segments and
+   * INSIDE the throttle (#5) gate: when open it fast-fails before retry /
+   * timeout run, so one tripped breaker call is recorded per fully
+   * exhausted attempt, not per retry. See
+   * `.standards/pre-from-filter-chain.md`.
+   *
+   * @internal
+   */
+  readonly circuitBreaker?: CircuitBreakerController;
 };
 
 /**

--- a/packages/routecraft/src/step-builder-base.ts
+++ b/packages/routecraft/src/step-builder-base.ts
@@ -37,6 +37,10 @@ import {
   type ThrottleOptions,
 } from "./operations/throttle-wrapper.ts";
 import {
+  CircuitBreakerWrapperStep,
+  type CircuitBreakerOptions,
+} from "./operations/circuit-breaker-wrapper.ts";
+import {
   type Processor,
   type CallableProcessor,
   ProcessStep,
@@ -384,6 +388,45 @@ export abstract class StepBuilderBase<S extends BuilderState = BuilderState> {
   throttle(options: ThrottleOptions): this {
     this.pendingStepWrappers.push(
       (inner) => new ThrottleWrapperStep(inner, options),
+    );
+    return this;
+  }
+
+  /**
+   * Protect the next step with a circuit breaker. Counts the step's
+   * failures over a sliding `windowMs`; once `failureThreshold` failures
+   * accumulate the breaker trips OPEN and subsequent calls fast-fail
+   * (returning `fallback(exchange)` when set, otherwise throwing
+   * `RC5025`) without running the step. After `cooldownMs` the breaker
+   * goes HALF-OPEN and admits up to `halfOpenMax` probe calls: one
+   * success closes it, one failure re-opens it.
+   *
+   * Deterministic errors do not count toward the threshold by default
+   * (any `RoutecraftError` flagged `retryable: false`, e.g. auth or
+   * validation), since they are not evidence the downstream is unhealthy;
+   * override with `isFailure`.
+   *
+   * Only the immediately-next step is protected; later steps run
+   * normally. The breaker state is shared per route (one circuit across
+   * every exchange on the route), not per exchange.
+   *
+   * On `RouteBuilder`, this method is dual-mode: called BEFORE `.from()`
+   * it protects the whole pipeline at pre-from filter chain position 6
+   * (outside `.retry()` / `.timeout()`, so it records one tripped call
+   * per fully exhausted attempt); called AFTER `.from()` it wraps the
+   * next step.
+   *
+   * Stacks with other wrappers in declaration order (first-declared
+   * outermost).
+   *
+   * @param options - `failureThreshold` (required), `windowMs` (default
+   *   60_000), `cooldownMs` (default 30_000), `halfOpenMax` (default 1),
+   *   optional `fallback`, `onStateChange`, `isFailure`, and `label`.
+   * @returns This builder (same subclass, same body type)
+   */
+  circuitBreaker(options: CircuitBreakerOptions): this {
+    this.pendingStepWrappers.push(
+      (inner) => new CircuitBreakerWrapperStep(inner, options),
     );
     return this;
   }

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -513,6 +513,44 @@ export interface EventDetailsMap {
     label?: string;
   };
 
+  // -- Circuit breaker (route- and step-scope wrapper) --
+  /** The breaker tripped to open: failures reached the threshold (from closed) or a probe failed (from half-open). */
+  "route:circuitBreaker:opened": ExchangeScoped & {
+    /** Label of the wrapped step, or `"route"` when `scope === "route"`. */
+    stepLabel: string;
+    scope: "route" | "step";
+    /** Counted failures in the window at the moment the breaker tripped. */
+    failureCount: number;
+    /** Configured failure threshold. */
+    threshold: number;
+    /** Cooldown before the breaker will admit a probe (half-open). */
+    cooldownMs: number;
+    /** Breaker label, when `.circuitBreaker({ label })` is set. */
+    label?: string;
+  };
+  /** Cooldown elapsed; the breaker admitted a probe call to test recovery. */
+  "route:circuitBreaker:halfOpen": ExchangeScoped & {
+    stepLabel: string;
+    scope: "route" | "step";
+    label?: string;
+  };
+  /** A probe succeeded; the breaker recovered to closed. */
+  "route:circuitBreaker:closed": ExchangeScoped & {
+    stepLabel: string;
+    scope: "route" | "step";
+    label?: string;
+  };
+  /** A call was rejected because the breaker is open (or half-open at capacity); a `fallback` ran or `RC5025` followed. */
+  "route:circuitBreaker:rejected": ExchangeScoped & {
+    stepLabel: string;
+    scope: "route" | "step";
+    /** Breaker state at rejection time. */
+    state: "open" | "half-open";
+    /** Time until the breaker would admit a probe, for a Retry-After style hint (0 when half-open at capacity). */
+    retryAfterMs: number;
+    label?: string;
+  };
+
   // -- Error handler (route- and step-scope wrappers) --
   "route:error-handler:invoked": ExchangeScoped & {
     originalError: unknown;

--- a/packages/routecraft/test/circuit-breaker.bun.test.ts
+++ b/packages/routecraft/test/circuit-breaker.bun.test.ts
@@ -169,6 +169,36 @@ describe("CircuitBreakerMachine (state transitions)", () => {
     expect(m.state).toBe("closed");
     expect(events).toEqual([]);
   });
+
+  /**
+   * @case Stale non-probe results do not drive half-open transitions
+   * @preconditions failureThreshold 1, cooldownMs 100; trip, half-open at t=150 with one probe in flight, then a call admitted while closed resolves late
+   * @expectedResult A non-probe failure and a non-probe success while half-open are both ignored (state stays half-open); only the probe's outcome closes or re-opens it
+   */
+  test("half-open ignores stale non-probe failures and successes", () => {
+    const m = new CircuitBreakerMachine(
+      resolveCircuitBreakerOptions({ failureThreshold: 1, cooldownMs: 100 }),
+    );
+    const { events, hooks } = recorder();
+
+    // Trip, then half-open with a probe in flight.
+    m.acquire(0, hooks);
+    m.recordFailure(0, false, true, hooks);
+    const probe = m.acquire(150, hooks);
+    expect(probe).toEqual({ admitted: true, probe: true });
+
+    // A stale call admitted while closed resolves now (probe=false). Neither
+    // its failure nor a success may move the breaker out of half-open.
+    m.recordFailure(150, false, true, hooks);
+    expect(m.state).toBe("half-open");
+    m.recordSuccess(false, hooks);
+    expect(m.state).toBe("half-open");
+
+    // The genuine probe's success is what closes it.
+    m.recordSuccess(true, hooks);
+    expect(m.state).toBe("closed");
+    expect(events).toEqual(["opened:1", "halfOpen", "closed"]);
+  });
 });
 
 describe("Circuit breaker step scope (.circuitBreaker() after .from())", () => {

--- a/packages/routecraft/test/circuit-breaker.bun.test.ts
+++ b/packages/routecraft/test/circuit-breaker.bun.test.ts
@@ -460,4 +460,46 @@ describe("Circuit breaker route scope (.circuitBreaker() before .from())", () =>
     expect(opened).toHaveLength(1);
     expect(opened[0]).toMatchObject({ scope: "route", threshold: 1 });
   });
+
+  /**
+   * @case A fallback can forward to a direct route to build a dynamic response
+   * @preconditions Breaker with a fallback that calls forward('cb-fallback', body); a second route serves that endpoint
+   * @expectedResult Once open, the rejected call resolves with the fallback route's result (proving forward is wired and the async fallback is awaited)
+   */
+  test("fallback forwards to a direct route for a dynamic response", async () => {
+    const fallbackSink = spy();
+    let primaryCalls = 0;
+
+    t = await testContext()
+      .routes([
+        craft()
+          .id("cb-primary")
+          .circuitBreaker({
+            failureThreshold: 1,
+            cooldownMs: 10_000,
+            fallback: (exchange, forward) =>
+              forward("cb-fallback", exchange.body),
+          })
+          .from(direct())
+          .transform(() => {
+            primaryCalls++;
+            throw new Error("primary down");
+          })
+          .to(spy()),
+        craft()
+          .id("cb-fallback")
+          .from<string>(direct())
+          .transform((body: string) => `fallback:${body}`)
+          .to(fallbackSink),
+      ])
+      .build();
+
+    await t.startAndWaitReady();
+    await expect(t.client.sendDirect("cb-primary", "a")).rejects.toThrow(); // trips
+    const result = await t.client.sendDirect("cb-primary", "b"); // open -> fallback forwards
+
+    expect(primaryCalls).toBe(1); // primary not run while open
+    expect(result).toBe("fallback:b");
+    expect(fallbackSink.received.map((e) => e.body)).toEqual(["fallback:b"]);
+  });
 });

--- a/packages/routecraft/test/circuit-breaker.bun.test.ts
+++ b/packages/routecraft/test/circuit-breaker.bun.test.ts
@@ -1,0 +1,433 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { testContext, spy, type TestContext } from "@routecraft/testing";
+import { craft, direct, rcError } from "@routecraft/routecraft";
+import {
+  CircuitBreakerMachine,
+  resolveCircuitBreakerOptions,
+  type CircuitBreakerHooks,
+} from "../src/operations/circuit-breaker-wrapper.ts";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Build a {@link CircuitBreakerHooks} that records transitions as flat
+ * strings so the state-machine tests can assert the exact sequence
+ * without caring about event payloads (covered by the integration tests).
+ */
+function recorder(): { events: string[]; hooks: CircuitBreakerHooks } {
+  const events: string[] = [];
+  return {
+    events,
+    hooks: {
+      onOpened: (count) => void events.push(`opened:${count}`),
+      onHalfOpen: () => void events.push("halfOpen"),
+      onClosed: () => void events.push("closed"),
+      onRejected: (state) => void events.push(`rejected:${state}`),
+    },
+  };
+}
+
+describe("CircuitBreakerMachine (state transitions)", () => {
+  /**
+   * @case Counted failures up to the threshold trip the breaker
+   * @preconditions failureThreshold 3, all failures inside the window, each call admitted while closed
+   * @expectedResult State is open only after the third failure; the opened transition reports the failure count
+   */
+  test("trips from closed to open at the failure threshold", () => {
+    const m = new CircuitBreakerMachine(
+      resolveCircuitBreakerOptions({ failureThreshold: 3, windowMs: 1000 }),
+    );
+    const { events, hooks } = recorder();
+
+    for (let i = 0; i < 3; i++) {
+      const d = m.acquire(i, hooks);
+      expect(d).toEqual({ admitted: true, probe: false });
+      m.recordFailure(i, false, true, hooks);
+    }
+
+    expect(m.state).toBe("open");
+    expect(events).toEqual(["opened:3"]);
+  });
+
+  /**
+   * @case The failure window genuinely slides
+   * @preconditions failureThreshold 3, windowMs 100; two failures at t=0,10 then one at t=200
+   * @expectedResult The two stale failures are pruned, so the late failure leaves the breaker closed
+   */
+  test("prunes failures older than the window so it never trips on stale ones", () => {
+    const m = new CircuitBreakerMachine(
+      resolveCircuitBreakerOptions({ failureThreshold: 3, windowMs: 100 }),
+    );
+    const { events, hooks } = recorder();
+
+    m.recordFailure(0, false, true, hooks);
+    m.recordFailure(10, false, true, hooks);
+    m.recordFailure(200, false, true, hooks);
+
+    expect(m.state).toBe("closed");
+    expect(events).toEqual([]);
+  });
+
+  /**
+   * @case An open breaker fast-fails until the cooldown elapses, then probes
+   * @preconditions failureThreshold 1, cooldownMs 100; trip at t=0, acquire at t=50 and t=150
+   * @expectedResult The t=50 acquire is rejected (open); the t=150 acquire transitions to half-open and admits a probe
+   */
+  test("open rejects within cooldown and half-opens after it", () => {
+    const m = new CircuitBreakerMachine(
+      resolveCircuitBreakerOptions({ failureThreshold: 1, cooldownMs: 100 }),
+    );
+    const { events, hooks } = recorder();
+
+    m.acquire(0, hooks);
+    m.recordFailure(0, false, true, hooks);
+    expect(m.state).toBe("open");
+
+    const rejected = m.acquire(50, hooks);
+    expect(rejected.admitted).toBe(false);
+    if (!rejected.admitted) {
+      expect(rejected.state).toBe("open");
+      expect(rejected.retryAfterMs).toBe(50);
+    }
+
+    const probe = m.acquire(150, hooks);
+    expect(probe).toEqual({ admitted: true, probe: true });
+    expect(m.state).toBe("half-open");
+    expect(events).toEqual(["opened:1", "rejected:open", "halfOpen"]);
+  });
+
+  /**
+   * @case A successful probe closes the breaker; a failed probe re-opens it
+   * @preconditions failureThreshold 1, cooldownMs 100; trip, half-open at t=150, then resolve the probe
+   * @expectedResult Success returns the breaker to closed; failure returns it to open
+   */
+  test("half-open closes on probe success and re-opens on probe failure", () => {
+    const closing = new CircuitBreakerMachine(
+      resolveCircuitBreakerOptions({ failureThreshold: 1, cooldownMs: 100 }),
+    );
+    let r = recorder();
+    closing.acquire(0, r.hooks);
+    closing.recordFailure(0, false, true, r.hooks);
+    const probe = closing.acquire(150, r.hooks);
+    expect(probe.admitted && probe.probe).toBe(true);
+    closing.recordSuccess(true, r.hooks);
+    expect(closing.state).toBe("closed");
+    expect(r.events).toEqual(["opened:1", "halfOpen", "closed"]);
+
+    const reopening = new CircuitBreakerMachine(
+      resolveCircuitBreakerOptions({ failureThreshold: 1, cooldownMs: 100 }),
+    );
+    r = recorder();
+    reopening.acquire(0, r.hooks);
+    reopening.recordFailure(0, false, true, r.hooks);
+    reopening.acquire(150, r.hooks);
+    reopening.recordFailure(150, true, true, r.hooks);
+    expect(reopening.state).toBe("open");
+    expect(r.events).toEqual(["opened:1", "halfOpen", "opened:1"]);
+  });
+
+  /**
+   * @case Half-open admits at most halfOpenMax concurrent probes
+   * @preconditions failureThreshold 1, cooldownMs 100, halfOpenMax 1; two acquires after cooldown before either resolves
+   * @expectedResult The first probe is admitted; the second is rejected (half-open at capacity)
+   */
+  test("half-open caps concurrent probes at halfOpenMax", () => {
+    const m = new CircuitBreakerMachine(
+      resolveCircuitBreakerOptions({
+        failureThreshold: 1,
+        cooldownMs: 100,
+        halfOpenMax: 1,
+      }),
+    );
+    const { hooks } = recorder();
+
+    m.acquire(0, hooks);
+    m.recordFailure(0, false, true, hooks);
+
+    const first = m.acquire(150, hooks);
+    const second = m.acquire(150, hooks);
+
+    expect(first).toEqual({ admitted: true, probe: true });
+    expect(second.admitted).toBe(false);
+    if (!second.admitted) expect(second.state).toBe("half-open");
+  });
+
+  /**
+   * @case Non-counting failures never trip the breaker
+   * @preconditions failureThreshold 1; a single failure recorded with counts=false
+   * @expectedResult The breaker stays closed and emits no transition
+   */
+  test("a failure flagged as non-counting does not trip the breaker", () => {
+    const m = new CircuitBreakerMachine(
+      resolveCircuitBreakerOptions({ failureThreshold: 1 }),
+    );
+    const { events, hooks } = recorder();
+
+    m.acquire(0, hooks);
+    m.recordFailure(0, false, false, hooks);
+
+    expect(m.state).toBe("closed");
+    expect(events).toEqual([]);
+  });
+});
+
+describe("Circuit breaker step scope (.circuitBreaker() after .from())", () => {
+  let t: TestContext;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+  });
+
+  /**
+   * @case Once tripped, the breaker fast-fails with the fallback without running the wrapped step
+   * @preconditions failureThreshold 2, long cooldown, fallback set; two failing calls then two more
+   * @expectedResult The wrapped step runs only twice; later calls return the fallback body and continue to the sink
+   */
+  test("fast-fails with fallback after tripping, skipping the wrapped step", async () => {
+    const sink = spy();
+    let calls = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cb-step-fallback")
+          .from(direct())
+          .circuitBreaker({
+            failureThreshold: 2,
+            cooldownMs: 10_000,
+            fallback: () => "FALLBACK",
+          })
+          .transform(() => {
+            calls++;
+            throw new Error("downstream down");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await expect(
+      t.client.sendDirect("cb-step-fallback", "a"),
+    ).rejects.toThrow();
+    await expect(
+      t.client.sendDirect("cb-step-fallback", "b"),
+    ).rejects.toThrow();
+    await t.client.sendDirect("cb-step-fallback", "c");
+    await t.client.sendDirect("cb-step-fallback", "d");
+
+    expect(calls).toBe(2);
+    expect(sink.received.map((e) => e.body)).toEqual(["FALLBACK", "FALLBACK"]);
+  });
+
+  /**
+   * @case With no fallback, an open breaker throws RC5025
+   * @preconditions failureThreshold 1, long cooldown, no fallback; one failing call then another
+   * @expectedResult The second call is rejected with RC5025 without running the wrapped step
+   */
+  test("throws RC5025 when open and no fallback is configured", async () => {
+    let calls = 0;
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("cb-step-throw")
+          .from(direct())
+          .circuitBreaker({ failureThreshold: 1, cooldownMs: 10_000 })
+          .transform(() => {
+            calls++;
+            throw new Error("downstream down");
+          })
+          .to(spy()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await expect(t.client.sendDirect("cb-step-throw", "a")).rejects.toThrow();
+    const rejection = await t.client
+      .sendDirect("cb-step-throw", "b")
+      .then(() => undefined)
+      .catch((err: unknown) => err);
+
+    expect(calls).toBe(1);
+    expect((rejection as { rc?: string }).rc).toBe("RC5025");
+  });
+
+  /**
+   * @case The breaker emits opened and rejected with step scope
+   * @preconditions failureThreshold 2, no fallback; two failing calls trip it, a third is rejected
+   * @expectedResult One route:circuitBreaker:opened (scope step, failureCount 2, threshold 2) and a route:circuitBreaker:rejected (scope step, state open)
+   */
+  test("emits opened and rejected events with scope step", async () => {
+    const opened: Array<Record<string, unknown>> = [];
+    const rejected: Array<Record<string, unknown>> = [];
+
+    t = await testContext()
+      .on("route:circuitBreaker:opened", (p) => {
+        opened.push(p.details as Record<string, unknown>);
+      })
+      .on("route:circuitBreaker:rejected", (p) => {
+        rejected.push(p.details as Record<string, unknown>);
+      })
+      .routes(
+        craft()
+          .id("cb-step-events")
+          .from(direct())
+          .circuitBreaker({ failureThreshold: 2, cooldownMs: 10_000 })
+          .transform(() => {
+            throw new Error("downstream down");
+          })
+          .to(spy()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await t.client.sendDirect("cb-step-events", "a").catch(() => {});
+    await t.client.sendDirect("cb-step-events", "b").catch(() => {});
+    await t.client.sendDirect("cb-step-events", "c").catch(() => {});
+
+    expect(opened).toHaveLength(1);
+    expect(opened[0]).toMatchObject({
+      scope: "step",
+      failureCount: 2,
+      threshold: 2,
+    });
+    expect(rejected.length).toBeGreaterThanOrEqual(1);
+    expect(rejected[0]).toMatchObject({ scope: "step", state: "open" });
+  });
+
+  /**
+   * @case Deterministic (non-retryable) errors do not count toward the threshold
+   * @preconditions failureThreshold 2; the wrapped step always throws a non-retryable RoutecraftError (RC5012)
+   * @expectedResult Every call runs the step (the breaker never trips), so it is called for all four sends
+   */
+  test("does not count non-retryable errors toward the threshold", async () => {
+    const opened: unknown[] = [];
+    let calls = 0;
+
+    t = await testContext()
+      .on("route:circuitBreaker:opened", (p) => {
+        opened.push(p.details);
+      })
+      .routes(
+        craft()
+          .id("cb-step-noncounting")
+          .from(direct())
+          .circuitBreaker({ failureThreshold: 2, cooldownMs: 10_000 })
+          .transform(() => {
+            calls++;
+            throw rcError("RC5012");
+          })
+          .to(spy()),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    for (const body of ["a", "b", "c", "d"]) {
+      await t.client.sendDirect("cb-step-noncounting", body).catch(() => {});
+    }
+
+    expect(calls).toBe(4);
+    expect(opened).toHaveLength(0);
+  });
+
+  /**
+   * @case After the cooldown, a successful probe closes the breaker
+   * @preconditions failureThreshold 1, cooldownMs 30, no fallback; trip while failing, then recover after the cooldown
+   * @expectedResult halfOpen then closed events fire and post-recovery calls deliver the real body
+   */
+  test("recovers through half-open to closed after the cooldown", async () => {
+    const sink = spy();
+    const transitions: string[] = [];
+    let fail = true;
+    let calls = 0;
+
+    t = await testContext()
+      .on("route:circuitBreaker:halfOpen", () => {
+        transitions.push("halfOpen");
+      })
+      .on("route:circuitBreaker:closed", () => {
+        transitions.push("closed");
+      })
+      .routes(
+        craft()
+          .id("cb-step-recover")
+          .from<string>(direct())
+          .circuitBreaker({ failureThreshold: 1, cooldownMs: 30 })
+          .transform((body: string) => {
+            calls++;
+            if (fail) throw new Error("downstream down");
+            return body.toUpperCase();
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    // Trip the breaker, then confirm it is open (RC5025, step not run).
+    await t.client.sendDirect("cb-step-recover", "a").catch(() => {});
+    await expect(t.client.sendDirect("cb-step-recover", "b")).rejects.toThrow();
+
+    // Downstream recovers; wait out the cooldown so the next call probes.
+    fail = false;
+    await sleep(60);
+    await t.client.sendDirect("cb-step-recover", "c");
+    await t.client.sendDirect("cb-step-recover", "d");
+
+    expect(transitions).toEqual(["halfOpen", "closed"]);
+    // a (fail) + c (probe) + d (closed) ran the step; b was rejected by the
+    // open breaker without running it.
+    expect(calls).toBe(3);
+    expect(sink.received.map((e) => e.body)).toEqual(["C", "D"]);
+  });
+});
+
+describe("Circuit breaker route scope (.circuitBreaker() before .from())", () => {
+  let t: TestContext;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+  });
+
+  /**
+   * @case A route-scope breaker protects the whole pipeline and short-circuits to the fallback
+   * @preconditions failureThreshold 1, fallback set; one failing call trips it, a second is served the fallback
+   * @expectedResult The pipeline (transform + sink) runs once; once open the whole tail is skipped and opened fires with scope route
+   */
+  test("short-circuits the whole pipeline to the fallback when open", async () => {
+    const sink = spy();
+    const opened: Array<Record<string, unknown>> = [];
+    let calls = 0;
+
+    t = await testContext()
+      .on("route:circuitBreaker:opened", (p) => {
+        opened.push(p.details as Record<string, unknown>);
+      })
+      .routes(
+        craft()
+          .id("cb-route")
+          .circuitBreaker({
+            failureThreshold: 1,
+            cooldownMs: 10_000,
+            fallback: () => "ROUTE-FALLBACK",
+          })
+          .from(direct())
+          .transform(() => {
+            calls++;
+            throw new Error("downstream down");
+          })
+          .to(sink),
+      )
+      .build();
+
+    await t.startAndWaitReady();
+    await expect(t.client.sendDirect("cb-route", "a")).rejects.toThrow();
+    await t.client.sendDirect("cb-route", "b");
+    await t.client.sendDirect("cb-route", "c");
+
+    // Only the first call reached the pipeline; the rest were short-circuited.
+    expect(calls).toBe(1);
+    expect(sink.received).toHaveLength(0);
+    expect(opened).toHaveLength(1);
+    expect(opened[0]).toMatchObject({ scope: "route", threshold: 1 });
+  });
+});


### PR DESCRIPTION
## Summary

Implements `.circuitBreaker()`, a dual-mode resilience operation that trips after repeated failures and fast-fails until the protected downstream recovers. Closes #139.

## What it does

- **Step scope** (after `.from()`): wraps the immediately-next step.
- **Route scope** (before `.from()`): a segment at pre-from filter chain **position #6**, wrapping the chain tail **outside** retry (#7) / timeout (#8) and **inside** throttle (#5). One fully-exhausted retry attempt is recorded as a single breaker failure, not one per retry, and an open breaker fast-fails before retry/timeout run.
- **State machine**: per-Route sliding-window (ring buffer of failure timestamps) `closed -> open -> half-open`, keyed by a `WeakMap` so a definition reused across contexts gets isolated circuits.
- **Open behaviour**: returns `fallback(exchange)` if configured, else throws the new non-retryable **`RC5025`**.
- Failures flagged `retryable: false` (auth, validation) do not count toward the threshold by default (`isFailure` override available).
- Emits `route:circuitBreaker:opened` / `:halfOpen` / `:closed` / `:rejected`, which an MCP server plugin can subscribe to in order to mark a tool unavailable while the breaker is open.

## Options

| Option | Default | Description |
|--------|---------|-------------|
| `failureThreshold` | required | failures in the window that trip the breaker |
| `windowMs` | `60_000` | sliding window for counting failures |
| `cooldownMs` | `30_000` | time open before a probe is allowed |
| `halfOpenMax` | `1` | max concurrent probes in half-open |
| `fallback` | none | value returned when open (else `RC5025`) |
| `onStateChange` | none | transition callback (isolated; may not throw) |
| `isFailure` | retryable check | which errors count toward the threshold |
| `label` | none | tag on the breaker's events |

## Out of scope (tracked follow-up)

Consumer-pausing during cooldown (true source backpressure) is not implemented, consistent with throttle. The route-scope breaker fast-fails when open (flowing backpressure to the caller) but the source keeps pulling. Noted in `.standards/resilience-wrappers.md` §7.

## Docs and standards

New operation reference page, events reference entries, the operations index card, and updates to `.standards/pre-from-filter-chain.md` and `.standards/resilience-wrappers.md` marking filter #6 shipped.

## Testing

25 new tests (deterministic state-machine unit tests + route- and step-scope integration tests covering trip/fast-fail, fallback vs `RC5025`, half-open recovery, non-counting errors, and event emission). Full `@routecraft/routecraft` suite green (1013 tests); typecheck, lint, and format clean.

## Review

Self-reviewed via the project's `/code-review` and `/dev:codereview` (six-lens) skills; the resulting correctness, reuse, and docs fixes are folded into the later commits on this branch.

https://claude.ai/code/session_01S4z48koWDNkDCLG6z4YNuu

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4z48koWDNkDCLG6z4YNuu)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a dual‑mode `.circuitBreaker()` that trips after repeated failures and fast‑fails until recovery, now with async `fallback(exchange, forward)` for dynamic responses. Ships at pre‑from filter position #6 per #139 and introduces non‑retryable `RC5025`.

- **New Features**
  - Dual mode: step scope wraps the next step; route scope is a segment at chain position 6 (outside `.retry()`/`.timeout()`, inside `.throttle()`), so one exhausted attempt counts as one failure.
  - Per‑route sliding‑window state (closed → open → half‑open); reused definitions get isolated circuits.
  - Open behavior: run `fallback(exchange, forward)` (awaited) or throw `RC5025`. Non‑retryable failures don’t count by default; override with `isFailure`.
  - Events: `route:circuitBreaker:opened`, `:halfOpen`, `:closed`, `:rejected` with scope `"route"`/`"step"`. Added `OperationType.CIRCUIT_BREAKER`; docs, events, and standards updated; operation listed in the index.
  - Follow‑up: pausing the source during cooldown (true backpressure) is still pending.

- **Bug Fixes**
  - Guarded user callbacks: `isFailure` is isolated so thrown errors don’t mask failures or leak probe slots; only the admitted probe drives half‑open transitions.
  - Builder errors now include `.circuitBreaker()` in staged‑metadata and orphaned‑wrapper messages (`RC2001`).

<sup>Written for commit 65fe92d58794d340e65eaddaae9abd8b962f7897. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

