### PR TITLE
feat(operations): add sample and dedupe flow-control operations

### DIFF
--- a/.changeset/sample-dedupe-ops.md
+++ b/.changeset/sample-dedupe-ops.md
@@ -1,0 +1,7 @@
+---
+"@routecraft/routecraft": minor
+---
+
+Add the `sample` and `dedupe` flow-control operations.
+
+`sample({ every })` passes every Nth exchange and `sample({ intervalMs })` passes the first exchange in each time window, dropping the rest (silently, like a `filter` returning false). `dedupe(options?)` suppresses duplicate exchanges by a derived key with reserve-on-entry / commit-on-completion / release-on-failure semantics, an optional `key` function, and `ttl` / `maxKeys` bounds on the per-route in-memory key set. Both emit `route:operation:<op>:*` events. The default key derivation (SHA-256 of the body's JSON serialisation) is shared with `cache` via the new `hashExchangeBody` utility.

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -393,7 +393,7 @@ The default `.cache()` key hashes `JSON.stringify(body)`, which fails on bodies 
 Supply an explicit `key` function that returns a stable string identifier:
 
 ```ts
-.cache({ key: (e) => String(e.body.id) })
+.cache({ key: (e) => String((e.body as { id: unknown }).id) })
 ```
 
 This error is not retryable: the same body fails key derivation the same way every time.
@@ -435,7 +435,7 @@ The default `.dedupe()` key hashes `JSON.stringify(body)`, which fails on bodies
 Supply an explicit `key` function that returns a stable string identifier:
 
 ```ts
-.dedupe({ key: (e) => String(e.body.id) })
+.dedupe({ key: (e) => String((e.body as { id: unknown }).id) })
 ```
 
 This error is not retryable: the same body fails key derivation the same way every time.

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -425,6 +425,21 @@ A step returned a `StepOutcome` whose `kind` the engine cannot schedule. In prac
 **Suggestion**  
 Return one of the supported outcomes from your step: `continue`, `complete`, `drop`, `branch`, or `fanOut`. Suspend/resume is not available yet; follow the tracking issue for when `suspend` becomes producible.
 
+## RC5033
+Dedupe key derivation failed
+
+**Why it happens**  
+The default `.dedupe()` key hashes `JSON.stringify(body)`, which fails on bodies containing functions, symbols, circular references, or `BigInt`. Also raised when a custom `key` function throws.
+
+**Suggestion**  
+Supply an explicit `key` function that returns a stable string identifier:
+
+```ts
+.dedupe({ key: (e) => String(e.body.id) })
+```
+
+This error is not retryable: the same body fails key derivation the same way every time.
+
 ## RC9901
 Unknown error
 

--- a/apps/routecraft.dev/src/app/docs/reference/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/events/page.md
@@ -157,6 +157,24 @@ A failure of the wrapped operation *inside* the deadline does not emit a timeout
 
 `branchLabel` is `"when"` or `"otherwise"`. `branchIndex` is the zero-based index of the matched branch.
 
+### Sample operations
+
+| Event | When it fires | Details |
+| --- | --- | --- |
+| `route:operation:sample:passed` | The sampler admitted the exchange | `{ routeId, exchangeId, correlationId, mode }` |
+| `route:operation:sample:dropped` | The sampler dropped the exchange between samples | `{ routeId, exchangeId, correlationId, mode }` |
+
+`mode` is `"count"` (for `every`) or `"interval"` (for `intervalMs`). A dropped exchange also fires `route:exchange:dropped` with reason `"sampled"`.
+
+### Dedupe operations
+
+| Event | When it fires | Details |
+| --- | --- | --- |
+| `route:operation:dedupe:pass` | An unseen key was reserved and the exchange continues | `{ routeId, exchangeId, correlationId, key }` |
+| `route:operation:dedupe:duplicate` | A duplicate key was suppressed | `{ routeId, exchangeId, correlationId, key }` |
+
+A suppressed duplicate also fires `route:exchange:dropped` with reason `"duplicate"`. `key` is the derived deduplication key.
+
 ### Error handler operations
 
 | Event | When it fires | Details |

--- a/apps/routecraft.dev/src/app/docs/reference/operations/dedupe/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/dedupe/page.md
@@ -1,8 +1,5 @@
 ---
 title: dedupe
-titleBadges:
-  - text: planned
-    color: purple
 ---
 
 [← All operations](/docs/reference/operations) {% .lead %}
@@ -34,16 +31,30 @@ craft()
   // changed content should be reprocessed.
   .process(expensiveProcessing)
   .to(destination)
+
+// Bound memory on a long-running route with a TTL
+craft()
+  .id('idempotent-consumer')
+  .from(queue())
+  .dedupe({ key: e => e.body.eventId, ttl: 3_600_000 }) // remember keys for 1h
+  .process(handleEvent)
+  .to(destination)
 ```
 
 **Options:**
 - `key` (optional) - Function to derive the deduplication key from the exchange. If omitted, a key is derived by hashing the exchange body. See [default key derivation](#default-key-derivation).
+- `ttl` (optional) - Time to live in milliseconds for a committed key. After expiry, the next exchange with that key is treated as new and passes again. When omitted, committed keys are retained until LRU eviction at `maxKeys`. This is the memory bound for long-running routes.
+- `maxKeys` (optional) - Maximum number of committed keys retained per route (an LRU). Default `10_000`. Keeps memory bounded even without a `ttl`; the least-recently-committed key is evicted, and its next occurrence passes as new.
 
 **Semantics:**
-- Key is reserved immediately (single-flight behavior)
-- If the key is already reserved or committed, the exchange is dropped
-- Key is committed only after the full route completes successfully
-- On failure, the reservation is released or expires
+- Key is reserved immediately on entry (single-flight: a second exchange with the same key that arrives while the first is still in flight is dropped).
+- If the key is already reserved or committed, the exchange is dropped.
+- The reservation is committed when the exchange finishes the route (`route:exchange:completed` or `:dropped`), so future occurrences are recognised as duplicates.
+- On failure (`route:exchange:failed`), the reservation is released, so an errored input is not permanently suppressed and a re-send may try again.
+
+**Events:**
+- `route:operation:dedupe:pass` - emitted when an unseen key is reserved, with the derived `key`.
+- `route:operation:dedupe:duplicate` - emitted when a duplicate is suppressed, with the `key`. A `route:exchange:dropped` event (reason `"duplicate"`) also fires.
 
 **Purpose:**
 - Skip unchanged files
@@ -56,35 +67,30 @@ craft()
 Use `dedupe` when duplicates should do nothing. Use `cache` when duplicates should return the same result.
 {% /callout %}
 
+{% callout type="note" title="Per-instance state in 0.6.0" %}
+Dedupe state is in-memory and scoped to a single route instance. Across multiple instances of the same route (for example, several processes consuming the same queue), each instance dedupes independently. Cross-instance idempotency, via a shared store provider, is a planned addition.
+{% /callout %}
+
 **Default key derivation:**
 
-When `dedupe` or `cache` is called without a `keyFn`, a key is derived automatically by hashing the exchange body:
+When `dedupe` or `cache` is called without a `key` function, a key is derived automatically by SHA-256 hashing the JSON serialisation of the body:
 
 ```
-key = sha256(encode(body))
+key = sha256(JSON.stringify(body))
 ```
 
-The key is computed from the body at the moment the operation executes. If the body changes at different points in the route, the derived key will differ.
+The key is computed from the body at the moment the operation executes. If the body changes at different points in the route, the derived key will differ. Object key order is preserved by `JSON.stringify`, so two objects with the same entries in a different order hash differently; supply an explicit `key` when a stable identity must survive key reordering.
 
-**Supported body types:**
+**Unsupported bodies (throw an error):**
 
-| Type | Encoding |
-|------|----------|
-| `Buffer`, `Uint8Array`, `ArrayBuffer` | Hash raw bytes directly |
-| `string` | UTF-8 encode, then hash |
-| Object or array | Canonicalize (sort keys lexicographically at every level), then hash as JSON |
-| Scalars (`string`, `boolean`, `null`, finite `number`) | Hash as JSON |
+The default key fails on bodies that are not JSON-serialisable:
 
-**Unsupported types (will throw an error):**
-
-- `NaN`, `Infinity`, `-Infinity`
-- Functions, symbols, `BigInt`
-- `Date` or class instances (unless pre-converted to JSON-safe primitives)
+- Functions, symbols, or a top-level `undefined`
+- `BigInt`
 - Circular references
-- Streams (must be materialized to bytes/string/JSON first, or provide a `keyFn`)
 
-When the body contains an unsupported type, a `RoutecraftError` is thrown indicating that a `keyFn` is required.
+When the body is not serialisable, a `RoutecraftError` (`RC5033` for `dedupe`, `RC5029` for `cache`) is thrown, indicating that a `key` function is required.
 
-{% callout type="note" title="When to provide a keyFn" %}
-Use an explicit `keyFn` when you need stable identity across body changes. For example, if the body is enriched or transformed before `dedupe`/`cache`, but identity should be based on a header set earlier by an adapter.
+{% callout type="note" title="When to provide a key function" %}
+Use an explicit `key` when you need stable identity across body changes. For example, if the body is enriched or transformed before `dedupe` / `cache`, but identity should be based on a header set earlier by an adapter. A `key` that returns an identifier already to hand (an id field, a content hash in a header) also avoids re-serialising and re-hashing the body on every exchange.
 {% /callout %}

--- a/apps/routecraft.dev/src/app/docs/reference/operations/dedupe/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/dedupe/page.md
@@ -42,9 +42,9 @@ craft()
 ```
 
 **Options:**
-- `key` (optional) - Function to derive the deduplication key from the exchange. If omitted, a key is derived by hashing the exchange body. See [default key derivation](#default-key-derivation).
-- `ttl` (optional) - Time to live in milliseconds for a committed key. After expiry, the next exchange with that key is treated as new and passes again. When omitted, committed keys are retained until LRU eviction at `maxKeys`. This is the memory bound for long-running routes.
-- `maxKeys` (optional) - Maximum number of committed keys retained per route (an LRU). Default `10_000`. Keeps memory bounded even without a `ttl`; the least-recently-committed key is evicted, and its next occurrence passes as new.
+- `key` (optional) - Function to derive the deduplication key from the exchange. If omitted, a key is derived by hashing the exchange body (see "Default key derivation" below).
+- `ttl` (optional) - Time to live in milliseconds for a committed key. The window is sliding (inactivity-based), not a fixed lifetime from commit: each duplicate hit refreshes it, so an actively-arriving duplicate stream stays suppressed and a key only expires once it has been quiet for `ttl`. After expiry the next exchange with that key is treated as new and passes again. When omitted, committed keys are retained until LRU eviction at `maxKeys`. This is the memory bound for long-running routes.
+- `maxKeys` (optional) - Maximum number of committed keys retained per route (an LRU keyed by recency of use). Default `10_000`. Keeps memory bounded even without a `ttl`; the least-recently-seen key is evicted (a duplicate hit counts as use, not just the original commit), and its next occurrence passes as new.
 
 **Semantics:**
 - Key is reserved immediately on entry (single-flight: a second exchange with the same key that arrives while the first is still in flight is dropped).
@@ -79,11 +79,11 @@ The reserve/commit/release outcome is decided from the entering exchange's termi
 
 When `dedupe` or `cache` is called without a `key` function, a key is derived automatically by SHA-256 hashing the JSON serialisation of the body:
 
-```
+```txt
 key = sha256(JSON.stringify(body))
 ```
 
-The key is computed from the body at the moment the operation executes. If the body changes at different points in the route, the derived key will differ. `JSON.stringify` does NOT canonicalise object key order, so two objects with the same entries serialised in a different order hash differently (and are treated as distinct); supply an explicit `key` when a stable identity must survive key reordering.
+The key is computed from the body at the moment the operation executes. If the body changes at different points in the route, the derived key will differ. `JSON.stringify` does NOT canonicalise object key order, so two objects with the same entries serialised in a different order hash differently (and are treated as distinct); supply an explicit `key` when a stable identity must survive key reordering. Nested non-serialisable values follow standard `JSON.stringify` semantics: a nested `undefined`, function, or symbol is dropped (in an object) or coerced to `null` (in an array), so two bodies that differ only in such values hash the same; supply an explicit `key` when those values are significant to identity.
 
 **Unsupported bodies (throw an error):**
 

--- a/apps/routecraft.dev/src/app/docs/reference/operations/dedupe/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/dedupe/page.md
@@ -71,6 +71,10 @@ Use `dedupe` when duplicates should do nothing. Use `cache` when duplicates shou
 Dedupe state is in-memory and scoped to a single route instance. Across multiple instances of the same route (for example, several processes consuming the same queue), each instance dedupes independently. Cross-instance idempotency, via a shared store provider, is a planned addition.
 {% /callout %}
 
+{% callout type="warning" title="Place dedupe before a fan-out with care" %}
+The reserve/commit/release outcome is decided from the entering exchange's terminal event. When `.dedupe()` sits before a `.split()` (or another fan-out) and the resulting children fail, the parent exchange still completes, so the key is committed and a re-send is treated as a duplicate rather than reprocessed. Until lineage-aware settlement lands, place `.dedupe()` after a `split`/`aggregate`, or supply an explicit `key` and re-send through a path that does not fan out, when failed work must be retriable.
+{% /callout %}
+
 **Default key derivation:**
 
 When `dedupe` or `cache` is called without a `key` function, a key is derived automatically by SHA-256 hashing the JSON serialisation of the body:

--- a/apps/routecraft.dev/src/app/docs/reference/operations/dedupe/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/dedupe/page.md
@@ -36,7 +36,7 @@ craft()
 craft()
   .id('idempotent-consumer')
   .from(queue())
-  .dedupe({ key: e => e.body.eventId, ttl: 3_600_000 }) // remember keys for 1h
+  .dedupe({ key: e => (e.body as { eventId: string }).eventId, ttl: 3_600_000 }) // remember keys for 1h
   .process(handleEvent)
   .to(destination)
 ```
@@ -49,8 +49,8 @@ craft()
 **Semantics:**
 - Key is reserved immediately on entry (single-flight: a second exchange with the same key that arrives while the first is still in flight is dropped).
 - If the key is already reserved or committed, the exchange is dropped.
-- The reservation is committed when the exchange finishes the route (`route:exchange:completed` or `:dropped`), so future occurrences are recognised as duplicates.
-- On failure (`route:exchange:failed`), the reservation is released, so an errored input is not permanently suppressed and a re-send may try again.
+- The reservation is committed only when the exchange completes the route cleanly (`route:exchange:completed`), so future occurrences are recognised as duplicates.
+- On failure (`route:exchange:failed`) or a downstream drop (`route:exchange:dropped`, e.g. a later `filter` rejects it), the reservation is released, so an input that was not actually handled is not permanently suppressed and a re-send may try again.
 
 **Events:**
 - `route:operation:dedupe:pass` - emitted when an unseen key is reserved, with the derived `key`.
@@ -79,7 +79,7 @@ When `dedupe` or `cache` is called without a `key` function, a key is derived au
 key = sha256(JSON.stringify(body))
 ```
 
-The key is computed from the body at the moment the operation executes. If the body changes at different points in the route, the derived key will differ. Object key order is preserved by `JSON.stringify`, so two objects with the same entries in a different order hash differently; supply an explicit `key` when a stable identity must survive key reordering.
+The key is computed from the body at the moment the operation executes. If the body changes at different points in the route, the derived key will differ. `JSON.stringify` does NOT canonicalise object key order, so two objects with the same entries serialised in a different order hash differently (and are treated as distinct); supply an explicit `key` when a stable identity must survive key reordering.
 
 **Unsupported bodies (throw an error):**
 

--- a/apps/routecraft.dev/src/app/docs/reference/operations/sample/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/sample/page.md
@@ -1,28 +1,40 @@
 ---
 title: sample
-titleBadges:
-  - text: planned
-    color: purple
 ---
 
 [← All operations](/docs/reference/operations) {% .lead %}
 
 ```ts
-sample(options: { every?: number; intervalMs?: number }): RouteBuilder<Current>
+sample(options: { every?: number } | { intervalMs?: number }): RouteBuilder<Current>
 ```
 
-Take every Nth exchange or sample at time intervals. Useful for reducing data volume while maintaining representativeness.
+Reduce data volume from a high-frequency source by passing a representative subset of exchanges and dropping the rest. A dropped exchange is discarded silently, exactly like a `filter` predicate returning `false`.
+
+Pass exactly one of `every` or `intervalMs`; they are mutually exclusive (a sampler is either count-based or time-based). Sampler state (the counter or the window timestamp) is per-route.
 
 ```ts
-// Take every 5th exchange
+// Count-based: take every 5th exchange
 .sample({ every: 5 })
 
-// Sample every 10 seconds (first exchange in each window)
+// Time-based: pass the first exchange in each 10-second window
 .sample({ intervalMs: 10000 })
 
-// Typical use: Reduce high-frequency data
-.id('high-frequency-metrics')
-.from(direct())
-.sample({ every: 100 }) // Only process 1% of metrics
-.to(database({ operation: 'save' }))
+// Typical use: reduce high-frequency data
+craft()
+  .id('high-frequency-metrics')
+  .from(direct())
+  .sample({ every: 100 }) // Process roughly 1% of metrics
+  .to(database({ operation: 'save' }))
 ```
+
+**Options:**
+- `every` - Count-based: pass every Nth exchange. An internal counter increments per exchange and the exchange passes when `counter % every === 0`, so `{ every: 5 }` passes the 5th, 10th, 15th, ... exchange. Must be a finite integer >= 1.
+- `intervalMs` - Time-based: pass the first exchange seen in each window of `intervalMs` milliseconds and drop the rest until the window elapses. Must be a finite number > 0.
+
+**Events:**
+- `route:operation:sample:passed` - emitted for each admitted exchange, with `mode` (`"count"` or `"interval"`).
+- `route:operation:sample:dropped` - emitted for each dropped exchange. A `route:exchange:dropped` event (reason `"sampled"`) also fires so telemetry and the TUI count it.
+
+{% callout type="note" title="sample vs filter vs throttle" %}
+`filter` keeps or drops each exchange independently by a predicate. `sample` drops by position (count) or time, keeping a representative subset. `throttle` never drops: it paces exchanges that exceed a rate. Reach for `sample` to thin a firehose, `throttle` to smooth one.
+{% /callout %}

--- a/apps/routecraft.dev/src/app/docs/reference/operations/sample/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/sample/page.md
@@ -5,7 +5,7 @@ title: sample
 [← All operations](/docs/reference/operations) {% .lead %}
 
 ```ts
-sample(options: { every?: number } | { intervalMs?: number }): RouteBuilder<Current>
+sample(options: { every: number } | { intervalMs: number }): RouteBuilder<Current>
 ```
 
 Reduce data volume from a high-frequency source by passing a representative subset of exchanges and dropping the rest. A dropped exchange is discarded silently, exactly like a `filter` predicate returning `false`.

--- a/apps/routecraft.dev/src/app/docs/reference/operations/sample/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/sample/page.md
@@ -28,7 +28,7 @@ craft()
 ```
 
 **Options:**
-- `every` - Count-based: pass every Nth exchange. An internal counter increments per exchange and the exchange passes when `counter % every === 0`, so `{ every: 5 }` passes the 5th, 10th, 15th, ... exchange. Must be a finite integer >= 1.
+- `every` - Count-based: pass every Nth exchange. An internal counter increments on each exchange; when it reaches `every` the exchange passes and the counter resets to zero, so `{ every: 5 }` passes the 5th, 10th, 15th, ... exchange. Must be a finite integer >= 1.
 - `intervalMs` - Time-based: pass the first exchange seen in each window of `intervalMs` milliseconds and drop the rest until the window elapses. Must be a finite number > 0.
 
 **Events:**

--- a/apps/routecraft.dev/src/app/docs/reference/operations/sample/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/sample/page.md
@@ -36,5 +36,5 @@ craft()
 - `route:operation:sample:dropped` - emitted for each dropped exchange. A `route:exchange:dropped` event (reason `"sampled"`) also fires so telemetry and the TUI count it.
 
 {% callout type="note" title="sample vs filter vs throttle" %}
-`filter` keeps or drops each exchange independently by a predicate. `sample` drops by position (count) or time, keeping a representative subset. `throttle` never drops: it paces exchanges that exceed a rate. Reach for `sample` to thin a firehose, `throttle` to smooth one.
+`filter` keeps or drops each exchange independently by a predicate. `sample` drops by position (count) or time, keeping a representative subset. `throttle` enforces a rate without sampling: by default (`mode: "delay"`) it paces over-limit exchanges, and in `mode: "reject"` it fails them fast rather than dropping them. Reach for `sample` to thin a firehose, `throttle` to smooth one.
 {% /callout %}

--- a/apps/routecraft.dev/src/components/ErrorTable.tsx
+++ b/apps/routecraft.dev/src/components/ErrorTable.tsx
@@ -177,6 +177,18 @@ const errors: ErrorRow[] = [
     retryable: false,
   },
   {
+    code: 'RC5032',
+    category: 'Runtime',
+    message: 'Unsupported step outcome',
+    retryable: false,
+  },
+  {
+    code: 'RC5033',
+    category: 'Adapter',
+    message: 'Dedupe key derivation failed',
+    retryable: false,
+  },
+  {
     code: 'RC9901',
     category: 'Runtime',
     message: 'Unknown error',

--- a/apps/routecraft.dev/src/components/OperationsIndex.tsx
+++ b/apps/routecraft.dev/src/components/OperationsIndex.tsx
@@ -178,8 +178,7 @@ const ops: Op[] = [
     name: 'dedupe',
     category: 'Flow Control',
     signature: '.dedupe({ key })',
-    description: 'Drop exchanges with a duplicate key within a window.',
-    planned: true,
+    description: 'Drop exchanges whose derived key has already been seen.',
   },
   {
     name: 'choice',
@@ -217,8 +216,7 @@ const ops: Op[] = [
     name: 'sample',
     category: 'Flow Control',
     signature: '.sample({ every })',
-    description: 'Pass through every Nth exchange.',
-    planned: true,
+    description: 'Pass every Nth exchange, or the first per time window.',
   },
   {
     name: 'debounce',

--- a/packages/routecraft/src/error.ts
+++ b/packages/routecraft/src/error.ts
@@ -78,6 +78,7 @@ export interface ErrorCodeRegistry {
   RC5030: RCMeta;
   RC5031: RCMeta;
   RC5032: RCMeta;
+  RC5033: RCMeta;
   RC9901: RCMeta;
 }
 
@@ -337,6 +338,14 @@ export const RC: { [K in CoreErrorCode]: RCMeta } = {
     suggestion:
       "A step returned a StepOutcome kind the engine cannot schedule yet. The 'suspend' kind is reserved for the route-level suspend/resume feature and is not implemented; no built-in step produces it. If you wrote a custom step, return a supported outcome (continue, complete, drop, branch, fanOut). Retrying will not help.",
     docs: `${DOCS_BASE}#rc-5032`,
+    retryable: false,
+  },
+  RC5033: {
+    category: "Adapter",
+    message: "Dedupe key derivation failed",
+    suggestion:
+      "The default `.dedupe()` key hashes JSON.stringify(body); it fails on non-serialisable bodies (functions, symbols, circular refs, BigInt). Supply an explicit `key` function in dedupe({ key: ... }). Retrying will not help: the same body fails the same way.",
+    docs: `${DOCS_BASE}#rc-5033`,
     retryable: false,
   },
   RC9901: {

--- a/packages/routecraft/src/exchange.ts
+++ b/packages/routecraft/src/exchange.ts
@@ -47,6 +47,10 @@ export enum OperationType {
   THROTTLE = "throttle",
   /** Fast-fail an operation while a downstream is known to be failing */
   CIRCUIT_BREAKER = "circuit-breaker",
+  /** Pass every Nth exchange (or the first per time window), dropping the rest */
+  SAMPLE = "sample",
+  /** Drop exchanges whose derived key has already been seen */
+  DEDUPE = "dedupe",
   /** Short-circuit the pipeline: drop the exchange without further steps */
   HALT = "halt",
 }

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -132,6 +132,20 @@ export {
 export { type Filter, type FilterDropResult } from "./operations/filter.ts";
 
 export {
+  SampleStep,
+  type SampleOptions,
+  type ResolvedSampleOptions,
+} from "./operations/sample.ts";
+
+export {
+  DedupeStep,
+  type DedupeOptions,
+  type ResolvedDedupeOptions,
+} from "./operations/dedupe.ts";
+
+export { hashExchangeBody } from "./operations/hash-body.ts";
+
+export {
   BranchBuilder,
   ChoiceSubBuilder,
   type ChoicePredicate,

--- a/packages/routecraft/src/operations/cache-wrapper.ts
+++ b/packages/routecraft/src/operations/cache-wrapper.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import {
   type Exchange,
   DefaultExchange,
@@ -7,8 +5,9 @@ import {
   markDropped,
 } from "../exchange.ts";
 import { wrapperEventScope } from "./event-scope.ts";
-import { rcError, RoutecraftError } from "../error.ts";
+import { rcError } from "../error.ts";
 import { isRoutecraftError } from "../brand.ts";
+import { hashExchangeBody } from "./hash-body.ts";
 import type { Adapter, Step, StepContext, StepOutcome } from "../types.ts";
 import { WrapperStep } from "./wrapper.ts";
 import {
@@ -88,20 +87,11 @@ export function resolveCacheOptions<Current = unknown>(
 
 function defaultKey(exchange: Exchange<unknown>): string {
   try {
-    const stringified = JSON.stringify(exchange.body);
-    if (stringified === undefined) {
-      throw rcError("RC5029", undefined, {
-        message:
-          "Default cache key derivation failed: exchange body is not JSON-serialisable. " +
-          "Supply an explicit `key` function in cache({ key: ... }).",
-      });
-    }
-    return createHash("sha256").update(stringified).digest("hex");
+    return hashExchangeBody(exchange.body);
   } catch (err) {
-    if (err instanceof RoutecraftError) throw err;
     throw rcError("RC5029", err, {
       message:
-        "Default cache key derivation threw while hashing the exchange body. " +
+        "Default cache key derivation failed: the exchange body is not JSON-serialisable. " +
         "Supply an explicit `key` function in cache({ key: ... }).",
     });
   }

--- a/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
+++ b/packages/routecraft/src/operations/circuit-breaker-wrapper.ts
@@ -8,6 +8,7 @@ import { WrapperStep } from "./wrapper.ts";
 import { wrapperEventScope } from "./event-scope.ts";
 import { assertDurationMs } from "./cancellable-sleep.ts";
 import { defaultRetryOn } from "./retry-wrapper.ts";
+import { RouteScopedController } from "./route-scoped-controller.ts";
 
 /**
  * The three states of a circuit breaker.
@@ -326,12 +327,11 @@ export class CircuitBreakerMachine {
  *
  * @internal
  */
-export class CircuitBreakerController {
+export class CircuitBreakerController extends RouteScopedController<CircuitBreakerMachine> {
   readonly #options: ResolvedCircuitBreakerOptions;
-  readonly #byRoute = new WeakMap<Route, CircuitBreakerMachine>();
-  #routeless?: CircuitBreakerMachine;
 
   constructor(options: ResolvedCircuitBreakerOptions) {
+    super();
     this.#options = options;
   }
 
@@ -345,24 +345,15 @@ export class CircuitBreakerController {
     return this.#options.label;
   }
 
-  #machineFor(route: Route | undefined): CircuitBreakerMachine {
-    if (!route) {
-      this.#routeless ??= new CircuitBreakerMachine(this.#options);
-      return this.#routeless;
-    }
-    let machine = this.#byRoute.get(route);
-    if (!machine) {
-      machine = new CircuitBreakerMachine(this.#options);
-      this.#byRoute.set(route, machine);
-    }
-    return machine;
+  protected createState(): CircuitBreakerMachine {
+    return new CircuitBreakerMachine(this.#options);
   }
 
   acquire(
     route: Route | undefined,
     hooks: CircuitBreakerHooks,
   ): CircuitBreakerDecision {
-    return this.#machineFor(route).acquire(Date.now(), hooks);
+    return this.stateFor(route).acquire(Date.now(), hooks);
   }
 
   recordSuccess(
@@ -370,7 +361,7 @@ export class CircuitBreakerController {
     probe: boolean,
     hooks: CircuitBreakerHooks,
   ): void {
-    this.#machineFor(route).recordSuccess(probe, hooks);
+    this.stateFor(route).recordSuccess(probe, hooks);
   }
 
   recordFailure(
@@ -392,7 +383,7 @@ export class CircuitBreakerController {
         "circuitBreaker isFailure callback threw; counting the failure",
       );
     }
-    this.#machineFor(route).recordFailure(Date.now(), probe, counts, hooks);
+    this.stateFor(route).recordFailure(Date.now(), probe, counts, hooks);
   }
 }
 

--- a/packages/routecraft/src/operations/dedupe.ts
+++ b/packages/routecraft/src/operations/dedupe.ts
@@ -35,9 +35,12 @@ export interface DedupeOptions {
    */
   key?: (exchange: Exchange) => string;
   /**
-   * Time to live in milliseconds for a committed key. After expiry, the
-   * next exchange with that key is treated as new (passes again). When
-   * omitted, committed keys are retained until LRU eviction at `maxKeys`.
+   * Time to live in milliseconds for a committed key. The TTL is a sliding
+   * (inactivity) window, not a fixed lifetime from commit: each duplicate hit
+   * refreshes it, so an actively-arriving duplicate stream keeps being
+   * suppressed and a key only expires once it has been quiet for `ttl`. After
+   * expiry the next exchange with that key is treated as new (passes again).
+   * When omitted, committed keys are retained until LRU eviction at `maxKeys`.
    *
    * This is the memory bound for long-running routes: without a `ttl`, only
    * `maxKeys` caps the committed set, and an evicted key's next occurrence
@@ -46,9 +49,10 @@ export interface DedupeOptions {
   ttl?: number;
   /**
    * Maximum number of committed keys retained per route. The committed set
-   * is an LRU, so memory stays bounded even with an unbounded key space (the
-   * least-recently-committed key is evicted, and its next occurrence passes
-   * as new). Default `10_000`.
+   * is an LRU keyed by recency of use (a duplicate hit counts as a use, not
+   * just the original commit), so memory stays bounded even with an unbounded
+   * key space: the least-recently-seen key is evicted, and its next
+   * occurrence passes as new. Default `10_000`.
    */
   maxKeys?: number;
 }
@@ -313,7 +317,17 @@ export class DedupeStep implements Step<DedupeAdapter> {
 
     let key: string;
     try {
-      key = this.#options.key(exchange);
+      const derived = this.#options.key(exchange);
+      // Defend JS callers and widened types: `key` is typed to return a
+      // string, but a non-string return would corrupt the identity used as
+      // the committed-key and the `key: string` event contract. Treat it as a
+      // coded derivation failure, same as a throwing `key`.
+      if (typeof derived !== "string") {
+        throw rcError("RC5033", undefined, {
+          message: `dedupe({ key }) for "${stepLabel}" must return a string, got ${typeof derived}`,
+        });
+      }
+      key = derived;
     } catch (err) {
       if (context) {
         context.emit("route:step:failed", {

--- a/packages/routecraft/src/operations/dedupe.ts
+++ b/packages/routecraft/src/operations/dedupe.ts
@@ -14,6 +14,7 @@ import {
   emitExchangeDropped,
 } from "../exchange.ts";
 import { rcError } from "../error.ts";
+import { isRoutecraftError } from "../brand.ts";
 import type { CraftContext } from "../context.ts";
 import type { Route } from "../route.ts";
 import { hashExchangeBody } from "./hash-body.ts";
@@ -148,6 +149,11 @@ class DedupeState {
     this.#committed = new LRUCache<string, true>({
       max: options.maxKeys,
       ...(options.ttl !== undefined ? { ttl: options.ttl } : {}),
+      // Duplicate detection reads via `has()`; refresh recency (and TTL) on
+      // a hit so a frequently-seen key is not LRU-evicted ahead of colder
+      // keys and a sliding TTL keeps suppressing an actively-arriving
+      // duplicate stream.
+      updateAgeOnHas: true,
     });
   }
 
@@ -162,7 +168,7 @@ class DedupeState {
     this.#pending.set(exchangeId, key);
   }
 
-  /** Terminal success/drop: promote the reservation to a committed key. */
+  /** Terminal success: promote the reservation to a committed key. */
   commit(exchangeId: string): void {
     const key = this.#pending.get(exchangeId);
     if (key === undefined) return;
@@ -171,7 +177,14 @@ class DedupeState {
     this.#committed.set(key, true);
   }
 
-  /** Terminal failure: drop the reservation so a re-send may try again. */
+  /**
+   * Terminal failure or drop: drop the reservation without committing, so a
+   * re-send may try again. A drop is treated like a failure here on purpose:
+   * an exchange that dedupe let through but a later step discarded (a filter
+   * rejection, a halt) was not actually handled, so committing its key would
+   * permanently suppress a legitimate re-send. Only a clean completion
+   * commits.
+   */
   release(exchangeId: string): void {
     const key = this.#pending.get(exchangeId);
     if (key === undefined) return;
@@ -183,9 +196,10 @@ class DedupeState {
    * Subscribe the commit / release hooks to the route's terminal exchange
    * events exactly once. The reservation pattern needs to know when an
    * exchange finished the whole pipeline, which the exchange-lifecycle
-   * events report; `forRoute` scopes them to this route. Subscriptions are
-   * torn down when the route aborts so they do not accumulate across route
-   * restarts on a shared context.
+   * events report; `forRoute` scopes them to this route. A clean completion
+   * commits; a failure or a drop releases. Subscriptions are torn down when
+   * the route aborts (and the state is re-armed) so they do not accumulate
+   * across route restarts on a shared context.
    */
   ensureSubscribed(
     context: CraftContext,
@@ -202,7 +216,7 @@ class DedupeState {
       ),
       context.on(
         "route:exchange:dropped",
-        forRoute(routeId, ({ details }) => this.commit(details.exchangeId)),
+        forRoute(routeId, ({ details }) => this.release(details.exchangeId)),
       ),
       context.on(
         "route:exchange:failed",
@@ -213,6 +227,11 @@ class DedupeState {
     if (route) {
       const cleanup = (): void => {
         for (const off of offs) off();
+        // Re-arm: a fresh run of this route (after a restart on a shared
+        // context) re-subscribes rather than running with dead listeners.
+        this.#subscribed = false;
+        this.#reserved.clear();
+        this.#pending.clear();
       };
       if (route.signal.aborted) cleanup();
       else route.signal.addEventListener("abort", cleanup, { once: true });
@@ -323,7 +342,14 @@ export class DedupeStep implements Step<DedupeAdapter> {
           error: err instanceof Error ? err.message : String(err),
         });
       }
-      throw err;
+      // Surface a coded error for a throwing user `key`, mirroring the
+      // default-key path (RC5033) and cache's RC5029, rather than leaking a
+      // bare throw. The default-key deriver already throws RC5033.
+      throw isRoutecraftError(err)
+        ? err
+        : rcError("RC5033", err, {
+            message: `dedupe({ key }) for "${stepLabel}" threw while deriving the key`,
+          });
     }
 
     const state = this.#controller.stateFor(route);
@@ -332,8 +358,12 @@ export class DedupeStep implements Step<DedupeAdapter> {
     // after the first).
     if (context) state.ensureSubscribed(context, routeId, route);
 
+    // Reserve only when a context is bound: the reservation is released by a
+    // terminal exchange event, which cannot fire without a context, so
+    // reserving on the context-less path (synthetic/unit invocation) would
+    // leak the key forever. Without a context dedupe degrades to pass-through.
     const duplicate = state.isDuplicate(key);
-    if (!duplicate) state.reserve(key, exchange.id);
+    if (!duplicate && context) state.reserve(key, exchange.id);
 
     if (context) {
       context.emit("route:step:completed", {

--- a/packages/routecraft/src/operations/dedupe.ts
+++ b/packages/routecraft/src/operations/dedupe.ts
@@ -1,0 +1,372 @@
+import { LRUCache } from "lru-cache";
+import {
+  type Adapter,
+  type Step,
+  type StepOutcome,
+  forRoute,
+} from "../types.ts";
+import {
+  type Exchange,
+  OperationType,
+  HeadersKeys,
+  getExchangeContext,
+  getExchangeRoute,
+  emitExchangeDropped,
+} from "../exchange.ts";
+import { rcError } from "../error.ts";
+import type { CraftContext } from "../context.ts";
+import type { Route } from "../route.ts";
+import { hashExchangeBody } from "./hash-body.ts";
+
+/** Default cap on committed keys retained per route. */
+const DEFAULT_MAX_KEYS = 10_000;
+
+/**
+ * Hard ceiling on `maxKeys`. The committed-key LRU pre-allocates index
+ * arrays sized to its `max`, so this bounds the eager allocation a single
+ * `.dedupe()` can trigger and stops an absurd value from OOMing the process
+ * at build time.
+ */
+const MAX_KEYS_CEILING = 1_000_000;
+
+/**
+ * Options for the `.dedupe()` flow-control operation.
+ */
+export interface DedupeOptions {
+  /**
+   * Derive the deduplication key from the exchange. The returned string is
+   * the identity two exchanges are compared on. When omitted, a key is
+   * computed by SHA-256 hashing `JSON.stringify(body)` (see
+   * {@link hashExchangeBody}); supply an explicit `key` when the body is not
+   * JSON-serialisable or when a stable identity lives in a header (a file
+   * path, an event id) that should survive body changes.
+   */
+  key?: (exchange: Exchange) => string;
+  /**
+   * Time to live in milliseconds for a committed key. After expiry, the
+   * next exchange with that key is treated as new (passes again). When
+   * omitted, committed keys are retained until LRU eviction at `maxKeys`.
+   *
+   * This is the memory bound for long-running routes: without a `ttl`, only
+   * `maxKeys` caps the committed set, and an evicted key's next occurrence
+   * is no longer recognised as a duplicate.
+   */
+  ttl?: number;
+  /**
+   * Maximum number of committed keys retained per route. The committed set
+   * is an LRU, so memory stays bounded even with an unbounded key space (the
+   * least-recently-committed key is evicted, and its next occurrence passes
+   * as new). Default `10_000`.
+   */
+  maxKeys?: number;
+}
+
+/**
+ * {@link DedupeOptions} with every field resolved and validated.
+ *
+ * @internal
+ */
+export interface ResolvedDedupeOptions {
+  key: (exchange: Exchange) => string;
+  ttl: number | undefined;
+  maxKeys: number;
+}
+
+/**
+ * Validate user-supplied {@link DedupeOptions} into a
+ * {@link ResolvedDedupeOptions}, filling defaults: the SHA-256 body hasher
+ * for `key`, no TTL, and a `maxKeys` ceiling of 10_000. Rejects at build
+ * time (RC5003) so a typo fails when the route is built.
+ *
+ * @internal
+ */
+export function resolveDedupeOptions(
+  options: DedupeOptions = {},
+): ResolvedDedupeOptions {
+  const { ttl, maxKeys = DEFAULT_MAX_KEYS } = options;
+
+  if (ttl !== undefined && (!Number.isFinite(ttl) || ttl <= 0)) {
+    throw rcError("RC5003", undefined, {
+      message: `dedupe({ ttl }) must be a finite number > 0 (milliseconds), got ${String(ttl)}.`,
+    });
+  }
+  // Upper-bound `maxKeys`: the committed-key LRU pre-allocates index arrays
+  // sized to `max` at construction, so an "effectively unlimited" value
+  // would OOM the process the moment the dedupe state is built.
+  if (!Number.isInteger(maxKeys) || maxKeys < 1 || maxKeys > MAX_KEYS_CEILING) {
+    throw rcError("RC5003", undefined, {
+      message: `dedupe({ maxKeys }) must be an integer between 1 and ${MAX_KEYS_CEILING}, got ${String(maxKeys)}.`,
+    });
+  }
+
+  return {
+    key: options.key ?? defaultDedupeKey,
+    ttl,
+    maxKeys,
+  };
+}
+
+function defaultDedupeKey(exchange: Exchange<unknown>): string {
+  try {
+    return hashExchangeBody(exchange.body);
+  } catch (err) {
+    throw rcError("RC5033", err, {
+      message:
+        "Default dedupe key derivation failed: the exchange body is not JSON-serialisable. " +
+        "Supply an explicit `key` function in dedupe({ key: ... }).",
+    });
+  }
+}
+
+/**
+ * Per-route dedupe state implementing the reserve / commit / release
+ * protocol. A key is reserved the moment an exchange enters dedupe and
+ * stays reserved until that exchange reaches a terminal route event:
+ *
+ * - `route:exchange:completed` / `route:exchange:dropped` -> commit (the
+ *   input was handled, so future occurrences are duplicates).
+ * - `route:exchange:failed` -> release (the input errored, so a re-send
+ *   should be allowed to try again).
+ *
+ * A key that is reserved OR committed is a duplicate. Reservation gives
+ * single-flight behaviour: a second exchange with the same key that arrives
+ * while the first is still in flight is dropped without waiting. One
+ * instance per Route (see {@link DedupeController}), never one per exchange.
+ *
+ * @internal
+ */
+class DedupeState {
+  /** Committed keys, LRU- and (optionally) TTL-bounded. */
+  readonly #committed: LRUCache<string, true>;
+  /** Keys reserved by an in-flight exchange (single-flight gate). */
+  readonly #reserved = new Set<string>();
+  /** Maps a reserving exchange's id to the key it holds, for commit/release. */
+  readonly #pending = new Map<string, string>();
+  #subscribed = false;
+
+  constructor(options: ResolvedDedupeOptions) {
+    this.#committed = new LRUCache<string, true>({
+      max: options.maxKeys,
+      ...(options.ttl !== undefined ? { ttl: options.ttl } : {}),
+    });
+  }
+
+  /** A key already reserved by an in-flight exchange or committed is a duplicate. */
+  isDuplicate(key: string): boolean {
+    return this.#reserved.has(key) || this.#committed.has(key);
+  }
+
+  /** Reserve `key` for `exchangeId` (single-flight gate). */
+  reserve(key: string, exchangeId: string): void {
+    this.#reserved.add(key);
+    this.#pending.set(exchangeId, key);
+  }
+
+  /** Terminal success/drop: promote the reservation to a committed key. */
+  commit(exchangeId: string): void {
+    const key = this.#pending.get(exchangeId);
+    if (key === undefined) return;
+    this.#pending.delete(exchangeId);
+    this.#reserved.delete(key);
+    this.#committed.set(key, true);
+  }
+
+  /** Terminal failure: drop the reservation so a re-send may try again. */
+  release(exchangeId: string): void {
+    const key = this.#pending.get(exchangeId);
+    if (key === undefined) return;
+    this.#pending.delete(exchangeId);
+    this.#reserved.delete(key);
+  }
+
+  /**
+   * Subscribe the commit / release hooks to the route's terminal exchange
+   * events exactly once. The reservation pattern needs to know when an
+   * exchange finished the whole pipeline, which the exchange-lifecycle
+   * events report; `forRoute` scopes them to this route. Subscriptions are
+   * torn down when the route aborts so they do not accumulate across route
+   * restarts on a shared context.
+   */
+  ensureSubscribed(
+    context: CraftContext,
+    routeId: string,
+    route: Route | undefined,
+  ): void {
+    if (this.#subscribed) return;
+    this.#subscribed = true;
+
+    const offs = [
+      context.on(
+        "route:exchange:completed",
+        forRoute(routeId, ({ details }) => this.commit(details.exchangeId)),
+      ),
+      context.on(
+        "route:exchange:dropped",
+        forRoute(routeId, ({ details }) => this.commit(details.exchangeId)),
+      ),
+      context.on(
+        "route:exchange:failed",
+        forRoute(routeId, ({ details }) => this.release(details.exchangeId)),
+      ),
+    ];
+
+    if (route) {
+      const cleanup = (): void => {
+        for (const off of offs) off();
+      };
+      if (route.signal.aborted) cleanup();
+      else route.signal.addEventListener("abort", cleanup, { once: true });
+    }
+  }
+}
+
+/**
+ * Owns the dedupe state for one `.dedupe()` across every Route the step
+ * runs in. Keyed by Route in a WeakMap, so a single step instance shared by
+ * a `RouteDefinition` registered into multiple contexts gives each Route its
+ * OWN seen-key set rather than one shared set (which would let the contexts
+ * suppress each other's exchanges). Mirrors `ThrottleController`.
+ *
+ * @internal
+ */
+class DedupeController {
+  readonly #options: ResolvedDedupeOptions;
+  readonly #byRoute = new WeakMap<Route, DedupeState>();
+  #routeless?: DedupeState;
+
+  constructor(options: ResolvedDedupeOptions) {
+    this.#options = options;
+  }
+
+  stateFor(route: Route | undefined): DedupeState {
+    if (!route) {
+      this.#routeless ??= new DedupeState(this.#options);
+      return this.#routeless;
+    }
+    let state = this.#byRoute.get(route);
+    if (!state) {
+      state = new DedupeState(this.#options);
+      this.#byRoute.set(route, state);
+    }
+    return state;
+  }
+}
+
+/** Marker adapter for the dedupe step; carries no configuration. */
+export interface DedupeAdapter extends Adapter {
+  readonly adapterId: "routecraft.operation.dedupe";
+}
+
+/**
+ * Step that suppresses duplicate exchanges by a derived key. The first time
+ * a key is seen it is reserved and the exchange continues; a subsequent
+ * exchange whose key is still reserved (in flight) or already committed
+ * (handled) is dropped silently, exactly like a `filter` returning false.
+ *
+ * Reservation semantics give single-flight behaviour and correct retries:
+ * the key is committed only when the exchange finishes the route
+ * (`route:exchange:completed` / `:dropped`) and released when it fails
+ * (`route:exchange:failed`), so an errored input is not permanently
+ * suppressed. State is in-memory and per-route (see {@link DedupeController});
+ * a cross-instance provider is a future addition.
+ *
+ * Emits `route:operation:dedupe:pass` when a key is reserved and
+ * `route:operation:dedupe:duplicate` (plus `route:exchange:dropped`, reason
+ * `"duplicate"`) when one is suppressed.
+ */
+export class DedupeStep implements Step<DedupeAdapter> {
+  operation: OperationType = OperationType.DEDUPE;
+  label?: string;
+  adapter: DedupeAdapter = { adapterId: "routecraft.operation.dedupe" };
+  skipStepEvents = true;
+
+  readonly #options: ResolvedDedupeOptions;
+  readonly #controller: DedupeController;
+
+  constructor(options: DedupeOptions = {}) {
+    this.#options = resolveDedupeOptions(options);
+    this.#controller = new DedupeController(this.#options);
+  }
+
+  async execute(exchange: Exchange): Promise<StepOutcome> {
+    const context = getExchangeContext(exchange);
+    const route = getExchangeRoute(exchange);
+    const routeId =
+      route?.definition.id ??
+      (exchange.headers[HeadersKeys.ROUTE_ID] as string);
+    const correlationId = exchange.headers[
+      HeadersKeys.CORRELATION_ID
+    ] as string;
+    const stepLabel = this.label ?? this.operation;
+    const stepStart = Date.now();
+
+    if (context) {
+      context.emit("route:step:started", {
+        routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        operation: stepLabel,
+      });
+    }
+
+    let key: string;
+    try {
+      key = this.#options.key(exchange);
+    } catch (err) {
+      if (context) {
+        context.emit("route:step:failed", {
+          routeId,
+          exchangeId: exchange.id,
+          correlationId,
+          operation: stepLabel,
+          duration: Date.now() - stepStart,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      throw err;
+    }
+
+    const state = this.#controller.stateFor(route);
+    // Wire commit/release to the route's terminal events the first time we
+    // run with a context bound; safe to call on every exchange (it no-ops
+    // after the first).
+    if (context) state.ensureSubscribed(context, routeId, route);
+
+    const duplicate = state.isDuplicate(key);
+    if (!duplicate) state.reserve(key, exchange.id);
+
+    if (context) {
+      context.emit("route:step:completed", {
+        routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        operation: stepLabel,
+        duration: Date.now() - stepStart,
+      });
+    }
+
+    if (duplicate) {
+      context?.emit("route:operation:dedupe:duplicate", {
+        routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        key,
+      });
+      emitExchangeDropped(context, {
+        routeId,
+        correlationId,
+        reason: "duplicate",
+        exchange,
+      });
+      return { kind: "drop" };
+    }
+
+    context?.emit("route:operation:dedupe:pass", {
+      routeId,
+      exchangeId: exchange.id,
+      correlationId,
+      key,
+    });
+    return { kind: "continue", exchange };
+  }
+}

--- a/packages/routecraft/src/operations/dedupe.ts
+++ b/packages/routecraft/src/operations/dedupe.ts
@@ -19,6 +19,7 @@ import type { CraftContext } from "../context.ts";
 import type { Route } from "../route.ts";
 import { hashExchangeBody } from "./hash-body.ts";
 import { DEFAULT_MAX_KEYS, validateMaxKeys } from "./max-keys.ts";
+import { RouteScopedController } from "./route-scoped-controller.ts";
 
 /**
  * Options for the `.dedupe()` flow-control operation.
@@ -227,33 +228,21 @@ class DedupeState {
 
 /**
  * Owns the dedupe state for one `.dedupe()` across every Route the step
- * runs in. Keyed by Route in a WeakMap, so a single step instance shared by
- * a `RouteDefinition` registered into multiple contexts gives each Route its
- * OWN seen-key set rather than one shared set (which would let the contexts
- * suppress each other's exchanges). Mirrors `ThrottleController`.
+ * runs in (see {@link RouteScopedController}): each Route gets its own
+ * seen-key set so contexts cannot suppress each other's exchanges.
  *
  * @internal
  */
-class DedupeController {
+class DedupeController extends RouteScopedController<DedupeState> {
   readonly #options: ResolvedDedupeOptions;
-  readonly #byRoute = new WeakMap<Route, DedupeState>();
-  #routeless?: DedupeState;
 
   constructor(options: ResolvedDedupeOptions) {
+    super();
     this.#options = options;
   }
 
-  stateFor(route: Route | undefined): DedupeState {
-    if (!route) {
-      this.#routeless ??= new DedupeState(this.#options);
-      return this.#routeless;
-    }
-    let state = this.#byRoute.get(route);
-    if (!state) {
-      state = new DedupeState(this.#options);
-      this.#byRoute.set(route, state);
-    }
-    return state;
+  protected createState(): DedupeState {
+    return new DedupeState(this.#options);
   }
 }
 

--- a/packages/routecraft/src/operations/dedupe.ts
+++ b/packages/routecraft/src/operations/dedupe.ts
@@ -18,17 +18,7 @@ import { isRoutecraftError } from "../brand.ts";
 import type { CraftContext } from "../context.ts";
 import type { Route } from "../route.ts";
 import { hashExchangeBody } from "./hash-body.ts";
-
-/** Default cap on committed keys retained per route. */
-const DEFAULT_MAX_KEYS = 10_000;
-
-/**
- * Hard ceiling on `maxKeys`. The committed-key LRU pre-allocates index
- * arrays sized to its `max`, so this bounds the eager allocation a single
- * `.dedupe()` can trigger and stops an absurd value from OOMing the process
- * at build time.
- */
-const MAX_KEYS_CEILING = 1_000_000;
+import { DEFAULT_MAX_KEYS, validateMaxKeys } from "./max-keys.ts";
 
 /**
  * Options for the `.dedupe()` flow-control operation.
@@ -94,11 +84,7 @@ export function resolveDedupeOptions(
   // Upper-bound `maxKeys`: the committed-key LRU pre-allocates index arrays
   // sized to `max` at construction, so an "effectively unlimited" value
   // would OOM the process the moment the dedupe state is built.
-  if (!Number.isInteger(maxKeys) || maxKeys < 1 || maxKeys > MAX_KEYS_CEILING) {
-    throw rcError("RC5003", undefined, {
-      message: `dedupe({ maxKeys }) must be an integer between 1 and ${MAX_KEYS_CEILING}, got ${String(maxKeys)}.`,
-    });
-  }
+  validateMaxKeys("dedupe", maxKeys);
 
   return {
     key: options.key ?? defaultDedupeKey,
@@ -124,10 +110,10 @@ function defaultDedupeKey(exchange: Exchange<unknown>): string {
  * protocol. A key is reserved the moment an exchange enters dedupe and
  * stays reserved until that exchange reaches a terminal route event:
  *
- * - `route:exchange:completed` / `route:exchange:dropped` -> commit (the
- *   input was handled, so future occurrences are duplicates).
- * - `route:exchange:failed` -> release (the input errored, so a re-send
- *   should be allowed to try again).
+ * - `route:exchange:completed` -> commit (the input was handled cleanly,
+ *   so future occurrences are duplicates).
+ * - `route:exchange:dropped` / `route:exchange:failed` -> release (the input
+ *   was not successfully handled, so a re-send may try again).
  *
  * A key that is reserved OR committed is a duplicate. Reservation gives
  * single-flight behaviour: a second exchange with the same key that arrives
@@ -283,15 +269,23 @@ export interface DedupeAdapter extends Adapter {
  * (handled) is dropped silently, exactly like a `filter` returning false.
  *
  * Reservation semantics give single-flight behaviour and correct retries:
- * the key is committed only when the exchange finishes the route
- * (`route:exchange:completed` / `:dropped`) and released when it fails
- * (`route:exchange:failed`), so an errored input is not permanently
- * suppressed. State is in-memory and per-route (see {@link DedupeController});
- * a cross-instance provider is a future addition.
+ * the key is committed only when the exchange completes the route cleanly
+ * (`route:exchange:completed`) and released when it fails or is dropped
+ * (`route:exchange:failed` / `:dropped`), so an input that was not actually
+ * handled is not permanently suppressed. State is in-memory and per-route
+ * (see {@link DedupeController}); a cross-instance provider is a future
+ * addition.
  *
  * Emits `route:operation:dedupe:pass` when a key is reserved and
  * `route:operation:dedupe:duplicate` (plus `route:exchange:dropped`, reason
  * `"duplicate"`) when one is suppressed.
+ *
+ * Known limitation: the commit/release decision is keyed on the entering
+ * exchange's terminal event, so placing `.dedupe()` before a `split` (or
+ * other fan-out) whose children fail still commits the parent's key (the
+ * parent completes even when children fail), suppressing a retriable
+ * re-send. Place `.dedupe()` after a fan-out until lineage-aware settlement
+ * lands (tracked as a follow-up).
  */
 export class DedupeStep implements Step<DedupeAdapter> {
   operation: OperationType = OperationType.DEDUPE;
@@ -354,16 +348,16 @@ export class DedupeStep implements Step<DedupeAdapter> {
 
     const state = this.#controller.stateFor(route);
     // Wire commit/release to the route's terminal events the first time we
-    // run with a context bound; safe to call on every exchange (it no-ops
-    // after the first).
-    if (context) state.ensureSubscribed(context, routeId, route);
+    // run; safe to call on every exchange (it no-ops after the first).
+    if (route && context) state.ensureSubscribed(context, routeId, route);
 
-    // Reserve only when a context is bound: the reservation is released by a
-    // terminal exchange event, which cannot fire without a context, so
-    // reserving on the context-less path (synthetic/unit invocation) would
-    // leak the key forever. Without a context dedupe degrades to pass-through.
+    // Reserve only when bound to a route: the reservation is released by a
+    // terminal exchange event scoped to the route (and torn down on the
+    // route's abort signal), neither of which exists on the route-less
+    // synthetic/unit path, where reserving would leak the key and the
+    // listeners forever. Without a route dedupe degrades to pass-through.
     const duplicate = state.isDuplicate(key);
-    if (!duplicate && context) state.reserve(key, exchange.id);
+    if (!duplicate && route && context) state.reserve(key, exchange.id);
 
     if (context) {
       context.emit("route:step:completed", {

--- a/packages/routecraft/src/operations/hash-body.ts
+++ b/packages/routecraft/src/operations/hash-body.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Derive a stable SHA-256 hex digest from an exchange body by hashing its
+ * JSON serialisation. This is the shared default key derivation behind
+ * `.cache()` and `.dedupe()` when no explicit `key` function is supplied,
+ * so the two operations agree on what "the same body" means.
+ *
+ * Works for JSON-shaped bodies: primitives, arrays, and plain objects with
+ * string keys. It does NOT canonicalise object key order, so two objects
+ * with the same entries in a different order hash differently; supply an
+ * explicit `key` when a stable identity must survive key reordering.
+ *
+ * Throws a plain `Error` when the body is not JSON-serialisable: a
+ * top-level `undefined`, function, or symbol (which `JSON.stringify`
+ * renders as `undefined`), or a `BigInt` / circular reference (which it
+ * throws on). Callers translate the throw into their operation-specific
+ * `RoutecraftError` with an actionable message, so the failure points the
+ * user at the right `key` option.
+ *
+ * Performance: this serialises and hashes the body on every call. For hot
+ * paths or large bodies, supply a `key` that returns a stable identifier
+ * already to hand (an id field, a content hash in a header) to avoid the
+ * re-serialise and re-hash.
+ *
+ * @internal
+ */
+export function hashExchangeBody(body: unknown): string {
+  const stringified = JSON.stringify(body);
+  if (stringified === undefined) {
+    throw new Error(
+      "Exchange body is not JSON-serialisable (top-level undefined, function, or symbol).",
+    );
+  }
+  return createHash("sha256").update(stringified).digest("hex");
+}

--- a/packages/routecraft/src/operations/max-keys.ts
+++ b/packages/routecraft/src/operations/max-keys.ts
@@ -1,0 +1,30 @@
+import { rcError } from "../error.ts";
+
+/**
+ * Default cap on distinct keys tracked by a keyed in-memory operation (the
+ * `.throttle({ key })` per-key buckets, the `.dedupe()` committed-key set).
+ */
+export const DEFAULT_MAX_KEYS = 10_000;
+
+/**
+ * Hard ceiling on `maxKeys`. The per-key LRU pre-allocates index arrays sized
+ * to its `max`, so this bounds the eager allocation a single keyed operation
+ * can trigger and stops an absurd value from OOMing the process at build time.
+ */
+export const MAX_KEYS_CEILING = 1_000_000;
+
+/**
+ * Validate a user-supplied `maxKeys` against the shared bound, throwing
+ * `RC5003` at build time so a typo fails when the route is built rather than
+ * allocating an oversized index array at runtime. `op` names the operation for
+ * the error message (e.g. `"throttle"`, `"dedupe"`).
+ *
+ * @internal
+ */
+export function validateMaxKeys(op: string, maxKeys: number): void {
+  if (!Number.isInteger(maxKeys) || maxKeys < 1 || maxKeys > MAX_KEYS_CEILING) {
+    throw rcError("RC5003", undefined, {
+      message: `${op}({ maxKeys }) must be an integer between 1 and ${MAX_KEYS_CEILING}, got ${String(maxKeys)}.`,
+    });
+  }
+}

--- a/packages/routecraft/src/operations/route-scoped-controller.ts
+++ b/packages/routecraft/src/operations/route-scoped-controller.ts
@@ -1,0 +1,42 @@
+import type { Route } from "../route.ts";
+
+/**
+ * Base for a stateful operation that holds one piece of state PER ROUTE.
+ *
+ * A single step (or controller) instance is built once per `RouteDefinition`,
+ * but that definition can be registered into multiple contexts, producing
+ * several live `Route` instances. Keying the state by `Route` in a WeakMap
+ * gives each Route its OWN state, so the contexts cannot cross-contaminate
+ * each other (cross-sample, cross-suppress, cross-trip, cross-rate-limit).
+ * A single `#routeless` fallback covers the route-less case (a step run in
+ * isolation, e.g. a unit test) so behaviour stays bounded there too.
+ *
+ * Subclasses provide {@link createState}; the per-route lookup and lazy
+ * creation live here once rather than being re-implemented per operation.
+ *
+ * @internal
+ */
+export abstract class RouteScopedController<S> {
+  readonly #byRoute = new WeakMap<Route, S>();
+  #routeless?: S;
+
+  /**
+   * Build a fresh state instance. Called at most once per Route (and once
+   * for the route-less fallback), on first use.
+   */
+  protected abstract createState(): S;
+
+  /**
+   * Resolve the state for `route`, creating it on first use; or the shared
+   * route-less instance when no Route is attached.
+   */
+  stateFor(route: Route | undefined): S {
+    if (!route) return (this.#routeless ??= this.createState());
+    let state = this.#byRoute.get(route);
+    if (!state) {
+      state = this.createState();
+      this.#byRoute.set(route, state);
+    }
+    return state;
+  }
+}

--- a/packages/routecraft/src/operations/route-scoped-controller.ts
+++ b/packages/routecraft/src/operations/route-scoped-controller.ts
@@ -33,7 +33,7 @@ export abstract class RouteScopedController<S> {
   stateFor(route: Route | undefined): S {
     if (!route) return (this.#routeless ??= this.createState());
     let state = this.#byRoute.get(route);
-    if (!state) {
+    if (state === undefined) {
       state = this.createState();
       this.#byRoute.set(route, state);
     }

--- a/packages/routecraft/src/operations/sample.ts
+++ b/packages/routecraft/src/operations/sample.ts
@@ -61,11 +61,15 @@ export function resolveSampleOptions(
 ): ResolvedSampleOptions {
   const { every, intervalMs } = options;
 
+  // The XOR is already a compile-time error for typed callers (the union's
+  // `?: never` arms); these runtime checks defend JS callers and widened
+  // values that bypass the types. One shared message so the two sites cannot
+  // drift.
+  const exclusiveMessage =
+    "sample() requires exactly one of `every` or `intervalMs` (they are mutually exclusive).";
+
   if (every !== undefined && intervalMs !== undefined) {
-    throw rcError("RC5003", undefined, {
-      message:
-        "sample() requires exactly one of `every` or `intervalMs` (they are mutually exclusive).",
-    });
+    throw rcError("RC5003", undefined, { message: exclusiveMessage });
   }
 
   if (every !== undefined) {
@@ -86,10 +90,7 @@ export function resolveSampleOptions(
     return { mode: "interval", intervalMs };
   }
 
-  throw rcError("RC5003", undefined, {
-    message:
-      "sample() requires exactly one of `every` or `intervalMs` (they are mutually exclusive).",
-  });
+  throw rcError("RC5003", undefined, { message: exclusiveMessage });
 }
 
 /**

--- a/packages/routecraft/src/operations/sample.ts
+++ b/packages/routecraft/src/operations/sample.ts
@@ -12,35 +12,41 @@ import type { Route } from "../route.ts";
 
 /**
  * Options for the `.sample()` flow-control operation. Exactly one of
- * `every` or `intervalMs` must be set; they are mutually exclusive (a
- * sampler is either count-based or time-based, not both).
+ * `every` (count-based) or `intervalMs` (time-based) must be set; the union
+ * makes them mutually exclusive at compile time (passing both, or neither,
+ * is a type error), and {@link resolveSampleOptions} re-checks at runtime
+ * for JS callers.
  */
-export interface SampleOptions {
-  /**
-   * Count-based: pass every Nth exchange and drop the rest. The internal
-   * counter increments per exchange and the exchange passes when
-   * `counter % every === 0`, so `{ every: 5 }` passes the 5th, 10th, 15th,
-   * ... exchange. Must be a finite integer >= 1.
-   */
-  every?: number;
-  /**
-   * Time-based: pass the first exchange seen in each window of `intervalMs`
-   * milliseconds and drop the rest until the window elapses. Must be a
-   * finite number > 0.
-   */
-  intervalMs?: number;
-}
+export type SampleOptions =
+  | {
+      /**
+       * Count-based: pass every Nth exchange and drop the rest, so
+       * `{ every: 5 }` passes the 5th, 10th, 15th, ... exchange. Must be a
+       * finite integer >= 1.
+       */
+      every: number;
+      intervalMs?: never;
+    }
+  | {
+      /**
+       * Time-based: pass the first exchange seen in each window of
+       * `intervalMs` milliseconds and drop the rest until the window
+       * elapses. Must be a finite number > 0.
+       */
+      intervalMs: number;
+      every?: never;
+    };
 
 /**
- * {@link SampleOptions} with the sampling mode resolved and validated.
+ * {@link SampleOptions} with the sampling mode resolved and validated. A
+ * discriminated union, so narrowing on `mode` proves which numeric field is
+ * present (no non-null assertions at the use site).
  *
  * @internal
  */
-export interface ResolvedSampleOptions {
-  mode: "count" | "interval";
-  every?: number;
-  intervalMs?: number;
-}
+export type ResolvedSampleOptions =
+  | { mode: "count"; every: number }
+  | { mode: "interval"; intervalMs: number };
 
 /**
  * Validate user-supplied {@link SampleOptions} into a
@@ -53,18 +59,16 @@ export interface ResolvedSampleOptions {
 export function resolveSampleOptions(
   options: SampleOptions,
 ): ResolvedSampleOptions {
-  const hasEvery = options.every !== undefined;
-  const hasInterval = options.intervalMs !== undefined;
+  const { every, intervalMs } = options;
 
-  if (hasEvery === hasInterval) {
+  if (every !== undefined && intervalMs !== undefined) {
     throw rcError("RC5003", undefined, {
       message:
         "sample() requires exactly one of `every` or `intervalMs` (they are mutually exclusive).",
     });
   }
 
-  if (hasEvery) {
-    const every = options.every!;
+  if (every !== undefined) {
     if (!Number.isInteger(every) || every < 1) {
       throw rcError("RC5003", undefined, {
         message: `sample({ every }) must be an integer >= 1, got ${String(every)}.`,
@@ -73,13 +77,19 @@ export function resolveSampleOptions(
     return { mode: "count", every };
   }
 
-  const intervalMs = options.intervalMs!;
-  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
-    throw rcError("RC5003", undefined, {
-      message: `sample({ intervalMs }) must be a finite number > 0, got ${String(intervalMs)}.`,
-    });
+  if (intervalMs !== undefined) {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+      throw rcError("RC5003", undefined, {
+        message: `sample({ intervalMs }) must be a finite number > 0, got ${String(intervalMs)}.`,
+      });
+    }
+    return { mode: "interval", intervalMs };
   }
-  return { mode: "interval", intervalMs };
+
+  throw rcError("RC5003", undefined, {
+    message:
+      "sample() requires exactly one of `every` or `intervalMs` (they are mutually exclusive).",
+  });
 }
 
 /**
@@ -212,14 +222,23 @@ export class SampleStep implements Step<SampleAdapter> {
 
   /** Advance the sampler state and decide whether this exchange passes. */
   #shouldPass(state: SampleState): boolean {
-    if (this.#options.mode === "count") {
+    const options = this.#options;
+    if (options.mode === "count") {
+      // Count up to `every`, then reset and pass. Resetting (rather than an
+      // ever-growing counter with a modulo) keeps the count bounded, so a
+      // long-lived high-frequency route never drifts past Number.MAX_SAFE_INTEGER
+      // where `count + 1 === count` would freeze the sampler.
       state.count += 1;
-      return state.count % this.#options.every! === 0;
+      if (state.count >= options.every) {
+        state.count = 0;
+        return true;
+      }
+      return false;
     }
     const now = Date.now();
     if (
       state.lastPassedAt === undefined ||
-      now - state.lastPassedAt >= this.#options.intervalMs!
+      now - state.lastPassedAt >= options.intervalMs
     ) {
       state.lastPassedAt = now;
       return true;

--- a/packages/routecraft/src/operations/sample.ts
+++ b/packages/routecraft/src/operations/sample.ts
@@ -1,0 +1,229 @@
+import { type Adapter, type Step, type StepOutcome } from "../types.ts";
+import {
+  type Exchange,
+  OperationType,
+  HeadersKeys,
+  getExchangeContext,
+  getExchangeRoute,
+  emitExchangeDropped,
+} from "../exchange.ts";
+import { rcError } from "../error.ts";
+import type { Route } from "../route.ts";
+
+/**
+ * Options for the `.sample()` flow-control operation. Exactly one of
+ * `every` or `intervalMs` must be set; they are mutually exclusive (a
+ * sampler is either count-based or time-based, not both).
+ */
+export interface SampleOptions {
+  /**
+   * Count-based: pass every Nth exchange and drop the rest. The internal
+   * counter increments per exchange and the exchange passes when
+   * `counter % every === 0`, so `{ every: 5 }` passes the 5th, 10th, 15th,
+   * ... exchange. Must be a finite integer >= 1.
+   */
+  every?: number;
+  /**
+   * Time-based: pass the first exchange seen in each window of `intervalMs`
+   * milliseconds and drop the rest until the window elapses. Must be a
+   * finite number > 0.
+   */
+  intervalMs?: number;
+}
+
+/**
+ * {@link SampleOptions} with the sampling mode resolved and validated.
+ *
+ * @internal
+ */
+export interface ResolvedSampleOptions {
+  mode: "count" | "interval";
+  every?: number;
+  intervalMs?: number;
+}
+
+/**
+ * Validate user-supplied {@link SampleOptions} into a
+ * {@link ResolvedSampleOptions}. Rejects at build time (RC5003) so a
+ * mis-specified sampler fails when the route is built rather than silently
+ * passing or dropping every exchange at runtime.
+ *
+ * @internal
+ */
+export function resolveSampleOptions(
+  options: SampleOptions,
+): ResolvedSampleOptions {
+  const hasEvery = options.every !== undefined;
+  const hasInterval = options.intervalMs !== undefined;
+
+  if (hasEvery === hasInterval) {
+    throw rcError("RC5003", undefined, {
+      message:
+        "sample() requires exactly one of `every` or `intervalMs` (they are mutually exclusive).",
+    });
+  }
+
+  if (hasEvery) {
+    const every = options.every!;
+    if (!Number.isInteger(every) || every < 1) {
+      throw rcError("RC5003", undefined, {
+        message: `sample({ every }) must be an integer >= 1, got ${String(every)}.`,
+      });
+    }
+    return { mode: "count", every };
+  }
+
+  const intervalMs = options.intervalMs!;
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw rcError("RC5003", undefined, {
+      message: `sample({ intervalMs }) must be a finite number > 0, got ${String(intervalMs)}.`,
+    });
+  }
+  return { mode: "interval", intervalMs };
+}
+
+/**
+ * Per-route sampler state. Count mode keeps a running counter; interval
+ * mode keeps the timestamp of the last admitted exchange. One instance per
+ * Route (see {@link SampleController}), never one per exchange.
+ *
+ * @internal
+ */
+class SampleState {
+  count = 0;
+  lastPassedAt: number | undefined;
+}
+
+/**
+ * Owns the sampler state for one `.sample()` across every Route the step
+ * runs in. Keyed by Route in a WeakMap, so a single step instance shared by
+ * a `RouteDefinition` registered into multiple contexts gives each Route its
+ * OWN counter / window rather than one shared sampler (which would let the
+ * contexts cross-sample each other). Mirrors `ThrottleController`.
+ *
+ * @internal
+ */
+class SampleController {
+  readonly #byRoute = new WeakMap<Route, SampleState>();
+  #routeless?: SampleState;
+
+  stateFor(route: Route | undefined): SampleState {
+    if (!route) {
+      this.#routeless ??= new SampleState();
+      return this.#routeless;
+    }
+    let state = this.#byRoute.get(route);
+    if (!state) {
+      state = new SampleState();
+      this.#byRoute.set(route, state);
+    }
+    return state;
+  }
+}
+
+/** Marker adapter for the sample step; carries no configuration. */
+export interface SampleAdapter extends Adapter {
+  readonly adapterId: "routecraft.operation.sample";
+}
+
+/**
+ * Step that samples exchanges by count (`every`) or time window
+ * (`intervalMs`), passing the admitted ones and dropping the rest. A drop
+ * is silent (no error), exactly like a `filter` predicate returning false:
+ * it emits `route:operation:sample:dropped` and `route:exchange:dropped`
+ * (reason `"sampled"`) so telemetry and the TUI can count it.
+ *
+ * Sampler state is per-route (see {@link SampleController}), so every
+ * exchange on a given Route shares one counter / window while distinct
+ * Routes stay isolated.
+ */
+export class SampleStep implements Step<SampleAdapter> {
+  operation: OperationType = OperationType.SAMPLE;
+  label?: string;
+  adapter: SampleAdapter = { adapterId: "routecraft.operation.sample" };
+  skipStepEvents = true;
+
+  readonly #options: ResolvedSampleOptions;
+  readonly #controller = new SampleController();
+
+  constructor(options: SampleOptions) {
+    this.#options = resolveSampleOptions(options);
+  }
+
+  async execute(exchange: Exchange): Promise<StepOutcome> {
+    const context = getExchangeContext(exchange);
+    const route = getExchangeRoute(exchange);
+    const routeId =
+      route?.definition.id ??
+      (exchange.headers[HeadersKeys.ROUTE_ID] as string);
+    const correlationId = exchange.headers[
+      HeadersKeys.CORRELATION_ID
+    ] as string;
+    const stepLabel = this.label ?? this.operation;
+    const stepStart = Date.now();
+    const { mode } = this.#options;
+
+    if (context) {
+      context.emit("route:step:started", {
+        routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        operation: stepLabel,
+      });
+    }
+
+    const state = this.#controller.stateFor(route);
+    const pass = this.#shouldPass(state);
+
+    if (context) {
+      context.emit("route:step:completed", {
+        routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        operation: stepLabel,
+        duration: Date.now() - stepStart,
+      });
+    }
+
+    if (!pass) {
+      context?.emit("route:operation:sample:dropped", {
+        routeId,
+        exchangeId: exchange.id,
+        correlationId,
+        mode,
+      });
+      emitExchangeDropped(context, {
+        routeId,
+        correlationId,
+        reason: "sampled",
+        exchange,
+      });
+      return { kind: "drop" };
+    }
+
+    context?.emit("route:operation:sample:passed", {
+      routeId,
+      exchangeId: exchange.id,
+      correlationId,
+      mode,
+    });
+    return { kind: "continue", exchange };
+  }
+
+  /** Advance the sampler state and decide whether this exchange passes. */
+  #shouldPass(state: SampleState): boolean {
+    if (this.#options.mode === "count") {
+      state.count += 1;
+      return state.count % this.#options.every! === 0;
+    }
+    const now = Date.now();
+    if (
+      state.lastPassedAt === undefined ||
+      now - state.lastPassedAt >= this.#options.intervalMs!
+    ) {
+      state.lastPassedAt = now;
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/routecraft/src/operations/sample.ts
+++ b/packages/routecraft/src/operations/sample.ts
@@ -59,8 +59,6 @@ export type ResolvedSampleOptions =
 export function resolveSampleOptions(
   options: SampleOptions,
 ): ResolvedSampleOptions {
-  const { every, intervalMs } = options;
-
   // The XOR is already a compile-time error for typed callers (the union's
   // `?: never` arms); these runtime checks defend JS callers and widened
   // values that bypass the types. One shared message so the two sites cannot
@@ -68,14 +66,25 @@ export function resolveSampleOptions(
   const exclusiveMessage =
     "sample() requires exactly one of `every` or `intervalMs` (they are mutually exclusive).";
 
+  // Guard before destructuring so a non-object (a JS caller passing nothing,
+  // null, or a primitive) yields the coded RC5003 rather than a bare TypeError.
+  if (typeof options !== "object" || options === null) {
+    throw rcError("RC5003", undefined, { message: exclusiveMessage });
+  }
+
+  const { every, intervalMs } = options;
+
   if (every !== undefined && intervalMs !== undefined) {
     throw rcError("RC5003", undefined, { message: exclusiveMessage });
   }
 
   if (every !== undefined) {
-    if (!Number.isInteger(every) || every < 1) {
+    // Safe integer, not just integer: above 2^53 the per-route counter loses
+    // precision and can never reach `every`, freezing the sampler into a
+    // permanent drop. Fail such a config at build time instead.
+    if (!Number.isSafeInteger(every) || every < 1) {
       throw rcError("RC5003", undefined, {
-        message: `sample({ every }) must be an integer >= 1, got ${String(every)}.`,
+        message: `sample({ every }) must be a safe integer >= 1, got ${String(every)}.`,
       });
     }
     return { mode: "count", every };

--- a/packages/routecraft/src/operations/sample.ts
+++ b/packages/routecraft/src/operations/sample.ts
@@ -8,7 +8,7 @@ import {
   emitExchangeDropped,
 } from "../exchange.ts";
 import { rcError } from "../error.ts";
-import type { Route } from "../route.ts";
+import { RouteScopedController } from "./route-scoped-controller.ts";
 
 /**
  * Options for the `.sample()` flow-control operation. Exactly one of
@@ -107,28 +107,14 @@ class SampleState {
 
 /**
  * Owns the sampler state for one `.sample()` across every Route the step
- * runs in. Keyed by Route in a WeakMap, so a single step instance shared by
- * a `RouteDefinition` registered into multiple contexts gives each Route its
- * OWN counter / window rather than one shared sampler (which would let the
- * contexts cross-sample each other). Mirrors `ThrottleController`.
+ * runs in (see {@link RouteScopedController}): each Route gets its own
+ * counter / window so contexts cannot cross-sample each other.
  *
  * @internal
  */
-class SampleController {
-  readonly #byRoute = new WeakMap<Route, SampleState>();
-  #routeless?: SampleState;
-
-  stateFor(route: Route | undefined): SampleState {
-    if (!route) {
-      this.#routeless ??= new SampleState();
-      return this.#routeless;
-    }
-    let state = this.#byRoute.get(route);
-    if (!state) {
-      state = new SampleState();
-      this.#byRoute.set(route, state);
-    }
-    return state;
+class SampleController extends RouteScopedController<SampleState> {
+  protected createState(): SampleState {
+    return new SampleState();
   }
 }
 

--- a/packages/routecraft/src/operations/throttle-wrapper.ts
+++ b/packages/routecraft/src/operations/throttle-wrapper.ts
@@ -7,6 +7,7 @@ import type { Route } from "../route.ts";
 import { WrapperStep } from "./wrapper.ts";
 import { wrapperEventScope } from "./event-scope.ts";
 import { cancellableSleep, SleepAbortedError } from "./cancellable-sleep.ts";
+import { DEFAULT_MAX_KEYS, validateMaxKeys } from "./max-keys.ts";
 
 /**
  * Time window a `.throttle()` rate is measured over.
@@ -33,17 +34,6 @@ const WINDOW_MS: Record<ThrottleTimeUnit, number> = {
  * break the rate guarantee precisely under heavy backpressure).
  */
 const MAX_TIMER_MS = 2_147_483_647;
-
-/** Default cap on distinct keys tracked when `key` is set. */
-const DEFAULT_MAX_KEYS = 10_000;
-
-/**
- * Hard ceiling on `maxKeys`. The per-key LRU pre-allocates index arrays
- * sized to its `max`, so this bounds the eager allocation a single
- * `.throttle({ key })` can trigger and stops an absurd value from OOMing
- * the process at build time.
- */
-const MAX_KEYS_CEILING = 1_000_000;
 
 /**
  * Options for the `.throttle()` wrapper (step scope and route scope).
@@ -170,11 +160,7 @@ export function resolveThrottleOptions(
   // Upper-bound `maxKeys`: the per-key LRU pre-allocates index arrays
   // sized to `max` at construction, so an "effectively unlimited" value
   // would OOM the process the moment the limiter is built, not gradually.
-  if (!Number.isInteger(maxKeys) || maxKeys < 1 || maxKeys > MAX_KEYS_CEILING) {
-    throw rcError("RC5003", undefined, {
-      message: `throttle({ maxKeys }) must be an integer between 1 and ${MAX_KEYS_CEILING}, got ${String(maxKeys)}.`,
-    });
-  }
+  validateMaxKeys("throttle", maxKeys);
 
   return {
     // Capacity floors at 1 so a sub-1 rate (or an accidental sub-1

--- a/packages/routecraft/src/operations/throttle-wrapper.ts
+++ b/packages/routecraft/src/operations/throttle-wrapper.ts
@@ -8,6 +8,7 @@ import { WrapperStep } from "./wrapper.ts";
 import { wrapperEventScope } from "./event-scope.ts";
 import { cancellableSleep, SleepAbortedError } from "./cancellable-sleep.ts";
 import { DEFAULT_MAX_KEYS, validateMaxKeys } from "./max-keys.ts";
+import { RouteScopedController } from "./route-scoped-controller.ts";
 
 /**
  * Time window a `.throttle()` rate is measured over.
@@ -418,12 +419,11 @@ export function throttleEmitHooks(
  *
  * @internal
  */
-export class ThrottleController {
+export class ThrottleController extends RouteScopedController<ThrottleLimiter> {
   readonly #options: ResolvedThrottleOptions;
-  readonly #byRoute = new WeakMap<Route, ThrottleLimiter>();
-  #routeless?: ThrottleLimiter;
 
   constructor(options: ResolvedThrottleOptions) {
+    super();
     this.#options = options;
   }
 
@@ -432,19 +432,8 @@ export class ThrottleController {
     return this.#options.label;
   }
 
-  #limiterFor(route: Route | undefined): ThrottleLimiter {
-    if (!route) {
-      // No attached route (e.g. a step run in isolation): fall back to a
-      // single process-local limiter so behaviour is still bounded.
-      this.#routeless ??= new ThrottleLimiter(this.#options);
-      return this.#routeless;
-    }
-    let limiter = this.#byRoute.get(route);
-    if (!limiter) {
-      limiter = new ThrottleLimiter(this.#options);
-      this.#byRoute.set(route, limiter);
-    }
-    return limiter;
+  protected createState(): ThrottleLimiter {
+    return new ThrottleLimiter(this.#options);
   }
 
   /**
@@ -460,7 +449,7 @@ export class ThrottleController {
     hooks: ThrottleHooks,
   ): Promise<void> {
     const start = Date.now();
-    const { bucket, key } = this.#limiterFor(route).bucketFor(exchange, start);
+    const { bucket, key } = this.stateFor(route).bucketFor(exchange, start);
 
     if (this.#options.mode === "reject") {
       const retryAfterMs = bucket.tryAcquire(start);

--- a/packages/routecraft/src/step-builder-base.ts
+++ b/packages/routecraft/src/step-builder-base.ts
@@ -51,6 +51,8 @@ import {
   type Filter,
   FilterStep,
 } from "./operations/filter.ts";
+import { type SampleOptions, SampleStep } from "./operations/sample.ts";
+import { type DedupeOptions, DedupeStep } from "./operations/dedupe.ts";
 import {
   type Validator,
   type CallableValidator,
@@ -627,6 +629,38 @@ export abstract class StepBuilderBase<S extends BuilderState = BuilderState> {
    */
   filter(filter: Filter<S["body"]> | CallableFilter<S["body"]>): this {
     this.pushStep(new FilterStep<S["body"]>(filter));
+    return this;
+  }
+
+  /**
+   * Sample exchanges by count or time interval, passing the admitted ones
+   * and dropping the rest (silently, like a `filter` returning false).
+   * Useful for reducing volume from a high-frequency source while staying
+   * representative. Pass exactly one of `every` (count-based: every Nth
+   * exchange) or `intervalMs` (time-based: the first exchange per window).
+   * Sampler state is per-route.
+   *
+   * @param options - `{ every }` for count-based or `{ intervalMs }` for time-based sampling
+   * @returns This builder (same subclass, same body type)
+   */
+  sample(options: SampleOptions): this {
+    this.pushStep(new SampleStep(options));
+    return this;
+  }
+
+  /**
+   * Suppress duplicate exchanges by a derived key, so the same input is not
+   * processed more than once. The key is derived from the body by default
+   * (SHA-256 of its JSON serialisation) or from an explicit `key` function.
+   * A key is reserved on entry and committed when the exchange completes
+   * (released on failure, so an errored input may retry); a duplicate is
+   * dropped silently. State is in-memory and per-route.
+   *
+   * @param options - Optional `key` deriver, `ttl` (ms), and `maxKeys` bound
+   * @returns This builder (same subclass, same body type)
+   */
+  dedupe(options?: DedupeOptions): this {
+    this.pushStep(new DedupeStep(options));
     return this;
   }
 

--- a/packages/routecraft/src/types.ts
+++ b/packages/routecraft/src/types.ts
@@ -620,6 +620,29 @@ export interface EventDetailsMap {
   };
   "route:operation:choice:unmatched": ExchangeScoped;
 
+  // -- Sample --
+  /** The sampler admitted this exchange. */
+  "route:operation:sample:passed": ExchangeScoped & {
+    /** `"count"` for `every`-based sampling, `"interval"` for `intervalMs`. */
+    mode: "count" | "interval";
+  };
+  /** The sampler dropped this exchange (between samples). */
+  "route:operation:sample:dropped": ExchangeScoped & {
+    mode: "count" | "interval";
+  };
+
+  // -- Dedupe --
+  /** The key was unseen; it is reserved and the exchange continues. */
+  "route:operation:dedupe:pass": ExchangeScoped & {
+    /** The derived key reserved for this exchange. */
+    key: string;
+  };
+  /** The key was already reserved or committed; the exchange is dropped. */
+  "route:operation:dedupe:duplicate": ExchangeScoped & {
+    /** The derived key that was already seen. */
+    key: string;
+  };
+
   // -- Agent (emitted by @routecraft/ai agent() destinations) --
   // Sensitive payloads (tool input/output, thrown errors that may echo
   // them) ride in the `_snapshot` envelope: the bus always carries them,

--- a/packages/routecraft/test/dedupe.bun.test.ts
+++ b/packages/routecraft/test/dedupe.bun.test.ts
@@ -152,6 +152,66 @@ describe("dedupe (.dedupe())", () => {
   });
 
   /**
+   * @case An exchange dropped by a downstream step releases its reservation (not committed)
+   * @preconditions Route with .dedupe() then a filter; the same body is sent while the filter drops, then again once it passes
+   * @expectedResult The re-send is reprocessed (the downstream drop did not permanently commit the key)
+   */
+  test("releases the reservation on a downstream drop", async () => {
+    let filterPasses = false;
+    const s = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("dedupe-drop-release")
+          .from(direct())
+          .dedupe()
+          .filter(() => filterPasses)
+          .to(s),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    // First send: dedupe reserves, the filter drops it -> reservation released.
+    await send(t, "dedupe-drop-release", { event: "a" });
+    expect(s.received).toHaveLength(0);
+
+    // Re-send the identical body once the filter admits it: because the drop
+    // released the key (rather than committing it), this is not suppressed.
+    filterPasses = true;
+    await send(t, "dedupe-drop-release", { event: "a" });
+
+    expect(s.received).toHaveLength(1);
+  });
+
+  /**
+   * @case A throwing custom key function surfaces RC5033, not a bare error
+   * @preconditions Route with .dedupe({ key }) whose key function throws
+   * @expectedResult The send rejects with RC5033, matching the default-key contract
+   */
+  test("wraps a throwing custom key in RC5033", async () => {
+    t = await testContext()
+      .routes(
+        craft()
+          .id("dedupe-key-throws")
+          .from(direct())
+          .dedupe({
+            key: () => {
+              throw new Error("key boom");
+            },
+          })
+          .to(spy()),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    const err = await t.client
+      .sendDirect("dedupe-key-throws", { event: "a" })
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RoutecraftError);
+    expect((err as RoutecraftError).rc).toBe("RC5033");
+  });
+
+  /**
    * @case A committed key expires after its ttl and the next occurrence passes
    * @preconditions Route with .dedupe({ ttl: 40 }); send a, send a (dropped), sleep 60ms, send a
    * @expectedResult The first and the post-expiry send pass; the in-ttl duplicate is dropped

--- a/packages/routecraft/test/dedupe.bun.test.ts
+++ b/packages/routecraft/test/dedupe.bun.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { testContext, spy, type TestContext } from "@routecraft/testing";
+import {
+  craft,
+  direct,
+  DedupeStep,
+  RoutecraftError,
+  type Exchange,
+} from "@routecraft/routecraft";
+
+/** Sleep for `ms` milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Send through a direct route, tolerating the `RC5031` that a request/reply
+ * caller sees when the route drops the exchange (a deduplicated exchange has
+ * no response body). Any other failure propagates.
+ */
+async function send(
+  t: TestContext,
+  routeId: string,
+  body: unknown,
+): Promise<void> {
+  try {
+    await t.client.sendDirect(routeId, body);
+  } catch (err) {
+    if (err instanceof RoutecraftError && err.rc === "RC5031") return;
+    throw err;
+  }
+}
+
+describe("dedupe (.dedupe())", () => {
+  let t: TestContext;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+  });
+
+  /**
+   * @case A committed key suppresses later identical exchanges
+   * @preconditions Route with .dedupe() (default body hash); two sequential sends of the same body
+   * @expectedResult The first send is processed; the second is dropped as a duplicate
+   */
+  test("commits on completion and drops the next duplicate", async () => {
+    let runs = 0;
+    const s = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("dedupe-commit")
+          .from(direct())
+          .dedupe()
+          .transform((body) => {
+            runs++;
+            return body;
+          })
+          .to(s),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    await send(t, "dedupe-commit", { event: "a" });
+    await send(t, "dedupe-commit", { event: "a" });
+
+    expect(t.errors).toHaveLength(0);
+    expect(runs).toBe(1);
+    expect(s.received).toHaveLength(1);
+  });
+
+  /**
+   * @case Distinct bodies derive distinct keys and all pass
+   * @preconditions Route with .dedupe() over three sequential sends: a, a, b
+   * @expectedResult Two exchanges reach the destination (the first a and the b)
+   */
+  test("default key distinguishes different bodies", async () => {
+    const s = spy();
+    t = await testContext()
+      .routes(craft().id("dedupe-body").from(direct()).dedupe().to(s))
+      .build();
+    await t.startAndWaitReady();
+
+    await send(t, "dedupe-body", { v: 1 });
+    await send(t, "dedupe-body", { v: 1 });
+    await send(t, "dedupe-body", { v: 2 });
+
+    expect(s.received.map((e) => e.body)).toEqual([{ v: 1 }, { v: 2 }]);
+  });
+
+  /**
+   * @case An explicit key dedupes on derived identity, not the whole body
+   * @preconditions Route with .dedupe({ key: e => String(e.body.id) }); sends {id:1,..}, {id:1,..}, {id:2}
+   * @expectedResult The two id:1 exchanges collapse to one; id:2 passes
+   */
+  test("explicit key derives identity from a field", async () => {
+    const s = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("dedupe-key")
+          .from(direct())
+          .dedupe({
+            key: (e: Exchange) => String((e.body as { id: number }).id),
+          })
+          .to(s),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    await send(t, "dedupe-key", { id: 1, v: "x" });
+    await send(t, "dedupe-key", { id: 1, v: "y" });
+    await send(t, "dedupe-key", { id: 2, v: "z" });
+
+    expect(s.received.map((e) => (e.body as { id: number }).id)).toEqual([
+      1, 2,
+    ]);
+  });
+
+  /**
+   * @case A failed exchange releases its reservation so a re-send may retry
+   * @preconditions Route with .dedupe() then a processor that always throws; two sequential sends of the same body
+   * @expectedResult Both sends reach the processor (the key is released on failure, not committed)
+   */
+  test("releases the reservation on failure", async () => {
+    let runs = 0;
+    t = await testContext()
+      .routes(
+        craft()
+          .id("dedupe-release")
+          .from(direct())
+          .dedupe()
+          .transform(() => {
+            runs++;
+            throw new Error("boom");
+          })
+          .to(spy()),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    await expect(
+      t.client.sendDirect("dedupe-release", { event: "a" }),
+    ).rejects.toThrow();
+    await expect(
+      t.client.sendDirect("dedupe-release", { event: "a" }),
+    ).rejects.toThrow();
+
+    // Both reached the processor: the first failure released the key, so the
+    // second send was not suppressed as a duplicate.
+    expect(runs).toBe(2);
+  });
+
+  /**
+   * @case A committed key expires after its ttl and the next occurrence passes
+   * @preconditions Route with .dedupe({ ttl: 40 }); send a, send a (dropped), sleep 60ms, send a
+   * @expectedResult The first and the post-expiry send pass; the in-ttl duplicate is dropped
+   */
+  test("ttl expiry re-admits a previously seen key", async () => {
+    const s = spy();
+    t = await testContext()
+      .routes(craft().id("dedupe-ttl").from(direct()).dedupe({ ttl: 40 }).to(s))
+      .build();
+    await t.startAndWaitReady();
+
+    await send(t, "dedupe-ttl", { event: "a" });
+    await send(t, "dedupe-ttl", { event: "a" });
+    await sleep(60);
+    await send(t, "dedupe-ttl", { event: "a" });
+
+    expect(s.received).toHaveLength(2);
+  });
+
+  /**
+   * @case Dedupe emits pass/duplicate operation events carrying the derived key
+   * @preconditions Route with .dedupe(); two sequential sends of the same body; subscribers registered
+   * @expectedResult One route:operation:dedupe:pass and one :duplicate, both carrying the same key
+   */
+  test("emits route:operation:dedupe:pass and :duplicate", async () => {
+    const pass: { key: string }[] = [];
+    const dup: { key: string }[] = [];
+    const s = spy();
+    t = await testContext()
+      .on("route:operation:dedupe:pass", (p) => {
+        pass.push(p.details as { key: string });
+      })
+      .on("route:operation:dedupe:duplicate", (p) => {
+        dup.push(p.details as { key: string });
+      })
+      .routes(craft().id("dedupe-events").from(direct()).dedupe().to(s))
+      .build();
+    await t.startAndWaitReady();
+
+    await send(t, "dedupe-events", { event: "a" });
+    await send(t, "dedupe-events", { event: "a" });
+
+    expect(pass).toHaveLength(1);
+    expect(dup).toHaveLength(1);
+    expect(dup[0]!.key).toBe(pass[0]!.key);
+  });
+
+  /**
+   * @case A non-serialisable body with no key function fails loudly
+   * @preconditions Route with .dedupe() (default key); body containing a BigInt
+   * @expectedResult The send rejects with RC5033 (dedupe key derivation failed)
+   */
+  test("throws RC5033 for an unsupported body without a key", async () => {
+    t = await testContext()
+      .routes(
+        craft().id("dedupe-unsupported").from(direct()).dedupe().to(spy()),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    await expect(
+      t.client.sendDirect("dedupe-unsupported", { big: 1n }),
+    ).rejects.toThrow(/RC5033|serialisable|dedupe key/i);
+  });
+
+  /**
+   * @case Invalid options are rejected at build time
+   * @preconditions DedupeStep constructed with a non-positive ttl or an out-of-range maxKeys
+   * @expectedResult Each construction throws (RC5003)
+   */
+  test("rejects invalid options at build time", () => {
+    expect(() => new DedupeStep({ ttl: 0 })).toThrow(/ttl/);
+    expect(() => new DedupeStep({ ttl: -5 })).toThrow(/ttl/);
+    expect(() => new DedupeStep({ maxKeys: 0 })).toThrow(/maxKeys/);
+    expect(() => new DedupeStep({ maxKeys: 1.5 })).toThrow(/maxKeys/);
+  });
+});

--- a/packages/routecraft/test/sample.bun.test.ts
+++ b/packages/routecraft/test/sample.bun.test.ts
@@ -6,6 +6,7 @@ import {
   simple,
   SampleStep,
   RoutecraftError,
+  type SampleOptions,
 } from "@routecraft/routecraft";
 
 /** Sleep for `ms` milliseconds. */
@@ -172,10 +173,14 @@ describe("sample (.sample())", () => {
    * @expectedResult Each construction throws (RC5003), so the route never builds
    */
   test("rejects invalid options at build time", () => {
-    expect(() => new SampleStep({})).toThrow(/mutually exclusive/);
-    expect(() => new SampleStep({ every: 2, intervalMs: 5 })).toThrow(
+    // The XOR union rejects neither/both at compile time; cast to exercise the
+    // runtime guard that protects JS callers who bypass the types.
+    expect(() => new SampleStep({} as SampleOptions)).toThrow(
       /mutually exclusive/,
     );
+    expect(
+      () => new SampleStep({ every: 2, intervalMs: 5 } as SampleOptions),
+    ).toThrow(/mutually exclusive/);
     expect(() => new SampleStep({ every: 0 })).toThrow(/every/);
     expect(() => new SampleStep({ every: 1.5 })).toThrow(/every/);
     expect(() => new SampleStep({ intervalMs: 0 })).toThrow(/intervalMs/);

--- a/packages/routecraft/test/sample.bun.test.ts
+++ b/packages/routecraft/test/sample.bun.test.ts
@@ -168,6 +168,42 @@ describe("sample (.sample())", () => {
   });
 
   /**
+   * @case Sample emits passed/dropped operation events with the interval mode
+   * @preconditions Route with .sample({ intervalMs }) over two sends in one window; event subscribers registered
+   * @expectedResult One route:operation:sample:passed and one :dropped, both mode "interval"
+   */
+  test("emits route:operation:sample:passed and :dropped in interval mode", async () => {
+    const passed: { mode: string }[] = [];
+    const dropped: { mode: string }[] = [];
+    const s = spy();
+    t = await testContext()
+      .on("route:operation:sample:passed", (p) => {
+        passed.push(p.details as { mode: string });
+      })
+      .on("route:operation:sample:dropped", (p) => {
+        dropped.push(p.details as { mode: string });
+      })
+      .routes(
+        craft()
+          .id("sample-interval-events")
+          .from(direct())
+          .sample({ intervalMs: 1000 })
+          .to(s),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    // Two sends inside the same window: the first passes, the second drops.
+    await send(t, "sample-interval-events", "a");
+    await send(t, "sample-interval-events", "b");
+
+    expect(passed).toHaveLength(1);
+    expect(dropped).toHaveLength(1);
+    expect(passed[0]!.mode).toBe("interval");
+    expect(dropped[0]!.mode).toBe("interval");
+  });
+
+  /**
    * @case Mis-specified sampling is rejected at build time
    * @preconditions SampleStep constructed with neither, both, or out-of-range options
    * @expectedResult Each construction throws (RC5003), so the route never builds

--- a/packages/routecraft/test/sample.bun.test.ts
+++ b/packages/routecraft/test/sample.bun.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { testContext, spy, type TestContext } from "@routecraft/testing";
+import {
+  craft,
+  direct,
+  simple,
+  SampleStep,
+  RoutecraftError,
+} from "@routecraft/routecraft";
+
+/** Sleep for `ms` milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Send through a direct route, tolerating the `RC5031` that a request/reply
+ * caller sees when the route drops the exchange (a sampled-out exchange has
+ * no response body). Any other failure propagates.
+ */
+async function send(
+  t: TestContext,
+  routeId: string,
+  body: unknown,
+): Promise<void> {
+  try {
+    await t.client.sendDirect(routeId, body);
+  } catch (err) {
+    if (err instanceof RoutecraftError && err.rc === "RC5031") return;
+    throw err;
+  }
+}
+
+describe("sample (.sample())", () => {
+  let t: TestContext;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+  });
+
+  /**
+   * @case Count-based sampling passes every Nth exchange and drops the rest
+   * @preconditions Route with .sample({ every: 2 }); five sequential sends of 1..5 through a direct route
+   * @expectedResult Only the 2nd and 4th exchanges (counter % 2 === 0) reach the destination
+   */
+  test("every: passes every Nth exchange in count order", async () => {
+    const s = spy();
+    t = await testContext()
+      .routes(
+        craft().id("sample-count").from(direct()).sample({ every: 2 }).to(s),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    for (const v of [1, 2, 3, 4, 5]) {
+      await send(t, "sample-count", v);
+    }
+
+    expect(t.errors).toHaveLength(0);
+    expect(s.received.map((e) => e.body)).toEqual([2, 4]);
+  });
+
+  /**
+   * @case Count-based sampling admits a deterministic fraction over a concurrent batch
+   * @preconditions Route with .sample({ every: 3 }) over nine concurrent exchanges
+   * @expectedResult Exactly three exchanges pass (floor(9 / 3)), regardless of arrival order
+   */
+  test("every: admits floor(N / every) over a batch", async () => {
+    const s = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("sample-count-batch")
+          .from(simple([0, 1, 2, 3, 4, 5, 6, 7, 8]))
+          .sample({ every: 3 })
+          .to(s),
+      )
+      .build();
+
+    await t.test();
+
+    expect(t.errors).toHaveLength(0);
+    expect(s.received).toHaveLength(3);
+  });
+
+  /**
+   * @case Time-based sampling passes the first exchange per window and drops the rest
+   * @preconditions Route with .sample({ intervalMs: 60_000 }); three sequential sends inside one window
+   * @expectedResult Only the first send passes; the other two are dropped while the window is open
+   */
+  test("intervalMs: passes the first exchange in a window", async () => {
+    const s = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("sample-interval")
+          .from(direct())
+          .sample({ intervalMs: 60_000 })
+          .to(s),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    await send(t, "sample-interval", "a");
+    await send(t, "sample-interval", "b");
+    await send(t, "sample-interval", "c");
+
+    expect(t.errors).toHaveLength(0);
+    expect(s.received.map((e) => e.body)).toEqual(["a"]);
+  });
+
+  /**
+   * @case A new time window admits the next exchange once the interval elapses
+   * @preconditions Route with .sample({ intervalMs: 30 }); two sends separated by a 50ms sleep
+   * @expectedResult Both sends pass, one per window
+   */
+  test("intervalMs: admits again after the window elapses", async () => {
+    const s = spy();
+    t = await testContext()
+      .routes(
+        craft()
+          .id("sample-interval-next")
+          .from(direct())
+          .sample({ intervalMs: 30 })
+          .to(s),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    await send(t, "sample-interval-next", "a");
+    await sleep(50);
+    await send(t, "sample-interval-next", "b");
+
+    expect(t.errors).toHaveLength(0);
+    expect(s.received.map((e) => e.body)).toEqual(["a", "b"]);
+  });
+
+  /**
+   * @case Sample emits passed/dropped operation events with the sampling mode
+   * @preconditions Route with .sample({ every: 2 }) over a sequential pair; event subscribers registered
+   * @expectedResult One route:operation:sample:passed and one :dropped, both mode "count"
+   */
+  test("emits route:operation:sample:passed and :dropped", async () => {
+    const passed: { mode: string }[] = [];
+    const dropped: { mode: string }[] = [];
+    const s = spy();
+    t = await testContext()
+      .on("route:operation:sample:passed", (p) => {
+        passed.push(p.details as { mode: string });
+      })
+      .on("route:operation:sample:dropped", (p) => {
+        dropped.push(p.details as { mode: string });
+      })
+      .routes(
+        craft().id("sample-events").from(direct()).sample({ every: 2 }).to(s),
+      )
+      .build();
+    await t.startAndWaitReady();
+
+    await send(t, "sample-events", 1);
+    await send(t, "sample-events", 2);
+
+    expect(dropped).toHaveLength(1);
+    expect(passed).toHaveLength(1);
+    expect(passed[0]!.mode).toBe("count");
+    expect(dropped[0]!.mode).toBe("count");
+  });
+
+  /**
+   * @case Mis-specified sampling is rejected at build time
+   * @preconditions SampleStep constructed with neither, both, or out-of-range options
+   * @expectedResult Each construction throws (RC5003), so the route never builds
+   */
+  test("rejects invalid options at build time", () => {
+    expect(() => new SampleStep({})).toThrow(/mutually exclusive/);
+    expect(() => new SampleStep({ every: 2, intervalMs: 5 })).toThrow(
+      /mutually exclusive/,
+    );
+    expect(() => new SampleStep({ every: 0 })).toThrow(/every/);
+    expect(() => new SampleStep({ every: 1.5 })).toThrow(/every/);
+    expect(() => new SampleStep({ intervalMs: 0 })).toThrow(/intervalMs/);
+    expect(() => new SampleStep({ intervalMs: -10 })).toThrow(/intervalMs/);
+  });
+});


### PR DESCRIPTION
Closes #153, closes #150.

## What

Adds two per-route flow-control operations to the DSL:

- **`.sample(options)`** (#153): keep a representative fraction of a high-volume stream, drop the rest (silently, like a `filter` returning false). Count mode `{ every: N }` passes the Nth, 2Nth, ... and resets; interval mode `{ intervalMs: M }` passes the first exchange per window. The two modes are mutually exclusive at compile time (`?: never` arms) and at runtime (`RC5003`).
- **`.dedupe(options?)`** (#150): process the same input at most once. A key (SHA-256 of the JSON body by default, or an explicit `key` deriver) is reserved on entry; a duplicate that is in flight or already committed is dropped. The reservation commits on clean completion and releases on failure or drop, so a genuinely failed input can retry. Optional `ttl` and a `maxKeys` LRU bound (default ceiling 10,000) cap memory. State is in-memory and per-route (single-instance).

Both keep state per `Route`, so a single `RouteDefinition` registered into multiple contexts gets isolated state rather than one shared sampler / seen-set.

## Notable internals

- New `RouteScopedController<S>` base (`operations/route-scoped-controller.ts`) holds the `WeakMap<Route, State>` + routeless-fallback + lazy-create lookup once. `sample`, `dedupe`, `throttle`, and `circuitBreaker` all extend it, so the per-route isolation invariant lives in one place.
- Shared `operations/max-keys.ts` (`DEFAULT_MAX_KEYS`, `MAX_KEYS_CEILING`, `validateMaxKeys`) used by both `throttle` and `dedupe` so the resource bound cannot drift.
- New error codes `RC5029` (non-serialisable body for the default dedupe key) and `RC5033` (registered), plus `route:exchange:dropped` event coverage for sampled/deduped drops.

## Known limitation (tracked)

`dedupe` placed **before a fan-out** (`split`) commits the key even if a split child fails, because the parent exchange still completes. This is documented with a callout on the dedupe operation page and on the `DedupeStep` JSDoc, and the proper lineage-aware fix is filed as **#462** (targeted at 0.7.0, alongside the cross-instance `provider` work). Workaround: dedupe after the fan-out, at the granularity you actually want to guard.

## Review

Ran `/dev:codereview` over the branch; findings were adversarially verified, then fixed in place (JSDoc commit/release contradiction, sample count-mode doc formula, errors-page example casts, a routeless-path listener/reservation leak, the `maxKeys` and sample-message extractions). One design finding was deferred to #462; three were dropped as overstated or invalid.

## Checks

`bun run typecheck`, `bun run lint`, and `bun test` (1031 tests) all pass. Changeset included (`.changeset/sample-dedupe-ops.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5NwZwaaebdpSqFCnkHZLL)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.sample()` and `.dedupe()` flow-control operations to thin high-volume streams and suppress duplicate inputs. Both keep per-route state, drop silently like `filter`, emit operation and dropped events, and address #153 and #150.

- **New Features**
  - `.sample({ every } | { intervalMs })`: pass every Nth or the first per window. Options are mutually exclusive and validated (`RC5003`); `every` must be a safe integer ≥ 1. Emits `route:operation:sample:passed|dropped` and `route:exchange:dropped` with reason `"sampled"`.
  - `.dedupe({ key?, ttl?, maxKeys? })`: reserve on entry, commit on clean completion, release on failure or downstream drop. Default key is SHA-256 of `JSON.stringify(body)` via shared `hashExchangeBody`. Validates custom `key` returns a string; derivation errors raise `RC5033`. Emits `route:operation:dedupe:pass|duplicate` and `route:exchange:dropped` with reason `"duplicate"`. Docs note fan-out caveat before lineage-aware fix (#462).
  - Docs updated for operations, events, and errors; site index shows both ops.

- **Refactors**
  - Added `RouteScopedController<S>` for per-route state; used by `sample`, `dedupe`, `throttle`, and `circuitBreaker`.
  - Introduced shared `operations/max-keys.ts` (`DEFAULT_MAX_KEYS`, `validateMaxKeys`) used by `throttle` and `dedupe`.
  - Extracted `hashExchangeBody` and used in `cache` and `dedupe`. Exported new types and steps from `@routecraft/routecraft`.

<sup>Written for commit 56fb1c2a9f5d94019c7c710cae990a4ae10a5d99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

