### PR TITLE
feat(docs): hide draft blog posts from search and crawlers

### DIFF
--- a/apps/routecraft.dev/scripts/generate-raw-docs.mjs
+++ b/apps/routecraft.dev/scripts/generate-raw-docs.mjs
@@ -74,6 +74,13 @@ for (const file of files) {
   pages.set(url, { title, cleaned })
 }
 
+// Clean the output directory before regenerating. This script owns public/raw
+// entirely and rewrites it from scratch each run, so removing it first is what
+// keeps the mirror in sync with the source tree: a page that became a draft, or
+// was deleted or renamed, leaves no stale .md behind for the sitemap (which
+// enumerates whatever files exist under public/raw) to keep advertising.
+fs.rmSync(OUT_DIR, { recursive: true, force: true })
+
 // Write individual page files
 for (const [url, { cleaned }] of pages) {
   const relPath = url === '/' ? 'index.md' : `${url.replace(/^\//, '')}.md`

--- a/apps/routecraft.dev/scripts/generate-raw-docs.mjs
+++ b/apps/routecraft.dev/scripts/generate-raw-docs.mjs
@@ -45,6 +45,20 @@ function extractTitle(md) {
     : undefined
 }
 
+// Drafts and unpublished posts must not be mirrored to public/raw: those files
+// are publicly fetchable and get listed in the sitemap, so emitting one would
+// leak a draft's full content and make it discoverable. The blog index, RSS
+// feed, and per-post robots meta already hide drafts; this keeps the raw mirror
+// consistent with them.
+function isUnpublished(md) {
+  const match = md.match(/^---[\s\S]*?---/)
+  if (!match) return false
+  return (
+    /^draft:\s*true\s*$/m.test(match[0]) ||
+    /^published:\s*false\s*$/m.test(match[0])
+  )
+}
+
 // Build a map of url -> { title, cleaned markdown }
 const pages = new Map()
 
@@ -55,6 +69,7 @@ const files = glob
 for (const file of files) {
   const url = file === 'page.md' ? '/' : `/${file.replace(/\/page\.md$/, '')}`
   const md = fs.readFileSync(path.join(APP_DIR, file), 'utf8')
+  if (isUnpublished(md)) continue
   const title = extractTitle(md)
   const cleaned = cleanMarkdoc(md, title)
   pages.set(url, { title, cleaned })

--- a/apps/routecraft.dev/scripts/generate-raw-docs.mjs
+++ b/apps/routecraft.dev/scripts/generate-raw-docs.mjs
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'url'
 import glob from 'fast-glob'
 import { cleanMarkdoc } from '../src/lib/clean-markdoc.mjs'
 import { navigation } from '../src/lib/navigation.ts'
+import { parseFrontmatter } from '../src/lib/frontmatter.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
@@ -49,14 +50,12 @@ function extractTitle(md) {
 // are publicly fetchable and get listed in the sitemap, so emitting one would
 // leak a draft's full content and make it discoverable. The blog index, RSS
 // feed, and per-post robots meta already hide drafts; this keeps the raw mirror
-// consistent with them.
+// consistent with them. Detection goes through the same `parseFrontmatter`
+// (js-yaml) and the same rule as `src/lib/blog.ts`, so the two can't drift on
+// YAML boolean spellings (`draft: True`, `draft: yes`, `draft: true # note`).
 function isUnpublished(md) {
-  const match = md.match(/^---[\s\S]*?---/)
-  if (!match) return false
-  return (
-    /^draft:\s*true\s*$/m.test(match[0]) ||
-    /^published:\s*false\s*$/m.test(match[0])
-  )
+  const { data } = parseFrontmatter(md)
+  return Boolean(data.draft) || data.published === false
 }
 
 // Build a map of url -> { title, cleaned markdown }

--- a/apps/routecraft.dev/src/app/blog/page.tsx
+++ b/apps/routecraft.dev/src/app/blog/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next'
 import { BlogIndex } from '@/components/BlogIndex'
 import { FeaturedBlogCard } from '@/components/FeaturedBlogCard'
 import { SectionLabel } from '@/components/SectionLabel'
-import { getAllBlogPosts } from '@/lib/blog'
+import { getPublishedPosts } from '@/lib/blog'
 
 export const metadata: Metadata = {
   title: 'Blog',
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
 
 export default function BlogIndexPage() {
   // Drafts never appear on the public index, matching the sitemap and RSS feed.
-  const posts = getAllBlogPosts().filter((p) => !p.draft)
+  const posts = getPublishedPosts()
   // Lead with up to two posts (featured first, then most recent), then show the
   // remaining posts in the grid below.
   const featured = [

--- a/apps/routecraft.dev/src/app/feed.xml/route.ts
+++ b/apps/routecraft.dev/src/app/feed.xml/route.ts
@@ -1,4 +1,4 @@
-import { getAllBlogPosts } from '@/lib/blog'
+import { getPublishedPosts } from '@/lib/blog'
 import { absoluteUrl, siteDescription, siteName, siteUrl } from '@/lib/site'
 
 export const dynamic = 'force-static'
@@ -14,7 +14,7 @@ function escapeXml(value: string): string {
 
 // RSS 2.0 feed of published blog posts. Static-exported at /feed.xml.
 export function GET() {
-  const posts = getAllBlogPosts().filter((post) => !post.draft)
+  const posts = getPublishedPosts()
 
   const items = posts
     .map((post) => {

--- a/apps/routecraft.dev/src/app/sitemap.ts
+++ b/apps/routecraft.dev/src/app/sitemap.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import type { MetadataRoute } from 'next'
 
-import { getAllBlogPosts } from '@/lib/blog'
+import { getPublishedPosts, lastModifiedDate } from '@/lib/blog'
 import { siteUrl } from '@/lib/site'
 
 export const dynamic = 'force-static'
@@ -108,11 +108,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
     // lastmod comes from the post's `updated` (falling back to `date`), not the
     // file mtime: a fresh CI checkout resets every file's mtime to build time,
-    // which would tell crawlers every post changed on every deploy.
-    for (const post of getAllBlogPosts().filter((p) => !p.draft)) {
+    // which would tell crawlers every post changed on every deploy. A malformed
+    // date is omitted rather than passed on as an Invalid Date, which would make
+    // Next throw while serialising lastmod and fail the whole sitemap build.
+    for (const post of getPublishedPosts()) {
+      const lastModified = new Date(lastModifiedDate(post))
       routes.push({
         url: `${baseUrl}/blog/${post.slug}/`,
-        lastModified: new Date(post.updated ?? post.date),
+        ...(Number.isNaN(lastModified.getTime()) ? {} : { lastModified }),
         changeFrequency: 'monthly',
         priority: 0.7,
       })

--- a/apps/routecraft.dev/src/app/sitemap.ts
+++ b/apps/routecraft.dev/src/app/sitemap.ts
@@ -106,14 +106,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     })
 
+    // lastmod comes from the post's `updated` (falling back to `date`), not the
+    // file mtime: a fresh CI checkout resets every file's mtime to build time,
+    // which would tell crawlers every post changed on every deploy.
     for (const post of getAllBlogPosts().filter((p) => !p.draft)) {
-      const pagePath = path.join(blogBaseDir, post.slug, 'page.md')
-      const lastModified = fs.existsSync(pagePath)
-        ? fs.statSync(pagePath).mtime
-        : new Date(post.date)
       routes.push({
         url: `${baseUrl}/blog/${post.slug}/`,
-        lastModified,
+        lastModified: new Date(post.updated ?? post.date),
         changeFrequency: 'monthly',
         priority: 0.7,
       })

--- a/apps/routecraft.dev/src/components/BlogPostLayout.tsx
+++ b/apps/routecraft.dev/src/components/BlogPostLayout.tsx
@@ -8,7 +8,12 @@ import { BlogCoverInline } from '@/components/BlogCover'
 import { LightboxImage } from '@/components/Lightbox'
 import { RelatedPosts } from '@/components/RelatedPosts'
 import { collectSections } from '@/lib/sections'
-import { formatBlogDate, getAllBlogPosts, getRelatedPosts } from '@/lib/blog'
+import {
+  formatBlogDate,
+  getAllBlogPosts,
+  getPublishedPosts,
+  getRelatedPosts,
+} from '@/lib/blog'
 
 interface BlogPostFrontmatter {
   title?: string
@@ -32,9 +37,9 @@ function resolveSlugAndFigure(frontmatter: BlogPostFrontmatter): {
   slug: string
   figureNumber: number
 } {
-  const all = getAllBlogPosts()
-    .filter((post) => !post.draft)
-    .sort((a, b) => (a.date || '').localeCompare(b.date || ''))
+  const all = getPublishedPosts().sort((a, b) =>
+    (a.date || '').localeCompare(b.date || ''),
+  )
   const explicit = frontmatter.slug
   const match = explicit
     ? all.find((post) => post.slug === explicit)

--- a/apps/routecraft.dev/src/lib/blog-metadata.tsx
+++ b/apps/routecraft.dev/src/lib/blog-metadata.tsx
@@ -25,6 +25,20 @@ export function blogPostMetadata(slug: string): Metadata {
     title: post.title,
     description: post.description,
     alternates: { canonical: url },
+    // Drafts stay reachable by direct link (for preview and sharing) but must
+    // not be discoverable: keep them out of search indexes, and tell crawlers
+    // not to follow their links or cache them. The sitemap, RSS feed, and blog
+    // index already omit drafts; this covers the page itself.
+    ...(post.draft
+      ? {
+          robots: {
+            index: false,
+            follow: false,
+            nocache: true,
+            googleBot: { index: false, follow: false },
+          },
+        }
+      : {}),
     authors: post.author ? [{ name: post.author }] : undefined,
     openGraph: {
       type: 'article',
@@ -48,6 +62,10 @@ export function blogPostMetadata(slug: string): Metadata {
 export function BlogPostJsonLd({ slug }: { slug: string }) {
   const post = getBlogPostBySlug(slug)
   if (!post) return null
+  // A draft is noindex, so emitting BlogPosting/BreadcrumbList structured data
+  // for it would be contradictory (and could still surface the post in rich
+  // results). Drafts get no JSON-LD until they are published.
+  if (post.draft) return null
   const url = absoluteUrl(canonicalPath(`/blog/${slug}`))
   const published = isoDate(post.date)
 

--- a/apps/routecraft.dev/src/lib/blog-metadata.tsx
+++ b/apps/routecraft.dev/src/lib/blog-metadata.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getBlogPostBySlug } from '@/lib/blog'
+import { getBlogPostBySlug, lastModifiedDate } from '@/lib/blog'
 import { absoluteUrl, canonicalPath, siteName, siteUrl } from '@/lib/site'
 import { StructuredData } from '@/components/StructuredData'
 
@@ -10,6 +10,17 @@ function isoDate(date: string): string | undefined {
   return Number.isNaN(d.getTime()) ? undefined : d.toISOString()
 }
 
+// Robots directives for a post that must not be discoverable: kept out of
+// search indexes, with crawlers told not to follow its links or cache it.
+// Applied both to drafts and to a slug that has a route but no published post
+// behind it (e.g. `published: false`), so neither is left silently indexable.
+const NOINDEX_ROBOTS: Metadata['robots'] = {
+  index: false,
+  follow: false,
+  nocache: true,
+  googleBot: { index: false, follow: false },
+}
+
 /**
  * Per-post metadata, sourced from the post's frontmatter. Markdoc `.md` pages
  * can't export metadata, so each post folder has a thin `layout.tsx` that calls
@@ -17,29 +28,22 @@ function isoDate(date: string): string | undefined {
  */
 export function blogPostMetadata(slug: string): Metadata {
   const post = getBlogPostBySlug(slug)
-  if (!post) return {}
+  // No published post behind this route (unknown slug, or `published: false`).
+  // The `page.md` still builds a route, so return noindex rather than empty
+  // metadata to keep an unpublished page out of search results.
+  if (!post) return { robots: NOINDEX_ROBOTS }
   const url = canonicalPath(`/blog/${slug}`)
   const published = isoDate(post.date)
-  const modified = isoDate(post.updated ?? post.date)
+  const modified = isoDate(lastModifiedDate(post))
 
   return {
     title: post.title,
     description: post.description,
     alternates: { canonical: url },
     // Drafts stay reachable by direct link (for preview and sharing) but must
-    // not be discoverable: keep them out of search indexes, and tell crawlers
-    // not to follow their links or cache them. The sitemap, RSS feed, and blog
-    // index already omit drafts; this covers the page itself.
-    ...(post.draft
-      ? {
-          robots: {
-            index: false,
-            follow: false,
-            nocache: true,
-            googleBot: { index: false, follow: false },
-          },
-        }
-      : {}),
+    // not be discoverable. The sitemap, RSS feed, and blog index already omit
+    // drafts; this covers the page itself.
+    ...(post.draft ? { robots: NOINDEX_ROBOTS } : {}),
     authors: post.author ? [{ name: post.author }] : undefined,
     openGraph: {
       type: 'article',
@@ -69,7 +73,7 @@ export function BlogPostJsonLd({ slug }: { slug: string }) {
   if (post.draft) return null
   const url = absoluteUrl(canonicalPath(`/blog/${slug}`))
   const published = isoDate(post.date)
-  const modified = isoDate(post.updated ?? post.date)
+  const modified = isoDate(lastModifiedDate(post))
 
   const blogPosting = {
     '@context': 'https://schema.org',

--- a/apps/routecraft.dev/src/lib/blog-metadata.tsx
+++ b/apps/routecraft.dev/src/lib/blog-metadata.tsx
@@ -20,6 +20,7 @@ export function blogPostMetadata(slug: string): Metadata {
   if (!post) return {}
   const url = canonicalPath(`/blog/${slug}`)
   const published = isoDate(post.date)
+  const modified = isoDate(post.updated ?? post.date)
 
   return {
     title: post.title,
@@ -46,7 +47,7 @@ export function blogPostMetadata(slug: string): Metadata {
       description: post.description,
       url,
       publishedTime: published,
-      modifiedTime: published,
+      modifiedTime: modified,
       authors: post.author ? [post.author] : undefined,
       tags: post.tags,
     },
@@ -68,6 +69,7 @@ export function BlogPostJsonLd({ slug }: { slug: string }) {
   if (post.draft) return null
   const url = absoluteUrl(canonicalPath(`/blog/${slug}`))
   const published = isoDate(post.date)
+  const modified = isoDate(post.updated ?? post.date)
 
   const blogPosting = {
     '@context': 'https://schema.org',
@@ -77,7 +79,8 @@ export function BlogPostJsonLd({ slug }: { slug: string }) {
     url,
     mainEntityOfPage: url,
     datePublished: published,
-    dateModified: published,
+    dateModified: modified,
+    inLanguage: 'en-US',
     image: absoluteUrl(`/blog/${slug}/opengraph-image`),
     author: post.author ? { '@type': 'Person', name: post.author } : undefined,
     publisher: {

--- a/apps/routecraft.dev/src/lib/blog-og-image.tsx
+++ b/apps/routecraft.dev/src/lib/blog-og-image.tsx
@@ -4,7 +4,7 @@ import path from 'path'
 import { ImageResponse } from 'next/og'
 
 import { BlogCover, COVER_HEIGHT, COVER_WIDTH } from '@/components/BlogCover'
-import { getAllBlogPosts, getBlogPostBySlug } from '@/lib/blog'
+import { getBlogPostBySlug, getPublishedPosts } from '@/lib/blog'
 
 export const OG_SIZE = { width: COVER_WIDTH, height: COVER_HEIGHT }
 export const OG_CONTENT_TYPE = 'image/png'
@@ -80,9 +80,9 @@ export async function ogFonts() {
 }
 
 function figureNumberFor(slug: string): number {
-  const posts = getAllBlogPosts()
-    .filter((post) => !post.draft)
-    .sort((a, b) => (a.date || '').localeCompare(b.date || ''))
+  const posts = getPublishedPosts().sort((a, b) =>
+    (a.date || '').localeCompare(b.date || ''),
+  )
   const index = posts.findIndex((post) => post.slug === slug)
   return index >= 0 ? index + 1 : posts.length + 1
 }

--- a/apps/routecraft.dev/src/lib/blog.ts
+++ b/apps/routecraft.dev/src/lib/blog.ts
@@ -12,6 +12,14 @@ export interface BlogPostMeta {
   title: string
   description?: string
   date: string
+  /**
+   * Optional last-updated date (YYYY-MM-DD). Drives `dateModified`,
+   * `article:modified_time`, and the sitemap's `lastmod`. Bump it only when a
+   * post's content materially changes; it falls back to `date` when absent.
+   * Kept explicit rather than derived from file mtime so a fresh CI checkout
+   * (which resets every file's mtime to build time) can't fake freshness.
+   */
+  updated?: string
   author?: string
   authorRole?: string
   authorAvatar?: string
@@ -48,13 +56,15 @@ function readPost(blogDir: string, slug: string): BlogPostMeta | undefined {
   const { data, body } = parseFrontmatter(md)
   if (data.published === false) return undefined
 
-  const rawDate = data.date
-  const date =
-    rawDate instanceof Date
-      ? rawDate.toISOString().slice(0, 10)
-      : typeof rawDate === 'string'
-        ? rawDate
-        : ''
+  const toDateString = (value: unknown): string | undefined =>
+    value instanceof Date
+      ? value.toISOString().slice(0, 10)
+      : typeof value === 'string'
+        ? value
+        : undefined
+
+  const date = toDateString(data.date) ?? ''
+  const updated = toDateString(data.updated)
 
   return {
     slug,
@@ -62,6 +72,7 @@ function readPost(blogDir: string, slug: string): BlogPostMeta | undefined {
     description:
       typeof data.description === 'string' ? data.description : undefined,
     date,
+    updated,
     author: typeof data.author === 'string' ? data.author : undefined,
     authorRole:
       typeof data.authorRole === 'string' ? data.authorRole : undefined,

--- a/apps/routecraft.dev/src/lib/blog.ts
+++ b/apps/routecraft.dev/src/lib/blog.ts
@@ -49,19 +49,22 @@ function estimateReadingTime(body: string): number {
   return Math.max(1, Math.round(words / WORDS_PER_MINUTE))
 }
 
+// Coerce a frontmatter date value (js-yaml gives us a Date for bare `2026-01-02`
+// and a string for a quoted one) to a `YYYY-MM-DD` string.
+function toDateString(value: unknown): string | undefined {
+  return value instanceof Date
+    ? value.toISOString().slice(0, 10)
+    : typeof value === 'string'
+      ? value
+      : undefined
+}
+
 function readPost(blogDir: string, slug: string): BlogPostMeta | undefined {
   const file = path.join(blogDir, slug, 'page.md')
   if (!fs.existsSync(file)) return undefined
   const md = fs.readFileSync(file, 'utf8')
   const { data, body } = parseFrontmatter(md)
   if (data.published === false) return undefined
-
-  const toDateString = (value: unknown): string | undefined =>
-    value instanceof Date
-      ? value.toISOString().slice(0, 10)
-      : typeof value === 'string'
-        ? value
-        : undefined
 
   const date = toDateString(data.date) ?? ''
   const updated = toDateString(data.updated)
@@ -115,6 +118,27 @@ export function getAllBlogPosts(): BlogPostMeta[] {
   posts.sort((a, b) => (b.date || '').localeCompare(a.date || ''))
   cachedPosts = posts
   return posts
+}
+
+/**
+ * Posts safe to expose publicly (drafts excluded). The single definition of
+ * "publicly visible" shared by the sitemap, RSS feed, blog index, and OG image
+ * numbering, so those surfaces cannot drift on which posts are discoverable.
+ */
+export function getPublishedPosts(
+  posts: BlogPostMeta[] = getAllBlogPosts(),
+): BlogPostMeta[] {
+  return posts.filter((p) => !p.draft)
+}
+
+/**
+ * A post's effective last-modified date (`YYYY-MM-DD`): `updated` when the
+ * author set it, otherwise the publish `date`. One definition of the freshness
+ * policy so `dateModified`, `article:modified_time`, and the sitemap's `lastmod`
+ * cannot disagree for the same post.
+ */
+export function lastModifiedDate(post: BlogPostMeta): string {
+  return post.updated ?? post.date
 }
 
 export function getFeaturedPost(


### PR DESCRIPTION
Draft posts stay reachable by direct link (for preview and sharing) but
must not be discoverable while unpublished. The sitemap, RSS feed, and
blog index already omit drafts; two discovery surfaces still leaked them:

- The post page itself served normal indexable metadata plus BlogPosting
  JSON-LD. Drafts now emit `robots: noindex, nofollow, nocache` and no
  structured data.
- The raw markdown mirror under `public/raw` published a draft's full
  content and listed it in the sitemap. The raw-docs generator now skips
  any post with `draft: true` or `published: false`.

Claude-Session: https://claude.ai/code/session_012bBpF4u3ECefy1n8Yo1qpM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide draft blog posts from search and crawlers while keeping direct links usable. Unify and fix freshness signals using an optional `updated` frontmatter across sitemap, Open Graph, and JSON-LD.

- New Features
  - Added `updated` frontmatter for honest last-modified dates; used for sitemap `lastmod`, Open Graph `article:modified_time`, and BlogPosting `dateModified` (falls back to `date`).
  - Added `inLanguage: en-US` to BlogPosting JSON-LD.

- Bug Fixes
  - Draft posts now serve robots `noindex, nofollow, nocache` and emit no JSON-LD; routes without a published post also return noindex.
  - Raw docs mirror skips posts with `draft: true` or `published: false` using shared frontmatter parsing, preventing content leaks and sitemap exposure.
  - Sitemap no longer uses file mtimes; it reads `updated`/`date` and omits malformed dates to avoid build failures and fake freshness. Blog index, RSS feed, and OG numbering now share one “published only” filter.
  - Raw-docs generator cleans `public/raw` before regenerating to drop stale mirrors for drafts, deleted, or renamed pages so the sitemap can’t advertise them.

<sup>Written for commit c42557bf49f9d454194fff153243ac759e5921d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

