### PR TITLE
feat(routecraft): add xml adapter

### DIFF
--- a/.changeset/xml-adapter.md
+++ b/.changeset/xml-adapter.md
@@ -1,0 +1,6 @@
+---
+"@routecraft/routecraft": minor
+"@routecraft/cli": patch
+---
+
+Add the `xml` adapter: read, write, and transform XML through a plain-object representation, mirroring the `json` and `csv` codec adapters. Works as a transformer (parse an XML string in the body), a source (read and parse a file), a returning destination (`mode: 'read'`), a write destination, and a `delete` destination. Malformed XML surfaces as an observable per-exchange `RC5016` failure honouring `onParseError` (`fail` / `abort` / `drop`). `fast-xml-parser` is loaded as an optional peer dependency through `loadOptionalPeer` (missing install reports `RC5017` with an install hint) and bundled by the CLI.

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/page.md
@@ -8,7 +8,7 @@ Every source, destination, transformer, and processor in Routecraft. Each card o
 
 ## Parse error handling
 
-Source adapters that convert raw bytes into a structured body (`json`, `html`, `csv`, `jsonl`, `mail`) accept a uniform `onParseError` option that controls what happens when parsing fails (malformed JSON, structurally-invalid CSV row, broken MIME, etc.). The default is `'fail'`.
+Source adapters that convert raw bytes into a structured body (`json`, `html`, `csv`, `jsonl`, `xml`, `mail`) accept a uniform `onParseError` option that controls what happens when parsing fails (malformed JSON, structurally-invalid CSV row, broken MIME, etc.). The default is `'fail'`.
 
 All three modes are observable on the events bus, parse failures are never silent.
 

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/xml/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/xml/page.md
@@ -1,0 +1,117 @@
+---
+title: xml
+---
+
+[← All adapters](/docs/reference/adapters) {% .lead %}
+
+```ts
+xml(options?: XmlTransformerOptions): Transformer   // no path: parse an XML string in the body
+xml(options: XmlFileOptions & { mode: 'read' }): XmlReadAdapter
+xml(options: XmlFileOptions): XmlAdapter   // Source<XmlData> & Destination<unknown, void>
+```
+
+Read, write, and parse XML using a plain-object representation. **Requires `fast-xml-parser` as a peer dependency.**
+
+```bash
+bun add fast-xml-parser
+```
+
+XML maps to a plain object: each element becomes a key, attributes are kept under the `@_` prefix by default, and text content sits under `#text` when an element also has attributes or children. The same options drive parsing and building, so a read then write round-trip preserves structure.
+
+**Transformer mode** (parse an XML string already in the body):
+```ts
+// Parse an XML string (e.g. an http() response body) into an object
+.transform(xml())
+
+// Pluck the string and write the parsed object to a sub-field
+.transform(xml({
+  from: (b) => b.body,
+  to: (b, parsed) => ({ ...b, parsed })
+}))
+```
+
+**Source mode** (read XML files):
+```ts
+// Read and parse an XML file
+.from(xml({ path: './data.xml' }))
+// <note><to>Alice</to></note> -> { note: { to: 'Alice' } }
+
+// Coerce values and strip namespace prefixes
+.from(xml({
+  path: './data.xml',
+  parseAttributeValue: true,
+  removeNSPrefix: true,
+}))
+```
+
+**Read mid-route** (read + parse an XML file partway through a route): In `read` mode the adapter is also a destination whose `send` reads and parses the file and returns the object, so `.enrich()` / `.to()` can pull it in, the same way an HTTP `GET` returns a body. Read-as-destination accepts dynamic (function) paths. Parse failures throw and surface through the pipeline (the `onParseError` lifecycle controls apply to source mode only).
+
+```ts
+// Enrich the body with the parsed document, keeping the existing fields
+.enrich(
+  xml({ path: './config.xml', mode: 'read' }),
+  only((doc) => doc, 'config'),
+)
+
+// Replace the body with the parsed document
+.to(xml({ path: './data.xml', mode: 'read' }))
+```
+
+**Destination mode** (write XML files):
+```ts
+// Build the object body into an XML document and write it
+.to(xml({ path: './output.xml' }))
+// { note: { to: 'Alice' } } -> <note><to>Alice</to></note>
+
+// Pretty-print with indentation
+.to(xml({ path: './output.xml', format: true }))
+
+// Dynamic paths with directory creation
+.to(xml({
+  path: (exchange) => `./reports/${exchange.body.reportDate}.xml`,
+  createDirs: true,
+}))
+
+// Delete an XML file (idempotent: an already-absent path is a no-op)
+.to(xml({ path: (ex) => ex.body.processedPath, mode: 'delete' }))
+```
+
+There is no `append` mode: appending a serialized fragment to an XML file produces multiple root elements and an invalid document. Read the file in `read` mode, mutate the parsed object, and write it back instead.
+
+**Transformer Options** (when no `path` provided):
+
+| Option | Type | Default | Required | Description |
+|--------|------|---------|----------|-------------|
+| `from` | `(body) => string` | Uses `body` or `body.body` | No | Extract the XML string from the exchange |
+| `to` | `(body, parsed) => R` | Replaces body | No | Where to put the parsed object |
+| `ignoreAttributes` | `boolean` | `false` | No | Drop XML attributes from the output |
+| `attributeNamePrefix` | `string` | `'@_'` | No | Prefix for attribute keys |
+| `textNodeName` | `string` | `'#text'` | No | Property name for element text content |
+| `cdataPropName` | `string` | (merged into text) | No | Property name for CDATA sections |
+| `parseAttributeValue` | `boolean` | `false` | No | Coerce attribute values to number / boolean |
+| `parseTagValue` | `boolean` | `true` | No | Coerce tag text to number / boolean |
+| `trimValues` | `boolean` | `true` | No | Trim whitespace around values |
+| `removeNSPrefix` | `boolean` | `false` | No | Strip namespace prefixes from names |
+
+**File Options** (when `path` is provided): all parse options above (except `from` / `to`), plus:
+
+| Option | Type | Default | Required | Description |
+|--------|------|---------|----------|-------------|
+| `path` | `string \| (exchange) => string` | | Yes | File path (static, or dynamic for destinations) |
+| `encoding` | `BufferEncoding` | `'utf-8'` | No | Text encoding |
+| `mode` | `'read' \| 'write' \| 'delete'` | `'read'` for source, `'write'` for destination | No | File operation mode (`read` returns the parsed object mid-route; `delete` removes the file, idempotently) |
+| `createDirs` | `boolean` | `false` | No | Create parent directories (write mode only) |
+| `format` | `boolean` | `false` | No | Pretty-print the written XML (write mode only) |
+| `indentBy` | `string` | `'  '` | No | Indentation unit when `format` is true |
+| `suppressEmptyNode` | `boolean` | `false` | No | Collapse empty nodes to self-closing tags when building |
+| `onParseError` | `'fail' \| 'abort' \| 'drop'` | `'fail'` | No | How to handle a parse failure (source only). See [parse error handling](/docs/reference/adapters#parse-error-handling). |
+
+**Behavior:**
+- **Source**: Reads the file and emits the parsed object. Malformed XML is routed through the route's `.error()` handler by default (`onParseError: 'fail'`); `'abort'` fails the source; `'drop'` emits `exchange:dropped` with `reason: 'parse-failed'`.
+- **Destination** (`write`, default): Builds the object body into an XML document and writes it. The body must be a plain object.
+- **Destination** (`read`): Reads, parses, and returns the object for `.enrich()` / `.to()`.
+- **Destination** (`delete`): Deletes the file (idempotent) and passes the body through unchanged.
+
+**Peer dependency:** Requires `fast-xml-parser` to be installed separately.
+
+**Exported symbols:** types `XmlAdapter`, `XmlReadAdapter`, `XmlOptions`, `XmlTransformerOptions`, `XmlFileOptions`, `XmlParseOptions`, `XmlBuildOptions`, `XmlData`

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/xml/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/xml/page.md
@@ -92,6 +92,7 @@ There is no `append` mode: appending a serialized fragment to an XML file produc
 | `parseTagValue` | `boolean` | `true` | No | Coerce tag text to number / boolean |
 | `trimValues` | `boolean` | `true` | No | Trim whitespace around values |
 | `removeNSPrefix` | `boolean` | `false` | No | Strip namespace prefixes from names |
+| `isArray` | `(tagName, jPath, isLeafNode, isAttribute) => boolean` | (occurrence-based) | No | Force matching tags to always parse as arrays. Without it a tag that appears once parses as an object and repeated occurrences parse as an array; return `true` to pin a repeatable element to a stable array shape |
 
 **File Options** (when `path` is provided): all parse options above (except `from` / `to`), plus:
 
@@ -108,7 +109,7 @@ There is no `append` mode: appending a serialized fragment to an XML file produc
 
 **Behavior:**
 - **Source**: Reads the file and emits the parsed object. Malformed XML is routed through the route's `.error()` handler by default (`onParseError: 'fail'`); `'abort'` fails the source; `'drop'` emits `exchange:dropped` with `reason: 'parse-failed'`.
-- **Destination** (`write`, default): Builds the object body into an XML document and writes it. The body must be a plain object.
+- **Destination** (`write`, default): Builds the object body into an XML document and writes it. The body must be a plain object with exactly one root element (an optional `?xml` declaration key is allowed alongside it); arrays and multi-root objects are rejected because they would serialise to an invalid multiple-root document.
 - **Destination** (`read`): Reads, parses, and returns the object for `.enrich()` / `.to()`.
 - **Destination** (`delete`): Deletes the file (idempotent) and passes the body through unchanged.
 

--- a/apps/routecraft.dev/src/components/AdapterGrid.tsx
+++ b/apps/routecraft.dev/src/components/AdapterGrid.tsx
@@ -115,6 +115,12 @@ const adapters: Adapter[] = [
     roles: ['Source', 'Destination', 'Transformer'],
     description: 'Parse or write HTML, with DOM-style selection helpers.',
   },
+  {
+    name: 'xml',
+    category: 'File',
+    roles: ['Source', 'Destination', 'Transformer'],
+    description: 'Parse, write, or transform XML as a plain object.',
+  },
 
   // Messaging
   {

--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
         "commander": "^14.0.3",
         "croner": "^10.0.1",
         "dotenv": "^17.4.2",
+        "fast-xml-parser": "^5.9.2",
         "imapflow": "^1.3.3",
         "ink": "^5.2.1",
         "jose": "^6.2.3",
@@ -253,6 +254,7 @@
         "better-sqlite3": "^11.10.0",
         "cheerio": "^1.2.0",
         "croner": "^10.0.1",
+        "fast-xml-parser": "^5.9.2",
         "imapflow": "^1.3.3",
         "mailauth": "^4.13.2",
         "mailparser": "^3.9.8",
@@ -269,6 +271,7 @@
         "@opentelemetry/sdk-trace-base": "^2.6.0",
         "cheerio": "^1.2.0",
         "croner": "^10.0.1",
+        "fast-xml-parser": "^5.0.0",
         "imapflow": "^1.0.0",
         "jose": "^6.0.0",
         "mailauth": "^4.0.0",
@@ -282,6 +285,7 @@
         "@opentelemetry/sdk-trace-base",
         "cheerio",
         "croner",
+        "fast-xml-parser",
         "imapflow",
         "jose",
         "mailauth",
@@ -701,7 +705,7 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.9", "", { "os": "win32", "cpu": "x64" }, "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w=="],
 
-    "@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+    "@nodable/entities": ["@nodable/entities@2.2.0", "", {}, "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1601,7 +1605,7 @@
 
     "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
 
-    "fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+    "fast-xml-parser": ["fast-xml-parser@5.9.2", "", { "dependencies": { "@nodable/entities": "^2.2.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^1.0.1", "path-expression-matcher": "^1.5.0", "strnum": "^2.4.0", "xml-naming": "^0.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-DYPkXnVSJHAGAkSBeVYhEo/seIpz2SLr9OQcX7m6lXaX3gvoB+DCKzFdZIEhZGI3I1DUhObBAUOT/v2xfoXz/w=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -1850,6 +1854,8 @@
     "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
 
     "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
+
+    "is-unsafe": ["is-unsafe@1.0.1", "", {}, "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA=="],
 
     "is-url-superb": ["is-url-superb@4.0.0", "", {}, "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA=="],
 
@@ -2869,6 +2875,8 @@
 
     "dependency-tree/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
+    "edgedriver/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
     "edgedriver/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
     "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -2938,6 +2946,8 @@
     "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "madge/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "mailauth/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
 
     "mailauth/nodemailer": ["nodemailer@8.0.7", "", {}, "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow=="],
 
@@ -3149,6 +3159,8 @@
 
     "crc32-stream/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
+    "edgedriver/fast-xml-parser/@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+
     "edgedriver/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
@@ -3170,6 +3182,8 @@
     "log-update/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "mailauth/fast-xml-parser/@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -271,7 +271,7 @@
         "@opentelemetry/sdk-trace-base": "^2.6.0",
         "cheerio": "^1.2.0",
         "croner": "^10.0.1",
-        "fast-xml-parser": "^5.0.0",
+        "fast-xml-parser": "^5.7.0",
         "imapflow": "^1.0.0",
         "jose": "^6.0.0",
         "mailauth": "^4.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "commander": "^14.0.3",
     "croner": "^10.0.1",
     "dotenv": "^17.4.2",
+    "fast-xml-parser": "^5.9.2",
     "imapflow": "^1.3.3",
     "ink": "^5.2.1",
     "jose": "^6.2.3",

--- a/packages/routecraft/package.json
+++ b/packages/routecraft/package.json
@@ -78,7 +78,7 @@
     "@opentelemetry/sdk-trace-base": "^2.6.0",
     "cheerio": "^1.2.0",
     "croner": "^10.0.1",
-    "fast-xml-parser": "^5.0.0",
+    "fast-xml-parser": "^5.7.0",
     "imapflow": "^1.0.0",
     "jose": "^6.0.0",
     "mailauth": "^4.0.0",

--- a/packages/routecraft/package.json
+++ b/packages/routecraft/package.json
@@ -39,15 +39,16 @@
     "@opentelemetry/sdk-trace-base": "^2.8.0",
     "@routecraft/testing": "workspace:*",
     "@sinonjs/fake-timers": "^11.3.1",
-    "@types/sinonjs__fake-timers": "^15.0.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/mailparser": "^3.4.6",
     "@types/nodemailer": "^6.4.23",
     "@types/papaparse": "^5.5.2",
+    "@types/sinonjs__fake-timers": "^15.0.1",
     "arktype": "^2.2.0",
     "better-sqlite3": "^11.10.0",
     "cheerio": "^1.2.0",
     "croner": "^10.0.1",
+    "fast-xml-parser": "^5.9.2",
     "imapflow": "^1.3.3",
     "mailauth": "^4.13.2",
     "mailparser": "^3.9.8",
@@ -77,6 +78,7 @@
     "@opentelemetry/sdk-trace-base": "^2.6.0",
     "cheerio": "^1.2.0",
     "croner": "^10.0.1",
+    "fast-xml-parser": "^5.0.0",
     "imapflow": "^1.0.0",
     "jose": "^6.0.0",
     "mailauth": "^4.0.0",
@@ -91,6 +93,9 @@
       "optional": true
     },
     "croner": {
+      "optional": true
+    },
+    "fast-xml-parser": {
       "optional": true
     },
     "papaparse": {

--- a/packages/routecraft/src/adapters/xml/destination.ts
+++ b/packages/routecraft/src/adapters/xml/destination.ts
@@ -42,10 +42,17 @@ export class XmlDestinationAdapter implements Destination<unknown, unknown> {
       return deleteAdapter.send(exchange);
     }
 
-    // Write mode: the body must be an object describing the XML document.
-    if (exchange.body === null || typeof exchange.body !== "object") {
+    // Write mode: the body must be a single object describing the XML
+    // document. Arrays are rejected: they have no single root element, so the
+    // builder would emit numerically-named sibling tags (e.g. <0>...</0>) and
+    // an invalid document rather than failing.
+    if (
+      exchange.body === null ||
+      typeof exchange.body !== "object" ||
+      Array.isArray(exchange.body)
+    ) {
       throw new Error(
-        "xml adapter: write mode requires the exchange body to be an object representing the XML document",
+        "xml adapter: write mode requires the exchange body to be a single object representing the XML document (a single root element); arrays produce multiple root elements and an invalid document",
       );
     }
 

--- a/packages/routecraft/src/adapters/xml/destination.ts
+++ b/packages/routecraft/src/adapters/xml/destination.ts
@@ -1,0 +1,74 @@
+import type { Destination, CallableDestination } from "../../operations/to.ts";
+import type { XmlData, XmlFileOptions } from "./types.ts";
+import { file } from "../file/index.ts";
+import { buildXml, parseXml } from "./shared.ts";
+
+/**
+ * XmlDestinationAdapter handles XML file I/O as a destination.
+ *
+ * - `write` (default): build the exchange body (a plain object) into an XML
+ *   document and write it.
+ * - `read`: read the file, parse it, and return the parsed object, so the
+ *   adapter works mid-route via `.enrich()` / `.to()` (like an HTTP GET). Parse
+ *   failures throw; the route boundary surfaces them as `exchange:failed`. The
+ *   `onParseError` lifecycle controls (`'abort'` / `'drop'`) remain source-only.
+ * - `delete`: delete the file and pass the body through unchanged. Idempotent.
+ */
+export class XmlDestinationAdapter implements Destination<unknown, unknown> {
+  readonly adapterId = "routecraft.adapter.xml";
+
+  constructor(private readonly options: XmlFileOptions) {}
+
+  send: CallableDestination<unknown, unknown> = async (exchange) => {
+    const resolvedPath =
+      typeof this.options.path === "function"
+        ? this.options.path(exchange)
+        : this.options.path;
+
+    // Read mode: read the file via the file adapter, then parse and return.
+    if (this.options.mode === "read") {
+      const readAdapter = file({
+        path: resolvedPath,
+        mode: "read",
+        encoding: this.options.encoding || "utf-8",
+      });
+      const content = await readAdapter.send(exchange);
+      return (await parseXml(content, this.options)) as XmlData;
+    }
+
+    // Delete mode: delegate to the file adapter (no build). Idempotent.
+    if (this.options.mode === "delete") {
+      const deleteAdapter = file({ path: resolvedPath, mode: "delete" });
+      return deleteAdapter.send(exchange);
+    }
+
+    // Write mode: the body must be an object describing the XML document.
+    if (exchange.body === null || typeof exchange.body !== "object") {
+      throw new Error(
+        "xml adapter: write mode requires the exchange body to be an object representing the XML document",
+      );
+    }
+
+    let xmlString: string;
+    try {
+      xmlString = await buildXml(exchange.body, this.options);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`xml adapter: failed to build XML: ${message}`);
+    }
+
+    const fileAdapter = file({
+      path: resolvedPath,
+      encoding: this.options.encoding || "utf-8",
+      mode: "write",
+      createDirs: this.options.createDirs || false,
+    });
+
+    await fileAdapter.send({
+      ...exchange,
+      body: xmlString,
+    });
+
+    return undefined;
+  };
+}

--- a/packages/routecraft/src/adapters/xml/destination.ts
+++ b/packages/routecraft/src/adapters/xml/destination.ts
@@ -56,6 +56,21 @@ export class XmlDestinationAdapter implements Destination<unknown, unknown> {
       );
     }
 
+    // An XML document has exactly one root element. The builder emits a
+    // top-level tag for every object key, so a multi-key body like
+    // { a: {...}, b: {...} } would serialise to sibling roots (<a/><b/>) and
+    // an invalid document. Keys starting with "?" are the XML declaration and
+    // processing instructions (e.g. "?xml"), which the builder emits before
+    // the root, so they are not counted as roots.
+    const rootKeys = Object.keys(exchange.body).filter(
+      (key) => !key.startsWith("?"),
+    );
+    if (rootKeys.length !== 1) {
+      throw new Error(
+        `xml adapter: write mode requires the exchange body to have exactly one root element, but found ${rootKeys.length} (${rootKeys.join(", ") || "none"}); wrap your data in a single root object`,
+      );
+    }
+
     let xmlString: string;
     try {
       xmlString = await buildXml(exchange.body, this.options);

--- a/packages/routecraft/src/adapters/xml/index.ts
+++ b/packages/routecraft/src/adapters/xml/index.ts
@@ -1,0 +1,138 @@
+import type { Source } from "../../operations/from.ts";
+import type { Destination } from "../../operations/to.ts";
+import type { Transformer } from "../../operations/transform.ts";
+import { tagAdapter, factoryArgs } from "../shared/factory-tag.ts";
+import type {
+  XmlData,
+  XmlFileOptions,
+  XmlOptions,
+  XmlTransformerOptions,
+} from "./types.ts";
+import { XmlSourceAdapter } from "./source.ts";
+import { XmlDestinationAdapter } from "./destination.ts";
+import { XmlTransformerAdapter } from "./transformer.ts";
+
+/** Combined XML adapter type exposing both Source and Destination interfaces. */
+export type XmlAdapter = Source<XmlData> &
+  Destination<unknown, void> & { readonly adapterId: string };
+
+/**
+ * Read-mode XML adapter. As a destination its `send` reads + parses the file
+ * and returns the parsed object, so it works mid-route via `.enrich()` /
+ * `.to()` (like an HTTP GET). It remains usable as a `.from()` source. The
+ * parsed object is typed `T` (default `XmlData`); pass it explicitly
+ * (`xml<MyDoc>(...)`) for a typed merge.
+ */
+export type XmlReadAdapter<T = XmlData> = Source<T> &
+  Destination<unknown, T> & { readonly adapterId: string };
+
+/**
+ * Creates an XML transformer that parses an XML string already in the body.
+ *
+ * Requires `fast-xml-parser` to be installed as an optional peer dependency.
+ *
+ * @param options - Transformer options (`from`, `to`, parsing options); no `path`
+ * @returns A Transformer
+ */
+export function xml<T = unknown, R = unknown>(
+  options?: XmlTransformerOptions<T, R>,
+): Transformer<T, R> & { readonly adapterId: string };
+/**
+ * Creates a read-mode XML adapter (source, and destination that returns the
+ * parsed object).
+ *
+ * @param options - XML file options with mode: 'read'
+ * @returns A Source + read Destination adapter
+ */
+export function xml<T = XmlData>(
+  options: XmlFileOptions & { mode: "read" },
+): XmlReadAdapter<T>;
+/**
+ * Creates an XML adapter for reading or writing XML files.
+ *
+ * As a **source** (.from):
+ * - Reads an XML file and parses it into a plain object
+ *
+ * As a **destination** (.to):
+ * - Builds the object body into an XML document and writes it
+ * - Can create parent directories automatically
+ * - `mode: 'read'` returns the parsed object mid-route; `mode: 'delete'` removes
+ *   the file (idempotent) and passes the body through
+ *
+ * Requires `fast-xml-parser` to be installed as an optional peer dependency.
+ *
+ * @param options - XML path, parsing / formatting options
+ * @returns Combined Source and Destination adapter
+ *
+ * @example
+ * ```typescript
+ * // Parse an XML string already in the body (transformer mode)
+ * .transform(xml({ from: (b) => b.body }))
+ *
+ * // Read an XML file as a source
+ * .from(xml({ path: './data.xml' }))
+ *
+ * // Read mid-route (destination that returns the parsed object)
+ * .enrich(xml({ path: './data.xml', mode: 'read' }), only((doc) => doc, 'doc'))
+ *
+ * // Write to an XML file (pretty-printed)
+ * .to(xml({ path: './output.xml', format: true }))
+ *
+ * // Delete an XML file (idempotent)
+ * .to(xml({ path: (ex) => ex.body.processedPath, mode: 'delete' }))
+ * ```
+ */
+export function xml(options: XmlFileOptions): XmlAdapter;
+export function xml<T = unknown, R = unknown>(
+  options: XmlOptions<T, R> = {},
+):
+  | (Transformer<T, R> & { readonly adapterId: string })
+  | XmlReadAdapter
+  | XmlAdapter {
+  const args = factoryArgs(options);
+
+  // Transformer mode: no path means parse an XML string already in the body.
+  if (!("path" in options) || options.path === undefined) {
+    const transformer = new XmlTransformerAdapter<T, R>(
+      options as XmlTransformerOptions<T, R>,
+    );
+    return tagAdapter(
+      {
+        adapterId: "routecraft.adapter.xml",
+        transform: transformer.transform.bind(transformer),
+      },
+      xml,
+      args,
+    ) as Transformer<T, R> & { readonly adapterId: string };
+  }
+
+  const fileOptions = options as XmlFileOptions;
+  const source = new XmlSourceAdapter(fileOptions);
+  const destination = new XmlDestinationAdapter(fileOptions);
+  const tagged = tagAdapter(
+    {
+      adapterId: "routecraft.adapter.xml",
+      subscribe: source.subscribe,
+      send: destination.send,
+    },
+    xml,
+    args,
+  );
+  // In read mode `send` resolves to the parsed object; narrow accordingly so
+  // `.enrich()` / `.to()` infer the object. Otherwise `send` is a write (void).
+  // The runtime object is identical; only its declared type differs.
+  if (fileOptions.mode === "read") {
+    return tagged as unknown as XmlReadAdapter;
+  }
+  return tagged as unknown as XmlAdapter;
+}
+
+// Re-export types
+export type {
+  XmlOptions,
+  XmlTransformerOptions,
+  XmlFileOptions,
+  XmlParseOptions,
+  XmlBuildOptions,
+  XmlData,
+} from "./types.ts";

--- a/packages/routecraft/src/adapters/xml/shared.ts
+++ b/packages/routecraft/src/adapters/xml/shared.ts
@@ -13,9 +13,14 @@ let fxpPromise: Promise<typeof import("fast-xml-parser")> | null = null;
  * Load fast-xml-parser as an optional peer dependency. Missing-package
  * failures surface as RC5017 with an install hint.
  *
+ * Source mode calls this eagerly (before the first emit) so a missing peer
+ * surfaces as an honest RC5017 up front, rather than being deferred into the
+ * per-item parse callback where it would be rewrapped as an RC5016 parse
+ * failure (and silently swallowed under `onParseError: 'drop'`).
+ *
  * @internal Not exported from the package public API.
  */
-function getFastXmlParser(): Promise<typeof import("fast-xml-parser")> {
+export function getFastXmlParser(): Promise<typeof import("fast-xml-parser")> {
   fxpPromise ??= loadOptionalPeer(() => import("fast-xml-parser"), {
     adapterName: "xml",
     packageName: "fast-xml-parser",

--- a/packages/routecraft/src/adapters/xml/shared.ts
+++ b/packages/routecraft/src/adapters/xml/shared.ts
@@ -1,0 +1,90 @@
+import { loadOptionalPeer } from "../shared/optional-peer.ts";
+import type { XmlBuildOptions, XmlData, XmlParseOptions } from "./types.ts";
+
+// Memoise the loaded fast-xml-parser module so high-volume xml() calls do not
+// re-pay the dynamic-import lookup or re-allocate the loadOptionalPeer
+// closures. The promise is shared across all callers, so the import happens at
+// most once per process. A rejected promise is intentionally cached too: a
+// genuinely missing peer cannot appear mid-process, so retrying would only
+// reproduce the same RC5017 with the same install hint.
+let fxpPromise: Promise<typeof import("fast-xml-parser")> | null = null;
+
+/**
+ * Load fast-xml-parser as an optional peer dependency. Missing-package
+ * failures surface as RC5017 with an install hint.
+ *
+ * @internal Not exported from the package public API.
+ */
+function getFastXmlParser(): Promise<typeof import("fast-xml-parser")> {
+  fxpPromise ??= loadOptionalPeer(() => import("fast-xml-parser"), {
+    adapterName: "xml",
+    packageName: "fast-xml-parser",
+  });
+  return fxpPromise;
+}
+
+/**
+ * Validate and parse an XML string into a plain object.
+ *
+ * The content is validated first so malformed XML throws a descriptive error
+ * (fast-xml-parser's parser is otherwise lenient and would silently produce a
+ * partial object). Source / read-destination modes surface the throw as an
+ * RC5016 parse failure via the synthetic parse step.
+ *
+ * @internal Not exported from the package public API.
+ */
+export async function parseXml(
+  content: string,
+  options: XmlParseOptions,
+): Promise<XmlData> {
+  const { XMLParser, XMLValidator } = await getFastXmlParser();
+
+  const validation = XMLValidator.validate(content);
+  if (validation !== true) {
+    const { msg, line, col } = validation.err;
+    throw new Error(
+      `xml adapter: parse error at line ${line}, column ${col}: ${msg}`,
+    );
+  }
+
+  const parser = new XMLParser({
+    ignoreAttributes: options.ignoreAttributes ?? false,
+    attributeNamePrefix: options.attributeNamePrefix ?? "@_",
+    textNodeName: options.textNodeName ?? "#text",
+    parseAttributeValue: options.parseAttributeValue ?? false,
+    parseTagValue: options.parseTagValue ?? true,
+    trimValues: options.trimValues ?? true,
+    removeNSPrefix: options.removeNSPrefix ?? false,
+    ...(options.cdataPropName !== undefined
+      ? { cdataPropName: options.cdataPropName }
+      : {}),
+  });
+
+  return parser.parse(content) as XmlData;
+}
+
+/**
+ * Build an XML string from a plain object.
+ *
+ * @internal Not exported from the package public API.
+ */
+export async function buildXml(
+  value: unknown,
+  options: XmlParseOptions & XmlBuildOptions,
+): Promise<string> {
+  const { XMLBuilder } = await getFastXmlParser();
+
+  const builder = new XMLBuilder({
+    ignoreAttributes: options.ignoreAttributes ?? false,
+    attributeNamePrefix: options.attributeNamePrefix ?? "@_",
+    textNodeName: options.textNodeName ?? "#text",
+    format: options.format ?? false,
+    indentBy: options.indentBy ?? "  ",
+    suppressEmptyNode: options.suppressEmptyNode ?? false,
+    ...(options.cdataPropName !== undefined
+      ? { cdataPropName: options.cdataPropName }
+      : {}),
+  });
+
+  return builder.build(value) as string;
+}

--- a/packages/routecraft/src/adapters/xml/shared.ts
+++ b/packages/routecraft/src/adapters/xml/shared.ts
@@ -63,6 +63,21 @@ export async function parseXml(
     ...(options.cdataPropName !== undefined
       ? { cdataPropName: options.cdataPropName }
       : {}),
+    // Our public `isArray` types the jPath argument as a plain string (the
+    // documented common value) for DX. fast-xml-parser's own type widens that
+    // argument to a jPath-or-matcher union, so widen the param to `unknown` at
+    // the boundary to bridge the two without leaking the peer's types into our
+    // public API (which must resolve even when the peer is not installed).
+    ...(options.isArray !== undefined
+      ? {
+          isArray: options.isArray as (
+            tagName: string,
+            jPath: unknown,
+            isLeafNode: boolean,
+            isAttribute: boolean,
+          ) => boolean,
+        }
+      : {}),
   });
 
   return parser.parse(content) as XmlData;

--- a/packages/routecraft/src/adapters/xml/source.ts
+++ b/packages/routecraft/src/adapters/xml/source.ts
@@ -1,7 +1,7 @@
 import type { Source, CallableSource } from "../../operations/from.ts";
 import type { XmlData, XmlFileOptions } from "./types.ts";
 import { file } from "../file/index.ts";
-import { parseXml } from "./shared.ts";
+import { getFastXmlParser, parseXml } from "./shared.ts";
 import { DEFAULT_ON_PARSE_ERROR, isParseError } from "../shared/parse.ts";
 
 /**
@@ -25,6 +25,14 @@ export class XmlSourceAdapter implements Source<XmlData> {
 
   subscribe: CallableSource<XmlData> = async (sub) => {
     const onParseError = this.options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
+
+    // Resolve the optional peer up front so a missing install fails as RC5017
+    // (with an install hint) rather than being deferred into the per-item
+    // parse callback, where the synthetic parse step would rewrap it as an
+    // RC5016 parse failure and `onParseError: 'drop'` would swallow it
+    // silently. Mirrors csv's eager ensurePapaparse(). The promise is
+    // memoised, so the later parse re-await is free.
+    await getFastXmlParser();
 
     const filePath = this.options.path;
     if (typeof filePath !== "string") {

--- a/packages/routecraft/src/adapters/xml/source.ts
+++ b/packages/routecraft/src/adapters/xml/source.ts
@@ -1,0 +1,73 @@
+import type { Source, CallableSource } from "../../operations/from.ts";
+import type { XmlData, XmlFileOptions } from "./types.ts";
+import { file } from "../file/index.ts";
+import { parseXml } from "./shared.ts";
+import { DEFAULT_ON_PARSE_ERROR, isParseError } from "../shared/parse.ts";
+
+/**
+ * XmlSourceAdapter reads XML files and parses them via fast-xml-parser.
+ *
+ * Emits a single exchange whose body is the parsed object. Parsing is deferred
+ * to the route's pipeline by passing a `parse` callback to `emit`: the runtime
+ * applies it as a synthetic first step so a malformed XML file becomes an
+ * observable pipeline event:
+ *
+ * | `onParseError` | Lifecycle on bad XML                                          |
+ * |----------------|---------------------------------------------------------------|
+ * | `'fail'` (default) | `exchange:failed` (or `error:caught` if `.error()` recovers) |
+ * | `'abort'`      | `exchange:failed`, then source rejects and `context:error` fires |
+ * | `'drop'`       | `exchange:dropped` with `reason: "parse-failed"`              |
+ */
+export class XmlSourceAdapter implements Source<XmlData> {
+  readonly adapterId = "routecraft.adapter.xml";
+
+  constructor(private readonly options: XmlFileOptions) {}
+
+  subscribe: CallableSource<XmlData> = async (sub) => {
+    const onParseError = this.options.onParseError ?? DEFAULT_ON_PARSE_ERROR;
+
+    const filePath = this.options.path;
+    if (typeof filePath !== "string") {
+      throw new Error(
+        "xml adapter: path must be a string for source mode (dynamic paths are only supported for destinations)",
+      );
+    }
+
+    const fileAdapter = file({
+      path: filePath,
+      encoding: this.options.encoding || "utf-8",
+    });
+
+    const parseFn = (raw: unknown): Promise<XmlData> =>
+      parseXml(raw as string, this.options);
+
+    // Delegate to the file source with a derived subscription whose emit
+    // attaches the XML parse to the raw file content.
+    await fileAdapter.subscribe({
+      ...sub,
+      emit: async (msg) => {
+        // The raw file content is a string pre-parse; the synthetic parse
+        // step narrows it to XmlData (the standard pre-parse type caveat).
+        const promise = sub.emit({
+          message: msg.message as unknown as XmlData,
+          ...(msg.headers ? { headers: msg.headers } : {}),
+          parse: parseFn,
+          parseFailureMode: onParseError,
+        });
+        // 'abort' is parse-specific: only RC5016 should tear down the source.
+        // A downstream destination error must NOT propagate as an abort signal
+        // even when onParseError === 'abort'. Every other failure is
+        // debug-logged and swallowed (matching json/csv) so the source keeps
+        // reading.
+        return await promise.catch((err: unknown) => {
+          if (onParseError === "abort" && isParseError(err)) throw err;
+          sub.context.logger.debug(
+            { err, path: filePath, adapter: "xml" },
+            "xml adapter: pipeline failed for file; continuing",
+          );
+          return undefined as never;
+        });
+      },
+    });
+  };
+}

--- a/packages/routecraft/src/adapters/xml/transformer.ts
+++ b/packages/routecraft/src/adapters/xml/transformer.ts
@@ -1,0 +1,28 @@
+import type { Transformer } from "../../operations/transform.ts";
+import type { XmlData, XmlTransformerOptions } from "./types.ts";
+import { parseXml } from "./shared.ts";
+import { getBodyText } from "../shared/body-text.ts";
+
+/**
+ * XmlTransformerAdapter parses an XML string already in the exchange body into
+ * a plain object. It is the decode counterpart to the file source: use it when
+ * the XML text arrived in-memory (e.g. an HTTP response) rather than from disk.
+ *
+ * Requires `fast-xml-parser` to be installed as an optional peer dependency.
+ */
+export class XmlTransformerAdapter<
+  T = unknown,
+  R = unknown,
+> implements Transformer<T, R> {
+  readonly adapterId = "routecraft.adapter.xml";
+
+  constructor(private readonly options: XmlTransformerOptions<T, R>) {}
+
+  async transform(body: T): Promise<R> {
+    const text = getBodyText(body, this.options.from, "xml");
+    const parsed: XmlData = await parseXml(text, this.options);
+    const to = this.options.to;
+    if (to) return to(body, parsed);
+    return parsed as unknown as R;
+  }
+}

--- a/packages/routecraft/src/adapters/xml/types.ts
+++ b/packages/routecraft/src/adapters/xml/types.ts
@@ -1,0 +1,165 @@
+import type { Exchange } from "../../exchange.ts";
+import type { OnParseError } from "../shared/parse.ts";
+
+/**
+ * Parsing options shared by transformer, source, and read-destination modes.
+ *
+ * The attribute / text / CDATA naming keys (`attributeNamePrefix`,
+ * `textNodeName`, `cdataPropName`, `ignoreAttributes`) are also honoured when
+ * building XML in destination mode, so a parse then build round-trip preserves
+ * structure when the same options are used on both ends.
+ */
+export interface XmlParseOptions {
+  /**
+   * Drop XML attributes from the parsed output (and omit them when building).
+   * Routecraft defaults this to `false` so attributes survive a round-trip;
+   * fast-xml-parser's own default is `true`.
+   * Default: false
+   */
+  ignoreAttributes?: boolean;
+
+  /**
+   * Prefix applied to attribute keys in the parsed object (and recognised when
+   * building). Default: '@_'
+   */
+  attributeNamePrefix?: string;
+
+  /**
+   * Property name used for the text content of a node that also has attributes
+   * or children. Default: '#text'
+   */
+  textNodeName?: string;
+
+  /**
+   * Property name used for CDATA sections. When omitted, CDATA content is
+   * merged into the node text. Default: undefined
+   */
+  cdataPropName?: string;
+
+  /**
+   * Coerce attribute string values to number / boolean. Default: false
+   */
+  parseAttributeValue?: boolean;
+
+  /**
+   * Coerce tag text values to number / boolean. Default: true
+   */
+  parseTagValue?: boolean;
+
+  /**
+   * Trim whitespace around text values. Default: true
+   */
+  trimValues?: boolean;
+
+  /**
+   * Strip namespace prefixes from tag and attribute names (e.g. `ns:tag` ->
+   * `tag`). Default: false
+   */
+  removeNSPrefix?: boolean;
+}
+
+/**
+ * Formatting options used when building XML in destination write mode.
+ */
+export interface XmlBuildOptions {
+  /**
+   * Pretty-print the output with line breaks and indentation. Default: false
+   */
+  format?: boolean;
+
+  /**
+   * Indentation unit used when `format` is true. Default: '  ' (two spaces)
+   */
+  indentBy?: string;
+
+  /**
+   * Collapse empty nodes to self-closing tags (`<a/>` instead of `<a></a>`).
+   * Default: false
+   */
+  suppressEmptyNode?: boolean;
+}
+
+/**
+ * Transformer-mode options (no `path`): parse an XML string already in the body.
+ */
+export interface XmlTransformerOptions<
+  T = unknown,
+  R = unknown,
+> extends XmlParseOptions {
+  /**
+   * Pluck the XML string from the body. If omitted: body is used when it's a
+   * string, or body.body when body is an object (e.g. after http()).
+   */
+  from?: (body: T) => string;
+
+  /**
+   * Where to put the parsed object. If omitted, the result replaces the entire
+   * body. Use e.g. (body, parsed) => ({ ...body, parsed }) to write to a
+   * sub-field.
+   */
+  to?: (body: T, parsed: XmlData) => R;
+}
+
+/**
+ * Source / Destination mode options (with `path`).
+ *
+ * Note: XML has no `append` mode. Appending serialized fragments to an XML
+ * document produces multiple root elements and an invalid document, so the
+ * adapter deliberately omits it. Read the file, mutate the parsed object, and
+ * write it back instead.
+ */
+export interface XmlFileOptions extends XmlParseOptions, XmlBuildOptions {
+  /**
+   * File path for source / destination mode. A function form (resolved per
+   * exchange) is only valid for destinations.
+   */
+  path: string | ((exchange: Exchange) => string);
+
+  /**
+   * Text encoding. Default: 'utf-8'
+   */
+  encoding?: BufferEncoding;
+
+  /**
+   * Create parent directories if they don't exist (write mode only).
+   * Default: false
+   */
+  createDirs?: boolean;
+
+  /**
+   * File operation mode.
+   * - 'read': Read + parse the XML file. Works as a source (`.from`) and,
+   *   because read mode returns the parsed object, mid-route via `.enrich()` /
+   *   `.to()`. As a destination, parse failures throw (the route boundary
+   *   surfaces them as `exchange:failed`); the `onParseError` lifecycle controls
+   *   apply to source mode only.
+   * - 'write': Build the body object into an XML document and write / overwrite
+   *   the file (destination mode).
+   * - 'delete': Delete the XML file (destination mode). Idempotent: an already-
+   *   absent path is a no-op. The body is unchanged. Supports dynamic paths.
+   * Default: 'read' for source, 'write' for destination
+   */
+  mode?: "read" | "write" | "delete";
+
+  /**
+   * How to handle a parse failure on the file content (source mode only).
+   *
+   * - `'fail'` (default): `exchange:failed` fires; the route's `.error()`
+   *   handler can recover.
+   * - `'abort'`: `exchange:failed` fires, then the source dies
+   *   (`context:error`).
+   * - `'drop'`: `exchange:dropped` fires with `reason: "parse-failed"`.
+   *
+   * See `OnParseError` for full semantics.
+   *
+   * @default "fail"
+   */
+  onParseError?: OnParseError;
+}
+
+export type XmlOptions<T = unknown, R = unknown> =
+  | XmlTransformerOptions<T, R>
+  | XmlFileOptions;
+
+/** A parsed XML document represented as a plain object. */
+export type XmlData = Record<string, unknown>;

--- a/packages/routecraft/src/adapters/xml/types.ts
+++ b/packages/routecraft/src/adapters/xml/types.ts
@@ -56,6 +56,23 @@ export interface XmlParseOptions {
    * `tag`). Default: false
    */
   removeNSPrefix?: boolean;
+
+  /**
+   * Force specific tags to always parse as arrays, regardless of how many
+   * times they occur. Without this, a tag that appears once parses as an
+   * object while repeated occurrences parse as an array, a well-known
+   * fast-xml-parser footgun for consumers that expect a stable shape for
+   * repeatable elements (e.g. `<items><item/></items>`). Return true for the
+   * tags you want to always be arrays.
+   *
+   * Default: undefined (fast-xml-parser's own occurrence-based heuristic)
+   */
+  isArray?: (
+    tagName: string,
+    jPath: string,
+    isLeafNode: boolean,
+    isAttribute: boolean,
+  ) => boolean;
 }
 
 /**

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -332,6 +332,7 @@ export { file } from "./adapters/file/index.ts";
 export { html } from "./adapters/html/index.ts";
 export { json } from "./adapters/json/index.ts";
 export { csv } from "./adapters/csv/index.ts";
+export { xml } from "./adapters/xml/index.ts";
 export { jsonl } from "./adapters/jsonl/index.ts";
 export { group } from "./adapters/group/index.ts";
 export { event } from "./adapters/sources/event/index.ts";
@@ -398,6 +399,16 @@ export {
   type CsvReadAdapter,
   CsvHeaders,
 } from "./adapters/csv/index.ts";
+export {
+  type XmlOptions,
+  type XmlTransformerOptions,
+  type XmlFileOptions,
+  type XmlParseOptions,
+  type XmlBuildOptions,
+  type XmlData,
+  type XmlAdapter,
+  type XmlReadAdapter,
+} from "./adapters/xml/index.ts";
 export {
   type JsonlOptions,
   type JsonlFileOptions,

--- a/packages/routecraft/test/xml.bun.test.ts
+++ b/packages/routecraft/test/xml.bun.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { testContext, spy, type TestContext } from "@routecraft/testing";
+import { craft, simple, xml, only } from "@routecraft/routecraft";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+
+describe("XML Adapter", () => {
+  let t: TestContext;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "xml-adapter-test-"));
+  });
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    if (tmpDir) {
+      await fsp.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("source mode - reading XML files", () => {
+    /**
+     * @case Reads and parses an XML file into a plain object
+     * @preconditions XML file exists with a single root element and children
+     * @expectedResult Body is the parsed object with nested child values
+     */
+    test("reads an XML file", async () => {
+      const filePath = path.join(tmpDir, "data.xml");
+      await fsp.writeFile(
+        filePath,
+        "<note><to>Alice</to><from>Bob</from></note>",
+        "utf-8",
+      );
+
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-read")
+            .from(xml({ path: filePath }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      expect(s.received).toHaveLength(1);
+      expect(s.received[0].body).toEqual({
+        note: { to: "Alice", from: "Bob" },
+      });
+    });
+
+    /**
+     * @case Parses XML attributes with the default prefix
+     * @preconditions XML file has an element carrying attributes
+     * @expectedResult Attributes appear under the '@_' prefix alongside text
+     */
+    test("keeps attributes by default", async () => {
+      const filePath = path.join(tmpDir, "attrs.xml");
+      await fsp.writeFile(
+        filePath,
+        '<book id="42" lang="en">Routecraft</book>',
+        "utf-8",
+      );
+
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-attrs")
+            .from(xml({ path: filePath }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      expect(s.received[0].body).toEqual({
+        book: { "@_id": "42", "@_lang": "en", "#text": "Routecraft" },
+      });
+    });
+  });
+
+  describe("destination mode - writing XML files", () => {
+    /**
+     * @case Builds an object body into an XML document and writes it
+     * @preconditions Route body is a plain object describing one root element
+     * @expectedResult File on disk contains the serialized XML
+     */
+    test("writes an XML file", async () => {
+      const filePath = path.join(tmpDir, "out.xml");
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-write")
+            .from(simple({ note: { to: "Alice", from: "Bob" } }))
+            .to(xml({ path: filePath })),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const written = await fsp.readFile(filePath, "utf-8");
+      expect(written).toBe("<note><to>Alice</to><from>Bob</from></note>");
+    });
+
+    /**
+     * @case Pretty-prints output when format is enabled
+     * @preconditions format: true is set on the destination
+     * @expectedResult Written XML contains newlines and indentation
+     */
+    test("formats output when format is true", async () => {
+      const filePath = path.join(tmpDir, "pretty.xml");
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-format")
+            .from(simple({ note: { to: "Alice" } }))
+            .to(xml({ path: filePath, format: true })),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const written = await fsp.readFile(filePath, "utf-8");
+      expect(written).toContain("\n");
+      expect(written).toContain("  <to>Alice</to>");
+    });
+
+    /**
+     * @case Rejects a non-object body in write mode
+     * @preconditions Route body is a primitive string
+     * @expectedResult The exchange fails (spy receives nothing)
+     */
+    test("fails when the body is not an object", async () => {
+      const filePath = path.join(tmpDir, "invalid.xml");
+      const errors: unknown[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-write-invalid")
+            .error((err) => {
+              errors.push(err);
+              return undefined;
+            })
+            .from(simple("not an object"))
+            .to(xml({ path: filePath })),
+        )
+        .build();
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("read mode - mid-route enrichment", () => {
+    /**
+     * @case Reads an XML file mid-route as a returning destination
+     * @preconditions XML file exists; route enriches under a sub-field
+     * @expectedResult Parsed object is merged onto the body at 'doc'
+     */
+    test("reads a file mid-route via enrich", async () => {
+      const filePath = path.join(tmpDir, "config.xml");
+      await fsp.writeFile(
+        filePath,
+        "<config><level>5</level></config>",
+        "utf-8",
+      );
+
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-enrich")
+            .from(simple({ trigger: true }))
+            .enrich(
+              xml({ path: filePath, mode: "read" }),
+              only((doc) => doc, "doc"),
+            )
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      expect(s.received[0].body).toEqual({
+        trigger: true,
+        doc: { config: { level: 5 } },
+      });
+    });
+  });
+
+  describe("delete mode", () => {
+    /**
+     * @case Deletes an XML file and passes the body through
+     * @preconditions XML file exists on disk
+     * @expectedResult File is removed; body is unchanged
+     */
+    test("deletes a file idempotently", async () => {
+      const filePath = path.join(tmpDir, "gone.xml");
+      await fsp.writeFile(filePath, "<a/>", "utf-8");
+
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-delete")
+            .from(simple({ keep: true }))
+            .to(xml({ path: filePath, mode: "delete" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      await expect(fsp.access(filePath)).rejects.toThrow();
+      expect(s.received[0].body).toEqual({ keep: true });
+    });
+  });
+
+  describe("transformer mode - parsing an XML string in the body", () => {
+    /**
+     * @case Parses an XML string already in the body
+     * @preconditions Body is a raw XML string
+     * @expectedResult Body becomes the parsed object
+     */
+    test("parses an XML string", async () => {
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-transform")
+            .from(simple("<item><sku>A1</sku></item>"))
+            .transform(xml())
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      expect(s.received[0].body).toEqual({ item: { sku: "A1" } });
+    });
+
+    /**
+     * @case Plucks the XML string via from and writes via to
+     * @preconditions Body is an object carrying the XML under 'raw'
+     * @expectedResult Parsed object is written to a sub-field, body preserved
+     */
+    test("supports from and to", async () => {
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-transform-fromto")
+            .from(simple({ raw: "<x><y>1</y></x>", other: true }))
+            .transform(
+              xml({
+                from: (b: { raw: string }) => b.raw,
+                to: (b, parsed) => ({ ...b, parsed }),
+              }),
+            )
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      expect(s.received[0].body).toEqual({
+        raw: "<x><y>1</y></x>",
+        other: true,
+        parsed: { x: { y: 1 } },
+      });
+    });
+  });
+
+  describe("parse error handling", () => {
+    /**
+     * @case Malformed XML surfaces as a recoverable failure by default
+     * @preconditions XML file content is structurally invalid
+     * @expectedResult The route's .error() handler is invoked
+     */
+    test("fails on malformed XML (onParseError default)", async () => {
+      const filePath = path.join(tmpDir, "broken.xml");
+      await fsp.writeFile(filePath, "<note><to>Alice</from></note>", "utf-8");
+
+      const errors: { rc?: string }[] = [];
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-parse-fail")
+            .error((err) => {
+              errors.push(err as { rc?: string });
+              return undefined;
+            })
+            .from(xml({ path: filePath }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errors.length).toBe(1);
+      expect(errors[0].rc).toBe("RC5016");
+      expect(s.received).toHaveLength(0);
+    });
+
+    /**
+     * @case Malformed XML is dropped when onParseError is 'drop'
+     * @preconditions XML file content is structurally invalid; mode 'drop'
+     * @expectedResult No error handler invocation and no downstream delivery
+     */
+    test("drops malformed XML when onParseError is 'drop'", async () => {
+      const filePath = path.join(tmpDir, "broken-drop.xml");
+      await fsp.writeFile(filePath, "<note><to>Alice</from></note>", "utf-8");
+
+      const errors: unknown[] = [];
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-parse-drop")
+            .error((err) => {
+              errors.push(err);
+              return undefined;
+            })
+            .from(xml({ path: filePath, onParseError: "drop" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errors).toHaveLength(0);
+      expect(s.received).toHaveLength(0);
+    });
+  });
+});

--- a/packages/routecraft/test/xml.bun.test.ts
+++ b/packages/routecraft/test/xml.bun.test.ts
@@ -284,6 +284,36 @@ describe("XML Adapter", () => {
         parsed: { x: { y: 1 } },
       });
     });
+
+    /**
+     * @case Malformed XML in transformer mode surfaces as a route failure
+     * @preconditions Body is a structurally invalid XML string
+     * @expectedResult The route's .error() handler is invoked; spy receives nothing
+     */
+    test("fails on malformed XML in transformer mode", async () => {
+      const errors: unknown[] = [];
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-transform-error")
+            .error((err) => {
+              errors.push(err);
+              return undefined;
+            })
+            .from(simple("<bad><unclosed></bad>"))
+            .transform(xml())
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(s.received).toHaveLength(0);
+    });
   });
 
   describe("parse error handling", () => {
@@ -349,6 +379,47 @@ describe("XML Adapter", () => {
       await new Promise((r) => setTimeout(r, 0));
 
       expect(errors).toHaveLength(0);
+      expect(s.received).toHaveLength(0);
+    });
+
+    /**
+     * @case Malformed XML aborts the source when onParseError is 'abort'
+     * @preconditions XML file content is structurally invalid; mode 'abort'
+     * @expectedResult exchange:failed fires with RC5016, then context:error fires
+     */
+    test("aborts the source on malformed XML when onParseError is 'abort'", async () => {
+      const filePath = path.join(tmpDir, "broken-abort.xml");
+      await fsp.writeFile(filePath, "<note><to>Alice</from></note>", "utf-8");
+
+      const s = spy();
+      const failed: { error: unknown }[] = [];
+      const ctxErrs: { error: unknown }[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-parse-abort")
+            .from(xml({ path: filePath, onParseError: "abort" }))
+            .to(s),
+        )
+        .build();
+
+      t.ctx.on(
+        "route:exchange:failed" as never,
+        ((payload: { details: { error: unknown } }) => {
+          failed.push({ error: payload.details.error });
+        }) as never,
+      );
+      t.ctx.on("context:error", (payload) => {
+        ctxErrs.push({ error: payload.details.error });
+      });
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(failed.length).toBe(1);
+      expect((failed[0].error as { rc?: string }).rc).toBe("RC5016");
+      expect(ctxErrs.length).toBeGreaterThanOrEqual(1);
       expect(s.received).toHaveLength(0);
     });
   });

--- a/packages/routecraft/test/xml.bun.test.ts
+++ b/packages/routecraft/test/xml.bun.test.ts
@@ -160,6 +160,97 @@ describe("XML Adapter", () => {
 
       expect(errors.length).toBeGreaterThan(0);
     });
+
+    /**
+     * @case Rejects an array body in write mode
+     * @preconditions Route body is an array (no single root element)
+     * @expectedResult The exchange fails; no file is written
+     */
+    test("fails when the body is an array", async () => {
+      const filePath = path.join(tmpDir, "array.xml");
+      const errors: unknown[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-write-array")
+            .error((err) => {
+              errors.push(err);
+              return undefined;
+            })
+            // A scalar source + transform so the body is genuinely an array;
+            // simple([...]) would iterate and emit each element separately.
+            .from(simple({ trigger: true }))
+            .transform(() => [{ item: 1 }, { item: 2 }])
+            .to(xml({ path: filePath })),
+        )
+        .build();
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errors.length).toBeGreaterThan(0);
+      await expect(fsp.access(filePath)).rejects.toThrow();
+    });
+
+    /**
+     * @case Rejects a multi-root object body in write mode
+     * @preconditions Body object has two top-level element keys
+     * @expectedResult The exchange fails; no file is written
+     */
+    test("fails when the body has multiple root elements", async () => {
+      const filePath = path.join(tmpDir, "multiroot.xml");
+      const errors: unknown[] = [];
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-write-multiroot")
+            .error((err) => {
+              errors.push(err);
+              return undefined;
+            })
+            .from(simple({ a: { x: 1 }, b: { y: 2 } }))
+            .to(xml({ path: filePath })),
+        )
+        .build();
+
+      await t.ctx.start();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errors.length).toBeGreaterThan(0);
+      await expect(fsp.access(filePath)).rejects.toThrow();
+    });
+
+    /**
+     * @case Allows an XML declaration alongside the single root element
+     * @preconditions Body has a "?xml" declaration key plus one element key
+     * @expectedResult File is written with the declaration and single root
+     */
+    test("allows an xml declaration with a single root", async () => {
+      const filePath = path.join(tmpDir, "declared.xml");
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-write-declaration")
+            .from(
+              simple({
+                "?xml": { "@_version": "1.0", "@_encoding": "UTF-8" },
+                note: { to: "Alice" },
+              }),
+            )
+            .to(xml({ path: filePath })),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const written = await fsp.readFile(filePath, "utf-8");
+      expect(written).toBe(
+        '<?xml version="1.0" encoding="UTF-8"?><note><to>Alice</to></note>',
+      );
+    });
   });
 
   describe("read mode - mid-route enrichment", () => {
@@ -283,6 +374,29 @@ describe("XML Adapter", () => {
         other: true,
         parsed: { x: { y: 1 } },
       });
+    });
+
+    /**
+     * @case isArray forces a stable array shape for a single occurrence
+     * @preconditions XML has one <item>; isArray returns true for 'item'
+     * @expectedResult The single item parses as a one-element array
+     */
+    test("isArray forces repeatable elements to arrays", async () => {
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("xml-transform-isarray")
+            .from(simple("<list><item>only</item></list>"))
+            .transform(xml({ isArray: (tag) => tag === "item" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      expect(s.received[0].body).toEqual({ list: { item: ["only"] } });
     });
 
     /**


### PR DESCRIPTION
## What

Adds an `xml` adapter to `@routecraft/routecraft`, completing the file-based codec family alongside `json`, `csv`, and `jsonl`. XML maps to a plain object, and the same factory drops into every DSL slot:

```ts
.transform(xml())                              // parse an XML string already in the body
.from(xml({ path: "./data.xml" }))             // read + parse an XML file (source)
.enrich(xml({ path, mode: "read" }), only(...)) // pull a file in mid-route
.to(xml({ path, format: true }))               // build the object body into XML and write
.to(xml({ path, mode: "delete" }))             // idempotent delete
```

## Why

Consumers working with XML feeds and exports had no first-class codec, unlike JSON/CSV/JSONL. This closes that gap with an adapter that mirrors the existing patterns exactly.

## How it works

- Attributes are kept under the `@_` prefix and element text under `#text` by default, so the same options drive parse and build and a read/write round-trip preserves structure.
- Parsing is deferred to the synthetic parse step, so malformed XML is an observable per-exchange `RC5016` failure honouring `onParseError` (`fail` / `abort` / `drop`), consistent with `json`/`csv`/`jsonl`/`html`.
- `fast-xml-parser` is an optional peer dependency loaded through `loadOptionalPeer` (missing install reports `RC5017` with an install hint) and eagerly resolved in source mode so a missing peer never masquerades as a parse failure. It is a regular dependency of `@routecraft/cli` so the binary bundles it.
- No `append` mode: appending serialized fragments to an XML file yields multiple root elements and an invalid document. Write mode also rejects array bodies for the same reason.

## Scope

- New adapter: `packages/routecraft/src/adapters/xml/` (source, destination, transformer, shared, index, types)
- Exported from the package index; `fast-xml-parser` added as optional peer (core) and dependency (CLI)
- Reference docs page, adapter-grid entry, and overview parse-error list updated
- 13 tests covering source, destination, read, delete, transformer, and all three parse-error modes
- Changeset included (`@routecraft/routecraft` minor, `@routecraft/cli` patch)

## Review

Ran the internal six-lens code review comparing against the sibling file adapters. Standards audit came back FULL; the six real findings (eager peer load, array-body guard, peer-version floor, two error-path tests, changeset) are already fixed in the second commit. Locally green: tests, typecheck, lint, build, and pre-commit hooks all pass.

## Follow-ups (not in this PR, they touch sibling files)

- Extract a shared `memoiseOptionalPeer` helper (`html` and `xml` duplicate it)
- Align the `csv`/`json`/`html` docs option tables to the 5-column standard that this page follows

https://claude.ai/code/session_01DZvEGD782pHgeqTqhpCFcp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZvEGD782pHgeqTqhpCFcp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an `xml` adapter to `@routecraft/routecraft` to read, write, and transform XML as a plain object, mirroring `json`, `csv`, and `jsonl`. It adds consistent parse-error handling and enforces a single-root document when writing.

- **New Features**
  - Transformer: `.transform(xml())` parses an XML string in the body with `from`/`to`, plus `isArray` to force stable array shapes.
  - Source: `.from(xml({ path }))` reads and parses files with `onParseError: 'fail' | 'abort' | 'drop'`; eagerly loads `fast-xml-parser` so a missing peer throws a clear RC5017.
  - Destination: `.to(xml({ path }))` writes XML (supports `format`), requires exactly one root element (arrays and multi-root objects rejected; optional `'?xml'` declaration allowed). `mode: 'read'` returns the parsed doc for `.enrich()`. `mode: 'delete'` removes files idempotently. Dynamic paths and `createDirs` supported. No `append` mode.

- **Migration**
  - Install `fast-xml-parser` when using `@routecraft/routecraft` directly: `bun add fast-xml-parser`. The `@routecraft/cli` bundles it.
  - When writing, ensure the body has a single root element (an optional `'?xml'` declaration is fine). Use `mode: 'read'` to pull XML mid-route; use `mode: 'delete'` to remove files.

<sup>Written for commit 937f3f4f3c5714f1f224734b057f911455338a3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

