### PR TITLE
fix(routecraft): keep config-applier side-effect modules in the bundle

### DIFF
--- a/packages/routecraft/package.json
+++ b/packages/routecraft/package.json
@@ -18,7 +18,8 @@
   ],
   "sideEffects": [
     "./dist/index.js",
-    "./dist/index.cjs"
+    "./dist/index.cjs",
+    "./src/**/config.ts"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Problem

The published `1.0.0-canary-20260706182241` bundle contains **zero** `registerConfigApplier(...)` calls. The `sideEffects` field in `packages/routecraft/package.json` listed only the built dist files, so esbuild treated every *source* module as pure and dropped the side-effect-only imports from `src/index.ts`:

```ts
import "./plugins/http/config.ts";
import "./adapters/cron/config.ts";
import "./adapters/direct/config.ts";
import "./adapters/mail/config.ts";
import "./adapters/carddav/config.ts";
import "./telemetry/config.ts";
```

No config applier is ever registered, so `defineConfig` keys like `mail:` and `telemetry:` are silently ignored. Observed downstream in eywa: the mail source finds no `MailClientManager`, falls back to the standalone client path, and dies with `RC5003: Mail adapter IMAP host is required` despite a fully configured account.

`@routecraft/ai` is unaffected because it has no `sideEffects` field, which is why `agent:`/`llm:`/`mcp:` config keeps working while the core adapters' config keys are dead.

## Fix

Declare `src/**/config.ts` as side-effectful. One line; dist entries stay for downstream bundlers.

## Verification

After `bun run build` on this branch, `dist/index.js` contains all six registrations:

```
registerConfigApplier("carddav"|"cron"|"direct"|"http"|"mail"|"telemetry")
```

The currently published canary contains none.

Worth considering as a follow-up: a build smoke test that greps the bundle for the expected applier registrations, so a future refactor cannot silently drop them again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep config-applier modules in the `routecraft` bundle so `defineConfig` keys (e.g. `mail:`, `telemetry:`) work again and adapters register correctly.

- **Bug Fixes**
  - Marked `./src/**/config.ts` as side-effectful in `packages/routecraft/package.json` to prevent tree-shaking of `registerConfigApplier(...)` imports.
  - Verified build: `dist/index.js` now includes registrations for `carddav`, `cron`, `direct`, `http`, `mail`, and `telemetry`.

<sup>Written for commit a6c2f828533fb443d88ef6cb8a50e9867bd51721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

