### PR TITLE
fix(release): declare the retry backoff change as a v0 minor

### DIFF
--- a/.changeset/retry-factor.md
+++ b/.changeset/retry-factor.md
@@ -1,5 +1,5 @@
 ---
-"@routecraft/routecraft": major
+"@routecraft/routecraft": minor
 ---
 
 Harden `.retry()` backoff and remove the `exponential` option (breaking).

--- a/.standards/ci-cd.md
+++ b/.standards/ci-cd.md
@@ -145,6 +145,8 @@ The core invariant: **`package.json` always holds the LAST RELEASED version**, n
 
 Every PR with a user-facing change adds a changeset: run `bunx changeset`, pick the affected package(s) and bump level, describe the change. Internal-only changes skip it (or use `bunx changeset add --empty` if a status check demands one).
 
+**Bump levels during v0: breaking changes are `minor`, never `major`.** The whole 0.x line is the breaking window (see `api-stability.md`), so a conventional-commit `!` does NOT translate to a `major` changeset. A `major` bump would compute the next version as 1.0.0 and stamp every canary `1.0.0-canary-*` (this happened: a stray `major` shipped 1.0.0 canaries for weeks). `major` is reserved for the deliberate 1.0.0 release and requires explicit maintainer sign-off in the PR.
+
 ### Versioning model
 
 - `.changeset/config.json` declares a `fixed` group, the **core train**: `@routecraft/routecraft`, `@routecraft/cli`, `@routecraft/testing`, `create-routecraft`, `@routecraft/eslint-plugin-routecraft`, `@routecraft/prettier-plugin-routecraft`. These always share one version number.


### PR DESCRIPTION
## Problem

Every canary since July 19 has published as `1.0.0-canary-*` while the project works toward 0.6.0. Root cause: `.changeset/retry-factor.md` declares `"@routecraft/routecraft": major`, and changesets computes the next version from the highest pending bump, so a single `major` on the 0.5.0 base yields 1.0.0 and stamps every canary with it.

## Fix

- `retry-factor.md`: `major` -> `minor`. Per `.standards/api-stability.md` the entire 0.x line is the breaking window, so breaking changes ship as 0.x minors; the retry backoff change belongs in 0.6.0 like every other pending breaking change.
- `.standards/ci-cd.md` (contributor side): records the rule explicitly, since conventional-commit instinct (`!` = major) is exactly how the stray bump got in: **during v0, breaking changes are `minor` in changesets; `major` is reserved for the deliberate 1.0.0 and needs explicit maintainer sign-off.**

## Verification

`bunx changeset status` on this branch: every package now bumps at **minor**, i.e. the core train computes **0.6.0** and the next canary publishes as `0.6.0-canary-*`. The `canary` dist-tag moves to it on that publish, so `@canary` installs resolve the 0.6 line again with no manual tag surgery. The stray `1.0.0-canary-*` versions remain on the registry as unreferenced prereleases (deprecation optional, separate from this PR) and do not burn the eventual real 1.0.0.

https://claude.ai/code/session_01Bmc84goVRNM2nN9XPGekdU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bmc84goVRNM2nN9XPGekdU)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix canary versioning to target the 0.6 line. Change the retry backoff changeset to a v0 minor so the next canary publishes as 0.6.0-canary-*.

- **Bug Fixes**
  - `.changeset/retry-factor.md`: set `@routecraft/routecraft` from `major` to `minor` to restore 0.6.0 canaries.
  - `.standards/ci-cd.md`: document v0 rule — breaking changes use `minor`; `major` is reserved for 1.0.0 with maintainer sign-off.

<sup>Written for commit b16da5f1851aeb75d2c25ab34b86828d7dc0e1d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

