### PR TITLE
docs(routecraft,ai): helper-vs-operation drop note, softer override-only claim

### DIFF
--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -30,11 +30,11 @@ const SUPPORTED_AGENT_KEYS = new Set([
 ]);
 
 /**
- * Fields that can never live in frontmatter because their values are not
- * YAML-expressible (function-form block resolvers, Standard Schema objects
- * with a live `validate` function). They get a pointed error instead of
- * the generic "not yet supported" one, since no future release can lift
- * the limitation; the override map is the permanent home.
+ * Fields whose values are not YAML-expressible today (function-form block
+ * resolvers, Standard Schema objects with a live `validate` function).
+ * They get a pointed error instead of the generic "not yet supported"
+ * one: the override map is their home unless a serializable form (say, a
+ * JSON Schema string for `output`) is ever adopted.
  */
 const OVERRIDE_ONLY_AGENT_KEYS = new Set(["blocks", "output"]);
 

--- a/packages/routecraft/src/auth/delegate.ts
+++ b/packages/routecraft/src/auth/delegate.ts
@@ -123,11 +123,12 @@ function intersect(
  *   requested actor.
  *
  * Note for custom steps calling this helper directly: the `.delegate()`
- * route operation additionally DROPS a non-delegated direct principal when
- * its resolver finds no consent (fail closed; see `DelegateStepOptions`).
- * The helper itself only mints. A custom step that skips minting on a
- * missing grant must decide what happens to the caller's direct principal,
- * or an actor downstream inherits the caller's full authority precisely
+ * route operation defaults to DROPPING a non-delegated direct principal
+ * when its resolver returns `undefined` (fail closed;
+ * `DelegateStepOptions.otherwise: "keep"` is the opt-out). The helper
+ * itself only mints. A custom step that skips minting on a missing grant
+ * must decide what happens to the caller's direct principal, or the
+ * continuation runs with the caller's full direct authority precisely
  * when consent is absent.
  *
  * @example

--- a/packages/routecraft/src/auth/delegate.ts
+++ b/packages/routecraft/src/auth/delegate.ts
@@ -122,6 +122,14 @@ function intersect(
  * @throws RC5037 when `subject.mayAct` is present and no entry matches the
  *   requested actor.
  *
+ * Note for custom steps calling this helper directly: the `.delegate()`
+ * route operation additionally DROPS a non-delegated direct principal when
+ * its resolver finds no consent (fail closed; see `DelegateStepOptions`).
+ * The helper itself only mints. A custom step that skips minting on a
+ * missing grant must decide what happens to the caller's direct principal,
+ * or an actor downstream inherits the caller's full authority precisely
+ * when consent is absent.
+ *
  * @example
  * ```ts
  * const delegated = delegate(ex.principal, zoeIdentity, {


### PR DESCRIPTION
## What

Two comment-level fixes carried from review, both in package code:

- `packages/routecraft/src/auth/delegate.ts`: the `delegate()` helper JSDoc now warns custom-step authors that the `.delegate()` operation's fail-closed drop of undelegated principals (#518) is NOT inherited when calling the helper directly; a custom step that skips minting on a missing grant must decide the direct principal's fate itself.
- `packages/ai/src/agent/loader.ts`: the override-only comment no longer claims the limitation can never be lifted; a serializable schema form (e.g. a JSON Schema string for `output`) could adopt it someday.

## Why now

The canary pipeline publishes only packages changed by the push. #519 repaired the version computation (stray `major` -> `minor`, next version 0.6.0) but touched no package code, so its release run had nothing to publish and the `canary` dist-tag is still parked on the last `1.0.0-canary-*`. This push touches the core train and `@routecraft/ai`, so its canary publishes as `0.6.0-canary-*` and moves the tag onto the 0.6 line.

Note: `@routecraft/os` is untouched and its canary tag stays on the 1.0.0 stray until os next changes; the deprecation sweep marks it meanwhile.

https://claude.ai/code/session_01Bmc84goVRNM2nN9XPGekdU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bmc84goVRNM2nN9XPGekdU)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies docs: the `.delegate()` route operation drops a non-delegated direct principal by default (opt-out with `otherwise: "keep"`), but the `delegate()` helper only mints and never drops—so if a custom step skips minting on a missing grant, the caller’s direct principal continues unless the step decides otherwise. Also softens the override-only note in `@routecraft/ai` agent loader: `blocks`/`output` require overrides today but could accept a serializable form later (e.g., a JSON Schema string for `output`); no runtime changes, and this triggers a canary publish for core and `@routecraft/ai` on the `0.6.0-canary` line.

<sup>Written for commit a96823ed93239613c820c34401f7c9cf0b097dd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

