### PR TITLE
fix(release): declare the input chain fold as a v0 minor

### DIFF
--- a/.changeset/input-chain-fold.md
+++ b/.changeset/input-chain-fold.md
@@ -1,5 +1,5 @@
 ---
-"@routecraft/routecraft": major
+"@routecraft/routecraft": minor
 ---
 
 Fold `.input()` validation into the pre-from filter chain (breaking behaviour change).


### PR DESCRIPTION
## Summary

One-line changeset fix: `.changeset/input-chain-fold.md` declared `"@routecraft/routecraft": major`, which is the one bump level [`.standards/ci-cd.md`](../blob/main/.standards/ci-cd.md) forbids during v0.

This is the same correction #519 applied to `retry-factor.md`. That rule landed roughly an hour before #481 merged, so the pre-existing changeset in that branch was never re-checked against it, and the next canary published as `1.0.0-canary-20260805105331`.

**No behaviour change.** The `.input()` fold is still a breaking behaviour change and is still documented as such in the changeset body and the 0.5-to-0.6 migration guide. Only the release bump level changes.

## Why not a revert of #481

The 1.0.0 canaries are not caused by #481 and reverting it would not be the fix:

| | |
|---|---|
| `retry-factor.md` (`major`) added | 2026-06-18, PR #468 |
| First `1.0.0-canary` published | 2026-06-18 |
| `input-chain-fold.md` reached main | 2026-08-05, PR #481 |

11 of the 12 stray canaries (18 Jun through 4 Aug) predate #481 entirely and came from #468's `major` — the "stray major shipped 1.0.0 canaries for weeks" that #519 diagnosed and fixed. Only `1.0.0-canary-20260805105331` is attributable to #481.

Reverting #481 would drop the `.input()` chain fold, the `.timeout()` AbortSignal propagation, and the config-applier bundle fix, and reopen #423 / #447 / #450, while only incidentally clearing the version (by deleting the changeset file along with everything else).

The computed version depends solely on the changesets pending in `.changeset/` on `main`, so this one word is the whole fix.

## Verification

Ran the real version computation against the current changeset set (with the changelog plugin swapped to the offline one, since `@changesets/changelog-github` needs a token):

```
routecraft 0.6.0    ai 0.6.0    cli 0.6.0    testing 0.6.0
```

The fixed train computes **0.6.0**, not 1.0.0. Working tree restored afterwards.

Full audit of all 18 pending changesets: 15 `minor`, 3 `patch`, **zero `major`**.

## Follow-up worth considering

Nothing mechanically enforces the v0 rule today; it exists only as prose, which is why it has now been violated twice by two different changes. A check in the `validate` job that fails when a `0.x` package gets a `major` changeset would make the rule binding, and an assertion before `changeset publish` would stop a bad version at the registry boundary rather than after it is published. Happy to add either if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg3CYqkxYc6cfiJ6r3sicr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg3CYqkxYc6cfiJ6r3sicr)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release bump for the input chain fold by changing `@routecraft/routecraft` from major to minor during v0. This keeps the train on 0.6.0 and stops accidental 1.0.0-canary publishes.

- **Bug Fixes**
  - Updated `.changeset/input-chain-fold.md` to `minor` per v0 policy; prevents 1.0.0-canary tags.
  - No runtime change; the `.input()` fold remains a breaking behavior within 0.x and is already covered by migration notes.

<sup>Written for commit 7c0b645bcb6d56f574d86c4d322f4537872f64bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

