### PR TITLE
feat(directory): enricher role to list a directory mid-route

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/adapters/csv/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/csv/page.md
@@ -12,6 +12,8 @@ csv(options: CsvFileOptions): CsvAdapter   // Source<CsvData> & Destination<unkn
 
 Read and write CSV files with automatic parsing/formatting. One factory, one type; the operation keyword selects the role: `.from()` reads, `.to()` writes, `.enrich()` reads mid-route. **Requires `papaparse` as a peer dependency.**
 
+"Presence" means the key was **supplied**, not that it holds something truthy. Only an omitted `path` selects the transformer role; a supplied `path` that is empty or `undefined` is refused with `RC5003` rather than silently demoted to a transformer that would ignore every file option passed alongside it.
+
 ```bash
 bun add papaparse
 ```

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/directory/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/directory/page.md
@@ -5,11 +5,13 @@ title: directory
 [← All adapters](/docs/reference/adapters) {% .lead %}
 
 ```ts
-directory(options: DirectoryOptions & { chunked: true }): Source<DirectoryEntry>
-directory(options: DirectoryOptions): Source<DirectoryEntry[]>
+directory(options & { path: string; chunked: true }): DirectoryChunkedAdapter // Source<DirectoryEntry> & Enricher<unknown, DirectoryEntry[]>
+directory(options: DirectoryOptions): DirectoryAdapter                        // Source<DirectoryEntry[]> & Enricher<unknown, DirectoryEntry[]>
 ```
 
 Scan a directory and list its entries. The directory adapter is the "find the files" half of working with a directory; the [`file`](/docs/reference/adapters/file) adapter reads or writes a single file. Compose the two to process every file in a directory.
+
+One factory, one type; the operation keyword selects the role: `.from()` emits the listing, `.enrich()` fetches it mid-route. There is no `send` (a listing is a read), so `.to()` resolves to the same fetch and the listing replaces the body.
 
 By default the source emits a single exchange whose body is the full `DirectoryEntry[]` listing, the same collection-in-one-exchange shape as the non-chunked [`csv`](/docs/reference/adapters/csv) and [`jsonl`](/docs/reference/adapters/jsonl) adapters. Pass `chunked: true` to emit one exchange per entry instead. Filtering is intentionally not built in either way: list the entries, then decide which ones.
 
@@ -36,14 +38,41 @@ craft()
   .to(log())
 ```
 
+**List mid-route:** the adapter's `fetch` returns the sorted `DirectoryEntry[]` listing, so you can list a directory partway through a route with `.enrich()` or `.to()`, the same way [`file`](/docs/reference/adapters/file)'s fetch pulls in a file's content. A listing is a read, so it belongs in the pull-in role. This is what makes the adapter usable inside a [`direct()`](/docs/reference/adapters/direct) capability, where there is no `.from()` slot to hang the listing on. The source role needs a static string path; the enricher also accepts a function, resolved against the exchange when the scan runs.
+
+```ts
+// An agent capability: list candidate files, read them, return the matches
+craft()
+  .from(direct('search-notes'))
+  .to(directory({ path: './notes', recursive: true }))   // body becomes DirectoryEntry[]
+  .transform((entries) => entries.filter((e) => e.ext === '.md'))
+  .split((ex) => ex.body)
+  .enrich(
+    file({ path: (ex) => ex.body.path }),
+    only((content: string) => content, 'content'),
+  )
+  .to(log())
+
+// List a directory whose path depends on the exchange
+craft()
+  .from(direct('inspect-dir'))
+  .enrich(
+    directory({ path: (ex) => ex.body.dir }),
+    only((entries: DirectoryEntry[]) => entries, 'candidates'),
+  )
+  .to(log())
+```
+
+An enclosing [`.timeout()`](/docs/reference/operations/timeout) that expires mid-scan makes the fetch **throw** rather than return the entries it had collected: a truncated listing is indistinguishable from a complete directory, so it is never handed to the route as a body. The source is unaffected (an abort there simply stops emission).
+
 **Options:**
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `path` | `string` | Required | Directory to scan (a source scans one directory, so no dynamic function form) |
+| `path` | `string \| (exchange) => string` | Required | Directory to scan. The source role requires a static string (a source is not per-exchange); the enricher also accepts the function form |
 | `recursive` | `boolean` | `false` | Descend into subdirectories |
 | `includeDirs` | `boolean` | `false` | Emit directory entries too, not just files |
-| `chunked` | `boolean` | `false` | Emit one exchange per entry instead of a single `DirectoryEntry[]` exchange |
+| `chunked` | `boolean` | `false` | Source only: emit one exchange per entry instead of a single `DirectoryEntry[]` exchange. The enricher role is unaffected and still fetches the whole listing |
 
 **Entry shape (`DirectoryEntry`):** the body of every emitted exchange.
 
@@ -69,4 +98,4 @@ craft()
 
 **Robust scanning:** an entry that vanishes between listing and reading its metadata (or a broken symlink) is skipped with a debug log rather than failing the whole scan; any other per-entry failure (for example an unreadable entry) is also skipped but logged as a warning, since the listing is incomplete. A missing or unreadable directory throws (`directory not found`, `not a directory`, or `permission denied`).
 
-**Exported symbols:** `directory`; types `DirectoryAdapter`, `DirectoryOptions`, `DirectoryEntry`
+**Exported symbols:** `directory`; types `DirectoryAdapter`, `DirectoryChunkedAdapter`, `DirectoryOptions`, `DirectoryEntry`

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/html/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/html/page.md
@@ -11,6 +11,8 @@ html(options: HtmlOptions & { path }): HtmlAdapter   // Source<HtmlResult> & Des
 
 Extract data from HTML using CSS selectors (powered by cheerio), or read/write HTML files. The presence of `path` selects the file roles; the operation keyword then picks one: `.from()` reads and extracts, `.to()` writes, `.enrich()` extracts mid-route. Without `path`, `html()` is a transformer over the body.
 
+"Presence" means the key was **supplied**, not that it holds something truthy. Only an omitted `path` selects the transformer role; a supplied `path` that is empty or `undefined` is refused with `RC5003` rather than silently demoted to a transformer that would ignore every file option passed alongside it.
+
 **Transformer role** (in-memory HTML parsing):
 ```ts
 // Extract text from title

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/json/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/json/page.md
@@ -11,6 +11,8 @@ json<T>(options: JsonFileOptions): JsonFileAdapterType<T> // Source<T> & Destina
 
 Parse and format JSON data, or read/write JSON files. The mere presence of `path` selects the file roles: `path` always means a file path, and the transformer's extraction key is `pointer`. With `path`, the operation keyword selects the role: `.from()` reads, `.to()` writes, `.enrich()` reads mid-route.
 
+"Presence" means the key was **supplied**, not that it holds something truthy. Only an omitted `path` selects the transformer role; a supplied `path` that is empty or `undefined` is refused with `RC5003` rather than silently demoted to a transformer that would ignore every file option passed alongside it.
+
 **Transformer role** (in-memory JSON parsing):
 ```ts
 // Parse JSON string from body

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/jsonl/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/jsonl/page.md
@@ -12,6 +12,8 @@ jsonl<T>(options: JsonlFileOptions): JsonlAdapter<T> // Source<T[]> & Destinatio
 
 Read and write [JSON Lines](https://jsonlines.org/) files (one JSON object per line). One factory, one type; the operation keyword selects the role: `.from()` reads, `.to()` writes, `.enrich()` reads mid-route.
 
+"Presence" means the key was **supplied**, not that it holds something truthy. Only an omitted `path` selects the transformer role; a supplied `path` that is empty or `undefined` is refused with `RC5003` rather than silently demoted to a transformer that would ignore every file option passed alongside it.
+
 **Transformer role** (parse a JSONL string already in the body):
 ```ts
 // Parse a JSONL string (e.g. an http() response body) into an array

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/mail/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/mail/page.md
@@ -5,16 +5,24 @@ title: mail
 [← All adapters](/docs/reference/adapters) {% .lead %}
 
 ```ts
-mail(folder: string, options: MailServerOptions): Source<MailBody>
-mail(folder: string): Enricher<unknown, MailFetchResult>
+mail(folder: string, options?: MailServerOptions): MailFolderAdapter
+mail(options: MailServerOptions & { folder: string }): MailFolderAdapter
 mail(action: MailAction): Destination<unknown>
-mail(options: MailServerOptions & { folder: string }): Enricher<unknown, MailFetchResult>
 mail(options?: MailClientOptions): Destination<MailSendPayload>
 ```
 
-Read email via IMAP, send via SMTP, or perform IMAP operations. The adapter has four roles determined by the arguments you pass.
+Read email via IMAP, send via SMTP, or perform IMAP operations. Which role you get is selected by the operation keyword and by which keys you supply, never by how many arguments you pass.
 
-**Source role (IMAP push):** Pass a folder and options to receive new messages via IMAP IDLE or polling. Each new email becomes a separate exchange.
+Naming a folder returns one read adapter, `MailFolderAdapter`, that carries both read roles. The operation keyword picks between them: `.from()` subscribes over IMAP IDLE or polling, `.enrich()` fetches a batch mid-route. The second argument only fills in options, so all four combinations below are valid:
+
+```ts
+.from(mail('INBOX'))                     // subscribe with defaults
+.from(mail('INBOX', { markSeen: true }))
+.enrich(mail('INBOX'))                   // fetch with defaults
+.enrich(mail('INBOX', { unseen: true }))
+```
+
+**Source role (IMAP push):** reached with `.from()`. Each new email becomes a separate exchange, delivered via IMAP IDLE or polling.
 
 The source follows the payload-on-`body`, envelope-on-`headers` convention shared with the HTTP source: the parsed message content (`text`, `html`, `attachments`) lands on `exchange.body` (a [`MailBody`](#mailbody-source-exchange-body)), and the envelope (from, to, subject, date, flags, sender, ...) lands on [`routecraft.mail.*` headers](#source-headers). This means `.input({ body })` validates against the message content alone, and the same `.transform()` / `.filter()` operators compose whether the payload arrived over mail or HTTP.
 

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/xml/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/xml/page.md
@@ -11,6 +11,8 @@ xml<T>(options: XmlFileOptions): XmlAdapter<T>   // Source<T> & Destination<unkn
 
 Read, write, and parse XML using a plain-object representation. With `path`, the operation keyword selects the role: `.from()` reads, `.to()` writes, `.enrich()` reads mid-route. **Requires `fast-xml-parser` as a peer dependency.**
 
+"Presence" means the key was **supplied**, not that it holds something truthy. Only an omitted `path` selects the transformer role; a supplied `path` that is empty or `undefined` is refused with `RC5003` rather than silently demoted to a transformer that would ignore every file option passed alongside it.
+
 ```bash
 bun add fast-xml-parser
 ```

--- a/apps/routecraft.dev/src/components/AdapterGrid.tsx
+++ b/apps/routecraft.dev/src/components/AdapterGrid.tsx
@@ -94,7 +94,7 @@ const adapters: Adapter[] = [
   {
     name: 'directory',
     category: 'File',
-    roles: ['Source'],
+    roles: ['Source', 'Enricher'],
     description:
       'Scan a directory for files, with metadata to filter on; list or per-file.',
   },

--- a/packages/routecraft/src/adapters/directory/enricher.ts
+++ b/packages/routecraft/src/adapters/directory/enricher.ts
@@ -1,6 +1,7 @@
 import type { Enricher, CallableEnricher } from "../../operations/enrich.ts";
 import type { DirectoryEntry, DirectoryOptions } from "./types.ts";
 import { getExchangeContext } from "../../exchange.ts";
+import { rcError } from "../../error.ts";
 import { scanDirectory } from "./scan.ts";
 
 /**
@@ -59,9 +60,15 @@ export class DirectoryEnricherAdapter implements Enricher<
     // never be mistaken for the real contents of the directory. Correctness
     // must not depend on the caller discarding the value.
     if (ctx?.signal?.aborted) {
-      throw new Error(
-        `directory adapter: listing aborted before completion: ${resolvedDir}`,
-      );
+      // RC5011 is what the timeout wrapper throws when its own deadline
+      // fires, so classifying this the same way keeps `.error()` handlers
+      // and retry policy treating a cut-short listing as the timeout it is,
+      // rather than as an opaque adapter failure.
+      throw rcError("RC5011", undefined, {
+        message: `directory adapter: listing aborted before completion: ${resolvedDir}`,
+        suggestion:
+          "Increase the enclosing .timeout() so the scan can finish, or narrow the scan (drop recursive, or point at a smaller directory)",
+      });
     }
 
     return entries;

--- a/packages/routecraft/src/adapters/directory/enricher.ts
+++ b/packages/routecraft/src/adapters/directory/enricher.ts
@@ -1,0 +1,69 @@
+import type { Enricher, CallableEnricher } from "../../operations/enrich.ts";
+import type { DirectoryEntry, DirectoryOptions } from "./types.ts";
+import { getExchangeContext } from "../../exchange.ts";
+import { scanDirectory } from "./scan.ts";
+
+/**
+ * DirectoryEnricherAdapter implements the Enricher (fetch) role for
+ * directories: `fetch` scans the resolved path and returns the sorted
+ * {@link DirectoryEntry}`[]` listing, so `.enrich(directory({ path }))` pulls
+ * a listing into the route mid-flow (and `.to(directory({ path }))` replaces
+ * the body with it, since directory has no `send`). A listing is a read, so
+ * it belongs in the pull-in role alongside a file read.
+ *
+ * This is what makes the adapter usable inside a `direct()` capability, where
+ * there is no `.from()` slot to hang the listing on. Dynamic (function) paths
+ * are supported because the exchange is available when the scan runs; the
+ * source role keeps its static-string requirement.
+ *
+ * `recursive`, `includeDirs`, symlink handling, and the deterministic sort
+ * order are identical to the source: both delegate to {@link scanDirectory}.
+ */
+export class DirectoryEnricherAdapter implements Enricher<
+  unknown,
+  DirectoryEntry[]
+> {
+  readonly adapterId = "routecraft.adapter.directory";
+
+  constructor(private readonly options: DirectoryOptions) {}
+
+  /**
+   * Fetch implementation: scan the resolved path and return the sorted
+   * listing. A missing or unreadable directory throws (`directory not
+   * found`, `not a directory`, `permission denied`), matching the source's
+   * error mapping.
+   */
+  fetch: CallableEnricher<unknown, DirectoryEntry[]> = async (
+    exchange,
+    ctx,
+  ) => {
+    const { path: dir, recursive = false, includeDirs = false } = this.options;
+
+    // Resolve the path (static or dynamic).
+    const resolvedDir = typeof dir === "function" ? dir(exchange) : dir;
+
+    const entries = await scanDirectory(
+      resolvedDir,
+      { recursive, includeDirs },
+      {
+        // An enclosing .timeout() abort stops the stat workers early.
+        signal: ctx?.signal,
+        logger: getExchangeContext(exchange)?.logger,
+      },
+    );
+
+    // An aborted scan returns whatever it had collected, which is a partial
+    // listing indistinguishable from a complete one. That is fine for the
+    // source (abort just stops emission) but not here: the fetched value
+    // becomes the route's body. Throw instead, so a truncated listing can
+    // never be mistaken for the real contents of the directory. Correctness
+    // must not depend on the caller discarding the value.
+    if (ctx?.signal?.aborted) {
+      throw new Error(
+        `directory adapter: listing aborted before completion: ${resolvedDir}`,
+      );
+    }
+
+    return entries;
+  };
+}

--- a/packages/routecraft/src/adapters/directory/index.ts
+++ b/packages/routecraft/src/adapters/directory/index.ts
@@ -1,23 +1,37 @@
 import type { Source } from "../../operations/from.ts";
+import type { Enricher } from "../../operations/enrich.ts";
 import { tagAdapter, factoryArgs } from "../shared/factory-tag.ts";
 import type { DirectoryEntry, DirectoryOptions } from "./types.ts";
 import { DirectorySourceAdapter } from "./source.ts";
+import { DirectoryEnricherAdapter } from "./enricher.ts";
 
 /**
- * Directory adapter type: a source that emits the directory listing as a single
- * `DirectoryEntry[]` exchange (the default, non-chunked shape).
+ * Directory adapter type: source and enricher on one honest type. The
+ * operation keyword selects the role (`.from()` subscribes and emits the
+ * listing, `.enrich()` fetches it mid-route). There is no `send`: a listing
+ * is a read, so `.to(directory({ path }))` resolves to the fetch and the
+ * listing replaces the body.
  */
-export type DirectoryAdapter = Source<DirectoryEntry[]> & {
-  readonly adapterId: string;
-};
+export type DirectoryAdapter = Source<DirectoryEntry[]> &
+  Enricher<unknown, DirectoryEntry[]> & { readonly adapterId: string };
 
 /**
- * Creates a directory source in chunked mode: one exchange per entry, each body a
- * {@link DirectoryEntry}. Filter by metadata or name with `.filter()`, then read
- * content with the file adapter.
+ * Directory adapter type in chunked mode: the source emits one
+ * {@link DirectoryEntry} per exchange. The enricher role is unaffected by
+ * `chunked` (a fetch produces one value) and still returns the full listing.
+ */
+export type DirectoryChunkedAdapter = Source<DirectoryEntry> &
+  Enricher<unknown, DirectoryEntry[]> & { readonly adapterId: string };
+
+/**
+ * Creates a directory adapter in chunked mode: the source emits one exchange
+ * per entry, each body a {@link DirectoryEntry}. Filter by metadata or name
+ * with `.filter()`, then read content with the file adapter. Chunked is a
+ * source-only emission shape, so the path must be a static string.
  *
  * @param options - Directory options with `chunked: true`
- * @returns A Source emitting one {@link DirectoryEntry} per entry
+ * @returns A Source emitting one {@link DirectoryEntry} per entry (plus the
+ *   unchanged enricher role)
  *
  * @example
  * ```typescript
@@ -33,13 +47,23 @@ export type DirectoryAdapter = Source<DirectoryEntry[]> & {
  * ```
  */
 export function directory(
-  options: DirectoryOptions & { chunked: true },
-): Source<DirectoryEntry> & { readonly adapterId: string };
+  options: Omit<DirectoryOptions, "path"> & { path: string; chunked: true },
+): DirectoryChunkedAdapter;
 /**
- * Creates a directory source that scans a directory and emits a single exchange
- * whose body is the full {@link DirectoryEntry}`[]` listing (sorted by relative
- * path). This is the default shape, mirroring the non-chunked `csv` / `jsonl`
- * adapters; pass `chunked: true` to emit one exchange per entry instead.
+ * Creates a directory adapter that scans a directory and produces the full
+ * {@link DirectoryEntry}`[]` listing (sorted by relative path). One factory,
+ * one type; the POSITION in the route selects the role:
+ *
+ * - **`.from(directory({ path }))`** emits a single exchange whose body is the
+ *   listing, mirroring the non-chunked `csv` / `jsonl` adapters; pass
+ *   `chunked: true` to emit one exchange per entry instead. The source role
+ *   needs a static string path.
+ * - **`.enrich(directory({ path }))`** scans the directory mid-route and the
+ *   listing replaces the body (pass an aggregator such as `only()` to merge
+ *   instead). Dynamic (function) paths resolve against the exchange.
+ * - **`.to(directory({ path }))`** has no `send` to prefer, so it resolves to
+ *   the same fetch and the listing becomes the body. This is what makes the
+ *   adapter usable inside a `direct()` capability.
  *
  * Filtering is not built in by design: list the entries, then narrow with the
  * normal operations (`.filter()` per-entry in chunked mode, or `.split()` /
@@ -47,7 +71,7 @@ export function directory(
  * keeps "find the files" and "decide which ones" composable.
  *
  * @param options - Directory path plus `recursive`, `includeDirs`, `chunked`
- * @returns A Source usable with `.from(directory(...))`
+ * @returns The combined Source + Enricher adapter
  *
  * @example
  * ```typescript
@@ -61,16 +85,25 @@ export function directory(
  *     only((content: string) => content, "content"),
  *   )
  *   .to(log());
+ *
+ * // List a directory mid-route, e.g. inside a direct() capability
+ * craft()
+ *   .from(direct("search-notes"))
+ *   .to(directory({ path: "./notes", recursive: true }))
+ *   .transform((entries) => entries.filter((e) => e.ext === ".md"))
+ *   .to(log());
  * ```
  */
 export function directory(options: DirectoryOptions): DirectoryAdapter;
 export function directory(
   options: DirectoryOptions,
-): Source<DirectoryEntry | DirectoryEntry[]> & { readonly adapterId: string } {
+): (Source<DirectoryEntry | DirectoryEntry[]> &
+  Enricher<unknown, DirectoryEntry[]>) & { readonly adapterId: string } {
   return tagAdapter(
     {
       adapterId: "routecraft.adapter.directory",
       subscribe: new DirectorySourceAdapter(options).subscribe,
+      fetch: new DirectoryEnricherAdapter(options).fetch,
     },
     directory,
     factoryArgs(options),
@@ -79,3 +112,7 @@ export function directory(
 
 // Re-export types for the public API.
 export type { DirectoryEntry, DirectoryOptions } from "./types.ts";
+
+// Re-export role classes for internal use, matching the file adapter.
+export { DirectorySourceAdapter } from "./source.ts";
+export { DirectoryEnricherAdapter } from "./enricher.ts";

--- a/packages/routecraft/src/adapters/directory/scan.ts
+++ b/packages/routecraft/src/adapters/directory/scan.ts
@@ -1,0 +1,159 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import type { Dirent, Stats } from "node:fs";
+import type { CraftContext } from "../../context.ts";
+import type { DirectoryEntry, DirectoryOptions } from "./types.ts";
+import { throwDirectoryError } from "../shared/fs-errors.ts";
+
+/**
+ * Max concurrent `stat` calls while resolving directory entries. Bounds the
+ * open-handle count so a huge recursive tree cannot exhaust file descriptors
+ * (EMFILE), while still overlapping the syscall latency that dominates a scan.
+ */
+const STAT_CONCURRENCY = 32;
+
+/**
+ * IO hooks for {@link scanDirectory}. Both are optional so the scan works
+ * from a source subscription (subscription signal + context logger) and from
+ * an enricher fetch (step signal, exchange-resolved logger) alike.
+ *
+ * @internal
+ */
+export interface DirectoryScanIo {
+  /**
+   * When it aborts, workers stop claiming entries and the partial result is
+   * returned. Callers that must not act on a partial listing check the
+   * signal after the scan resolves (the enricher throws; the source simply
+   * stops emitting).
+   */
+  signal?: AbortSignal | undefined;
+  /** Logger for per-entry skip diagnostics; skips are silent when omitted. */
+  logger?: CraftContext["logger"] | undefined;
+}
+
+/**
+ * Scan a directory and return its entries, sorted deterministically. This is
+ * the single scan implementation shared by the directory source (`.from()`)
+ * and the directory enricher (`.enrich()` / `.to()`), so `recursive`,
+ * `includeDirs`, symlink handling, and ordering behave identically in every
+ * role by construction rather than by discipline.
+ *
+ * Entries are sorted by their relative path with separators normalized to
+ * `/`, so emission order (chunked source), array order (non-chunked source),
+ * and the enricher's returned array are deterministic and identical across
+ * platforms (raw `readdir` order, the concurrent stat phase below, and a raw
+ * sort on OS-separator paths are not).
+ *
+ * Symlinks are followed (`stat`): a symlink to a directory is treated as a
+ * directory (skipped unless `includeDirs`), a symlink to a file is listed
+ * with the target's metadata, and a broken symlink is skipped.
+ *
+ * A missing or unreadable directory throws via {@link throwDirectoryError}.
+ *
+ * @internal
+ */
+export async function scanDirectory(
+  dir: string,
+  options: Pick<DirectoryOptions, "recursive" | "includeDirs">,
+  io: DirectoryScanIo = {},
+): Promise<DirectoryEntry[]> {
+  const { recursive = false, includeDirs = false } = options;
+  const { signal, logger } = io;
+
+  let dirents: Dirent[];
+  try {
+    dirents = await fsp.readdir(dir, { withFileTypes: true, recursive });
+  } catch (err) {
+    throwDirectoryError("directory", dir, err);
+  }
+
+  // Resolve each entry's stats with bounded concurrency. The results feed an
+  // in-memory array that is not visible until the whole scan completes, so
+  // there is no backpressure reason to serialise these syscalls, and a large
+  // recursive scan is dominated by stat latency. Directory-ness is decided
+  // from the followed stats, not the Dirent, so a symlink to a directory is
+  // treated consistently for both the includeDirs filter and the returned
+  // isDirectory field.
+  const entries: DirectoryEntry[] = [];
+  let cursor = 0;
+  const resolveEntries = async (): Promise<void> => {
+    while (!signal?.aborted) {
+      // `cursor++` is a single synchronous step (no await between read and
+      // increment), so workers never claim the same index.
+      const index = cursor++;
+      if (index >= dirents.length) return;
+      const dirent = dirents[index];
+
+      // Skip plain directories before paying for a stat. Dirent type
+      // checks reflect lstat semantics, so isDirectory() is false for a
+      // symlink pointing at a directory; those fall through to the
+      // followed stat below and are filtered by the post-stat check.
+      if (!includeDirs && dirent.isDirectory()) continue;
+
+      // Node always sets parentPath on Dirents (>= 22); fall back to the
+      // scanned dir for the non-recursive case to be safe.
+      const parent = dirent.parentPath ?? dir;
+      const fullPath = path.join(parent, dirent.name);
+
+      let stats: Stats;
+      try {
+        stats = await fsp.stat(fullPath);
+      } catch (err) {
+        // ENOENT means the entry vanished between listing and statting,
+        // or is a broken symlink: expected churn, skip at debug. Any
+        // other failure (EACCES, EMFILE, ELOOP) also skips the entry so
+        // one bad node cannot fail the whole scan, but warns, because
+        // the listing is now silently incomplete otherwise.
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          logger?.debug(
+            { err, path: fullPath, adapter: "directory" },
+            "directory adapter: entry vanished or broken symlink; skipping",
+          );
+        } else {
+          logger?.warn(
+            { err, path: fullPath, adapter: "directory" },
+            "directory adapter: could not stat entry; listing is incomplete",
+          );
+        }
+        continue;
+      }
+
+      const isDirectory = stats.isDirectory();
+      if (isDirectory && !includeDirs) continue;
+
+      entries.push({
+        path: fullPath,
+        name: dirent.name,
+        dir: parent,
+        ext: path.extname(dirent.name).toLowerCase(),
+        relativePath: path.relative(dir, fullPath),
+        size: stats.size,
+        modifiedAt: stats.mtime,
+        createdAt: stats.birthtime,
+        isDirectory,
+      });
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(STAT_CONCURRENCY, dirents.length) }, () =>
+      resolveEntries(),
+    ),
+  );
+
+  // Sort on a separator-normalized key so the order is identical across
+  // platforms: a raw sort on relativePath would diverge on Windows, where
+  // the backslash separator (0x5C) sorts after characters that `/` (0x2F)
+  // sorts before (digits, uppercase letters).
+  const sortKey = (e: DirectoryEntry): string =>
+    path.sep === "/"
+      ? e.relativePath
+      : e.relativePath.split(path.sep).join("/");
+  entries.sort((a, b) => {
+    const ka = sortKey(a);
+    const kb = sortKey(b);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
+
+  return entries;
+}

--- a/packages/routecraft/src/adapters/directory/source.ts
+++ b/packages/routecraft/src/adapters/directory/source.ts
@@ -1,5 +1,6 @@
 import type { Source, CallableSource } from "../../operations/from.ts";
 import type { DirectoryEntry, DirectoryOptions } from "./types.ts";
+import { staticSourcePathError } from "../shared/file-role-guards.ts";
 import { scanDirectory } from "./scan.ts";
 
 /**
@@ -43,9 +44,7 @@ export class DirectorySourceAdapter implements Source<
     } = this.options;
 
     if (typeof dir !== "string") {
-      throw new Error(
-        "directory adapter: the source role requires a static string path (dynamic paths are only supported by the enricher role, which runs per exchange)",
-      );
+      throw staticSourcePathError("directory");
     }
 
     // Ready means "wired and able to produce", so signal before scanning

--- a/packages/routecraft/src/adapters/directory/source.ts
+++ b/packages/routecraft/src/adapters/directory/source.ts
@@ -1,16 +1,6 @@
-import * as fsp from "node:fs/promises";
-import * as path from "node:path";
-import type { Dirent, Stats } from "node:fs";
 import type { Source, CallableSource } from "../../operations/from.ts";
 import type { DirectoryEntry, DirectoryOptions } from "./types.ts";
-import { throwDirectoryError } from "../shared/fs-errors.ts";
-
-/**
- * Max concurrent `stat` calls while resolving directory entries. Bounds the
- * open-handle count so a huge recursive tree cannot exhaust file descriptors
- * (EMFILE), while still overlapping the syscall latency that dominates a scan.
- */
-const STAT_CONCURRENCY = 32;
+import { scanDirectory } from "./scan.ts";
 
 /**
  * DirectorySourceAdapter implements the Source interface for scanning a
@@ -20,18 +10,13 @@ const STAT_CONCURRENCY = 32;
  *
  * Filtering is intentionally not built in: list the entries and let the route
  * decide. In chunked mode, filter on the body (`.filter((ex) => ex.body.ext
- * === ".json")`), then read content with the file adapter (`file({ path: (ex)
- * => ex.body.path })`). This keeps "find files" and "decide which ones" as
- * separate, composable steps.
+ * === ".json")`), then read content with the file adapter (`.enrich(file({
+ * path: (ex) => ex.body.path }))`). This keeps "find files" and "decide which
+ * ones" as separate, composable steps.
  *
- * Entries are sorted by their relative path with separators normalized to
- * `/`, so emission order (chunked) and array order (non-chunked) are
- * deterministic and identical across platforms (raw `readdir` order, the
- * concurrent stat phase below, and a raw sort on OS-separator paths are not).
- *
- * Symlinks are followed (`stat`): a symlink to a directory is treated as a
- * directory (skipped unless `includeDirs`), a symlink to a file is emitted
- * with the target's metadata, and a broken symlink is skipped.
+ * The scan itself (entry resolution, symlink handling, deterministic sort
+ * order) lives in {@link scanDirectory}, shared with the enricher role so
+ * every role lists the same tree identically.
  */
 export class DirectorySourceAdapter implements Source<
   DirectoryEntry | DirectoryEntry[]
@@ -59,7 +44,7 @@ export class DirectorySourceAdapter implements Source<
 
     if (typeof dir !== "string") {
       throw new Error(
-        "directory adapter: path must be a string (the directory source scans one directory)",
+        "directory adapter: the source role requires a static string path (dynamic paths are only supported by the enricher role, which runs per exchange)",
       );
     }
 
@@ -67,101 +52,12 @@ export class DirectorySourceAdapter implements Source<
     // rather than after every entry has been emitted.
     sub.ready();
 
-    let dirents: Dirent[];
-    try {
-      dirents = await fsp.readdir(dir, { withFileTypes: true, recursive });
-    } catch (err) {
-      throwDirectoryError("directory", dir, err);
-    }
-
-    // Resolve each entry's stats with bounded concurrency. The results feed an
-    // in-memory array that is not emitted until the whole scan completes, so
-    // (unlike the emit() calls below) there is no backpressure reason to
-    // serialise these syscalls, and a large recursive scan is dominated by
-    // stat latency. Directory-ness is decided from the followed stats, not the
-    // Dirent, so a symlink to a directory is treated consistently for both the
-    // includeDirs filter and the emitted isDirectory field.
-    const entries: DirectoryEntry[] = [];
-    let cursor = 0;
-    const resolveEntries = async (): Promise<void> => {
-      while (!sub.signal.aborted) {
-        // `cursor++` is a single synchronous step (no await between read and
-        // increment), so workers never claim the same index.
-        const index = cursor++;
-        if (index >= dirents.length) return;
-        const dirent = dirents[index];
-
-        // Skip plain directories before paying for a stat. Dirent type
-        // checks reflect lstat semantics, so isDirectory() is false for a
-        // symlink pointing at a directory; those fall through to the
-        // followed stat below and are filtered by the post-stat check.
-        if (!includeDirs && dirent.isDirectory()) continue;
-
-        // Node always sets parentPath on Dirents (>= 22); fall back to the
-        // scanned dir for the non-recursive case to be safe.
-        const parent = dirent.parentPath ?? dir;
-        const fullPath = path.join(parent, dirent.name);
-
-        let stats: Stats;
-        try {
-          stats = await fsp.stat(fullPath);
-        } catch (err) {
-          // ENOENT means the entry vanished between listing and statting,
-          // or is a broken symlink: expected churn, skip at debug. Any
-          // other failure (EACCES, EMFILE, ELOOP) also skips the entry so
-          // one bad node cannot fail the whole scan, but warns, because
-          // the listing is now silently incomplete otherwise.
-          const code = (err as NodeJS.ErrnoException).code;
-          if (code === "ENOENT") {
-            sub.context.logger.debug(
-              { err, path: fullPath, adapter: "directory" },
-              "directory adapter: entry vanished or broken symlink; skipping",
-            );
-          } else {
-            sub.context.logger.warn(
-              { err, path: fullPath, adapter: "directory" },
-              "directory adapter: could not stat entry; listing is incomplete",
-            );
-          }
-          continue;
-        }
-
-        const isDirectory = stats.isDirectory();
-        if (isDirectory && !includeDirs) continue;
-
-        entries.push({
-          path: fullPath,
-          name: dirent.name,
-          dir: parent,
-          ext: path.extname(dirent.name).toLowerCase(),
-          relativePath: path.relative(dir, fullPath),
-          size: stats.size,
-          modifiedAt: stats.mtime,
-          createdAt: stats.birthtime,
-          isDirectory,
-        });
-      }
-    };
-    await Promise.all(
-      Array.from({ length: Math.min(STAT_CONCURRENCY, dirents.length) }, () =>
-        resolveEntries(),
-      ),
+    const entries = await scanDirectory(
+      dir,
+      { recursive, includeDirs },
+      { signal: sub.signal, logger: sub.context.logger },
     );
     if (sub.signal.aborted) return;
-
-    // Sort on a separator-normalized key so the order is identical across
-    // platforms: a raw sort on relativePath would diverge on Windows, where
-    // the backslash separator (0x5C) sorts after characters that `/` (0x2F)
-    // sorts before (digits, uppercase letters).
-    const sortKey = (e: DirectoryEntry): string =>
-      path.sep === "/"
-        ? e.relativePath
-        : e.relativePath.split(path.sep).join("/");
-    entries.sort((a, b) => {
-      const ka = sortKey(a);
-      const kb = sortKey(b);
-      return ka < kb ? -1 : ka > kb ? 1 : 0;
-    });
 
     if (chunked) {
       for (const entry of entries) {

--- a/packages/routecraft/src/adapters/directory/types.ts
+++ b/packages/routecraft/src/adapters/directory/types.ts
@@ -1,3 +1,5 @@
+import type { Exchange } from "../../exchange.ts";
+
 /**
  * One file (or directory) discovered while scanning a directory. This is the
  * body shape the directory source emits, one exchange per entry.
@@ -44,12 +46,21 @@ export interface DirectoryEntry {
 }
 
 /**
- * Options for the directory source. The directory adapter is source-only: it scans
- * a directory and emits one exchange per entry.
+ * Options for the directory adapter, in both of its roles. As a source
+ * (`.from()`) it scans a directory and emits the listing; as an enricher
+ * (`.enrich()` / `.to()`) its `fetch` returns the listing, so a directory can
+ * be listed mid-route (a listing is a read, like the file adapter's fetch).
+ * `recursive`, `includeDirs`, and the deterministic ordering behave
+ * identically in either role; `chunked` is a source-only emission shape.
  */
 export interface DirectoryOptions {
-  /** Directory to scan. Must be a string (a source is not per-exchange). */
-  path: string;
+  /**
+   * Directory to scan: a path string, or a function that returns one.
+   * The source role requires a static string (a source is not per-exchange);
+   * the enricher role also accepts the function form, which receives the
+   * exchange when the scan runs.
+   */
+  path: string | ((exchange: Exchange) => string);
   /**
    * Descend into subdirectories. When false, only the immediate children of
    * `path` are emitted. Default: false.

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -418,6 +418,7 @@ export {
 export {
   type DirectoryOptions,
   type DirectoryAdapter,
+  type DirectoryChunkedAdapter,
   type DirectoryEntry,
 } from "./adapters/directory/index.ts";
 export {

--- a/packages/routecraft/test/directory.bun.test.ts
+++ b/packages/routecraft/test/directory.bun.test.ts
@@ -10,7 +10,10 @@ import {
   directory,
   file,
   only,
+  simple,
   type DirectoryEntry,
+  type DirectoryAdapter,
+  type Exchange,
 } from "@routecraft/routecraft";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
@@ -448,5 +451,373 @@ describe("Directory Adapter - Source", () => {
         testSubscription({ context: t.ctx, handler: () => undefined }),
       ),
     ).rejects.toThrow(/directory not found/);
+  });
+
+  /**
+   * @case The source role rejects a dynamic (function) path at runtime
+   * @preconditions Adapter built with a function path, used via .from(); the
+   *   shape is legal for the enricher role, so only the source guard fires
+   * @expectedResult subscribe rejects, pointing at the enricher role
+   */
+  test("source rejects a dynamic (function) path", async () => {
+    const adapter = directory({ path: () => tmpDir });
+
+    t = await testContext().build();
+
+    await expect(
+      adapter.subscribe(
+        testSubscription({ context: t.ctx, handler: () => undefined }),
+      ),
+    ).rejects.toThrow(/the source role requires a static string path/);
+  });
+});
+
+describe("Directory Adapter - Enricher (list mid-route)", () => {
+  let t: TestContext | undefined;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    t = undefined;
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "directory-fetch-test-"));
+  });
+
+  afterEach(async () => {
+    if (t) {
+      await t.stop();
+      t = undefined;
+    }
+    if (tmpDir) {
+      await fsp.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * @case .to() resolves the fetch (no send exists), so the listing becomes
+   *   the body: a directory can be listed mid-route, e.g. in a capability
+   * @preconditions Directory with three files exists
+   * @expectedResult The body becomes the sorted DirectoryEntry[] listing
+   */
+  test("to() replaces the body with the listing", async () => {
+    await fsp.writeFile(path.join(tmpDir, "b.txt"), "bbb", "utf-8");
+    await fsp.writeFile(path.join(tmpDir, "a.txt"), "aaa", "utf-8");
+    await fsp.writeFile(path.join(tmpDir, "c.txt"), "ccc", "utf-8");
+
+    const s = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("directory-fetch-to")
+          .from(simple("ignored"))
+          .to(directory({ path: tmpDir }))
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    expect(s.received).toHaveLength(1);
+    const entries = s.received[0].body as DirectoryEntry[];
+    expect(entries.map((e) => e.name)).toEqual(["a.txt", "b.txt", "c.txt"]);
+  });
+
+  /**
+   * @case .enrich() with an aggregator merges the listing alongside the body
+   * @preconditions Directory with one file; body carries an unrelated field
+   * @expectedResult The original body survives with the listing merged in
+   */
+  test("enrich merges the listing with an aggregator", async () => {
+    await fsp.writeFile(path.join(tmpDir, "only.txt"), "x", "utf-8");
+
+    const s = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("directory-fetch-enrich")
+          .from(simple({ query: "notes" }))
+          .enrich(
+            directory({ path: tmpDir }),
+            only((entries: DirectoryEntry[]) => entries, "candidates"),
+          )
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    expect(s.received).toHaveLength(1);
+    const body = s.received[0].body as {
+      query: string;
+      candidates: DirectoryEntry[];
+    };
+    expect(body.query).toBe("notes");
+    expect(body.candidates.map((e) => e.name)).toEqual(["only.txt"]);
+  });
+
+  /**
+   * @case The enricher resolves a dynamic (function) path from the exchange,
+   *   which the source role rejects
+   * @preconditions Body carries the directory name; path is a function of it
+   * @expectedResult The directory selected by the body is listed
+   */
+  test("supports a dynamic (function) path", async () => {
+    const sub = path.join(tmpDir, "picked");
+    await fsp.mkdir(sub);
+    await fsp.writeFile(path.join(sub, "inside.txt"), "x", "utf-8");
+
+    const s = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("directory-fetch-dynamic")
+          .from(simple<{ dir: string }>({ dir: sub }))
+          .to(directory({ path: (ex) => (ex.body as { dir: string }).dir }))
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    expect(s.received).toHaveLength(1);
+    const entries = s.received[0].body as DirectoryEntry[];
+    expect(entries.map((e) => e.name)).toEqual(["inside.txt"]);
+  });
+
+  /**
+   * @case Recursive fetch descends into subdirectories
+   * @preconditions Nested directories each contain a file
+   * @expectedResult Files at every depth appear with correct relativePath
+   */
+  test("recursive scan descends into subdirectories", async () => {
+    await fsp.writeFile(path.join(tmpDir, "top.txt"), "1", "utf-8");
+    await fsp.mkdir(path.join(tmpDir, "nested"));
+    await fsp.writeFile(path.join(tmpDir, "nested", "deep.txt"), "2", "utf-8");
+
+    const s = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("directory-fetch-recursive")
+          .from(simple("go"))
+          .to(directory({ path: tmpDir, recursive: true }))
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    const entries = s.received[0].body as DirectoryEntry[];
+    expect(entries.map((e) => e.relativePath).sort()).toEqual([
+      path.join("nested", "deep.txt"),
+      "top.txt",
+    ]);
+  });
+
+  /**
+   * @case includeDirs lists directory entries too in the enricher role
+   * @preconditions Directory contains one file and one subdirectory
+   * @expectedResult Both appear, and the directory is flagged isDirectory
+   */
+  test("includeDirs lists directory entries", async () => {
+    await fsp.writeFile(path.join(tmpDir, "file.txt"), "x", "utf-8");
+    await fsp.mkdir(path.join(tmpDir, "subdir"));
+
+    const s = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("directory-fetch-include-dirs")
+          .from(simple("go"))
+          .to(directory({ path: tmpDir, includeDirs: true }))
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    const entries = s.received[0].body as DirectoryEntry[];
+    expect(entries).toHaveLength(2);
+    expect(entries.find((e) => e.name === "subdir")?.isDirectory).toBe(true);
+  });
+
+  /**
+   * @case An empty directory fetches an empty array, not an error
+   * @preconditions An empty directory exists
+   * @expectedResult The body becomes an empty DirectoryEntry[]
+   */
+  test("empty directory fetches an empty array", async () => {
+    const s = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("directory-fetch-empty")
+          .from(simple("go"))
+          .to(directory({ path: tmpDir }))
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    expect(s.received).toHaveLength(1);
+    expect(s.received[0].body).toEqual([]);
+  });
+
+  /**
+   * @case A missing directory rejects through the shared error mapping
+   * @preconditions Path points to a directory that does not exist
+   * @expectedResult fetch rejects with "directory not found"
+   */
+  test("throws for non-existent directory", async () => {
+    const missing = path.join(tmpDir, "does-not-exist");
+    const adapter = directory({ path: missing });
+
+    await expect(
+      adapter.fetch({ body: undefined, headers: {} } as unknown as Exchange),
+    ).rejects.toThrow(/directory not found/);
+  });
+
+  /**
+   * @case An aborted scan throws instead of returning a partial listing
+   * @preconditions Directory has files; fetch runs with an already-aborted
+   *   signal, as an enclosing .timeout() would supply
+   * @expectedResult fetch rejects rather than resolving with a truncated
+   *   listing that is indistinguishable from a complete one
+   */
+  test("throws when the scan is aborted rather than returning a partial listing", async () => {
+    await fsp.writeFile(path.join(tmpDir, "a.txt"), "a", "utf-8");
+    await fsp.writeFile(path.join(tmpDir, "b.txt"), "b", "utf-8");
+
+    const adapter = directory({ path: tmpDir });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      adapter.fetch({ body: undefined, headers: {} } as unknown as Exchange, {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/aborted before completion/);
+  });
+
+  /**
+   * @case The enricher's listing is identical to the source's for the same
+   *   options, since both delegate to the shared scan
+   * @preconditions A tree with nested files, a subdirectory, and mixed
+   *   extensions; both roles scan it with recursive and includeDirs enabled
+   * @expectedResult The fetched DirectoryEntry[] deep-equals the source's
+   *   emitted body, including order
+   */
+  test("parity: enricher listing equals source listing", async () => {
+    await fsp.writeFile(path.join(tmpDir, "b.md"), "b", "utf-8");
+    await fsp.writeFile(path.join(tmpDir, "a.txt"), "a", "utf-8");
+    await fsp.mkdir(path.join(tmpDir, "sub"));
+    await fsp.writeFile(path.join(tmpDir, "sub", "deep.json"), "{}", "utf-8");
+
+    const options = { path: tmpDir, recursive: true, includeDirs: true };
+    const fromSource = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("directory-parity-source")
+          .from(directory(options))
+          .to(fromSource),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    const adapter: DirectoryAdapter = directory(options);
+    const fetched = await adapter.fetch({
+      body: undefined,
+      headers: {},
+    } as unknown as Exchange);
+
+    expect(fromSource.received).toHaveLength(1);
+    const sourceEntries = fromSource.received[0].body as DirectoryEntry[];
+    expect(fetched).toEqual(sourceEntries);
+    expect(fetched.map((e) => e.relativePath)).toEqual([
+      "a.txt",
+      "b.md",
+      "sub",
+      path.join("sub", "deep.json"),
+    ]);
+  });
+
+  /**
+   * @case The enricher role survives `chunked: true` and still fetches the
+   *   whole listing: chunked is a source-only emission shape, so it must not
+   *   strip the fetch slot from the runtime object (regression guard for
+   *   declared-type-vs-runtime-slot drift)
+   * @preconditions Directory with two files; adapter built with chunked
+   * @expectedResult .enrich() fetches the full DirectoryEntry[], not one entry
+   */
+  test("chunked keeps the enricher role and fetches the whole listing", async () => {
+    await fsp.writeFile(path.join(tmpDir, "a.txt"), "a", "utf-8");
+    await fsp.writeFile(path.join(tmpDir, "b.txt"), "b", "utf-8");
+
+    const chunkedAdapter = directory({ path: tmpDir, chunked: true });
+    expect(typeof chunkedAdapter.fetch).toBe("function");
+
+    const s = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("directory-chunked-fetch")
+          .from(simple({ q: "x" }))
+          .enrich(
+            chunkedAdapter,
+            only((entries: DirectoryEntry[]) => entries, "listing"),
+          )
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    expect(s.received).toHaveLength(1);
+    const body = s.received[0].body as { listing: DirectoryEntry[] };
+    expect(body.listing.map((e) => e.name)).toEqual(["a.txt", "b.txt"]);
+  });
+
+  /**
+   * @case The full capability shape: list, narrow, split, read each file
+   * @preconditions A notes directory with one .md and one .txt file
+   * @expectedResult Only the .md file flows through, with its content read
+   */
+  test("capability shape: list, filter, split, then read each file", async () => {
+    await fsp.writeFile(path.join(tmpDir, "keep.md"), "# Keep", "utf-8");
+    await fsp.writeFile(path.join(tmpDir, "skip.txt"), "ignored", "utf-8");
+
+    const s = spy();
+
+    t = await testContext()
+      .routes(
+        craft()
+          .id("directory-capability")
+          .from(simple("search"))
+          .to(directory({ path: tmpDir, recursive: true }))
+          .transform((entries) => entries.filter((e) => e.ext === ".md"))
+          .split((ex) => ex.body)
+          .enrich(
+            file({ path: (ex) => (ex.body as DirectoryEntry).path }),
+            only((content: string) => content, "content"),
+          )
+          .to(s),
+      )
+      .build();
+
+    await t.ctx.start();
+
+    expect(s.received).toHaveLength(1);
+    const body = s.received[0].body as DirectoryEntry & { content: string };
+    expect(body.name).toBe("keep.md");
+    expect(body.content).toBe("# Keep");
   });
 });

--- a/packages/routecraft/test/directory.bun.test.ts
+++ b/packages/routecraft/test/directory.bun.test.ts
@@ -686,8 +686,8 @@ describe("Directory Adapter - Enricher (list mid-route)", () => {
    * @case An aborted scan throws instead of returning a partial listing
    * @preconditions Directory has files; fetch runs with an already-aborted
    *   signal, as an enclosing .timeout() would supply
-   * @expectedResult fetch rejects rather than resolving with a truncated
-   *   listing that is indistinguishable from a complete one
+   * @expectedResult fetch rejects with the RC5011 timeout code rather than
+   *   resolving with a truncated listing indistinguishable from a complete one
    */
   test("throws when the scan is aborted rather than returning a partial listing", async () => {
     await fsp.writeFile(path.join(tmpDir, "a.txt"), "a", "utf-8");
@@ -697,11 +697,15 @@ describe("Directory Adapter - Enricher (list mid-route)", () => {
     const controller = new AbortController();
     controller.abort();
 
-    await expect(
-      adapter.fetch({ body: undefined, headers: {} } as unknown as Exchange, {
-        signal: controller.signal,
-      }),
-    ).rejects.toThrow(/aborted before completion/);
+    const fetching = adapter.fetch(
+      { body: undefined, headers: {} } as unknown as Exchange,
+      { signal: controller.signal },
+    );
+
+    await expect(fetching).rejects.toThrow(/aborted before completion/);
+    // Classified as a timeout, matching what the timeout wrapper itself
+    // throws, so .error() handlers and retry policy can act on the code.
+    await expect(fetching).rejects.toMatchObject({ rc: "RC5011" });
   });
 
   /**


### PR DESCRIPTION
Closes #527. Rebuilt on the role model (#538) — the branch was reset to `main` and re-implemented, so this is a fresh diff, not the parked destination-mode work.

## Summary

The directory adapter was source-only, so a listing could only be obtained at `.from()`. A listing is a read, which under the role model belongs in the **pull-in role**: `directory()` now implements `Enricher`, so `.enrich(directory({ path }))` fetches the listing mid-route. Since directory has no `send` to prefer, `.to(directory({ path }))` resolves to the same fetch and the listing replaces the body — no new API surface, just the role that was missing.

```ts
// An agent capability: list candidates, read them, return the matches
craft()
  .from(direct('search-notes'))
  .to(directory({ path: './notes', recursive: true }))   // body becomes DirectoryEntry[]
  .transform((entries) => entries.filter((e) => e.ext === '.md'))
  .split((ex) => ex.body)
  .enrich(file({ path: (ex) => ex.body.path }), only((c: string) => c, 'content'))
  .to(log())
```

Without this there is nowhere to hang the listing step inside a `direct()` capability, which forces consumers into `node:fs` and out of the framework.

## Changes

- **`scan.ts`** (new): the scan (bounded-concurrency stat resolution, symlink handling, separator-normalized deterministic sort) extracted from `source.ts` into one implementation shared by both roles, so `recursive`, `includeDirs`, and ordering cannot drift between them.
- **`enricher.ts`** (new): `fetch` resolves the path and returns the sorted `DirectoryEntry[]`, mirroring `file/enricher.ts`. Missing or unreadable directories throw through the shared `throwDirectoryError` mapping.
- **Dynamic paths**: `path` accepts `string | ((exchange) => string)`. The enricher resolves the function against the exchange; the source keeps its static-string requirement, rejected via the shared `staticSourcePathError` helper so the message matches the rest of the file family.
- **Abort semantics**: an aborted scan (enclosing `.timeout()`) makes the fetch throw `RC5011` — the same code the timeout wrapper itself throws — rather than return the entries collected so far. A truncated listing is indistinguishable from a complete directory and must never become a body. The source is unchanged: abort there simply stops emission.
- **`chunked` stays source-only**, and the enricher role is explicitly unaffected (`DirectoryChunkedAdapter` = `Source<DirectoryEntry> & Enricher<unknown, DirectoryEntry[]>`), with a test asserting the runtime object really carries `fetch` when chunked, so the declared type and the runtime slots cannot drift.
- **Docs**: reference page gains the mid-route section, updated signatures, options, and exported symbols; adapter grid roles now `Source, Enricher`.

## Tests

26 in the directory suite: `.to()` replacing the body, `.enrich()` merging with an aggregator, dynamic path, recursive, includeDirs, empty and missing directory, abort-throws with the RC code asserted, chunked-keeps-fetch, the full capability shape end to end, and a parity test asserting the fetched listing deep-equals the source's emitted body for the same options.

Full gate green: typecheck, lint, format, build, and the full bun suite.

## Correction

An earlier revision of this description reported a "pre-existing runtime issue" in which a context with two finite routes would auto-stop after the first completed, so the second never started. **That was wrong, and there is no such bug.** The repro called `.routes(routeA, routeB)`, but `routes()` is not variadic — it takes a single array or route, so the second argument was silently dropped and never registered. With `.routes([routeA, routeB])` both routes start and both receive normally. `bun run typecheck` catches the misuse (`TS2554: Expected 1 arguments, but got 2`); it went unnoticed because the throwaway repro was only ever run through `bun test`, which does not typecheck. No framework change is needed and nothing should be filed.