### PR TITLE
docs(operations): correct stale index card signatures

### DIFF
--- a/apps/routecraft.dev/src/app/docs/reference/operations/cache/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/cache/page.md
@@ -61,6 +61,8 @@ craft()
 - `ttl` (optional) - Time to live in milliseconds. After expiry, the next execution recomputes the value. When omitted, the provider's default expiry applies (the bundled in-memory provider keeps entries until LRU eviction).
 - `provider` (optional) - A `CacheProvider` implementation. Defaults to a process-wide `MemoryCacheProvider` backed by `lru-cache`. Pass a custom provider to plug in Redis, multi-tier, or file-backed stores.
 
+**Memory is bounded by default.** The default `MemoryCacheProvider` caps the store at `max: 1000` entries and evicts the least-recently-used entry once full, so an unbounded key space cannot grow the cache without limit, with or without a `ttl`. Raise or lower the cap with your own instance (`new MemoryCacheProvider({ max: 10_000 })`); there is no unbounded setting.
+
 **Concurrency:** When multiple exchanges race against the same key, the provider's `getOrCompute` is responsible for deduplication. The bundled `MemoryCacheProvider` runs the wrapped step at most once per key per TTL window; concurrent waiters share the result.
 
 **Caching semantics:**

--- a/apps/routecraft.dev/src/components/OperationsIndex.tsx
+++ b/apps/routecraft.dev/src/components/OperationsIndex.tsx
@@ -46,8 +46,8 @@ const ops: Op[] = [
   {
     name: 'tag',
     category: 'Route',
-    signature: '.tag(key, value)',
-    description: 'Attach metadata for filtering and metrics.',
+    signature: '.tag(value)',
+    description: 'Attach one or more tags for filtering and discovery.',
   },
   {
     name: 'batch',
@@ -139,8 +139,8 @@ const ops: Op[] = [
   {
     name: 'authenticate',
     category: 'Transform',
-    signature: '.authenticate(claims)',
-    description: 'Mint a principal from verified claims.',
+    signature: '.authenticate(resolver)',
+    description: 'Mint a principal from claims the resolver has verified.',
   },
   {
     name: 'delegate',
@@ -179,8 +179,9 @@ const ops: Op[] = [
   {
     name: 'validate',
     category: 'Flow Control',
-    signature: '.validate(schema)',
-    description: 'Halt the exchange if the body fails the schema.',
+    signature: '.validate(validator)',
+    description:
+      'Check the body with a validator; the coerced result replaces it.',
   },
   {
     name: 'schema',
@@ -210,8 +211,8 @@ const ops: Op[] = [
   {
     name: 'aggregate',
     category: 'Flow Control',
-    signature: '.aggregate({ key, every })',
-    description: 'Collect exchanges into a batch by key or interval.',
+    signature: '.aggregate(fn?)',
+    description: 'Fold the children of a split back into one exchange.',
   },
   {
     name: 'multicast',
@@ -235,7 +236,7 @@ const ops: Op[] = [
   {
     name: 'sample',
     category: 'Flow Control',
-    signature: '.sample({ every })',
+    signature: '.sample({ every } | { intervalMs })',
     description: 'Pass every Nth exchange, or the first per time window.',
   },
   {
@@ -250,8 +251,9 @@ const ops: Op[] = [
   {
     name: 'tap',
     category: 'Side Effects',
-    signature: '.tap(processor)',
-    description: 'Run a processor without changing the body.',
+    signature: '.tap(target)',
+    description:
+      'Run a destination or enricher fire-and-forget; the body is unchanged.',
   },
   {
     name: 'log',
@@ -262,8 +264,8 @@ const ops: Op[] = [
   {
     name: 'debug',
     category: 'Side Effects',
-    signature: '.debug(selector?)',
-    description: 'Emit a verbose dump of the exchange.',
+    signature: '.debug(formatter?)',
+    description: 'Emit a log line for the exchange at debug level.',
   },
   {
     name: 'to',


### PR DESCRIPTION
Closes #451.

## Summary

The operation index cards in `OperationsIndex.tsx` advertised signatures that no longer matched the shipped builder methods. The per-operation reference pages were already correct, so only the cards changed. Also adds the cache reference confirmation that the default cache provider is memory-bounded.

## State of the issue when picked up

Three of the four items #451 lists had already been fixed by later PRs. Verified against `packages/routecraft/src/builder.ts`:

- **choice** already reads `.choice(when(...), otherwise(...)?)`, matching the shipped variadic `choice<Out>(...descriptors)`.
- **multicast** already reads `.multicast(...paths)`, matching `multicast(...paths: Path<...>[])`.
- **circuitBreaker** is present in the index and correctly *not* marked planned: it is shipped (`circuit-breaker-wrapper.ts`, `RouteBuilder.circuitBreaker`). The issue's request to add it as `planned` is out of date.
- **aggregate** was still stale, and is fixed here.

The `window` op does not exist yet (no `window.ts`, no reference page), so the cross-link #451 asks for has nothing to point at. That stays open for 0.7.0.

## Changes

Since the issue's scope is "fix stale index cards", every card was diffed against its shipped signature rather than only the four named ones. Four further mismatches surfaced:

| Op | Was | Now |
|---|---|---|
| `aggregate` | `.aggregate({ key, every })` | `.aggregate(fn?)` |
| `tag` | `.tag(key, value)` | `.tag(value)` |
| `authenticate` | `.authenticate(claims)` | `.authenticate(resolver)` |
| `validate` | `.validate(schema)` | `.validate(validator)` |
| `sample` | `.sample({ every })` | `.sample({ every } \| { intervalMs })` |
| `tap` | `.tap(processor)` | `.tap(target)` |
| `debug` | `.debug(selector?)` | `.debug(formatter?)` |

Descriptions were corrected alongside the signatures where they were wrong rather than merely imprecise:

- `aggregate` is split-join only; there is no key or interval batching.
- `tag` takes string labels, not key/value pairs (`Tag = KnownTag | (string & {})`).
- `validate` does not halt the exchange; it takes a Validator adapter or callable and the coerced return value replaces the body.
- `tap` accepts a destination or an enricher and runs fire-and-forget, not a processor.

`.input({ body, headers })` and `.output({ body, headers })` were left as-is. Both also accept a bare Standard Schema, so those cards are incomplete rather than wrong, and spelling out the union costs more than it buys on a one-line card.

## Cache memory bounds

Confirmed as a no-op on code, as #451 predicted. `MemoryCacheProvider` defaults to `max: 1000` with LRU eviction (`packages/routecraft/src/operations/cache-provider.ts:142`) and `MemoryCacheProviderOptions` exposes no unbounded setting. Added a one-line confirmation to the cache reference page stating the default bound and that there is no unbounded configuration.

## Verification

- `bun run lint` passes
- `bun run typecheck` passes
- `bun run build` in `apps/routecraft.dev` passes (docs site prerenders all operation pages)

Docs-only change; no runtime code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMby5VeGyBtHgG8theWdP4)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the operations index cards to match current builder method signatures and descriptions, and clarified cache memory bounds with a configurable cap. Addresses #451.

- **Bug Fixes**
  - Operations index: corrected signatures/descriptions for `aggregate` -> `.aggregate(fn?)`, `tag` -> `.tag(value)`, `authenticate` -> `.authenticate(resolver)`, `validate` -> `.validate(validator)`, `sample` -> `.sample({ every } | { intervalMs })`, `tap` -> `.tap(target)`, `debug` -> `.debug(formatter?)`.
  - Cache docs: default `MemoryCacheProvider` caps at 1,000 entries with LRU eviction (backed by `lru-cache`); documented how to change the cap (`new MemoryCacheProvider({ max })`); no unbounded setting.

<sup>Written for commit c0480063331d9c924ba48a07906d12eba4a39168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

