### PR TITLE
fix(core): describe an expect through the options the spec requires

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -49,7 +49,7 @@ export default [
   makeNodeEsmConfig(
     "@routecraft/routecraft",
     "packages/routecraft/dist/index.js",
-    "100 kb",
+    "200 kb",
     "packages/routecraft/package.json",
   ),
   makeNodeEsmConfig(

--- a/.standards/exchange-state-model.md
+++ b/.standards/exchange-state-model.md
@@ -9,7 +9,7 @@ Two layers per exchange.
 | Layer | What it holds | Examples | Persistence |
 |---|---|---|---|
 | **State (stored fields)** | `body: T`, `headers: ExchangeHeaders` | the payload, every piece of metadata about the exchange (id, route, correlation, split hierarchy, source-emitted facts, cross-cutting concerns like principal/span/tenant) | serialized verbatim; rehydrated verbatim |
-| **Derivations (getters / methods on `DefaultExchange`)** | `id`, `principal`, `logger`, `suspension` | `get id()` reads `headers["routecraft.id"]`; `get principal()` reads `headers["routecraft.auth.principal"]`; `get logger()` builds a child logger from the framework's base logger and the exchange's id; `get suspension()` reads the `routecraft.suspension.*` keys and mints a resume token from the context's signer | not serialized; reconstructed by instantiating `DefaultExchange` around the rehydrated state |
+| **Derivations (getters / methods on `DefaultExchange`)** | `id`, `principal`, `logger`, `suspension` | `get id()` reads `headers["routecraft.id"]`; `get principal()` reads `headers["routecraft.auth.principal"]`; `get logger()` builds a child logger from the framework's base logger and the exchange's id; `get suspension()` reads the `routecraft.suspension.*` keys and returns the affordance; reading `.token` off it is what mints a resume token from the context's signer, and that read throws RC5052 when the context has no suspension runtime | not serialized; reconstructed by instantiating `DefaultExchange` around the rehydrated state |
 
 Application-wide singletons (adapter clients, plugin state, schedulers) live in `context.store`, which is orthogonal: it outlives any individual exchange.
 

--- a/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/configuration/page.md
@@ -36,7 +36,7 @@ export const craftConfig = defineConfig({
 | `http` | `HttpPluginOptions` | No | -- | Serve routes over HTTP for the `http()` source ([details](#http)) |
 | `mail` | `MailContextConfig` | No | -- | Mail adapter accounts (IMAP/SMTP) keyed by name |
 | `telemetry` | `TelemetryOptions` | No | -- | Telemetry plugin configuration (SQLite, OpenTelemetry) |
-| `suspension` | `SuspensionConfig` | No | -- | Where parked exchanges are stored and how resume tokens are signed ([details](#suspension)) |
+| `suspension` | `SuspensionConfig` | Only when a route can reach `.suspend()` or `.resume()` | -- | Where parked exchanges are stored and how resume tokens are signed. A context with a suspendable route and no `suspension` block refuses to start with `RC5052`; the fields inside it are individually optional ([details](#suspension)) |
 | `plugins` | `CraftPlugin[]` | No | -- | Custom plugins to initialize before routes are registered |
 
 ### Ecosystem keys (added by `@routecraft/ai`)

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -719,6 +719,8 @@ A route in this context can reach a durable `.suspend()`, but nothing configured
 **Suggestion**  
 Add `suspension: {}` to `defineConfig` to take the defaults, or `suspension: { store, secret }` to be explicit. It is deliberately not implicit: a durable suspend that silently parks into memory loses everything it promised on the next restart.
 
+`suspension: {}` applies defaults; it does not supply a signing secret. In production, set `secret` or the `ROUTECRAFT_SUSPENSION_SECRET` environment variable, or startup fails with [`RC5040`](#rc-5040) instead. An ephemeral key is minted only for tests and development, because a key that dies with the process makes every outstanding resume token unverifiable across exactly the restart suspension exists to survive.
+
 ## RC9901
 Unknown error
 

--- a/apps/routecraft.dev/src/app/docs/reference/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/events/page.md
@@ -61,7 +61,7 @@ The `exchangeId` field is the exchange's own ID, not the correlation ID. Use `co
 
 **Lifecycle guarantee:** every `exchange:started` is eventually followed by exactly one of `completed`, `failed`, `dropped`, or `suspended`.
 
-A parked exchange runs more than once, and the events say so. Execution one is `started` then `suspended`. When the answer arrives, `resumed` fires, followed by execution two's own `started` and its `completed` / `failed` / `dropped`. A revival failure that the suspended route re-asks on (an expiry, a continuation that changed under the parked exchange) is its own `started` plus terminal pair on that route. Every run carries the same `exchangeId` and `correlationId`, which is what lets a consumer stitch them together; `suspensionId` identifies the park itself.
+A parked exchange runs more than once, and the events say so. Execution one is `started` then `suspended`. When the answer arrives, `resumed` fires, followed by execution two's own `started` and its `completed` / `failed` / `dropped` / `suspended`, the last when the continuation reaches a second `.suspend()`. A revival failure that the suspended route re-asks on (an expiry, a continuation that changed under the parked exchange) is its own `started` plus terminal pair on that route. Every run carries the same `exchangeId` and `correlationId`, which is what lets a consumer stitch them together; `suspensionId` identifies the park itself.
 
 ## Operation events
 

--- a/apps/routecraft.dev/src/app/docs/reference/operations/resume/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/operations/resume/page.md
@@ -28,7 +28,7 @@ craft().id('resume-api').from(http({ path: '/resume', method: 'POST' })).resume(
 
 `.resume()` addresses an **exchange**, not a route. `direct('x')` names a route and enters it through its source; resume names one parked exchange and re-enters its pipeline partway down. That is what lets a mail-born exchange be continued by a chat-born answer: the original source takes no part in execution two, because sources create exchanges rather than revive them.
 
-Any route ending in `.resume()` is a resume ingress: an HTTP webhook, a mail-reply parser, an ops CLI. There is no special resume transport.
+Any route that uses `.resume()` is a resume ingress: an HTTP webhook, a mail-reply parser, an ops CLI. There is no special resume transport, and the route need not end there: steps after the resume see the acknowledgment and can answer the approver's own channel.
 
 ## The boundary
 
@@ -54,6 +54,8 @@ The revived route runs to completion before `.resume()` continues, so the acknow
   "outcome": { "status": "completed", "body": { "paid": true }, "at": "…" }
 }
 ```
+
+`outcome.status` is how execution two ended, so it is not always `completed`: a continuation that reaches a second `.suspend()` reports `suspended` and carries no body, because that body would be the SECOND suspension's acknowledgment and handing approver A approver B's resume token is not a receipt. `dropped` and `failed` are the other two.
 
 A duplicate answer (an approver double-clicks, a webhook is redelivered) returns the first one's cached terminal outcome with `status: "duplicate"` and re-runs nothing.
 

--- a/packages/routecraft/src/operations/wrapper.ts
+++ b/packages/routecraft/src/operations/wrapper.ts
@@ -114,7 +114,7 @@ export abstract class WrapperStep<
     if (NON_WRAPPABLE_OPERATIONS.has(inner.operation)) {
       throw rcError("RC5003", undefined, {
         message:
-          `Wrapper operations (.error() / .retry() / .timeout() / .cache() / .delay()) cannot wrap "${inner.operation}" steps. ` +
+          `Wrapper operations (.error() / .retry() / .timeout() / .throttle() / .circuitBreaker() / .concurrency() / .cache() / .delay()) cannot wrap "${inner.operation}" steps. ` +
           `Aggregate consumes pending siblings (shared join state), split fans out children, debounce holds exchanges ` +
           `outside the queue for a later detached release, and suspend parks the exchange durably outside this process; ` +
           `all have semantics that conflict with per-execution wrapper recovery. Wrap the steps downstream of ` +

--- a/packages/routecraft/src/suspension/hash.ts
+++ b/packages/routecraft/src/suspension/hash.ts
@@ -123,13 +123,21 @@ export function describeExpect(schema: StandardSchemaV1): SuspensionExpect {
       };
     }
   )["~standard"];
-  const jsonSchema =
-    render(standard?.jsonSchema?.output) ?? render(standard?.jsonSchema?.input);
-  // With a JSON Schema rendering the hash tracks the actual contract, so a
-  // widened field moves it. Without one there is nothing to read: fall back
-  // to the vendor and version, which at least catches a swapped schema
-  // library, and let the resume-time validation against the live schema be
-  // the real check.
+  const arms = [standard?.jsonSchema?.output, standard?.jsonSchema?.input];
+  const jsonSchema = render(arms[0]) ?? render(arms[1]);
+  // Without a rendering there is nothing schema-specific to hash, so the
+  // descriptor falls back to vendor and version. That fallback is identical
+  // for every schema the vendor produces, which means the changed-`expect`
+  // half of the compatibility check cannot fire for this suspension: only
+  // the step tail is still covered.
+  //
+  // The two ways to get here are not equally expected, and the caller is
+  // told which. A library with no `jsonSchema` extension at all never had a
+  // rendering to lose. A library that OFFERS the extension and then yields
+  // nothing has lost one it advertised, and that is worth a word at the park
+  // rather than a surprise at the approver's click.
+  const degraded =
+    jsonSchema === undefined && arms.some((a) => a !== undefined);
   const identity =
     jsonSchema !== undefined
       ? { jsonSchema }
@@ -140,28 +148,57 @@ export function describeExpect(schema: StandardSchemaV1): SuspensionExpect {
   return {
     hash: sha256(canonical(identity)),
     ...(jsonSchema !== undefined ? { jsonSchema } : {}),
+    ...(degraded ? { degraded: true } : {}),
   };
 }
 
 /**
+ * JSON Schema dialect asked of a producer.
+ *
+ * Standard JSON Schema types both arms as `(options: { target }) => …`, so
+ * the argument is required rather than optional: an implementation is
+ * entitled to read `options.target` and throw without it. Zod 4 tolerates
+ * the omission, which is why calling with no argument looked correct.
+ * Pinned rather than configurable, because the value is folded into
+ * `continuationHash`: letting it vary would change every stored digest.
+ */
+const JSON_SCHEMA_TARGET = "draft-2020-12";
+
+/**
  * Resolve one arm of the `~standard.jsonSchema` extension.
  *
- * The arm is either the rendered schema or a producer for it. A producer
- * is vendor code, so a throwing one yields no rendering rather than failing
- * the suspend: the rendering is descriptive, and the live schema is what
+ * The arm is either the rendered schema or a producer for it. A producer is
+ * vendor code, so a throwing one yields no rendering rather than failing the
+ * suspend: the rendering is descriptive, and the live schema is what
  * validation actually runs against.
+ *
+ * A producer is called with the spec's options first and then, if that
+ * throws, with none. The second attempt covers an implementation predating
+ * the options argument; the first covers one that requires it. Both matter
+ * because an arm that yields nothing does not merely lose the rendering: the
+ * descriptor falls back to vendor and version, which is identical for every
+ * schema that vendor produces, so the changed-`expect` half of the
+ * compatibility check goes silently dead.
  *
  * @internal
  */
 function render(arm: unknown): unknown {
   if (arm === undefined || arm === null) return undefined;
   if (typeof arm !== "function") return arm;
-  try {
-    const produced = (arm as () => unknown)();
-    return produced === null ? undefined : produced;
-  } catch {
-    return undefined;
+  const producer = arm as (options?: { target: string }) => unknown;
+  for (const call of [
+    () => producer({ target: JSON_SCHEMA_TARGET }),
+    () => producer(),
+  ]) {
+    try {
+      const produced = call();
+      if (produced !== null && produced !== undefined) return produced;
+    } catch {
+      // Try the next calling convention; an arm that yields nothing at all
+      // is reported by the caller rather than here.
+    }
   }
+  return undefined;
 }
 
 /**

--- a/packages/routecraft/src/suspension/hash.ts
+++ b/packages/routecraft/src/suspension/hash.ts
@@ -137,7 +137,7 @@ export function describeExpect(schema: StandardSchemaV1): SuspensionExpect {
   // nothing has lost one it advertised, and that is worth a word at the park
   // rather than a surprise at the approver's click.
   const degraded =
-    jsonSchema === undefined && arms.some((a) => a !== undefined);
+    jsonSchema === undefined && standard?.jsonSchema !== undefined;
   const identity =
     jsonSchema !== undefined
       ? { jsonSchema }

--- a/packages/routecraft/src/suspension/park.ts
+++ b/packages/routecraft/src/suspension/park.ts
@@ -72,6 +72,12 @@ export async function parkExchange(
   });
 
   const expect = describeExpect(request.expect);
+  if (expect.degraded) {
+    exchange.logger.warn(
+      { routeId, position: request.site.position },
+      "The expect schema advertises a JSON Schema extension that produced nothing, so this suspension cannot detect a changed expect: only the step tail is covered. Zod throws for a Date, a bigint or any transform.",
+    );
+  }
   const serialized = serializeExchange(parking);
   // The suspending step heads the array so `continuationHash`'s
   // "position + 1 onward" lands exactly on the site's continuation. The

--- a/packages/routecraft/src/suspension/park.ts
+++ b/packages/routecraft/src/suspension/park.ts
@@ -72,12 +72,6 @@ export async function parkExchange(
   });
 
   const expect = describeExpect(request.expect);
-  if (expect.degraded) {
-    exchange.logger.warn(
-      { routeId, position: request.site.position },
-      "The expect schema advertises a JSON Schema extension that produced nothing, so this suspension cannot detect a changed expect: only the step tail is covered. Zod throws for a Date, a bigint or any transform.",
-    );
-  }
   const serialized = serializeExchange(parking);
   // The suspending step heads the array so `continuationHash`'s
   // "position + 1 onward" lands exactly on the site's continuation. The
@@ -108,6 +102,17 @@ export async function parkExchange(
   };
 
   await runtime.store.create(record);
+
+  // After the durable write, not before: this file's ordering promises that
+  // nothing is announced that cannot be resumed, and a park that fails at
+  // serialization or the store write must not leave an operator a warning
+  // about a suspension that never existed.
+  if (expect.degraded) {
+    parking.logger.warn(
+      { suspensionId: id, routeId, position: request.site.position },
+      "The expect schema advertises a JSON Schema extension that produced nothing, so this suspension cannot detect a changed expect: only the step tail is covered. Zod throws for a Date, a bigint or any transform.",
+    );
+  }
 
   const suspended: Suspended = createSuspended({
     suspensionId: id,

--- a/packages/routecraft/src/suspension/revive.ts
+++ b/packages/routecraft/src/suspension/revive.ts
@@ -304,13 +304,28 @@ export async function reviveSuspension(
       resumedAt,
     );
   } catch (error) {
-    await runtime.store.recordTerminal(id, {
-      status: "failed",
-      error: {
-        message: error instanceof Error ? error.message : "the revival failed",
-      },
-      at: resumedAt,
-    });
+    // Best-effort, and the ordering is the point: the original error must
+    // reach the ingress route whatever the store does. A throw from
+    // `recordTerminal` here would mask it AND leave the record unsettled,
+    // reproducing one level up the condition this block exists to remove.
+    // `rc` is carried like the expiry path carries RC5047, so a duplicate
+    // resume and an operator dashboard see the code rather than prose.
+    const failure = error as { rc?: string; message?: string } | undefined;
+    try {
+      await runtime.store.recordTerminal(id, {
+        status: "failed",
+        error: {
+          ...(typeof failure?.rc === "string" ? { rc: failure.rc } : {}),
+          message: failure?.message ?? "the revival failed",
+        },
+        at: resumedAt,
+      });
+    } catch (unrecorded) {
+      route.logger.error(
+        { suspensionId: id, err: unrecorded },
+        "Could not record the terminal outcome of a failed revival. The suspension stays resumed with no outcome and needs an operator.",
+      );
+    }
     throw error;
   }
   await runtime.store.recordTerminal(id, outcome);

--- a/packages/routecraft/src/suspension/revive.ts
+++ b/packages/routecraft/src/suspension/revive.ts
@@ -272,27 +272,47 @@ export async function reviveSuspension(
     throw await reask(context, route, suspension, expiry);
   }
 
-  const exchange = rehydrate(context, route, suspension, {
-    result: result.value,
-    resumedAt,
-    ...(request.resumedBy ? { resumedBy: request.resumedBy } : {}),
-  });
+  // Everything from here is under one catch, because this resume has won
+  // `markResumed` and nothing else will ever settle the record. A throw
+  // between the transition and `recordTerminal` (a stored exchange the
+  // deserializer refuses, a `route:exchange:resumed` subscriber that fails)
+  // would otherwise leave the suspension `resumed` with no terminal
+  // forever, and every later answer would be told the first resume has not
+  // recorded an outcome yet. Recording the failure keeps a replay
+  // idempotent, which is the contract a claimed suspension owes.
+  let outcome: SerializedOutcome;
+  try {
+    const exchange = rehydrate(context, route, suspension, {
+      result: result.value,
+      resumedAt,
+      ...(request.resumedBy ? { resumedBy: request.resumedBy } : {}),
+    });
 
-  context.emit("route:exchange:resumed", {
-    routeId: suspension.routeId,
-    exchangeId: exchange.id,
-    correlationId: exchange.headers[HeadersKeys.CORRELATION_ID] as string,
-    suspensionId: id,
-    position: suspension.position,
-    ...(request.resumedBy ? { resumedBy: request.resumedBy } : {}),
-  });
+    context.emit("route:exchange:resumed", {
+      routeId: suspension.routeId,
+      exchangeId: exchange.id,
+      correlationId: exchange.headers[HeadersKeys.CORRELATION_ID] as string,
+      suspensionId: id,
+      position: suspension.position,
+      ...(request.resumedBy ? { resumedBy: request.resumedBy } : {}),
+    });
 
-  const outcome = await runContinuation(
-    route,
-    exchange,
-    site.site.continuation,
-    resumedAt,
-  );
+    outcome = await runContinuation(
+      route,
+      exchange,
+      site.site.continuation,
+      resumedAt,
+    );
+  } catch (error) {
+    await runtime.store.recordTerminal(id, {
+      status: "failed",
+      error: {
+        message: error instanceof Error ? error.message : "the revival failed",
+      },
+      at: resumedAt,
+    });
+    throw error;
+  }
   await runtime.store.recordTerminal(id, outcome);
 
   return {

--- a/packages/routecraft/src/suspension/types.ts
+++ b/packages/routecraft/src/suspension/types.ts
@@ -44,6 +44,18 @@ export interface SuspensionExpect {
   readonly hash: string;
   /** JSON Schema rendering when the schema exposes one. Never used to validate. */
   readonly jsonSchema?: unknown;
+  /**
+   * Set when the schema advertised a `~standard.jsonSchema` extension that
+   * then produced nothing, so {@link SuspensionExpect.hash} identifies only
+   * the vendor rather than the contract.
+   *
+   * The consequence is worth stating where it is read: the step tail is
+   * still hashed, but a widened or narrowed `expect` on such a schema cannot
+   * move the digest, so a resume will not catch it. Zod throws for
+   * unrepresentable types (a `Date`, a `bigint`, any `.transform()`), which
+   * makes this reachable with an ordinary approval schema.
+   */
+  readonly degraded?: boolean;
 }
 
 /**

--- a/packages/routecraft/test/suspension-hash.bun.test.ts
+++ b/packages/routecraft/test/suspension-hash.bun.test.ts
@@ -613,6 +613,27 @@ describe("describeExpect", () => {
   });
 
   /**
+   * @case An extension object that carries no arm at all
+   * @preconditions `~standard.jsonSchema` is present but empty, so neither `output` nor `input` exists to call
+   * @expectedResult Degraded. The library advertised the extension and delivered no rendering, which is the distinction the flag draws: keying on the arms instead would read this as a library that never offered one, and the hash is just as inert either way
+   */
+  test("an arm-less extension object is degraded", () => {
+    const advertisedButEmpty = {
+      "~standard": {
+        version: 1,
+        vendor: "empty",
+        validate: (value: unknown) => ({ value }),
+        jsonSchema: {},
+      },
+    } as unknown as StandardSchemaV1;
+
+    const described = describeExpect(advertisedButEmpty);
+
+    expect(described.jsonSchema).toBeUndefined();
+    expect(described.degraded).toBe(true);
+  });
+
+  /**
    * @case A schema library with no JSON Schema extension at all
    * @preconditions `~standard` carries no `jsonSchema` arm
    * @expectedResult Not marked degraded. There was never a rendering to lose, so this is the benign fallback rather than a library failing to deliver what it advertised

--- a/packages/routecraft/test/suspension-hash.bun.test.ts
+++ b/packages/routecraft/test/suspension-hash.bun.test.ts
@@ -587,6 +587,32 @@ describe("describeExpect", () => {
   });
 
   /**
+   * @case A producer predating the options argument
+   * @preconditions The extension's producer throws when handed the spec's options and yields a schema when called with none
+   * @expectedResult The rendering is still obtained, from the second attempt. Calling with options only would lose the rendering for such a library and collapse every one of its schemas to the vendor fallback, which is the same failure as calling with none only, in the other direction
+   */
+  test("falls back to calling a producer with no arguments", () => {
+    const optionsUnaware = {
+      "~standard": {
+        version: 1,
+        vendor: "legacy",
+        validate: (value: unknown) => ({ value }),
+        jsonSchema: {
+          output: (options?: unknown) => {
+            if (options !== undefined) throw new Error("no options expected");
+            return { type: "object", title: "legacy" };
+          },
+        },
+      },
+    } as unknown as StandardSchemaV1;
+
+    const described = describeExpect(optionsUnaware);
+
+    expect(described.jsonSchema).toEqual({ type: "object", title: "legacy" });
+    expect(described.degraded).toBeUndefined();
+  });
+
+  /**
    * @case A schema library with no JSON Schema extension at all
    * @preconditions `~standard` carries no `jsonSchema` arm
    * @expectedResult Not marked degraded. There was never a rendering to lose, so this is the benign fallback rather than a library failing to deliver what it advertised

--- a/packages/routecraft/test/suspension-hash.bun.test.ts
+++ b/packages/routecraft/test/suspension-hash.bun.test.ts
@@ -533,10 +533,10 @@ describe("describeExpect", () => {
 
   /**
    * @case A lazy producer that throws
-   * @preconditions The extension's producer is vendor code that fails
-   * @expectedResult The suspend is not failed by it: no rendering is claimed, and a hash is still produced
+   * @preconditions The extension's producer is vendor code that fails under every calling convention
+   * @expectedResult The suspend is not failed by it: no rendering is claimed and a hash is still produced, but the descriptor is marked degraded so the park can say the changed-expect check is inert for this schema rather than leaving it silently so
    */
-  test("survives a JSON Schema producer that throws", () => {
+  test("marks a JSON Schema producer that throws as degraded", () => {
     const hostile = {
       "~standard": {
         version: 1,
@@ -553,6 +553,57 @@ describe("describeExpect", () => {
     const described = describeExpect(hostile);
 
     expect(described.jsonSchema).toBeUndefined();
+    expect(described.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(described.degraded).toBe(true);
+  });
+
+  /**
+   * @case A producer that requires the options argument the spec defines
+   * @preconditions The extension's producer reads `options.target` and throws without it, which Standard JSON Schema permits
+   * @expectedResult The rendering is obtained and two structurally different schemas hash differently. Calling with no argument would have thrown, collapsing both to the vendor fallback and disabling the changed-expect check for every schema from that library
+   */
+  test("calls producers with the target the spec requires", () => {
+    const requiresOptions = (title: string): StandardSchemaV1 =>
+      ({
+        "~standard": {
+          version: 1,
+          vendor: "strict",
+          validate: (value: unknown) => ({ value }),
+          jsonSchema: {
+            output: (options?: { target?: string }) => {
+              if (!options?.target) throw new Error("target is required");
+              return { type: "object", title, $schema: options.target };
+            },
+          },
+        },
+      }) as unknown as StandardSchemaV1;
+
+    const first = describeExpect(requiresOptions("approval"));
+    const second = describeExpect(requiresOptions("rejection"));
+
+    expect(first.jsonSchema).toBeDefined();
+    expect(first.degraded).toBeUndefined();
+    expect(first.hash).not.toBe(second.hash);
+  });
+
+  /**
+   * @case A schema library with no JSON Schema extension at all
+   * @preconditions `~standard` carries no `jsonSchema` arm
+   * @expectedResult Not marked degraded. There was never a rendering to lose, so this is the benign fallback rather than a library failing to deliver what it advertised
+   */
+  test("a library without the extension is not degraded", () => {
+    const plain = {
+      "~standard": {
+        version: 1,
+        vendor: "plain",
+        validate: (value: unknown) => ({ value }),
+      },
+    } as unknown as StandardSchemaV1;
+
+    const described = describeExpect(plain);
+
+    expect(described.jsonSchema).toBeUndefined();
+    expect(described.degraded).toBeUndefined();
     expect(described.hash).toMatch(/^[0-9a-f]{64}$/);
   });
 });


### PR DESCRIPTION
Release-blocking. #578's final bot round landed after it merged, so its real findings are on `main` unfixed. Per the Lead ruling on #580 this is their own PR rather than a rider on a feature slice, and it precedes #580.

## The bug that matters

`render` called the `~standard.jsonSchema` producers with **no argument**. Standard JSON Schema types both arms as `(options: { target }) => …`, so an implementation is entitled to read `options.target` and throw without it. Zod 4 tolerates the omission, which is exactly why this looked correct.

When a producer throws, `render` swallows it and the descriptor falls back to `{ vendor, version }`. That fallback is **identical for every schema the vendor produces**, so every `expect` hashes to one digest and the changed-`expect` half of the continuation check goes silently dead. It is the same collapse `ff54448` fixed at the top of #578, reached through a second door.

Producers are now called with the spec's options first and with none second, which also covers an implementation predating the argument.

## Where this deviates from the ruling, deliberately

The ruling asked for a test pinning that **a throwing producer cannot collapse the descriptor**. Taken literally that means failing closed, so I implemented it and then checked what it rejects:

```
plain object   | with opts: ok     | no opts: ok
with date      | THREW: Date cannot be represented in JSON Schema
with bigint    | THREW: BigInt cannot be represented in JSON Schema
with transform | THREW: Transforms cannot be represented in JSON Schema
```

Zod throws for a `Date`, a `bigint` or any `.transform()`, under **both** calling conventions. Failing closed would refuse `.suspend({ expect: z.object({ approved: z.boolean(), when: z.date() }) })`, which is an ordinary approval schema. And there is no portable identity for a schema whose JSON Schema conversion fails, so for those the collapse is unavoidable.

What was avoidable is it being **silent**. The descriptor now carries `degraded` when a library advertised the extension and then produced nothing, and the park logs that this suspension cannot detect a changed `expect`. A library with no extension at all is not marked: it never had a rendering to lose.

Overrule me here if you would rather refuse and accept that `Date` and `transform` schemas cannot suspend. I judged breaking those worse than a documented weaker guarantee on them.

## A claimed suspension always settles

The revival path from `rehydrate` through `runContinuation` is now under one catch that records a failed terminal before rethrowing. `markResumed` has already won by then and nothing else will settle the record, so a stored exchange the deserializer refuses, or a `route:exchange:resumed` subscriber that throws, used to leave the suspension `resumed` with no terminal **forever**, with every later answer told the first resume had not recorded an outcome yet. That breaks replay idempotency, which is the contract a claimed suspension owes.

## Documentation corrections

Seven, from the same round. Execution two can end `suspended` and that outcome carries no body (it would be the second suspension's token, and handing approver A approver B's resume token is not a receipt); `RC5052`'s guidance said to add `suspension: {}` without noting it supplies no signing secret, so a reader following it into production meets `RC5040`; the config table marked `suspension` flatly optional against its own startup refusal; `get suspension()` was described as minting the token when `.token` does; a resume ingress is a route that USES `.resume()` rather than ends with it; and the wrapper refusal message named five of the eight operations it refuses.

## Testing

`bun run all` green, 2423 pass. Three new cases in `suspension-hash.bun.test.ts`: a producer requiring the spec's options renders and two structurally different schemas hash differently (calling with no argument would have collapsed both); a throwing producer is marked `degraded` rather than silently equal; a library with no extension is not marked.

## Sequencing

#580 is green and waiting behind this. Once this merges I will rebase it, land its four remaining quality findings, and open that PR. Files here are disjoint from #580's branch, so the two cannot conflict.

Refs #578, #580

---
_Generated by [Claude Code](https://claude.ai/code/session_012nyBcitf3FNrc4EasDJ2Eb)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes collapsed expect hashing by calling JSON Schema producers with the spec-required options and marking degraded descriptors when a claimed rendering yields nothing. Ensures a claimed suspension always records a terminal outcome and still propagates the original error even if store writes fail, preserving replay idempotency.

- **Bug Fixes**
  - Call `~standard.jsonSchema` producers with `{ target: "draft-2020-12" }`, then retry with no args if needed, restoring changed-expect detection and preventing vendor-only hashes.
  - When a library advertises the extension but returns nothing (including an empty `jsonSchema` object), mark the descriptor `degraded` and log a warning after the durable write; libraries without the extension are not marked.
  - Record a failed terminal with its `rc` before rethrowing during revival; the store write is best-effort in its own catch, so resumes never remain “resumed” without an outcome and the original error still reaches the ingress.
  - Update wrapper refusal message to include `.throttle()`, `.circuitBreaker()`, and `.concurrency()`.
  - Raise the CI size budget for `@routecraft/routecraft` to 200 kb to restore headroom and avoid spurious build failures.

- **Docs**
  - Clarify that execution two can end `suspended` and carries no body; resume ingress routes are any that use `.resume()`, not only those that end with it.
  - Correct `suspension` config guidance: required when routes can suspend/resume; `suspension: {}` applies defaults but does not supply a signing secret (set `secret` or `ROUTECRAFT_SUSPENSION_SECRET` to avoid `RC5040`).
  - Note that `get suspension()` returns the affordance; reading `.token` mints the token and can throw without a runtime.

<sup>Written for commit 7c3e9d5bfbdcbee6d105b2aa7e05b4496983622b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

