### PR TITLE
feat(cli,ai,core): craft start and Claude Code agent-file compatibility

### DIFF
--- a/.changeset/craft-start-project-runtime.md
+++ b/.changeset/craft-start-project-runtime.md
@@ -1,0 +1,19 @@
+---
+"@routecraft/routecraft": minor
+"@routecraft/cli": minor
+"@routecraft/ai": minor
+---
+
+`craft start`, the convention-based project runtime (#131), and drop-in compatibility for Claude Code agent files (#340).
+
+**`craft start [dir]`** boots a whole project from its folder layout instead of a hand-written barrel: `craft.config.ts`, then `plugins/`, then any folder an ecosystem package has claimed, then `capabilities/`. Both the root-level and `src/`-nested layouts work, and a folder that is absent is skipped. A directory holding `route.ts` is one capability and is not descended into, so colocated tests, fixtures and private helpers are never imported. A `plugins/` module that default-exports a factory is an error naming the file, because a factory needs arguments the runtime cannot invent.
+
+**`registerProjectDiscoverer`** lets a package claim a convention folder and turn it into a config fragment, which is how `agents/` and `skills/` get their meaning without the CLI ever depending on `@routecraft/ai`. A discoverer receives a context object (the folder, the content root, the project root, and the configuration accumulated so far) and declares its ordering as `after: ["skills"]` rather than a magic number. Cycles are an error; a dependency on a folder nobody registered is satisfied. A claimed folder present with no discoverer registered fails loudly, naming the erased type-import case, since that is the one the author will be staring at.
+
+Skills compose house folder, then frontmatter `skills:` refs in declared order, then the bundle's own folder, most specific winning and every source named in the startup log. Refs are local paths or `npm:` package refs resolved against installed packages only. Precedence is code wins, convention fills the gaps, applied per field: an agent declared in `craft.config.ts` keeps every field it set and discovery contributes only the skill set it left unset.
+
+`--once` shuts down after the first exchange reaches a terminal outcome, and pairs with `--timeout <ms>` so a project that produces nothing reports instead of hanging.
+
+**Claude Code agent files** load without edits: unknown frontmatter is ignored with a warning, `tools` and `disallowedTools` accept Claude's comma-separated string, `model` accepts the `opus` / `sonnet` / `haiku` aliases and `inherit`, and a reference to a Claude built-in this runtime does not provide is dropped with a warning rather than failing the load. `disallowedTools` without `tools` is rejected at load: a per-agent list replaces the context default rather than narrowing it, so a deny list alone cannot be honoured and silently inheriting the denied tools would be the worst reading of the file.
+
+New error code `AI1004` for a `skills:` ref that does not resolve.

--- a/apps/routecraft.dev/src/app/docs/advanced/call-an-mcp/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/call-an-mcp/page.md
@@ -23,7 +23,7 @@ Add `mcpPlugin` to your `craft.config.ts` and list the servers your capabilities
 import { mcpPlugin } from '@routecraft/ai'
 import type { CraftConfig } from '@routecraft/routecraft'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   plugins: [
     mcpPlugin({
       clients: {
@@ -34,7 +34,6 @@ const config: CraftConfig = {
   ],
 }
 
-export default config
 ```
 
 Each key under `clients` is the server alias you use in your capabilities.

--- a/apps/routecraft.dev/src/app/docs/advanced/merged-options/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/merged-options/page.md
@@ -24,11 +24,10 @@ Core adapters (`cron`, `direct`) have dedicated fields on `CraftConfig`. Set the
 // craft.config.ts
 import type { CraftConfig } from '@routecraft/routecraft'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   cron: { timezone: 'UTC', jitterMs: 2000 },
 }
 
-export default config
 ```
 
 Now every `cron()` source inherits `timezone: 'UTC'` and `jitterMs: 2000` unless overridden:
@@ -49,7 +48,7 @@ Adapters from other packages (like `@routecraft/ai`) use the plugin pattern. Reg
 import type { CraftConfig } from '@routecraft/routecraft'
 import { llmPlugin, embeddingPlugin } from '@routecraft/ai'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   plugins: [
     llmPlugin({
       providers: { anthropic: { apiKey: process.env.ANTHROPIC_API_KEY } },

--- a/apps/routecraft.dev/src/app/docs/advanced/plugins/page.md
+++ b/apps/routecraft.dev/src/app/docs/advanced/plugins/page.md
@@ -59,11 +59,10 @@ import type { CraftConfig } from '@routecraft/routecraft'
 import logger from './plugins/logger'
 import metrics from './plugins/metrics'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   plugins: [logger, metrics],
 }
 
-export default config
 ```
 
 ## Setting global adapter defaults
@@ -74,7 +73,7 @@ Core adapters have dedicated fields on `CraftConfig`:
 
 ```ts
 // craft.config.ts
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   cron: { timezone: 'UTC', jitterMs: 2000 },
   direct: { channelType: KafkaChannel },
 }
@@ -85,7 +84,7 @@ External adapters (from `@routecraft/ai`, etc.) use companion plugins:
 ```ts
 import { llmPlugin } from '@routecraft/ai'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   cron: { timezone: 'UTC' },
   plugins: [
     llmPlugin({
@@ -95,7 +94,6 @@ const config: CraftConfig = {
   ],
 }
 
-export default config
 ```
 
 Every `cron()` source and `llm()` destination in the context inherits those defaults unless overridden per-adapter. This keeps shared configuration out of every capability file.
@@ -109,7 +107,7 @@ Plugins can manage long-lived external processes. The built-in `mcpPlugin` demon
 ```ts
 import { mcpPlugin } from '@routecraft/ai'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   plugins: [
     mcpPlugin({
       clients: {

--- a/apps/routecraft.dev/src/app/docs/introduction/adapters/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/adapters/page.md
@@ -82,11 +82,10 @@ Many adapters support **merged options**: they merge their own per-call options 
 // craft.config.ts
 import type { CraftConfig } from '@routecraft/routecraft'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   cron: { timezone: 'UTC', jitterMs: 2000 },
 }
 
-export default config
 ```
 
 ```ts

--- a/apps/routecraft.dev/src/app/docs/introduction/events/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/events/page.md
@@ -18,7 +18,7 @@ The simplest way to react to events is via the `on` property in `craft.config.ts
 // craft.config.ts
 import type { CraftConfig } from '@routecraft/routecraft'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   on: {
     'context:started': ({ ts }) => {
       console.log(`Context ready at ${ts}`)
@@ -32,7 +32,6 @@ const config: CraftConfig = {
   },
 }
 
-export default config
 ```
 
 Each key is an event name (or the catch-all `'*'`). The value can be a single handler or an array of handlers.

--- a/apps/routecraft.dev/src/app/docs/introduction/project-structure/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/project-structure/page.md
@@ -34,13 +34,55 @@ my-app
 │       └── types.ts
 ├── plugins
 │   └── logger.ts
+├── skills                            # house skills, available to every agent
+│   ├── tone-of-voice.md
+│   └── incident-response
+│       └── SKILL.md
+├── agents
+│   ├── triage.md                     # flat agent
+│   └── aria                          # agent bundle
+│       ├── AGENT.md
+│       └── skills                    # scoped to aria only
+│           └── refund-policy.md
 ├── package.json
 ├── tsconfig.json
 └── .env
 ```
 
 All application code can live at the project root or inside an optional `src` folder.
-Routecraft treats both layouts identically.
+Routecraft treats both layouts identically. Put the convention folders in one place or the
+other, not both: `craft start` uses the root-level layout when it finds folders there and
+warns that the `src` copies are ignored.
+
+## What `craft start` discovers
+
+[`craft start`](/docs/reference/cli#start) boots the whole project from this layout, so an
+application needs no barrel file. Each folder is optional; one that is absent is skipped.
+
+| Folder | Produces | Rule |
+| --- | --- | --- |
+| `capabilities/` | Routes | A directory holding `route.ts` is one capability: that file is imported and the directory is not descended into, so colocated tests, fixtures and private helpers are never loaded. Any other module is a single-file capability. Other directories are grouping. |
+| `plugins/` | Context plugins | Each module default-exports a plugin instance (an object with `apply`). A factory export is an error: a factory needs arguments the runtime cannot invent, so call it in `craft.config.ts` instead. |
+| `agents/` | Registered agents | Loaded by `@routecraft/ai`. See [agents](#agents). |
+| `skills/` | The default skill set for every agent | Loaded by `@routecraft/ai`. See [skills](#skills). |
+| `adapters/` | Nothing | Part of the convention as a place to put code. Importing an adapter module registers nothing, so there is nothing for `start` to load. |
+
+Code wins and convention fills the gaps: anything `craft.config.ts` declares is kept, and
+discovery adds only what the config left out. Every discovered capability, plugin and agent
+is logged with the file it came from, so precedence is visible in a startup log.
+
+`agents/` and `skills/` mean nothing to the CLI itself. `@routecraft/ai` claims those folder
+names when it is imported, which is why a project using them has to import the package for
+its side effects:
+
+```ts
+// craft.config.ts
+import "@routecraft/ai";
+```
+
+A type-only import (`import type { ... } from "@routecraft/ai"`) is erased at compile time
+and registers nothing, so it produces the "nothing knows how to load this folder" error while
+the import statement above it looks perfectly correct.
 
 ## The capability folder
 
@@ -135,27 +177,117 @@ Sub-folders inside `capabilities/` are supported to any depth. The capability id
 system). A plugin extends the runtime itself (exposing MCP, adding metrics, wiring up
 observability).
 
+## Agents
+
+An agent sits beside a capability, not inside one. Both are first-class, and they compose in
+both directions: a capability can call an agent, and an agent can be granted a capability as
+a tool.
+
+Two forms live under `agents/`, and they can be mixed:
+
+```text
+agents
+├── triage.md                   # flat agent, at any depth
+├── review
+│   └── security.md             # grouping folder, walked
+└── aria                        # agent bundle
+    ├── AGENT.md
+    └── skills                  # aria's skills, never agents
+        └── refund-policy.md
+```
+
+An agent's identity is its frontmatter `name`, never the filename or the folder path, which
+is what lets an existing Claude Code `.claude/agents/` tree drop in unchanged. The one
+exception is a bundle: a directory holding `AGENT.md` is exactly one agent, is not descended
+into, and its frontmatter `name` must match the directory name. A directory named `skills` is
+never scanned for agents at any depth.
+
+```md
+---
+name: triage
+description: Routes inbound mail to the right queue
+model: anthropic:claude-sonnet-4-6
+tools:
+  - Direct(classify-mail)
+---
+You triage inbound mail.
+```
+
+## Skills
+
+Skills resolve at two levels.
+
+**House skills.** The top-level `skills/` folder becomes the default skill set every agent
+carries, grouped under the `skills` key so a leaf resolves as `skills__<name>`. An agent drops
+the whole set with `blocks: { skills: false }`. Both the flat `<name>.md` and the nested
+`<name>/SKILL.md` forms work.
+
+**Per-agent skills.** An agent declares its own with a `skills:` list in frontmatter, and an
+agent bundle may also hold a sibling `skills/` folder:
+
+```md
+---
+name: zoe
+description: Handles customer conversations
+skills:
+  - ./skills                                  # local path, relative to the agent file
+  - npm:@acme/claude-skills/support           # installed package, subpath into its tree
+---
+```
+
+An `npm:` ref resolves against installed packages, so there is no network access at boot and
+no trust surface beyond the dependencies already in `package.json`. `npm:<pkg>/<subpath>`
+looks for `<package root>/<subpath>` and then `<package root>/skills/<subpath>`; `npm:<pkg>`
+with no subpath looks for `<package root>/skills` and then the package root itself. A ref that
+resolves to no directory fails the boot with `AI1004` naming the ref and what was tried.
+
+Sources compose in one order, most specific last:
+
+1. the house `skills/` folder,
+2. the frontmatter `skills:` refs, in declared order,
+3. the bundle's own `skills/` folder.
+
+A name present in more than one resolves to the most specific copy, and both sources are
+logged at info so the shadowing is visible rather than mysterious.
+
+An agent that declares no skills at all inherits the house set. That is deliberate: absent
+means "the house default", never "no skills", so a dropped-in agent file written for another
+harness lands in the ambient behaviour its author expected.
+
+{% callout type="warning" title="Config blocks replace, they do not merge" %}
+A per-agent `blocks` entry replaces a same-named default wholesale. If you set
+`blocks: { skills: ... }` for an agent in `craft.config.ts`, that agent no longer receives the
+discovered folder skills at all; spread them in explicitly if you want both. Discovery
+composes for you only when it owns the agent's skill set.
+{% /callout %}
+
 ## Files
 
 | File | Purpose |
 | --- | --- |
-| `craft.config.ts` | Registers plugins and configures the context. Exported as default. |
+| `craft.config.ts` | Registers plugins and configures the context. Exported as the named `craftConfig` export. |
 | `package.json` | Dependencies and convenience scripts. |
 | `tsconfig.json` | TypeScript configuration. |
 | `.env` | Environment variables. Pass a custom path with `--env` in CLI commands. |
 
 ## craft.config.ts
 
-The config file is the entry point for the Routecraft runtime. A minimal setup:
+The config file is the entry point for the Routecraft runtime. It is read through the named
+`craftConfig` export, which is what `defineConfig` is built for:
 
 ```ts
 // craft.config.ts
-import type { CraftConfig } from "@routecraft/routecraft";
+import { defineConfig } from "@routecraft/routecraft";
 
-const config: CraftConfig = {};
-
-export default config;
+export const craftConfig = defineConfig({});
 ```
+
+A default export is accepted as a fallback and warns, because earlier versions of this page
+showed that form and nothing read it. Rename it to `craftConfig`.
+
+Importing this file is also what pulls ecosystem packages into the module graph, which is how
+their config keys and their folder discoverers get registered. An agent project therefore
+imports `@routecraft/ai` here even when every agent is declared in markdown.
 
 ---
 

--- a/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
@@ -38,7 +38,7 @@ For a new project, use a single `vitest.config.mjs` at the project root:
 ```js
 import { defineConfig } from "vitest/config";
 
-export const craftConfig = defineConfig({
+export default defineConfig({
   test: {
     environment: "node",
     coverage: { provider: "v8", reporter: ["text", "lcov"] },

--- a/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
+++ b/apps/routecraft.dev/src/app/docs/introduction/testing/page.md
@@ -38,7 +38,7 @@ For a new project, use a single `vitest.config.mjs` at the project root:
 ```js
 import { defineConfig } from "vitest/config";
 
-export default defineConfig({
+export const craftConfig = defineConfig({
   test: {
     environment: "node",
     coverage: { provider: "v8", reporter: ["text", "lcov"] },

--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -83,17 +83,20 @@ craft run mcp-server.js --log-level silent
 
 ### 1.4 Define your config with `defineConfig`
 
-`CraftConfig` switched from `type` to `interface` so ecosystem packages can declaration-merge first-class config keys onto it. The recommended way to author your config is now the new `defineConfig` helper, which preserves literal-type inference at the call site without you having to declare a config type yourself:
+`CraftConfig` switched from `type` to `interface` so ecosystem packages can declaration-merge first-class config keys onto it. The recommended way to author your config is now the new `defineConfig` helper, which preserves literal-type inference at the call site without you having to declare a config type yourself.
+
+Rename the export while you are here: the runtime reads a named `craftConfig` export, and the default export earlier pages showed was never read. `craft start` accepts a default export with a warning so the old form is not a silent failure.
 
 **Before (0.4.0):**
 
 ```ts
 import type { CraftConfig } from "@routecraft/routecraft"
 
-export const craftConfig: CraftConfig = {
+const config: CraftConfig = {
   plugins: [...],
   routes: [...],
 }
+export default config
 ```
 
 **After (0.5.0):**

--- a/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
+++ b/apps/routecraft.dev/src/app/docs/migrating/0.4-to-0.5/page.md
@@ -90,11 +90,10 @@ craft run mcp-server.js --log-level silent
 ```ts
 import type { CraftConfig } from "@routecraft/routecraft"
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   plugins: [...],
   routes: [...],
 }
-export default config
 ```
 
 **After (0.5.0):**
@@ -103,7 +102,7 @@ export default config
 import { defineConfig } from "@routecraft/routecraft"
 import "@routecraft/ai" // side-effect import enables first-class llm/agent/mcp/embedding keys
 
-export default defineConfig({
+export const craftConfig = defineConfig({
   llm: { providers: { anthropic: { apiKey: process.env.ANTHROPIC_API_KEY } } },
   agent: { defaultOptions: { model: "anthropic:claude-opus-4-7" } },
   routes: [...],

--- a/apps/routecraft.dev/src/app/docs/reference/adapters/carddav/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/adapters/carddav/page.md
@@ -21,7 +21,7 @@ Requires the optional peer `tsdav` (DAV client): `bun add tsdav`. A missing peer
 ```ts
 import { defineConfig } from '@routecraft/routecraft'
 
-export default defineConfig({
+export const craftConfig = defineConfig({
   carddav: {
     accounts: {
       default: {

--- a/apps/routecraft.dev/src/app/docs/reference/cli/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/cli/page.md
@@ -116,7 +116,7 @@ Options:
 | `[dir]` | Project root. Defaults to the current directory |
 | `--env <path>` | Load environment variables from a .env file |
 | `--once` | Shut down cleanly after the first exchange reaches a terminal outcome on any route |
-| `--timeout <ms>` | With `--once`, give up and exit non-zero after this many milliseconds |
+| `--timeout <ms>` | Give up and exit non-zero after this many milliseconds. Requires `--once`, and must be at least 1 |
 
 What it loads, and in what order:
 
@@ -133,9 +133,14 @@ Code wins and convention fills the gaps: whatever `craft.config.ts` declares is 
 discovery supplies only what it left out. Every discovered capability, plugin and agent is
 logged with the file it came from.
 
-`--once` is for CI smoke checks and cron-style one-shot invocations. A failure and a drop
-count as terminal alongside a completion, so a broken exchange reports instead of hanging
-until the job is killed; a first exchange that failed exits non-zero.
+`--once` is for CI smoke checks and cron-style one-shot invocations. A failure, a drop and a
+suspension all count as terminal alongside a completion, so a broken or parked exchange
+reports instead of hanging until the job is killed; a first exchange that failed exits
+non-zero.
+
+A route that throws on the way up fails the command too, in either mode. Starting settles
+every route rather than racing them, so a project can come up with one route dead and the
+rest healthy; `start` reports that as a failed boot rather than a clean one.
 
 Pair it with `--timeout <ms>` in CI. Without one, a project whose sources never produce an
 exchange waits indefinitely, which reports as a killed job rather than as a diagnosis; with

--- a/apps/routecraft.dev/src/app/docs/reference/cli/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/cli/page.md
@@ -103,7 +103,7 @@ instead of a hand-written barrel file. Where `run` executes one entry file, `sta
 plugins, agents, and skills.
 
 ```bash
-craft start [dir] [--env <.env path>] [--once]
+craft start [dir] [--env <.env path>] [--once] [--timeout <ms>]
 ```
 
 With no argument it starts the project in the current directory. Both the root-level and the
@@ -116,6 +116,7 @@ Options:
 | `[dir]` | Project root. Defaults to the current directory |
 | `--env <path>` | Load environment variables from a .env file |
 | `--once` | Shut down cleanly after the first exchange reaches a terminal outcome on any route |
+| `--timeout <ms>` | With `--once`, give up and exit non-zero after this many milliseconds |
 
 What it loads, and in what order:
 
@@ -123,8 +124,9 @@ What it loads, and in what order:
    export is accepted with a warning. Importing this file is what pulls ecosystem packages
    into the module graph.
 2. `plugins/`, one plugin instance per module.
-3. Folder discoverers, in their registered order. `@routecraft/ai` claims `skills/` and then
-   `agents/`, so an agent can compose the house skills rather than replacing them.
+3. Folder discoverers, ordered by the dependencies they declare. `@routecraft/ai` claims
+   `skills/` and `agents/`, and the agents discoverer declares `after: ["skills"]` so an
+   agent can compose the house skills rather than replacing them.
 4. `capabilities/`, one or more routes per capability.
 
 Code wins and convention fills the gaps: whatever `craft.config.ts` declares is kept, and
@@ -133,9 +135,17 @@ logged with the file it came from.
 
 `--once` is for CI smoke checks and cron-style one-shot invocations. A failure and a drop
 count as terminal alongside a completion, so a broken exchange reports instead of hanging
-until the job is killed; a first exchange that failed exits non-zero. A project whose sources
-never produce an exchange (an HTTP server with no traffic, say) will wait, which is what makes
-`--once` a smoke check rather than a timeout.
+until the job is killed; a first exchange that failed exits non-zero.
+
+Pair it with `--timeout <ms>` in CI. Without one, a project whose sources never produce an
+exchange waits indefinitely, which reports as a killed job rather than as a diagnosis; with
+one, the command exits non-zero saying nothing reached a terminal outcome in time.
+
+Two limits worth knowing. `--once` settles on the first terminal exchange on **any** route, so
+on a project with a heartbeat timer beside the route you meant to exercise, the timer can win
+the race. Scoping the wait to a single route is tracked as a follow-up. And a project with a
+server ingress (`http`, `direct`, `mcp`) never finishes starting by design, which is why
+`--once` races the first exchange against startup rather than waiting for startup to complete.
 
 ```bash
 craft start ./apps/eywa --once

--- a/apps/routecraft.dev/src/app/docs/reference/cli/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/cli/page.md
@@ -143,7 +143,8 @@ one, the command exits non-zero saying nothing reached a terminal outcome in tim
 
 Two limits worth knowing. `--once` settles on the first terminal exchange on **any** route, so
 on a project with a heartbeat timer beside the route you meant to exercise, the timer can win
-the race. Scoping the wait to a single route is tracked as a follow-up. And a project with a
+the race. Scoping the wait to a single route is tracked in
+[#584](https://github.com/routecraftjs/routecraft/issues/584). And a project with a
 server ingress (`http`, `direct`, `mcp`) never finishes starting by design, which is why
 `--once` races the first exchange against startup rather than waiting for startup to complete.
 

--- a/apps/routecraft.dev/src/app/docs/reference/cli/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/cli/page.md
@@ -30,7 +30,7 @@ craft --log-level info --log-file craft.log run ./capabilities/orders.ts
 ```
 
 {% callout type="note" title="More commands coming" %}
-`dev`, `build`, `start`, and `exec` are planned for future releases.
+`dev`, `build`, and `exec` are planned for future releases.
 {% /callout %}
 
 ## Project scaffolding
@@ -94,6 +94,52 @@ Options:
 | --- | --- |
 | `<file>` | TypeScript or JavaScript file (.ts/.mjs/.js/.cjs) to execute |
 | `--env <path>` | Load environment variables from a .env file |
+
+### start
+
+Boot a whole project from its [folder convention](/docs/introduction/project-structure)
+instead of a hand-written barrel file. Where `run` executes one entry file, `start` reads
+`craft.config.ts` and then discovers what the project declares on disk: capabilities,
+plugins, agents, and skills.
+
+```bash
+craft start [dir] [--env <.env path>] [--once]
+```
+
+With no argument it starts the project in the current directory. Both the root-level and the
+`src/`-nested layouts work.
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `[dir]` | Project root. Defaults to the current directory |
+| `--env <path>` | Load environment variables from a .env file |
+| `--once` | Shut down cleanly after the first exchange reaches a terminal outcome on any route |
+
+What it loads, and in what order:
+
+1. `craft.config.ts` from the project root, via its named `craftConfig` export. A default
+   export is accepted with a warning. Importing this file is what pulls ecosystem packages
+   into the module graph.
+2. `plugins/`, one plugin instance per module.
+3. Folder discoverers, in their registered order. `@routecraft/ai` claims `skills/` and then
+   `agents/`, so an agent can compose the house skills rather than replacing them.
+4. `capabilities/`, one or more routes per capability.
+
+Code wins and convention fills the gaps: whatever `craft.config.ts` declares is kept, and
+discovery supplies only what it left out. Every discovered capability, plugin and agent is
+logged with the file it came from.
+
+`--once` is for CI smoke checks and cron-style one-shot invocations. A failure and a drop
+count as terminal alongside a completion, so a broken exchange reports instead of hanging
+until the job is killed; a first exchange that failed exits non-zero. A project whose sources
+never produce an exchange (an HTTP server with no traffic, say) will wait, which is what makes
+`--once` a smoke check rather than a timeout.
+
+```bash
+craft start ./apps/eywa --once
+```
 
 ## Shutdown helpers
 

--- a/apps/routecraft.dev/src/app/docs/reference/errors/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/errors/page.md
@@ -406,6 +406,21 @@ A block's shape is invalid at construction:
 - Progressive-mode blocks: `{ mode: "progressive", description: "...", value: <string | function> }`.
 - Use the `BlockMode` and `BlockLifetime` types exported from `@routecraft/ai` to catch typos at the type level.
 
+## AI1004
+Skills source could not be resolved
+
+**Why it happens**  
+A `skills:` ref in agent frontmatter did not resolve to a directory on disk:
+- A local ref (`./skills`, `../shared-skills`) named a path that does not exist relative to the agent file that declared it.
+- An `npm:` ref named a package that is not installed in the project.
+- An `npm:` ref resolved to an installed package, but neither the plain subpath nor the package's `skills/` root held the named folder.
+- An `npm:` ref used `../` segments that point outside the package root.
+
+**Suggestion**  
+- Local refs resolve against the agent file's own directory, not the project root. For an agent bundle that is the bundle folder.
+- Install the package the ref names; resolution reads `node_modules` only, with no network access at boot.
+- `npm:<pkg>/<subpath>` looks for `<root>/<subpath>` then `<root>/skills/<subpath>`; `npm:<pkg>` looks for `<root>/skills` then `<root>`. The error message lists the paths that were tried.
+
 ## RC5028
 Cache provider failed
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
@@ -123,7 +123,11 @@ The loader is deliberately tolerant so an existing agent file works without edit
 
 **Unimplemented Claude built-ins are skipped, not fatal.** A reference to `Read`, `Edit`, `Write`, `Glob`, `Grep`, `Bash`, `WebFetch`, `WebSearch` and friends is dropped with a warning when this runtime provides no tool of that name, so a coding agent still boots here with its remaining tools instead of failing the load. The check runs against the live registry, so a fn you register under one of those names resolves normally. A name that is neither registered nor a recognised built-in is still a hard error, because that is a typo or a missing registration rather than a known gap.
 
-`disallowedTools` applies to the list the agent itself declares. It cannot narrow an inherited `agentPlugin({ defaultOptions: { tools } })`, because a per-agent list replaces that default outright; setting `disallowedTools` with no `tools` warns rather than quietly doing nothing.
+`disallowedTools` applies to the list the agent itself declares. It cannot narrow an inherited `agentPlugin({ defaultOptions: { tools } })`, because a per-agent list replaces that default outright.
+
+{% callout type="warning" title="A deny list needs an allow list" %}
+Setting `disallowedTools` with no `tools` throws `RC5003` at load. There is no reading of that file the runtime can honour: with no per-agent list the agent inherits the context default, so it would receive the very tools its file denies. A field whose whole purpose is removing capability is not something to fail open on, so it fails loudly instead. List the tools the agent may use in `tools`, or drop `disallowedTools`. Honouring a deny list against inherited defaults is tracked in [#583](https://github.com/routecraftjs/routecraft/issues/583); that is the Claude-faithful end state, and it needs the deny to apply where defaults are merged at dispatch rather than where the file is parsed.
+{% /callout %}
 
 ### The `skills:` frontmatter key
 

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/agentplugin/page.md
@@ -106,6 +106,25 @@ Duplicate `name` values anywhere in the tree throw `RC5003` naming both files. I
 
 Passing a single `.md` path loads that one file.
 
+### Claude Code compatibility
+
+The loader is deliberately tolerant so an existing agent file works without edits.
+
+| Field | Accepted forms |
+|-------|----------------|
+| `tools` | A YAML array (`- Direct(cancel-order)`) or Claude's comma-separated string (`tools: Read, Grep, echo`) |
+| `disallowedTools` | Same two forms. Removes references from **this agent's own** list |
+| `model` | A full `provider:model` reference, or the aliases `opus`, `sonnet`, `haiku`, `inherit` |
+| anything else | Ignored with a warning |
+
+**Unknown keys are never fatal.** A file carrying `permissionMode`, `color`, `hooks` or a key a future version of another harness introduces still loads; each ignored key is warned about once. The two Routecraft-owned keys `blocks` and `output` are the exception and still throw, because they point at a real mistake: their values cannot be expressed in YAML and belong in the override map.
+
+**Model aliases map to pinned references**: `opus`, `sonnet` and `haiku` resolve to specific Anthropic model ids rather than "whatever is newest", because an agent whose model changes under it is not reproducible. Write the full `provider:model` form to pick a different version. `inherit` leaves the model unset, which is exactly right: the agent then picks up `agentPlugin({ defaultOptions: { model } })` at dispatch.
+
+**Unimplemented Claude built-ins are skipped, not fatal.** A reference to `Read`, `Edit`, `Write`, `Glob`, `Grep`, `Bash`, `WebFetch`, `WebSearch` and friends is dropped with a warning when this runtime provides no tool of that name, so a coding agent still boots here with its remaining tools instead of failing the load. The check runs against the live registry, so a fn you register under one of those names resolves normally. A name that is neither registered nor a recognised built-in is still a hard error, because that is a typo or a missing registration rather than a known gap.
+
+`disallowedTools` applies to the list the agent itself declares. It cannot narrow an inherited `agentPlugin({ defaultOptions: { tools } })`, because a per-agent list replaces that default outright; setting `disallowedTools` with no `tools` warns rather than quietly doing nothing.
+
 ### The `skills:` frontmatter key
 
 An agent file may declare where its skills come from:

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/embeddingplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/embeddingplugin/page.md
@@ -14,7 +14,7 @@ Registers embedding provider credentials in the context store. Required when any
 import { embeddingPlugin } from '@routecraft/ai'
 import type { CraftConfig } from '@routecraft/routecraft'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   plugins: [
     embeddingPlugin({
       providers: {
@@ -24,7 +24,6 @@ const config: CraftConfig = {
   ],
 }
 
-export default config
 ```
 
 **Options:**

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/llmplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/llmplugin/page.md
@@ -14,7 +14,7 @@ Registers LLM provider credentials in the context store. Required when any capab
 import { llmPlugin } from '@routecraft/ai'
 import type { CraftConfig } from '@routecraft/routecraft'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   plugins: [
     llmPlugin({
       providers: {
@@ -25,7 +25,6 @@ const config: CraftConfig = {
   ],
 }
 
-export default config
 ```
 
 **Options:**

--- a/apps/routecraft.dev/src/app/docs/reference/plugins/mcpplugin/page.md
+++ b/apps/routecraft.dev/src/app/docs/reference/plugins/mcpplugin/page.md
@@ -16,7 +16,7 @@ Tools discovered from remote MCP servers (stdio clients and HTTP clients) are co
 import { mcpPlugin, jwt } from '@routecraft/ai'
 import type { CraftConfig } from '@routecraft/routecraft'
 
-const config: CraftConfig = {
+export const craftConfig: CraftConfig = {
   plugins: [
     mcpPlugin({
       transport: 'http',
@@ -45,7 +45,6 @@ const config: CraftConfig = {
   ],
 }
 
-export default config
 ```
 
 **Options:**

--- a/apps/routecraft.dev/src/components/ErrorTable.tsx
+++ b/apps/routecraft.dev/src/components/ErrorTable.tsx
@@ -360,6 +360,12 @@ const errors: ErrorRow[] = [
     retryable: false,
   },
   {
+    code: 'AI1004',
+    category: 'Adapter',
+    message: 'Skills source could not be resolved',
+    retryable: false,
+  },
+  {
     code: 'AI2001',
     category: 'Adapter',
     message: 'MCP tool output violated its declared schema',

--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -346,7 +346,7 @@ function toAgent(doc: ParsedMarkdown): LoadedAgentFile {
     // no allow cannot be honoured, and an agent that inherits the very
     // tools its file denies is the worst possible reading of the file.
     throw rcError("RC5003", undefined, {
-      message: `Markdown file "${source}": "disallowedTools" is set but "tools" is not, and a deny list alone cannot be honoured: a per-agent tool list replaces the context default outright rather than narrowing it, so this agent would inherit the very tools it denies. List the tools this agent may use in "tools", or drop "disallowedTools".`,
+      message: `Markdown file "${source}": "disallowedTools" is set but "tools" is not, and a deny list alone cannot be honoured: a per-agent tool list replaces the context default outright rather than narrowing it, so this agent would inherit the very tools it denies. List the tools this agent may use in "tools", or drop "disallowedTools". Honouring a deny list against inherited defaults is tracked in routecraftjs/routecraft#583.`,
     });
   }
   // Frontmatter carries only the boolean form; the function-renderer
@@ -470,16 +470,16 @@ export async function loadAgentFiles(path: string): Promise<LoadedAgentFile[]> {
  * |               |          | `provider:model` form only)            |
  * | `maxTurns`    | no       | `AgentRegisteredOptions.maxTurns`      |
  * | `tools`       | no       | `tools(stringArray)`                   |
+ * | `disallowedTools` | no   | removals from this agent's own `tools` |
  * | `principal`   | no       | `AgentRegisteredOptions.principal`     |
  * |               |          | (boolean only; renderer via override)  |
  * | `skills`      | no       | declaration consumed by `craft start`  |
  *
  * Body of the file becomes `system`. Other Claude subagent fields
- * (`disallowedTools`, `permissionMode`, `mcpServers`, `hooks`,
- * `memory`, `background`, `effort`, `isolation`, `color`,
- * `initialPrompt`, ...) throw `RC5003` "not yet supported" at load
- * and will land in follow-up stories as the runtime gains the
- * underlying features.
+ * (`permissionMode`, `mcpServers`, `hooks`, `memory`, `background`,
+ * `effort`, `isolation`, `color`, `initialPrompt`, ...) throw
+ * `RC5003` "not yet supported" at load and will land in follow-up
+ * stories as the runtime gains the underlying features.
  *
  * `skills` is validated as a list of strings and otherwise passed
  * through: resolving a ref into blocks needs the house skill folder

--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -8,6 +8,7 @@ import {
   type ParsedMarkdown,
 } from "../block/markdown.ts";
 import { tools } from "./tools/index.ts";
+import type { ToolSelection } from "./tools/selection.ts";
 import type { LlmModelId } from "../llm/types.ts";
 import type { AgentRegisteredOptions } from "./types.ts";
 
@@ -31,13 +32,14 @@ export const AGENT_BUNDLE_FILENAME = "AGENT.md";
 export const AGENT_RESERVED_DIRECTORIES = ["skills"] as const;
 
 /**
- * Frontmatter fields supported today. Claude's subagent schema covers
- * many more (`disallowedTools`, `permissionMode`, `mcpServers`,
- * `hooks`, `memory`, `background`, `effort`, `isolation`, `color`,
- * `initialPrompt`, ...) which we will add incrementally as the
- * underlying features land. Any other key in the frontmatter throws
- * `RC5003` "not yet supported" at load so a misspelt key never silently
- * disappears.
+ * Frontmatter fields this loader maps. Claude's subagent schema covers
+ * more (`permissionMode`, `mcpServers`, `hooks`, `memory`,
+ * `background`, `effort`, `isolation`, `color`, `initialPrompt`, ...)
+ * which we will add as the underlying features land. Any other key is
+ * ignored with a warning rather than throwing: tolerance is what keeps
+ * "drop your `.claude/agents/` tree in unchanged" true, and a file
+ * written for a harness that grows a new key must not stop booting
+ * this one.
  */
 const SUPPORTED_AGENT_KEYS = new Set([
   "name",
@@ -45,8 +47,52 @@ const SUPPORTED_AGENT_KEYS = new Set([
   "model",
   "maxTurns",
   "tools",
+  "disallowedTools",
   "principal",
   "skills",
+]);
+
+/**
+ * Claude model aliases mapped to the full `provider:model` form. The
+ * targets are pinned rather than "whatever is newest", because an
+ * agent whose model silently changes under it is not reproducible;
+ * write the full form to pick a different version.
+ */
+const MODEL_ALIASES: Record<string, LlmModelId> = {
+  opus: "anthropic:claude-opus-4-7" as LlmModelId,
+  sonnet: "anthropic:claude-sonnet-4-6" as LlmModelId,
+  haiku: "anthropic:claude-haiku-4-5" as LlmModelId,
+};
+
+/**
+ * Claude Code's built-in tool names. A reference to one of these that
+ * this runtime does not provide is dropped with a warning instead of
+ * failing the load, so an agent file written for a coding harness
+ * still boots here with its remaining tools. A genuinely unknown name
+ * is still a hard error, because that is a typo or a missing
+ * registration rather than a known gap.
+ *
+ * The check runs against the live catalog, so the moment Routecraft
+ * registers a fn under one of these names (`WebFetch` in #341,
+ * `WebSearch` in #342, `Bash` in #343) it resolves normally and no
+ * entry has to be removed from this list.
+ */
+const CLAUDE_BUILTIN_TOOLS = new Set([
+  "Bash",
+  "BashOutput",
+  "Edit",
+  "Glob",
+  "Grep",
+  "KillShell",
+  "MultiEdit",
+  "NotebookEdit",
+  "Read",
+  "SlashCommand",
+  "Task",
+  "TodoWrite",
+  "WebFetch",
+  "WebSearch",
+  "Write",
 ]);
 
 /**
@@ -130,6 +176,107 @@ export interface LoadedAgentFile {
 }
 
 /**
+ * Read a tool reference list from frontmatter. Accepts the YAML array
+ * form and Claude Code's comma-separated string
+ * (`tools: Read, Grep, Bash`), which is what an unmodified agent file
+ * carries.
+ *
+ * @internal
+ */
+function optionalToolRefs(
+  value: unknown,
+  field: string,
+  source: string,
+): string[] | undefined {
+  if (typeof value === "string") {
+    const refs = value
+      .split(",")
+      .map((ref) => ref.trim())
+      .filter((ref) => ref !== "");
+    if (refs.length === 0) {
+      throw rcError("RC5003", undefined, {
+        message: `Markdown file "${source}": frontmatter field "${field}" is an empty string. Remove the key or list at least one tool.`,
+      });
+    }
+    return refs;
+  }
+  return optionalStringArray(value, field, source);
+}
+
+/**
+ * Build the agent's tool selection from its frontmatter references.
+ *
+ * Two Claude-compatibility rules live here rather than in `tools()`,
+ * because they are properties of a dropped-in file and not of the
+ * selection grammar:
+ *
+ * - A reference to a Claude built-in this runtime does not provide is
+ *   dropped with a warning. Resolution runs per dispatch, so the
+ *   warning is emitted once per name per selection.
+ * - `disallowedTools` removes references from the agent's own list.
+ *   It cannot reach an inherited `defaultOptions.tools`, because a
+ *   per-agent list replaces that default outright rather than
+ *   narrowing it.
+ *
+ * @internal
+ */
+function toolSelection(
+  refs: string[],
+  disallowed: readonly string[],
+  source: string,
+): ToolSelection {
+  const denied = new Set(disallowed);
+  const warned = new Set<string>();
+  return tools((catalog) => {
+    const registered = new Set(catalog.fns.map((fn) => fn.name));
+    const kept: string[] = [];
+    for (const ref of refs) {
+      if (denied.has(ref)) continue;
+      if (!registered.has(ref) && CLAUDE_BUILTIN_TOOLS.has(ref)) {
+        if (!warned.has(ref)) {
+          warned.add(ref);
+          logger.warn(
+            `Markdown file "${source}": tool "${ref}" is a Claude Code built-in this runtime does not provide; skipping it for this agent.`,
+          );
+        }
+        continue;
+      }
+      kept.push(ref);
+    }
+    return kept;
+  });
+}
+
+/**
+ * Resolve the frontmatter `model` field to a full `provider:model`
+ * reference.
+ *
+ * Claude's aliases map onto pinned ids; `inherit` maps to nothing at
+ * all, which is exactly right here because an agent that sets no model
+ * already picks up `agentPlugin({ defaultOptions: { model } })` at
+ * dispatch.
+ *
+ * @internal
+ */
+function resolveModel(value: unknown, source: string): LlmModelId | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter "model" must be a string of the form "provider:model" (e.g. "anthropic:claude-sonnet-4-6").`,
+    });
+  }
+  if (value === "inherit") return undefined;
+  const alias = MODEL_ALIASES[value];
+  if (alias !== undefined) return alias;
+  if (!value.includes(":")) {
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": frontmatter "model" ("${value}") is neither a known alias (${Object.keys(MODEL_ALIASES).sort().join(", ")}, inherit) nor a full "provider:model" reference.`,
+    });
+  }
+  return value as LlmModelId;
+}
+
+/**
  * Convert a parsed markdown file into an `AgentRegisteredOptions`.
  * Identity comes from the frontmatter `name` field alone: the filename
  * and the directory path are grouping, not identity, which is what
@@ -155,9 +302,9 @@ function toAgent(doc: ParsedMarkdown): LoadedAgentFile {
       });
     }
     if (!SUPPORTED_AGENT_KEYS.has(key)) {
-      throw rcError("RC5003", undefined, {
-        message: `Markdown file "${source}": frontmatter field "${key}" is not yet supported. Currently supported fields: ${[...SUPPORTED_AGENT_KEYS].sort().join(", ")}.`,
-      });
+      logger.warn(
+        `Markdown file "${source}": frontmatter field "${key}" is not supported and was ignored. Supported fields: ${[...SUPPORTED_AGENT_KEYS].sort().join(", ")}.`,
+      );
     }
   }
   if (doc.bundleDirectory !== undefined && name !== doc.filename) {
@@ -175,23 +322,24 @@ function toAgent(doc: ParsedMarkdown): LoadedAgentFile {
       message: `Markdown file "${source}": agent body is empty. The body becomes the agent's system prompt; an empty system prompt is rejected at dispatch.`,
     });
   }
-  const modelRaw = frontmatter["model"];
-  if (modelRaw !== undefined && typeof modelRaw !== "string") {
-    throw rcError("RC5003", undefined, {
-      message: `Markdown file "${source}": frontmatter "model" must be a string of the form "provider:model" (e.g. "anthropic:claude-sonnet-4-6").`,
-    });
-  }
-  if (typeof modelRaw === "string" && !modelRaw.includes(":")) {
-    throw rcError("RC5003", undefined, {
-      message: `Markdown file "${source}": frontmatter "model" ("${modelRaw}") must use the full "provider:model" form. Bare model aliases like "sonnet" / "opus" / "haiku" are not yet supported by the markdown loader.`,
-    });
-  }
+  const model = resolveModel(frontmatter["model"], source);
   const maxTurns = optionalPositiveInt(
     frontmatter["maxTurns"],
     "maxTurns",
     source,
   );
-  const toolNames = optionalStringArray(frontmatter["tools"], "tools", source);
+  const toolRefs = optionalToolRefs(frontmatter["tools"], "tools", source);
+  const disallowed =
+    optionalToolRefs(
+      frontmatter["disallowedTools"],
+      "disallowedTools",
+      source,
+    ) ?? [];
+  if (disallowed.length > 0 && toolRefs === undefined) {
+    logger.warn(
+      `Markdown file "${source}": "disallowedTools" is set but "tools" is not. A per-agent tool list replaces the context default outright rather than narrowing it, so this deny list has nothing to apply to.`,
+    );
+  }
   // Frontmatter carries only the boolean form; the function-renderer
   // form is a closure YAML cannot express and is supplied via the
   // override map or agentPlugin({ defaultOptions }).
@@ -209,9 +357,10 @@ function toAgent(doc: ParsedMarkdown): LoadedAgentFile {
     description,
     system: body,
   };
-  if (modelRaw) agent.model = modelRaw as LlmModelId;
+  if (model !== undefined) agent.model = model;
   if (maxTurns !== undefined) agent.maxTurns = maxTurns;
-  if (toolNames !== undefined) agent.tools = tools(toolNames);
+  if (toolRefs !== undefined)
+    agent.tools = toolSelection(toolRefs, disallowed, source);
   if (principal !== undefined) agent.principal = principal;
   const loaded: LoadedAgentFile = { name, agent, source };
   if (doc.bundleDirectory !== undefined)

--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -477,9 +477,11 @@ export async function loadAgentFiles(path: string): Promise<LoadedAgentFile[]> {
  *
  * Body of the file becomes `system`. Other Claude subagent fields
  * (`permissionMode`, `mcpServers`, `hooks`, `memory`, `background`,
- * `effort`, `isolation`, `color`, `initialPrompt`, ...) throw
- * `RC5003` "not yet supported" at load and will land in follow-up
- * stories as the runtime gains the underlying features.
+ * `effort`, `isolation`, `color`, `initialPrompt`, ...) are ignored
+ * with one warning each and will land in follow-up stories as the
+ * runtime gains the underlying features. Tolerating them is the point:
+ * an unchanged `.claude/agents/` tree has to boot, and a key this
+ * runtime has not implemented yet is not a mistake in the file.
  *
  * `skills` is validated as a list of strings and otherwise passed
  * through: resolving a ref into blocks needs the house skill folder

--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -266,7 +266,12 @@ function resolveModel(value: unknown, source: string): LlmModelId | undefined {
     });
   }
   if (value === "inherit") return undefined;
-  const alias = MODEL_ALIASES[value];
+  // `Object.hasOwn` rather than a bare lookup: frontmatter is
+  // file-controlled, and `model: constructor` would otherwise resolve
+  // to a function off Object.prototype and be returned as a model id.
+  const alias = Object.hasOwn(MODEL_ALIASES, value)
+    ? MODEL_ALIASES[value]
+    : undefined;
   if (alias !== undefined) return alias;
   if (!value.includes(":")) {
     throw rcError("RC5003", undefined, {
@@ -336,9 +341,13 @@ function toAgent(doc: ParsedMarkdown): LoadedAgentFile {
       source,
     ) ?? [];
   if (disallowed.length > 0 && toolRefs === undefined) {
-    logger.warn(
-      `Markdown file "${source}": "disallowedTools" is set but "tools" is not. A per-agent tool list replaces the context default outright rather than narrowing it, so this deny list has nothing to apply to.`,
-    );
+    // Fail loud rather than fail open. A per-agent list replaces the
+    // context default outright rather than narrowing it, so a deny with
+    // no allow cannot be honoured, and an agent that inherits the very
+    // tools its file denies is the worst possible reading of the file.
+    throw rcError("RC5003", undefined, {
+      message: `Markdown file "${source}": "disallowedTools" is set but "tools" is not, and a deny list alone cannot be honoured: a per-agent tool list replaces the context default outright rather than narrowing it, so this agent would inherit the very tools it denies. List the tools this agent may use in "tools", or drop "disallowedTools".`,
+    });
   }
   // Frontmatter carries only the boolean form; the function-renderer
   // form is a closure YAML cannot express and is supplied via the

--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -226,6 +226,17 @@ function toolSelection(
   source: string,
 ): ToolSelection {
   const denied = new Set(disallowed);
+  // A deny that names something the agent never had is a typo, and the
+  // tool it meant to remove stays granted. Same reason a deny with no
+  // allow throws: a field whose whole purpose is removing capability
+  // must not fail quietly.
+  for (const ref of denied) {
+    if (!refs.includes(ref)) {
+      logger.warn(
+        `Markdown file "${source}": "disallowedTools" names "${ref}", which is not in "tools", so the entry removes nothing. Check the spelling.`,
+      );
+    }
+  }
   const warned = new Set<string>();
   return tools((catalog) => {
     const registered = new Set(catalog.fns.map((fn) => fn.name));

--- a/packages/ai/src/errors.ts
+++ b/packages/ai/src/errors.ts
@@ -51,6 +51,8 @@ declare module "@routecraft/routecraft" {
     AI1002: RCMeta;
     /** Agent block misconfigured (formerly RC5027) */
     AI1003: RCMeta;
+    /** Skills source could not be resolved */
+    AI1004: RCMeta;
   }
 }
 
@@ -81,6 +83,14 @@ registerErrorCodes(
       suggestion:
         "A block is missing required fields or has an invalid shape: every block needs a non-empty `name`, a `mode` of `inject` or `progressive`, and a string-or-function `value`. Progressive blocks additionally require a non-empty `description` so the model can decide whether to load them.",
       docs: `${DOCS_BASE}#ai1003`,
+      retryable: false,
+    },
+    AI1004: {
+      category: "Adapter",
+      message: "Skills source could not be resolved",
+      suggestion:
+        "A `skills:` ref in agent frontmatter did not resolve to a directory. A local ref is relative to the agent file; an `npm:` ref resolves against installed packages, so check the package is a dependency of the project and that the subpath exists inside it.",
+      docs: `${DOCS_BASE}#ai1004`,
       retryable: false,
     },
   },

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -7,6 +7,11 @@ import "./config.ts";
 // codes in the core error registry (declaration merge + runtime metadata).
 import "./errors.ts";
 
+// Side-effect import: registers the `skills` and `agents` project
+// discoverers so `craft start` can give those folders meaning without
+// the CLI depending on this package.
+import "./project.ts";
+
 // Cross-instance identity (Symbol.for) for MCP adapters
 export { BRAND, isMcpAdapter } from "./brand.ts";
 

--- a/packages/ai/src/project.ts
+++ b/packages/ai/src/project.ts
@@ -45,18 +45,6 @@ const PACKAGE_REF_PREFIX = "npm:";
 const CONFIG_FILE = "craft.config.ts";
 
 /**
- * Run order for the two discoverers this package registers. `agents`
- * runs second so it can read the house skills the `skills` discoverer
- * contributed: a per-agent block replaces a same-named default rather
- * than merging into it, so an agent with its own skills has to compose
- * the house set explicitly or it would silently lose it.
- *
- * @internal
- */
-const SKILLS_ORDER = 10;
-const AGENTS_ORDER = 20;
-
-/**
  * One resolved contribution to an agent's skill set, kept with the
  * place it came from so a collision can name both sides.
  *
@@ -108,6 +96,19 @@ function houseSkillGroup(config: Readonly<CraftConfig>): Blocks | undefined {
 }
 
 /**
+ * npm package names, per the registry's own rules. Validated before
+ * the specifier reaches `require.resolve`, because Node treats
+ * anything starting with `.` as a relative path: `npm:..` would
+ * otherwise resolve against the agent file's directory and point the
+ * skills loader at the project itself, which is exactly the trust
+ * boundary the `npm:` form promises to hold.
+ *
+ * @internal
+ */
+const PACKAGE_NAME =
+  /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+/**
  * Split a package ref into the package name and the subpath after it.
  * Scoped names take two segments, everything else one.
  *
@@ -149,7 +150,9 @@ function resolvePackageRoot(name: string, fromFile: string): string {
       message: `Skills package "${name}" is not installed (resolved from "${fromFile}"). Add it to the project's dependencies: bun add ${name}`,
     });
   }
-  for (let up = dir; ; up = dirname(up)) {
+  // Bounded climb, matching `package-info.ts` in core: a malformed
+  // install should fail with a message rather than walk to the root.
+  for (let up = dir, depth = 0; depth < 32; up = dirname(up), depth += 1) {
     const manifest = join(up, "package.json");
     if (existsSync(manifest)) {
       try {
@@ -202,6 +205,11 @@ function resolveSkillsRef(ref: string, agentFile: string): string {
       });
     }
     const { name, subpath } = splitPackageRef(spec);
+    if (!PACKAGE_NAME.test(name)) {
+      throw rcError("AI1004", undefined, {
+        message: `Skills ref "${ref}" declared in "${agentFile}" is not a package name. Use "npm:<package>" or "npm:<package>/<subpath>" for an installed package, or a plain relative path for a folder beside the agent file.`,
+      });
+    }
     const root = resolvePackageRoot(name, agentFile);
     if (subpath) {
       const within = resolve(root, subpath);
@@ -277,7 +285,11 @@ async function composeAgentSkills(
   if (own.length === 0) return undefined;
 
   const sources = house ? [house, ...own] : own;
-  const out: Blocks = {};
+  // Null-prototype map: a skill named `__proto__` would otherwise set
+  // the object's prototype instead of registering, which drops the
+  // skill silently and leaves a record the config merge treats as a
+  // value rather than a shape.
+  const out = Object.create(null) as Blocks;
   const origin = new Map<string, string>();
   for (const source of sources) {
     for (const [name, block] of Object.entries(source.blocks)) {
@@ -300,25 +312,21 @@ async function composeAgentSkills(
  * leaves resolve as `skills__<name>` and an agent can drop the whole
  * set with `blocks: { skills: false }`.
  */
-registerProjectDiscoverer(
-  SKILLS_FOLDER,
-  async (directory, config) => {
-    if (config.agent?.defaultOptions?.blocks?.[SKILLS_FOLDER] !== undefined) {
-      logger.info(
-        `Skills: "agent.defaultOptions.blocks.skills" is set in craft.config.ts; "${directory}" not loaded.`,
-      );
-      return {};
-    }
-    const loaded = await skills({ source: directory });
+registerProjectDiscoverer(SKILLS_FOLDER, async ({ directory, config }) => {
+  if (config.agent?.defaultOptions?.blocks?.[SKILLS_FOLDER] !== undefined) {
     logger.info(
-      `Skills: loaded ${Object.keys(loaded).length} house skill(s) from "${directory}".`,
+      `Skills: "agent.defaultOptions.blocks.skills" is set in ${CONFIG_FILE}; "${directory}" not loaded.`,
     );
-    return {
-      agent: { defaultOptions: { blocks: { [SKILLS_FOLDER]: loaded } } },
-    };
-  },
-  { order: SKILLS_ORDER },
-);
+    return {};
+  }
+  const loaded = await skills({ source: directory });
+  logger.info(
+    `Skills: loaded ${Object.keys(loaded).length} house skill(s) from "${directory}".`,
+  );
+  return {
+    agent: { defaultOptions: { blocks: { [SKILLS_FOLDER]: loaded } } },
+  };
+});
 
 /**
  * Agents: every definition under `agents/` is registered, and each
@@ -335,9 +343,8 @@ registerProjectDiscoverer(
  */
 registerProjectDiscoverer(
   AGENTS_FOLDER,
-  async (directory, config) => {
+  async ({ directory, contentRoot, config }) => {
     const declared = config.agent?.agents ?? {};
-    const contentRoot = dirname(directory);
     const houseBlocks = houseSkillGroup(config);
     const houseDirectory = join(contentRoot, SKILLS_FOLDER);
     const house: SkillSource | undefined = houseBlocks
@@ -349,7 +356,12 @@ registerProjectDiscoverer(
         }
       : undefined;
 
-    const discovered: Record<string, AgentRegisteredOptions> = {};
+    // Null-prototype for the same reason as the skill map above: a
+    // frontmatter `name` of `__proto__` must register as a real key.
+    const discovered = Object.create(null) as Record<
+      string,
+      Partial<AgentRegisteredOptions>
+    >;
     for (const file of await loadAgentFiles(directory)) {
       const declaredAgent = Object.prototype.hasOwnProperty.call(
         declared,
@@ -378,12 +390,11 @@ registerProjectDiscoverer(
           );
           continue;
         }
+        // Only the contribution. The merge preserves the fields the
+        // project declared, so copying them back would be redundant and
+        // would duplicate entries once any agent field is array-valued.
         discovered[file.name] = {
-          ...declaredAgent,
-          blocks: {
-            ...declaredAgent.blocks,
-            [SKILLS_FOLDER]: composed.blocks,
-          },
+          blocks: { [SKILLS_FOLDER]: composed.blocks },
         };
         logger.info(
           `Agent "${file.name}": ${configFields} from ${CONFIG_FILE}, ${skillsProvenance}.`,
@@ -407,7 +418,16 @@ registerProjectDiscoverer(
           : `Agent "${file.name}": loaded from ${from}, ${skillsProvenance}.`,
       );
     }
-    return { agent: { agents: discovered } };
+    // A fragment is a patch: for an agent the project declared, only
+    // `blocks.skills` is contributed and the merge supplies the rest.
+    // `Partial<CraftConfig>` is shallow, so it cannot express a partial
+    // value inside `agents`; one cast here beats padding every entry
+    // out to a complete agent it is not.
+    return {
+      agent: {
+        agents: discovered as Record<string, AgentRegisteredOptions>,
+      },
+    };
   },
-  { order: AGENTS_ORDER },
+  { after: [SKILLS_FOLDER] },
 );

--- a/packages/ai/src/project.ts
+++ b/packages/ai/src/project.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   logger,
@@ -214,7 +214,9 @@ function resolveSkillsRef(ref: string, agentFile: string): string {
     if (subpath) {
       const within = resolve(root, subpath);
       const rel = relative(root, within);
-      if (rel.startsWith("..") || isAbsolute(rel)) {
+      // A leading `..` segment, not a `..` prefix: a directory named
+      // `..shared` at the package root is inside it, not an escape.
+      if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
         throw rcError("AI1004", undefined, {
           message: `Skills ref "${ref}" declared in "${agentFile}" points outside the package root ("${root}"). Remove the "../" segments.`,
         });

--- a/packages/ai/src/project.ts
+++ b/packages/ai/src/project.ts
@@ -312,8 +312,8 @@ async function composeAgentSkills(
  * leaves resolve as `skills__<name>` and an agent can drop the whole
  * set with `blocks: { skills: false }`.
  */
-registerProjectDiscoverer(SKILLS_FOLDER, async ({ directory, config }) => {
-  if (config.agent?.defaultOptions?.blocks?.[SKILLS_FOLDER] !== undefined) {
+registerProjectDiscoverer(SKILLS_FOLDER, async ({ directory, declared }) => {
+  if (declared.agent?.defaultOptions?.blocks?.[SKILLS_FOLDER] !== undefined) {
     logger.info(
       `Skills: "agent.defaultOptions.blocks.skills" is set in ${CONFIG_FILE}; "${directory}" not loaded.`,
     );
@@ -343,15 +343,23 @@ registerProjectDiscoverer(SKILLS_FOLDER, async ({ directory, config }) => {
  */
 registerProjectDiscoverer(
   AGENTS_FOLDER,
-  async ({ directory, contentRoot, config }) => {
-    const declared = config.agent?.agents ?? {};
+  async ({ directory, contentRoot, config, declared: declaredConfig }) => {
+    const declared = declaredConfig.agent?.agents ?? {};
     const houseBlocks = houseSkillGroup(config);
     const houseDirectory = join(contentRoot, SKILLS_FOLDER);
+    // The config wins over the folder, so a project that declared the
+    // house set is the source even when a skills/ folder also exists:
+    // that folder was skipped, and naming it here would send a reader
+    // looking for a shadowing skill in a directory nothing read.
+    const houseFromConfig =
+      declaredConfig.agent?.defaultOptions?.blocks?.[SKILLS_FOLDER] !==
+      undefined;
     const house: SkillSource | undefined = houseBlocks
       ? {
-          label: isDirectory(houseDirectory)
-            ? displayPath(contentRoot, houseDirectory)
-            : "agent.defaultOptions.blocks.skills",
+          label:
+            !houseFromConfig && isDirectory(houseDirectory)
+              ? displayPath(contentRoot, houseDirectory)
+              : "agent.defaultOptions.blocks.skills",
           blocks: houseBlocks,
         }
       : undefined;
@@ -369,8 +377,20 @@ registerProjectDiscoverer(
       )
         ? declared[file.name]
         : undefined;
-      const composed = await composeAgentSkills(file, house, contentRoot);
       const from = displayPath(contentRoot, file.source);
+
+      // Before composing, not after: resolving a ref the config has
+      // already overridden can fail the boot on a path whose result
+      // would have been discarded, which is not what code-wins means.
+      if (declaredAgent?.blocks?.[SKILLS_FOLDER] !== undefined) {
+        const configFields = Object.keys(declaredAgent).sort().join(", ");
+        logger.info(
+          `Agent "${file.name}": ${configFields} from ${CONFIG_FILE}, including blocks.skills; the "skills:" refs in ${from} are not loaded.`,
+        );
+        continue;
+      }
+
+      const composed = await composeAgentSkills(file, house, contentRoot);
       const skillsProvenance =
         composed === undefined
           ? undefined
@@ -381,12 +401,6 @@ registerProjectDiscoverer(
         if (composed === undefined) {
           logger.info(
             `Agent "${file.name}": ${configFields} from ${CONFIG_FILE}; ${from} contributes nothing further.`,
-          );
-          continue;
-        }
-        if (declaredAgent.blocks?.[SKILLS_FOLDER] !== undefined) {
-          logger.info(
-            `Agent "${file.name}": ${configFields} from ${CONFIG_FILE}, including blocks.skills; the "skills:" refs in ${from} are not loaded.`,
           );
           continue;
         }

--- a/packages/ai/src/project.ts
+++ b/packages/ai/src/project.ts
@@ -265,8 +265,8 @@ async function composeAgentSkills(
       blocks: await skills({ source: directory }),
     });
   }
-  if (file.directory !== undefined) {
-    const bundleSkills = join(file.directory, SKILLS_FOLDER);
+  if (file.bundleDirectory !== undefined) {
+    const bundleSkills = join(file.bundleDirectory, SKILLS_FOLDER);
     if (isDirectory(bundleSkills)) {
       own.push({
         label: displayPath(contentRoot, bundleSkills),

--- a/packages/ai/src/project.ts
+++ b/packages/ai/src/project.ts
@@ -1,0 +1,413 @@
+import { createRequire } from "node:module";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  logger,
+  rcError,
+  registerProjectDiscoverer,
+  type CraftConfig,
+} from "@routecraft/routecraft";
+import { skills } from "./block/builders.ts";
+import { loadAgentFiles, type LoadedAgentFile } from "./agent/loader.ts";
+import type { Blocks } from "./block/types.ts";
+import type { AgentRegisteredOptions } from "./agent/types.ts";
+
+/**
+ * Folder holding skills, both as the project's house folder and as the
+ * folder scoped to a single agent bundle.
+ *
+ * @internal
+ */
+const SKILLS_FOLDER = "skills";
+
+/**
+ * Folder holding agent definitions.
+ *
+ * @internal
+ */
+const AGENTS_FOLDER = "agents";
+
+/**
+ * Prefix marking a skills ref that resolves against installed
+ * packages rather than the filesystem beside the agent file.
+ *
+ * @internal
+ */
+const PACKAGE_REF_PREFIX = "npm:";
+
+/**
+ * Name of the project configuration file, used in log lines that
+ * report which side of the precedence rule a field came from.
+ *
+ * @internal
+ */
+const CONFIG_FILE = "craft.config.ts";
+
+/**
+ * Run order for the two discoverers this package registers. `agents`
+ * runs second so it can read the house skills the `skills` discoverer
+ * contributed: a per-agent block replaces a same-named default rather
+ * than merging into it, so an agent with its own skills has to compose
+ * the house set explicitly or it would silently lose it.
+ *
+ * @internal
+ */
+const SKILLS_ORDER = 10;
+const AGENTS_ORDER = 20;
+
+/**
+ * One resolved contribution to an agent's skill set, kept with the
+ * place it came from so a collision can name both sides.
+ *
+ * @internal
+ */
+interface SkillSource {
+  label: string;
+  blocks: Blocks;
+}
+
+/**
+ * A composed skill group plus the sources that fed it, in the order
+ * they were applied. The labels are what the startup log reports as
+ * the provenance of `blocks.skills`.
+ *
+ * @internal
+ */
+interface ComposedSkills {
+  blocks: Blocks;
+  sources: string[];
+}
+
+/**
+ * Render a path for a log line: relative to the project's content root
+ * when it sits inside it, absolute otherwise.
+ *
+ * @internal
+ */
+function displayPath(contentRoot: string, path: string): string {
+  const rel = relative(contentRoot, path);
+  return rel === "" || rel.startsWith("..") ? path : rel;
+}
+
+/**
+ * Read the `skills` group already present on the agent defaults, if it
+ * is a group we can compose with. A single block body is a legitimate
+ * value that simply cannot be merged into, so it is left alone: the
+ * agent still inherits it through the normal default path when it
+ * declares no skills of its own.
+ *
+ * @internal
+ */
+function houseSkillGroup(config: Readonly<CraftConfig>): Blocks | undefined {
+  const existing = config.agent?.defaultOptions?.blocks?.[SKILLS_FOLDER];
+  if (existing === undefined) return undefined;
+  if (typeof (existing as { mode?: unknown }).mode === "string")
+    return undefined;
+  return existing as Blocks;
+}
+
+/**
+ * Split a package ref into the package name and the subpath after it.
+ * Scoped names take two segments, everything else one.
+ *
+ * @internal
+ */
+function splitPackageRef(ref: string): { name: string; subpath: string } {
+  const segments = ref.split("/").filter((s) => s !== "");
+  const nameSegments = ref.startsWith("@") ? 2 : 1;
+  return {
+    name: segments.slice(0, nameSegments).join("/"),
+    subpath: segments.slice(nameSegments).join("/"),
+  };
+}
+
+/**
+ * Locate the installed root directory of `name`, resolving from
+ * `fromFile` so the project's own `node_modules` is what gets searched
+ * rather than this package's.
+ *
+ * Tries the `./package.json` export first because it lands on the root
+ * directly. Packages with a restrictive `exports` map do not expose it,
+ * so the fallback resolves the package entry point and walks up to the
+ * manifest that names the package.
+ *
+ * @internal
+ */
+function resolvePackageRoot(name: string, fromFile: string): string {
+  const require = createRequire(pathToFileURL(fromFile));
+  try {
+    return dirname(require.resolve(`${name}/package.json`));
+  } catch {
+    // Fall through to the entry-point walk.
+  }
+  let dir: string;
+  try {
+    dir = dirname(require.resolve(name));
+  } catch (cause) {
+    throw rcError("AI1004", cause, {
+      message: `Skills package "${name}" is not installed (resolved from "${fromFile}"). Add it to the project's dependencies: bun add ${name}`,
+    });
+  }
+  for (let up = dir; ; up = dirname(up)) {
+    const manifest = join(up, "package.json");
+    if (existsSync(manifest)) {
+      try {
+        const parsed = JSON.parse(readFileSync(manifest, "utf-8")) as {
+          name?: unknown;
+        };
+        if (parsed.name === name) return up;
+      } catch {
+        // An unreadable manifest is not the one we are looking for.
+      }
+    }
+    if (dirname(up) === up) break;
+  }
+  throw rcError("AI1004", undefined, {
+    message: `Skills package "${name}" resolved to "${dir}" but no package.json naming it was found above that path. The package layout is not one this loader can read; point the ref at a local folder instead.`,
+  });
+}
+
+/**
+ * Resolve a skills ref to a directory on disk.
+ *
+ * A local ref is relative to the agent file that declared it, which
+ * keeps a bundle's `./skills` meaning the same wherever the bundle
+ * sits in the tree. A `npm:` ref resolves against installed packages,
+ * with no network access at boot and no trust surface beyond the
+ * dependencies already in `package.json`.
+ *
+ * The package layout rule, in order:
+ *
+ * 1. `npm:<pkg>/<subpath>` looks for `<root>/<subpath>`, then
+ *    `<root>/skills/<subpath>`.
+ * 2. `npm:<pkg>` looks for `<root>/skills`, then `<root>` itself.
+ *
+ * Plain subpath first, because that is what a package of skill trees
+ * (one folder per collection) reads like at the call site, and the
+ * `skills/` root second so a package that keeps its skills in one
+ * conventional place does not have to spell it out. Export maps are
+ * deliberately not consulted: they resolve to files, and a skill
+ * source is a directory.
+ *
+ * @internal
+ */
+function resolveSkillsRef(ref: string, agentFile: string): string {
+  const candidates: string[] = [];
+  if (ref.startsWith(PACKAGE_REF_PREFIX)) {
+    const spec = ref.slice(PACKAGE_REF_PREFIX.length).trim();
+    if (spec === "") {
+      throw rcError("AI1004", undefined, {
+        message: `Skills ref "${ref}" declared in "${agentFile}" names no package. Use "npm:<package>" or "npm:<package>/<subpath>".`,
+      });
+    }
+    const { name, subpath } = splitPackageRef(spec);
+    const root = resolvePackageRoot(name, agentFile);
+    if (subpath) {
+      const within = resolve(root, subpath);
+      const rel = relative(root, within);
+      if (rel.startsWith("..") || isAbsolute(rel)) {
+        throw rcError("AI1004", undefined, {
+          message: `Skills ref "${ref}" declared in "${agentFile}" points outside the package root ("${root}"). Remove the "../" segments.`,
+        });
+      }
+      candidates.push(within, join(root, SKILLS_FOLDER, subpath));
+    } else {
+      candidates.push(join(root, SKILLS_FOLDER), root);
+    }
+  } else {
+    candidates.push(resolve(dirname(agentFile), ref));
+  }
+  for (const candidate of candidates) {
+    if (isDirectory(candidate)) return candidate;
+  }
+  throw rcError("AI1004", undefined, {
+    message: `Skills ref "${ref}" declared in "${agentFile}" did not resolve to a directory. Looked in: ${candidates.join(", ")}.`,
+  });
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compose the skill sources that apply to one agent, most specific
+ * last: house folder, then the frontmatter refs in declared order,
+ * then the bundle's own `skills/` folder.
+ *
+ * Returns `undefined` when the agent declares nothing of its own, so
+ * the agent inherits `defaultOptions.blocks.skills` untouched. That
+ * matters for a dropped-in Claude Code agent file, which carries no
+ * `skills:` key at all: the absence means "the house set", never "no
+ * skills".
+ *
+ * @internal
+ */
+async function composeAgentSkills(
+  file: LoadedAgentFile,
+  house: SkillSource | undefined,
+  contentRoot: string,
+): Promise<ComposedSkills | undefined> {
+  const own: SkillSource[] = [];
+  for (const ref of file.skills ?? []) {
+    const directory = resolveSkillsRef(ref, file.source);
+    own.push({
+      // A package ref reads better as authored than as the path it
+      // resolved to inside node_modules; a local one reads better as
+      // the folder it actually landed on.
+      label: ref.startsWith(PACKAGE_REF_PREFIX)
+        ? ref
+        : displayPath(contentRoot, directory),
+      blocks: await skills({ source: directory }),
+    });
+  }
+  if (file.directory !== undefined) {
+    const bundleSkills = join(file.directory, SKILLS_FOLDER);
+    if (isDirectory(bundleSkills)) {
+      own.push({
+        label: displayPath(contentRoot, bundleSkills),
+        blocks: await skills({ source: bundleSkills }),
+      });
+    }
+  }
+  if (own.length === 0) return undefined;
+
+  const sources = house ? [house, ...own] : own;
+  const out: Blocks = {};
+  const origin = new Map<string, string>();
+  for (const source of sources) {
+    for (const [name, block] of Object.entries(source.blocks)) {
+      const prior = origin.get(name);
+      if (prior !== undefined) {
+        logger.info(
+          `Agent "${file.name}": skill "${name}" from ${source.label} shadows the one from ${prior}.`,
+        );
+      }
+      origin.set(name, source.label);
+      out[name] = block;
+    }
+  }
+  return { blocks: out, sources: sources.map((source) => source.label) };
+}
+
+/**
+ * House skills: `skills/` at the project's content root becomes the
+ * default skill group every agent inherits, grouped under `skills` so
+ * leaves resolve as `skills__<name>` and an agent can drop the whole
+ * set with `blocks: { skills: false }`.
+ */
+registerProjectDiscoverer(
+  SKILLS_FOLDER,
+  async (directory, config) => {
+    if (config.agent?.defaultOptions?.blocks?.[SKILLS_FOLDER] !== undefined) {
+      logger.info(
+        `Skills: "agent.defaultOptions.blocks.skills" is set in craft.config.ts; "${directory}" not loaded.`,
+      );
+      return {};
+    }
+    const loaded = await skills({ source: directory });
+    logger.info(
+      `Skills: loaded ${Object.keys(loaded).length} house skill(s) from "${directory}".`,
+    );
+    return {
+      agent: { defaultOptions: { blocks: { [SKILLS_FOLDER]: loaded } } },
+    };
+  },
+  { order: SKILLS_ORDER },
+);
+
+/**
+ * Agents: every definition under `agents/` is registered, and each
+ * agent's skills are composed from the house folder, its frontmatter
+ * `skills:` refs, and its own bundle folder.
+ *
+ * Code wins per field rather than wholesale. An agent the project
+ * already declared in `craft.config.ts` keeps every field it set; the
+ * only thing discovery contributes is the resolved skill set, and only
+ * when the config did not set one. That is what lets a project keep an
+ * `agents("./agents", { zoe: { tools } })` call for the fields YAML
+ * cannot carry (guards are functions) while zoe's skills live in her
+ * frontmatter.
+ */
+registerProjectDiscoverer(
+  AGENTS_FOLDER,
+  async (directory, config) => {
+    const declared = config.agent?.agents ?? {};
+    const contentRoot = dirname(directory);
+    const houseBlocks = houseSkillGroup(config);
+    const houseDirectory = join(contentRoot, SKILLS_FOLDER);
+    const house: SkillSource | undefined = houseBlocks
+      ? {
+          label: isDirectory(houseDirectory)
+            ? displayPath(contentRoot, houseDirectory)
+            : "agent.defaultOptions.blocks.skills",
+          blocks: houseBlocks,
+        }
+      : undefined;
+
+    const discovered: Record<string, AgentRegisteredOptions> = {};
+    for (const file of await loadAgentFiles(directory)) {
+      const declaredAgent = Object.prototype.hasOwnProperty.call(
+        declared,
+        file.name,
+      )
+        ? declared[file.name]
+        : undefined;
+      const composed = await composeAgentSkills(file, house, contentRoot);
+      const from = displayPath(contentRoot, file.source);
+      const skillsProvenance =
+        composed === undefined
+          ? undefined
+          : `blocks.skills from ${[from, ...composed.sources].join(" + ")}`;
+
+      if (declaredAgent !== undefined) {
+        const configFields = Object.keys(declaredAgent).sort().join(", ");
+        if (composed === undefined) {
+          logger.info(
+            `Agent "${file.name}": ${configFields} from ${CONFIG_FILE}; ${from} contributes nothing further.`,
+          );
+          continue;
+        }
+        if (declaredAgent.blocks?.[SKILLS_FOLDER] !== undefined) {
+          logger.info(
+            `Agent "${file.name}": ${configFields} from ${CONFIG_FILE}, including blocks.skills; the "skills:" refs in ${from} are not loaded.`,
+          );
+          continue;
+        }
+        discovered[file.name] = {
+          ...declaredAgent,
+          blocks: {
+            ...declaredAgent.blocks,
+            [SKILLS_FOLDER]: composed.blocks,
+          },
+        };
+        logger.info(
+          `Agent "${file.name}": ${configFields} from ${CONFIG_FILE}, ${skillsProvenance}.`,
+        );
+        continue;
+      }
+
+      discovered[file.name] =
+        composed === undefined
+          ? file.agent
+          : {
+              ...file.agent,
+              blocks: {
+                ...file.agent.blocks,
+                [SKILLS_FOLDER]: composed.blocks,
+              },
+            };
+      logger.info(
+        skillsProvenance === undefined
+          ? `Agent "${file.name}": loaded from ${from}.`
+          : `Agent "${file.name}": loaded from ${from}, ${skillsProvenance}.`,
+      );
+    }
+    return { agent: { agents: discovered } };
+  },
+  { order: AGENTS_ORDER },
+);

--- a/packages/ai/test/agent-loader.bun.test.ts
+++ b/packages/ai/test/agent-loader.bun.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import {
   mkdirSync,
   mkdtempSync,
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { logger } from "@routecraft/routecraft";
 import { testContext } from "@routecraft/testing";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { agentPlugin, agents, tools } from "../src/index.ts";
@@ -20,7 +21,16 @@ function tmpDir(): string {
 
 describe("agents() markdown loader", () => {
   let dirs: string[] = [];
+  // Claude-compatibility paths report through the logger rather than
+  // throwing, so the warning is the assertion surface.
+  let warn: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    warn = spyOn(logger, "warn").mockImplementation(() => {});
+  });
+
   afterEach(() => {
+    warn.mockRestore();
     for (const d of dirs) rmSync(d, { recursive: true, force: true });
     dirs = [];
   });
@@ -242,30 +252,60 @@ describe("agents() markdown loader", () => {
   });
 
   /**
-   * @case Unsupported Claude frontmatter field throws not-yet-supported
-   * @preconditions Agent with permissionMode set
-   * @expectedResult Throws RC5003 mentioning the field and the supported list
+   * @case Claude-specific frontmatter this loader does not map is tolerated
+   * @preconditions Agent carrying permissionMode and color
+   * @expectedResult The agent loads and each ignored key is warned about
    */
-  test("rejects unsupported Claude subagent frontmatter fields", async () => {
+  test("ignores unmapped Claude frontmatter with a warning", async () => {
     const dir = makeDir({
       "x.md":
-        "---\nname: x\ndescription: d\npermissionMode: default\n---\nsystem",
+        "---\nname: x\ndescription: d\npermissionMode: default\ncolor: blue\n---\nsystem",
     });
-    await expect(agents(dir)).rejects.toThrow(
-      /frontmatter field "permissionMode" is not yet supported/,
-    );
+    const result = await agents(dir);
+    expect(result["x"]?.description).toBe("d");
+    const warned = warn.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+    expect(warned).toMatch(/"permissionMode" is not supported/);
+    expect(warned).toMatch(/"color" is not supported/);
   });
 
   /**
-   * @case Bare model alias rejected with a clear hint
-   * @preconditions model: sonnet (no provider:)
-   * @expectedResult Throws RC5003 telling the user to use full provider:model form
+   * @case Claude model aliases map to full provider:model references
+   * @preconditions model: sonnet
+   * @expectedResult The agent carries the pinned anthropic reference
    */
-  test("rejects bare model aliases like 'sonnet'", async () => {
+  test("maps the model alias 'sonnet'", async () => {
     const dir = makeDir({
       "x.md": "---\nname: x\ndescription: d\nmodel: sonnet\n---\nsystem",
     });
-    await expect(agents(dir)).rejects.toThrow(/full "provider:model" form/);
+    const result = await agents(dir);
+    expect(result["x"]?.model).toBe("anthropic:claude-sonnet-4-6");
+  });
+
+  /**
+   * @case model: inherit leaves the model unset so the context default applies
+   * @preconditions model: inherit
+   * @expectedResult No model on the loaded agent
+   */
+  test("maps the model alias 'inherit' to no model at all", async () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\nmodel: inherit\n---\nsystem",
+    });
+    const result = await agents(dir);
+    expect(result["x"]?.model).toBeUndefined();
+  });
+
+  /**
+   * @case A model that is neither an alias nor provider:model is rejected
+   * @preconditions model: gpt-nine
+   * @expectedResult Throws RC5003 listing the known aliases
+   */
+  test("rejects a model that is neither alias nor provider:model", async () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\nmodel: gpt-nine\n---\nsystem",
+    });
+    await expect(agents(dir)).rejects.toThrow(
+      /neither a known alias .* nor a full "provider:model" reference/,
+    );
   });
 
   /**
@@ -524,6 +564,186 @@ describe("agents() markdown loader", () => {
     await expect(agents(join(root, "notes.txt"))).rejects.toThrow(
       /is a file but not a "\.md" file/,
     );
+  });
+
+  /**
+   * Resolve an agent's tool selection against a context holding the
+   * given fns, returning the resolved wire names.
+   */
+  async function resolveToolNames(
+    agent: { tools?: unknown } | undefined,
+    functions: Record<string, unknown> = {},
+  ): Promise<string[]> {
+    const t = await testContext()
+      .with({
+        plugins: [
+          agentPlugin({
+            functions: functions as NonNullable<
+              NonNullable<Parameters<typeof agentPlugin>[0]>["functions"]
+            >,
+          }),
+        ],
+      })
+      .build();
+    await t.startAndWaitReady();
+    try {
+      const selection = agent?.tools as
+        { resolve: (ctx: unknown) => Array<{ name: string }> } | undefined;
+      return (selection?.resolve(t.ctx) ?? []).map((tool) => tool.name).sort();
+    } finally {
+      await t.stop();
+    }
+  }
+
+  const echoFn = {
+    description: "Echoes",
+    input: {
+      "~standard": {
+        version: 1 as const,
+        vendor: "test",
+        validate: (value: unknown) => ({ value }),
+      },
+    },
+    handler: async (): Promise<string> => "ok",
+  };
+
+  /**
+   * @case Claude's comma-separated tools string is accepted
+   * @preconditions tools: echo, Read written as a plain string
+   * @expectedResult Both refs are parsed; the registered fn resolves
+   */
+  test("accepts a comma-separated tools string", async () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\ntools: echo, Read\n---\nsystem",
+    });
+    const result = await agents(dir);
+    expect(await resolveToolNames(result["x"], { echo: echoFn })).toEqual([
+      "echo",
+    ]);
+  });
+
+  /**
+   * @case A Claude built-in this runtime does not provide is skipped with a warning
+   * @preconditions tools listing Read alongside a registered fn
+   * @expectedResult Only the registered fn resolves; the skip is warned once
+   */
+  test("skips Claude built-ins this runtime does not provide", async () => {
+    const dir = makeDir({
+      "x.md":
+        "---\nname: x\ndescription: d\ntools:\n  - echo\n  - Read\n  - Bash\n---\nsystem",
+    });
+    const result = await agents(dir);
+    expect(await resolveToolNames(result["x"], { echo: echoFn })).toEqual([
+      "echo",
+    ]);
+    const warned = warn.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+    expect(warned).toMatch(/tool "Read" is a Claude Code built-in/);
+    expect(warned).toMatch(/tool "Bash" is a Claude Code built-in/);
+  });
+
+  /**
+   * @case A registered fn wins over the built-in skip list
+   * @preconditions A fn actually registered under the name Read
+   * @expectedResult It resolves normally rather than being skipped
+   */
+  test("a registered fn named like a built-in resolves normally", async () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\ntools:\n  - Read\n---\nsystem",
+    });
+    const result = await agents(dir);
+    expect(await resolveToolNames(result["x"], { Read: echoFn })).toEqual([
+      "Read",
+    ]);
+  });
+
+  /**
+   * @case A genuinely unknown tool name is still a hard error
+   * @preconditions tools listing a name that is neither registered nor a Claude built-in
+   * @expectedResult Resolution throws naming the unknown tool
+   */
+  test("a genuinely unknown tool still throws", async () => {
+    const dir = makeDir({
+      "x.md":
+        "---\nname: x\ndescription: d\ntools:\n  - notAThing\n---\nsystem",
+    });
+    const result = await agents(dir);
+    await expect(resolveToolNames(result["x"])).rejects.toThrow(
+      /unknown tool "notAThing"/,
+    );
+  });
+
+  /**
+   * @case disallowedTools removes a reference from the agent's own list
+   * @preconditions tools grants two fns; disallowedTools denies one
+   * @expectedResult Only the allowed fn resolves
+   */
+  test("disallowedTools removes a granted tool", async () => {
+    const dir = makeDir({
+      "x.md":
+        "---\nname: x\ndescription: d\ntools: echo, other\ndisallowedTools: other\n---\nsystem",
+    });
+    const result = await agents(dir);
+    expect(
+      await resolveToolNames(result["x"], { echo: echoFn, other: echoFn }),
+    ).toEqual(["echo"]);
+  });
+
+  /**
+   * @case disallowedTools without tools warns rather than silently doing nothing
+   * @preconditions Only disallowedTools is set
+   * @expectedResult A warning explains that a per-agent list replaces the default
+   */
+  test("disallowedTools without tools warns", async () => {
+    const dir = makeDir({
+      "x.md":
+        "---\nname: x\ndescription: d\ndisallowedTools: Bash\n---\nsystem",
+    });
+    await agents(dir);
+    const warned = warn.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+    expect(warned).toMatch(/"disallowedTools" is set but "tools" is not/);
+  });
+
+  /**
+   * @case A real Claude Code agents tree boots unchanged
+   * @preconditions Nested folders, Claude-only frontmatter, comma-separated tools
+   *   mixing a built-in with an MCP ref, filenames differing from declared names
+   * @expectedResult Every agent loads keyed by frontmatter name with aliases mapped,
+   *   unknown keys warned, and the unimplemented built-in skipped
+   */
+  test("a real .claude/agents tree boots unchanged", async () => {
+    const dir = makeDir({
+      "review/security-reviewer.md": [
+        "---",
+        "name: security",
+        "description: Reviews for vulnerabilities",
+        "model: opus",
+        "tools: Read, Grep, echo",
+        "color: red",
+        "permissionMode: default",
+        "---",
+        "You review code.",
+      ].join("\n"),
+      "research/market.md": [
+        "---",
+        "name: market-research",
+        "description: Researches markets",
+        "model: haiku",
+        "disallowedTools: Write",
+        "tools: WebSearch, echo",
+        "---",
+        "You research.",
+      ].join("\n"),
+    });
+    const result = await agents(dir);
+    expect(Object.keys(result).sort()).toEqual(["market-research", "security"]);
+    expect(result["security"]?.model).toBe("anthropic:claude-opus-4-7");
+    expect(result["market-research"]?.model).toBe("anthropic:claude-haiku-4-5");
+    expect(
+      await resolveToolNames(result["security"], { echo: echoFn }),
+    ).toEqual(["echo"]);
+    expect(
+      await resolveToolNames(result["market-research"], { echo: echoFn }),
+    ).toEqual(["echo"]);
   });
 
   /**

--- a/packages/ai/test/agent-loader.bun.test.ts
+++ b/packages/ai/test/agent-loader.bun.test.ts
@@ -689,18 +689,37 @@ describe("agents() markdown loader", () => {
   });
 
   /**
-   * @case disallowedTools without tools warns rather than silently doing nothing
-   * @preconditions Only disallowedTools is set
-   * @expectedResult A warning explains that a per-agent list replaces the default
+   * @case A deny list with no allow list fails the load rather than failing open
+   * @preconditions Only disallowedTools is set, so the agent would inherit the
+   *   context default including the tools the file denies
+   * @expectedResult Throws RC5003 explaining why it cannot be honoured and what
+   *   to write instead
    */
-  test("disallowedTools without tools warns", async () => {
+  test("disallowedTools without tools throws", async () => {
     const dir = makeDir({
       "x.md":
         "---\nname: x\ndescription: d\ndisallowedTools: Bash\n---\nsystem",
     });
-    await agents(dir);
-    const warned = warn.mock.calls.map((c: unknown[]) => String(c[0])).join("");
-    expect(warned).toMatch(/"disallowedTools" is set but "tools" is not/);
+    const error = await agents(dir).catch((err: unknown) => err);
+    expect(error).toMatchObject({ rc: "RC5003" });
+    expect((error as Error).message).toMatch(
+      /deny list alone cannot be honoured/,
+    );
+  });
+
+  /**
+   * @case A model naming an Object.prototype member is rejected
+   * @preconditions model: constructor, which a bare table lookup would resolve
+   *   to a function off the prototype chain
+   * @expectedResult Throws RC5003 rather than accepting a function as a model id
+   */
+  test("rejects a model that names a prototype member", async () => {
+    const dir = makeDir({
+      "x.md": "---\nname: x\ndescription: d\nmodel: constructor\n---\nsystem",
+    });
+    await expect(agents(dir)).rejects.toThrow(
+      /neither a known alias .* nor a full "provider:model" reference/,
+    );
   });
 
   /**

--- a/packages/ai/test/project-discoverers.bun.test.ts
+++ b/packages/ai/test/project-discoverers.bun.test.ts
@@ -1,0 +1,445 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  getProjectDiscoverers,
+  logger,
+  type CraftConfig,
+  type ProjectDiscoverer,
+} from "@routecraft/routecraft";
+import { tools } from "../src/index.ts";
+import type { AgentRegisteredOptions } from "../src/agent/types.ts";
+import type { BlockBody, Blocks } from "../src/block/types.ts";
+
+// Importing the package entry registers the discoverers as a side effect.
+import "../src/index.ts";
+
+function discovererFor(folder: string): ProjectDiscoverer {
+  const found = getProjectDiscoverers().find((d) => d.folder === folder);
+  if (!found) throw new Error(`no discoverer registered for "${folder}"`);
+  return found.discover;
+}
+
+function skillFile(name: string, body: string): string {
+  return `---\nname: ${name}\ndescription: The ${name} skill\n---\n${body}`;
+}
+
+function agentFile(name: string, frontmatter = ""): string {
+  return `---\nname: ${name}\ndescription: The ${name} agent\n${frontmatter}---\nYou are ${name}.`;
+}
+
+/** Names of the leaves inside a resolved `skills` block group. */
+function skillNames(agent: AgentRegisteredOptions | undefined): string[] {
+  const group = agent?.blocks?.["skills"];
+  if (!group || typeof group !== "object") return [];
+  return Object.keys(group as Blocks).sort();
+}
+
+function skillBody(
+  agent: AgentRegisteredOptions | undefined,
+  name: string,
+): string | undefined {
+  const group = agent?.blocks?.["skills"] as Blocks | undefined;
+  const leaf = group?.[name];
+  if (!leaf) return undefined;
+  const value = (leaf as BlockBody).value;
+  return typeof value === "string" ? value : undefined;
+}
+
+describe("project discoverers", () => {
+  let dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs = [];
+  });
+
+  /** Write a tree of files under a fresh temp project root. */
+  function makeProject(files: Record<string, string>): string {
+    const root = mkdtempSync(join(tmpdir(), "rc-project-"));
+    dirs.push(root);
+    for (const [name, content] of Object.entries(files)) {
+      const target = join(root, name);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, content, "utf-8");
+    }
+    return root;
+  }
+
+  /** Run skills then agents, threading the config the way `start` does. */
+  async function discover(
+    root: string,
+    config: CraftConfig = {},
+  ): Promise<CraftConfig> {
+    const { mergeProjectConfig } = await import("@routecraft/routecraft");
+    let out = config;
+    for (const folder of ["skills", "agents"]) {
+      const directory = join(root, folder);
+      // `craft start` only invokes a discoverer for a folder that
+      // exists; mirror that so a project without one is not an error.
+      if (!existsSync(directory)) continue;
+      out = mergeProjectConfig(
+        out,
+        await discovererFor(folder)(directory, out),
+      );
+    }
+    return out;
+  }
+
+  /**
+   * @case The house skills folder becomes the default skill group
+   * @preconditions skills/ holds a flat skill and a nested SKILL.md bundle
+   * @expectedResult Both land under agent.defaultOptions.blocks.skills
+   */
+  test("house skills load into the agent defaults", async () => {
+    const root = makeProject({
+      "skills/tone-of-voice.md": skillFile("tone-of-voice", "Be brief."),
+      "skills/incident-response/SKILL.md": skillFile(
+        "incident-response",
+        "Page someone.",
+      ),
+      "agents/triage.md": agentFile("triage"),
+    });
+    const config = await discover(root);
+    const house = config.agent?.defaultOptions?.blocks?.["skills"] as Blocks;
+    expect(Object.keys(house).sort()).toEqual([
+      "incident-response",
+      "tone-of-voice",
+    ]);
+  });
+
+  /**
+   * @case An agent with no skills declaration inherits the house set
+   * @preconditions Dropped-in agent file with no skills: key, house folder present
+   * @expectedResult The agent carries no own skills block, so the default applies
+   */
+  test("an agent without a skills key inherits the house default", async () => {
+    const root = makeProject({
+      "skills/tone-of-voice.md": skillFile("tone-of-voice", "Be brief."),
+      "agents/triage.md": agentFile("triage"),
+    });
+    const config = await discover(root);
+    // An empty own group would replace the default wholesale and leave
+    // the agent with nothing; absent is what makes it inherit.
+    expect(
+      config.agent?.agents?.["triage"]?.blocks?.["skills"],
+    ).toBeUndefined();
+  });
+
+  /**
+   * @case A bundle's own skills folder composes on top of the house set
+   * @preconditions House skill plus a bundle with its own skills/ folder
+   * @expectedResult The agent sees the union of both
+   */
+  test("a bundle composes house and bundle skills", async () => {
+    const root = makeProject({
+      "skills/tone-of-voice.md": skillFile("tone-of-voice", "Be brief."),
+      "agents/aria/AGENT.md": agentFile("aria"),
+      "agents/aria/skills/refund-policy.md": skillFile(
+        "refund-policy",
+        "Refund rules.",
+      ),
+    });
+    const config = await discover(root);
+    expect(skillNames(config.agent?.agents?.["aria"])).toEqual([
+      "refund-policy",
+      "tone-of-voice",
+    ]);
+  });
+
+  /**
+   * @case The most specific source wins a name collision
+   * @preconditions A skill name present in both the house folder and the bundle
+   * @expectedResult The bundle's body is the one the agent gets
+   */
+  test("a bundle skill shadows the house skill of the same name", async () => {
+    const root = makeProject({
+      "skills/tone-of-voice.md": skillFile("tone-of-voice", "House tone."),
+      "agents/aria/AGENT.md": agentFile("aria"),
+      "agents/aria/skills/tone-of-voice.md": skillFile(
+        "tone-of-voice",
+        "Aria tone.",
+      ),
+    });
+    const config = await discover(root);
+    expect(skillBody(config.agent?.agents?.["aria"], "tone-of-voice")).toBe(
+      "Aria tone.",
+    );
+  });
+
+  /**
+   * @case Frontmatter refs resolve as local paths relative to the agent file
+   * @preconditions Flat agent declaring skills: ../shared-skills
+   * @expectedResult The referenced folder's skills compose onto the house set
+   */
+  test("a local skills ref resolves relative to the agent file", async () => {
+    const root = makeProject({
+      "skills/tone-of-voice.md": skillFile("tone-of-voice", "Be brief."),
+      "shared-skills/escalation.md": skillFile("escalation", "Escalate."),
+      "agents/triage.md": agentFile(
+        "triage",
+        "skills:\n  - ../shared-skills\n",
+      ),
+    });
+    const config = await discover(root);
+    expect(skillNames(config.agent?.agents?.["triage"])).toEqual([
+      "escalation",
+      "tone-of-voice",
+    ]);
+  });
+
+  /**
+   * @case Composition order is house, then frontmatter refs, then bundle
+   * @preconditions One skill name declared in all three sources
+   * @expectedResult The bundle copy wins, proving it is applied last
+   */
+  test("composition order runs house then refs then bundle", async () => {
+    const root = makeProject({
+      "skills/policy.md": skillFile("policy", "House."),
+      "extra/policy.md": skillFile("policy", "Ref."),
+      "agents/aria/AGENT.md": agentFile("aria", "skills:\n  - ../../extra\n"),
+      "agents/aria/skills/policy.md": skillFile("policy", "Bundle."),
+    });
+    const config = await discover(root);
+    expect(skillBody(config.agent?.agents?.["aria"], "policy")).toBe("Bundle.");
+  });
+
+  /**
+   * @case An unresolvable local ref fails the boot with a typed error
+   * @preconditions skills: ./nope pointing at a folder that does not exist
+   * @expectedResult Throws AI1004 naming the ref
+   */
+  test("an unresolvable skills ref throws AI1004", async () => {
+    const root = makeProject({
+      "agents/triage.md": agentFile("triage", "skills:\n  - ./nope\n"),
+    });
+    const error = await discover(root).catch((err: unknown) => err);
+    expect(error).toMatchObject({ rc: "AI1004" });
+    expect((error as Error).message).toMatch(/\.\/nope/);
+  });
+
+  /**
+   * @case An npm: ref names a package that is not installed
+   * @preconditions skills: npm:@nope/not-installed
+   * @expectedResult Throws AI1004 with an install hint naming the package
+   */
+  test("an uninstalled skills package throws AI1004 with an install hint", async () => {
+    const root = makeProject({
+      "agents/triage.md": agentFile(
+        "triage",
+        "skills:\n  - npm:@nope/not-installed\n",
+      ),
+    });
+    const error = await discover(root).catch((err: unknown) => err);
+    expect(error).toMatchObject({ rc: "AI1004" });
+    expect((error as Error).message).toMatch(/bun add @nope\/not-installed/);
+  });
+
+  /**
+   * @case An npm: ref with a subpath resolves against the package root
+   * @preconditions A claude-skills-shaped package installed in node_modules,
+   *   holding its collections as plain subdirectories
+   * @expectedResult The subpath's skills compose onto the agent
+   */
+  test("an npm: ref resolves a plain subpath in the package", async () => {
+    const root = makeProject({
+      "node_modules/@acme/claude-skills/package.json": JSON.stringify({
+        name: "@acme/claude-skills",
+        version: "1.0.0",
+      }),
+      "node_modules/@acme/claude-skills/devoptix/handbook.md": skillFile(
+        "handbook",
+        "The handbook.",
+      ),
+      "agents/zoe.md": agentFile(
+        "zoe",
+        "skills:\n  - npm:@acme/claude-skills/devoptix\n",
+      ),
+    });
+    const config = await discover(root);
+    expect(skillNames(config.agent?.agents?.["zoe"])).toEqual(["handbook"]);
+  });
+
+  /**
+   * @case An npm: ref with no subpath falls back to the package's skills root
+   * @preconditions Package keeping its skills under a well-known skills/ folder
+   * @expectedResult The skills/ folder is used without naming it in the ref
+   */
+  test("an npm: ref with no subpath uses the package skills folder", async () => {
+    const root = makeProject({
+      "node_modules/@acme/house/package.json": JSON.stringify({
+        name: "@acme/house",
+        version: "1.0.0",
+      }),
+      "node_modules/@acme/house/skills/brand.md": skillFile("brand", "Brand."),
+      "agents/zoe.md": agentFile("zoe", "skills:\n  - npm:@acme/house\n"),
+    });
+    const config = await discover(root);
+    expect(skillNames(config.agent?.agents?.["zoe"])).toEqual(["brand"]);
+  });
+
+  /**
+   * @case An agent declared in code keeps its own fields
+   * @preconditions Config declares the agent with tools and a custom description
+   * @expectedResult The config's fields survive discovery untouched
+   */
+  test("a config-declared agent keeps its fields", async () => {
+    const root = makeProject({
+      "agents/zoe.md": agentFile("zoe"),
+    });
+    const selection = tools(["something"]);
+    const config = await discover(root, {
+      agent: {
+        agents: {
+          zoe: {
+            description: "From config",
+            system: "Config system",
+            tools: selection,
+          },
+        },
+      },
+    });
+    expect(config.agent?.agents?.["zoe"]).toMatchObject({
+      description: "From config",
+      system: "Config system",
+    });
+    expect(config.agent?.agents?.["zoe"]?.tools).toBe(selection);
+  });
+
+  /**
+   * @case A config override that sets only tools leaves frontmatter skills intact
+   * @preconditions Config declares zoe with tools only; her frontmatter declares skills
+   * @expectedResult Discovery resolves the refs onto her, and the tools object survives
+   */
+  test("a tools-only override still gets frontmatter-declared skills", async () => {
+    const root = makeProject({
+      "skills/tone-of-voice.md": skillFile("tone-of-voice", "Be brief."),
+      "devoptix/handbook.md": skillFile("handbook", "The handbook."),
+      "agents/zoe.md": agentFile("zoe", "skills:\n  - ../devoptix\n"),
+    });
+    const selection = tools(["something"]);
+    const config = await discover(root, {
+      agent: {
+        agents: {
+          zoe: {
+            description: "Zoe",
+            system: "You are Zoe.",
+            tools: selection,
+          },
+        },
+      },
+    });
+    expect(skillNames(config.agent?.agents?.["zoe"])).toEqual([
+      "handbook",
+      "tone-of-voice",
+    ]);
+    expect(config.agent?.agents?.["zoe"]?.tools).toBe(selection);
+  });
+
+  /**
+   * @case The startup log names which side each field of a merged agent came from
+   * @preconditions Config declares zoe with tools; her frontmatter adds a local
+   *   ref and a package ref on top of the house folder
+   * @expectedResult One info line names the config-set fields and every source
+   *   that fed blocks.skills, in composition order
+   */
+  test("logs field provenance for a merged agent", async () => {
+    const info = spyOn(logger, "info").mockImplementation(() => {});
+    try {
+      const root = makeProject({
+        "node_modules/@acme/claude-skills/package.json": JSON.stringify({
+          name: "@acme/claude-skills",
+          version: "1.0.0",
+        }),
+        "node_modules/@acme/claude-skills/support/refunds.md": skillFile(
+          "refunds",
+          "Refunds.",
+        ),
+        "skills/tone-of-voice.md": skillFile("tone-of-voice", "Be brief."),
+        "devoptix/handbook.md": skillFile("handbook", "The handbook."),
+        "agents/zoe.md": agentFile(
+          "zoe",
+          "skills:\n  - ../devoptix\n  - npm:@acme/claude-skills/support\n",
+        ),
+      });
+      await discover(root, {
+        agent: {
+          agents: {
+            zoe: {
+              description: "Zoe",
+              system: "You are Zoe.",
+              tools: tools(["something"]),
+            },
+          },
+        },
+      });
+      const line = info.mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .find((message) => message.startsWith('Agent "zoe"'));
+      expect(line).toBe(
+        'Agent "zoe": description, system, tools from craft.config.ts, ' +
+          "blocks.skills from agents/zoe.md + skills + devoptix + " +
+          "npm:@acme/claude-skills/support.",
+      );
+    } finally {
+      info.mockRestore();
+    }
+  });
+
+  /**
+   * @case A config-set blocks.skills is not overwritten by discovery
+   * @preconditions Config declares zoe with her own blocks.skills; frontmatter also declares refs
+   * @expectedResult The config's block group is the one that survives
+   */
+  test("a config-set blocks.skills wins over frontmatter refs", async () => {
+    const root = makeProject({
+      "devoptix/handbook.md": skillFile("handbook", "The handbook."),
+      "agents/zoe.md": agentFile("zoe", "skills:\n  - ../devoptix\n"),
+    });
+    const config = await discover(root, {
+      agent: {
+        agents: {
+          zoe: {
+            description: "Zoe",
+            system: "You are Zoe.",
+            blocks: {
+              skills: {
+                curated: { mode: "inject", value: "Curated." },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(skillNames(config.agent?.agents?.["zoe"])).toEqual(["curated"]);
+  });
+
+  /**
+   * @case A config-set house skill group stops the folder from loading
+   * @preconditions Config sets agent.defaultOptions.blocks.skills and skills/ exists
+   * @expectedResult The config's group survives; the folder is not read
+   */
+  test("config-set house skills win over the skills folder", async () => {
+    const root = makeProject({
+      "skills/tone-of-voice.md": skillFile("tone-of-voice", "Be brief."),
+      "agents/triage.md": agentFile("triage"),
+    });
+    const config = await discover(root, {
+      agent: {
+        defaultOptions: {
+          blocks: {
+            skills: { curated: { mode: "inject", value: "Curated." } },
+          },
+        },
+      },
+    });
+    const house = config.agent?.defaultOptions?.blocks?.["skills"] as Blocks;
+    expect(Object.keys(house)).toEqual(["curated"]);
+  });
+});

--- a/packages/ai/test/project-discoverers.bun.test.ts
+++ b/packages/ai/test/project-discoverers.bun.test.ts
@@ -259,6 +259,44 @@ describe("project discoverers", () => {
   });
 
   /**
+   * @case An npm: ref that is not a package name is rejected before resolution
+   * @preconditions skills: npm:.., which Node would otherwise resolve relatively
+   * @expectedResult Throws AI1004, so the npm: form cannot be used to reach a
+   *   directory outside the installed dependency set
+   */
+  test("an npm: ref that is not a package name throws AI1004", async () => {
+    const root = makeProject({
+      "agents/triage.md": agentFile("triage", "skills:\n  - npm:..\n"),
+    });
+    const error = await discover(root).catch((err: unknown) => err);
+    expect(error).toMatchObject({ rc: "AI1004" });
+    expect((error as Error).message).toMatch(/is not a package name/);
+  });
+
+  /**
+   * @case An npm: subpath climbing out of the package root is rejected
+   * @preconditions An installed package plus a ref whose subpath is ../../outside
+   * @expectedResult Throws AI1004 naming the package root, so a ref cannot read
+   *   a directory the dependency does not own
+   */
+  test("an npm: subpath escaping the package root throws AI1004", async () => {
+    const root = makeProject({
+      "node_modules/@acme/house/package.json": JSON.stringify({
+        name: "@acme/house",
+        version: "1.0.0",
+      }),
+      "node_modules/@acme/house/skills/policy.md": skillFile("policy", "Pkg."),
+      "agents/zoe.md": agentFile(
+        "zoe",
+        "skills:\n  - npm:@acme/house/../../outside\n",
+      ),
+    });
+    const error = await discover(root).catch((err: unknown) => err);
+    expect(error).toMatchObject({ rc: "AI1004" });
+    expect((error as Error).message).toMatch(/points outside the package root/);
+  });
+
+  /**
    * @case An npm: ref names a package that is not installed
    * @preconditions skills: npm:@nope/not-installed
    * @expectedResult Throws AI1004 with an install hint naming the package

--- a/packages/ai/test/project-discoverers.bun.test.ts
+++ b/packages/ai/test/project-discoverers.bun.test.ts
@@ -91,6 +91,7 @@ describe("project discoverers", () => {
           contentRoot: root,
           projectRoot: root,
           config: out,
+          declared: config,
         }),
       );
     }
@@ -227,6 +228,34 @@ describe("project discoverers", () => {
     const error = await discover(root).catch((err: unknown) => err);
     expect(error).toMatchObject({ rc: "AI1004" });
     expect((error as Error).message).toMatch(/\.\/nope/);
+  });
+
+  /**
+   * @case A config-set blocks.skills stops the frontmatter refs being resolved at all
+   * @preconditions The config declares the agent's blocks.skills, and the same
+   *   agent's frontmatter carries a ref that would fail to resolve
+   * @expectedResult The boot succeeds with the config's skills, because code
+   *   winning has to mean the ignored path is never walked, not merely that
+   *   its result is discarded after it has already thrown
+   */
+  test("a configured blocks.skills suppresses ref resolution entirely", async () => {
+    const root = makeProject({
+      "agents/triage.md": agentFile("triage", "skills:\n  - ./nope\n"),
+    });
+    const config = await discover(root, {
+      agent: {
+        agents: {
+          triage: {
+            description: "Declared in code",
+            system: "You are triage.",
+            blocks: { skills: { house: { mode: "inject", value: "Config." } } },
+          },
+        },
+      },
+    });
+    expect(skillBody(config.agent?.agents?.["triage"], "house")).toBe(
+      "Config.",
+    );
   });
 
   /**

--- a/packages/ai/test/project-discoverers.bun.test.ts
+++ b/packages/ai/test/project-discoverers.bun.test.ts
@@ -86,7 +86,12 @@ describe("project discoverers", () => {
       if (!existsSync(directory)) continue;
       out = mergeProjectConfig(
         out,
-        await discovererFor(folder)(directory, out),
+        await discovererFor(folder)({
+          directory,
+          contentRoot: root,
+          projectRoot: root,
+          config: out,
+        }),
       );
     }
     return out;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -135,6 +135,10 @@ program
     "--once",
     "Shut down after the first exchange reaches a terminal outcome",
   )
+  .option(
+    "--timeout <ms>",
+    "With --once, give up and exit non-zero after this many milliseconds",
+  )
   .action(async (dir: string | undefined, options) => {
     applyGlobalLogOptions();
 
@@ -146,7 +150,18 @@ program
     }
 
     const { startCommand } = await import("./start.js");
-    const result = await startCommand(dir, { once: options.once === true });
+    const timeoutMs =
+      options.timeout === undefined ? undefined : Number(options.timeout);
+    if (timeoutMs !== undefined && !Number.isFinite(timeoutMs)) {
+      // eslint-disable-next-line no-console
+      console.error(`--timeout must be a number of milliseconds.`);
+      setImmediate(() => process.exit(1));
+      return;
+    }
+    const result = await startCommand(dir, {
+      once: options.once === true,
+      ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    });
     if (!result.success) {
       if (result.message) {
         // eslint-disable-next-line no-console

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -142,19 +142,33 @@ program
   .action(async (dir: string | undefined, options) => {
     applyGlobalLogOptions();
 
+    const { resolve: resolvePath } = await import("node:path");
+    const projectRoot = resolvePath(process.cwd(), dir ?? ".");
+
     const { loadEnvFile } = await import("./util.js");
-    if (options.env !== undefined) {
-      loadEnvFile(options.env);
-    } else {
-      loadEnvFile();
-    }
+    // The conventional .env pair belongs to the project being started,
+    // not to whatever directory the shell happens to sit in.
+    loadEnvFile(options.env, projectRoot);
 
     const { startCommand } = await import("./start.js");
     const timeoutMs =
       options.timeout === undefined ? undefined : Number(options.timeout);
-    if (timeoutMs !== undefined && !Number.isFinite(timeoutMs)) {
+    if (
+      timeoutMs !== undefined &&
+      (!Number.isFinite(timeoutMs) || timeoutMs < 1)
+    ) {
       // eslint-disable-next-line no-console
-      console.error(`--timeout must be a number of milliseconds.`);
+      console.error(
+        `--timeout must be a number of milliseconds, at least 1. Received "${String(options.timeout)}".`,
+      );
+      setImmediate(() => process.exit(1));
+      return;
+    }
+    if (timeoutMs !== undefined && options.once !== true) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `--timeout bounds the wait for the first exchange, which only --once waits for. Add --once, or drop --timeout.`,
+      );
       setImmediate(() => process.exit(1));
       return;
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -139,56 +139,61 @@ program
     "--timeout <ms>",
     "With --once, give up and exit non-zero after this many milliseconds",
   )
-  .action(async (dir: string | undefined, options) => {
-    applyGlobalLogOptions();
+  .action(
+    async (
+      dir: string | undefined,
+      options: { env?: string; once?: boolean; timeout?: string },
+    ) => {
+      applyGlobalLogOptions();
 
-    const { resolve: resolvePath } = await import("node:path");
-    const projectRoot = resolvePath(process.cwd(), dir ?? ".");
+      const { resolve: resolvePath } = await import("node:path");
+      const projectRoot = resolvePath(process.cwd(), dir ?? ".");
 
-    const { loadEnvFile } = await import("./util.js");
-    // The conventional .env pair belongs to the project being started,
-    // not to whatever directory the shell happens to sit in.
-    loadEnvFile(options.env, projectRoot);
+      const { loadEnvFile } = await import("./util.js");
+      // The conventional .env pair belongs to the project being started,
+      // not to whatever directory the shell happens to sit in.
+      loadEnvFile(options.env, projectRoot);
 
-    const { startCommand } = await import("./start.js");
-    const timeoutMs =
-      options.timeout === undefined ? undefined : Number(options.timeout);
-    if (
-      timeoutMs !== undefined &&
-      (!Number.isFinite(timeoutMs) || timeoutMs < 1)
-    ) {
-      // eslint-disable-next-line no-console
-      console.error(
-        `--timeout must be a number of milliseconds, at least 1. Received "${String(options.timeout)}".`,
-      );
-      setImmediate(() => process.exit(1));
-      return;
-    }
-    if (timeoutMs !== undefined && options.once !== true) {
-      // eslint-disable-next-line no-console
-      console.error(
-        `--timeout bounds the wait for the first exchange, which only --once waits for. Add --once, or drop --timeout.`,
-      );
-      setImmediate(() => process.exit(1));
-      return;
-    }
-    const result = await startCommand(dir, {
-      once: options.once === true,
-      ...(timeoutMs === undefined ? {} : { timeoutMs }),
-    });
-    if (!result.success) {
-      if (result.message) {
+      const { startCommand } = await import("./start.js");
+      const timeoutMs =
+        options.timeout === undefined ? undefined : Number(options.timeout);
+      if (
+        timeoutMs !== undefined &&
+        (!Number.isFinite(timeoutMs) || timeoutMs < 1)
+      ) {
         // eslint-disable-next-line no-console
-        console.error(result.message);
+        console.error(
+          `--timeout must be a number of milliseconds, at least 1. Received "${String(options.timeout)}".`,
+        );
+        setImmediate(() => process.exit(1));
+        return;
       }
-      // Defer exit so pino/sonic-boom can finish initializing and avoid
-      // "sonic boom is not ready yet"
-      const code = result.code ?? 1;
-      setImmediate(() => process.exit(code));
-      return;
-    }
-    // Don't call process.exit(); let the event loop drain naturally.
-  });
+      if (timeoutMs !== undefined && options.once !== true) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `--timeout bounds the wait for the first exchange, which only --once waits for. Add --once, or drop --timeout.`,
+        );
+        setImmediate(() => process.exit(1));
+        return;
+      }
+      const result = await startCommand(dir, {
+        once: options.once === true,
+        ...(timeoutMs === undefined ? {} : { timeoutMs }),
+      });
+      if (!result.success) {
+        if (result.message) {
+          // eslint-disable-next-line no-console
+          console.error(result.message);
+        }
+        // Defer exit so pino/sonic-boom can finish initializing and avoid
+        // "sonic boom is not ready yet"
+        const code = result.code ?? 1;
+        setImmediate(() => process.exit(code));
+        return;
+      }
+      // Don't call process.exit(); let the event loop drain naturally.
+    },
+  );
 
 /**
  * The 'tui' command launches the Terminal UI for monitoring Routecraft execution.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,24 @@ if (process.argv.length <= 2) {
 }
 
 /**
+ * Push the global log options onto the environment before any import
+ * that constructs the logger. The logger reads env at module load, so
+ * this has to happen inside a command action but ahead of the lazy
+ * `run` / `start` imports.
+ */
+function applyGlobalLogOptions(): void {
+  const globalOpts = program.opts();
+  if (globalOpts["logLevel"] !== undefined) {
+    process.env["LOG_LEVEL"] = globalOpts["logLevel"];
+    process.env["CRAFT_LOG_LEVEL"] = globalOpts["logLevel"];
+  }
+  if (globalOpts["logFile"] !== undefined) {
+    process.env["LOG_FILE"] = globalOpts["logFile"];
+    process.env["CRAFT_LOG_FILE"] = globalOpts["logFile"];
+  }
+}
+
+/**
  * The 'run' command executes routes from a single file.
  *
  * Example:
@@ -70,16 +88,7 @@ program
   )
   .passThroughOptions()
   .action(async (filePath, args: string[], options) => {
-    // Apply global log options to env before any import that creates the logger
-    const globalOpts = program.opts();
-    if (globalOpts["logLevel"] !== undefined) {
-      process.env["LOG_LEVEL"] = globalOpts["logLevel"];
-      process.env["CRAFT_LOG_LEVEL"] = globalOpts["logLevel"];
-    }
-    if (globalOpts["logFile"] !== undefined) {
-      process.env["LOG_FILE"] = globalOpts["logFile"];
-      process.env["CRAFT_LOG_FILE"] = globalOpts["logFile"];
-    }
+    applyGlobalLogOptions();
 
     const { loadEnvFile } = await import("./util.js");
     if (options.env !== undefined) {
@@ -103,6 +112,53 @@ program
     // Don't call process.exit(); let the event loop drain naturally.
     // process.exit() triggers C++ static destructors that race with ONNX
     // Runtime cleanup (onnxruntime#25038: "mutex lock failed").
+  });
+
+/**
+ * The 'start' command boots a whole project from the folder convention.
+ *
+ * Example:
+ * craft start
+ * craft start ./apps/eywa --once
+ */
+program
+  .command("start")
+  .description(
+    "Start a project from its folder convention (capabilities, plugins, agents, skills)",
+  )
+  .argument("[dir]", "Project root (default: current directory)")
+  .option(
+    "--env <path>",
+    "Load environment variables from a .env file (default: .env)",
+  )
+  .option(
+    "--once",
+    "Shut down after the first exchange reaches a terminal outcome",
+  )
+  .action(async (dir: string | undefined, options) => {
+    applyGlobalLogOptions();
+
+    const { loadEnvFile } = await import("./util.js");
+    if (options.env !== undefined) {
+      loadEnvFile(options.env);
+    } else {
+      loadEnvFile();
+    }
+
+    const { startCommand } = await import("./start.js");
+    const result = await startCommand(dir, { once: options.once === true });
+    if (!result.success) {
+      if (result.message) {
+        // eslint-disable-next-line no-console
+        console.error(result.message);
+      }
+      // Defer exit so pino/sonic-boom can finish initializing and avoid
+      // "sonic boom is not ready yet"
+      const code = result.code ?? 1;
+      setImmediate(() => process.exit(code));
+      return;
+    }
+    // Don't call process.exit(); let the event loop drain naturally.
   });
 
 /**

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,9 +1,11 @@
 import { readdirSync, statSync } from "node:fs";
 import { extname, join, relative } from "node:path";
+import type { CraftPlugin } from "@routecraft/routecraft";
 
 /**
- * Module extensions the project runtime will import. Mirrors what
- * `craft run` accepts for its entry file.
+ * Module extensions the CLI will import, shared by `run` (its entry
+ * file) and `start` (every discovered module) so one path is never
+ * classified two ways.
  *
  * @internal
  */
@@ -43,7 +45,7 @@ export function isDirectory(path: string): boolean {
 }
 
 /** True when `path` exists and is a file. */
-export function isFile(path: string): boolean {
+function isFile(path: string): boolean {
   try {
     return statSync(path).isFile();
   } catch {
@@ -51,7 +53,7 @@ export function isFile(path: string): boolean {
   }
 }
 
-function isSkippedDirectory(name: string): boolean {
+function isSkippedProjectDirectory(name: string): boolean {
   return name.startsWith(".") || SKIPPED_DIRECTORIES.has(name);
 }
 
@@ -63,7 +65,7 @@ function isSkippedDirectory(name: string): boolean {
  * segment pair, so `route.test.ts` and `route.bun.test.ts` are both
  * excluded.
  */
-export function isImportableModule(name: string): boolean {
+function isImportableModule(name: string): boolean {
   if (!MODULE_EXTENSIONS.includes(extname(name))) return false;
   if (name.endsWith(".d.ts")) return false;
   return !/\.(test|spec)\.[^.]+$/.test(name);
@@ -83,70 +85,51 @@ function capabilityFile(dir: string): string | undefined {
 }
 
 /**
- * Walk a `capabilities/` tree and return every module that should be
- * imported, in path order.
+ * Walk a convention folder and return every module to import, in path
+ * order.
  *
- * Two forms are recognised, and they can be mixed in one tree:
- *
- * - **Folder form.** A directory holding `route.ts` is one capability.
- *   The file is imported and the directory is not descended into, so
- *   colocated tests, fixtures and private helpers are never loaded.
- * - **Single-file form.** Any other importable module is one
- *   capability on its own.
- *
- * A directory that is neither is a grouping folder (a domain) and is
- * walked.
+ * `claim` lets a directory stand for one unit rather than being walked
+ * into: the capability walk passes {@link capabilityFile}, so a folder
+ * holding `route.ts` yields that file and its colocated tests, fixtures
+ * and helpers are never seen. The root is never offered to `claim`,
+ * which is what keeps `capabilities/` itself from being mistaken for a
+ * capability.
  */
-export function discoverCapabilityModules(dir: string): string[] {
+function collectModules(
+  dir: string,
+  claim?: (directory: string) => string | undefined,
+): string[] {
   const out: string[] = [];
-  const walk = (current: string): void => {
-    const sentinel = capabilityFile(current);
-    if (sentinel !== undefined) {
-      out.push(sentinel);
-      return;
-    }
-    for (const entry of readdirSync(current, { withFileTypes: true })) {
-      const child = join(current, entry.name);
-      if (entry.isDirectory()) {
-        if (isSkippedDirectory(entry.name)) continue;
-        walk(child);
-        continue;
-      }
-      if (entry.isFile() && isImportableModule(entry.name)) out.push(child);
-    }
-  };
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const child = join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (isSkippedDirectory(entry.name)) continue;
-      walk(child);
+      if (isSkippedProjectDirectory(entry.name)) continue;
+      const claimed = claim?.(child);
+      if (claimed !== undefined) out.push(claimed);
+      else out.push(...collectModules(child, claim));
       continue;
     }
     if (entry.isFile() && isImportableModule(entry.name)) out.push(child);
   }
-  return out.sort((a, b) => a.localeCompare(b));
+  return out;
 }
 
 /**
- * Walk a `plugins/` tree and return every module that should be
- * imported, in path order. Subfolders are grouping only; there is no
+ * Walk a `capabilities/` tree. Two forms, mixable in one tree: a
+ * directory holding `route.ts` is one capability, and any other
+ * importable module is a single-file capability. Every other directory
+ * is a grouping folder.
+ */
+export function discoverCapabilityModules(dir: string): string[] {
+  return collectModules(dir, capabilityFile).sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Walk a `plugins/` tree. Subfolders are grouping only; there is no
  * sentinel form, because a plugin is one module.
  */
 export function discoverPluginModules(dir: string): string[] {
-  const out: string[] = [];
-  const walk = (current: string): void => {
-    for (const entry of readdirSync(current, { withFileTypes: true })) {
-      const child = join(current, entry.name);
-      if (entry.isDirectory()) {
-        if (isSkippedDirectory(entry.name)) continue;
-        walk(child);
-        continue;
-      }
-      if (entry.isFile() && isImportableModule(entry.name)) out.push(child);
-    }
-  };
-  walk(dir);
-  return out.sort((a, b) => a.localeCompare(b));
+  return collectModules(dir).sort((a, b) => a.localeCompare(b));
 }
 
 /**
@@ -178,7 +161,7 @@ export function findConfigFile(root: string): string | undefined {
  * callable `apply`. Structural rather than branded, matching how the
  * context itself consumes plugins.
  */
-export function isPluginInstance(value: unknown): boolean {
+export function isPluginInstance(value: unknown): value is CraftPlugin {
   return (
     typeof value === "object" &&
     value !== null &&

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,5 +1,5 @@
 import { readdirSync, statSync } from "node:fs";
-import { extname, join, relative } from "node:path";
+import { extname, join, relative, sep } from "node:path";
 import type { CraftPlugin } from "@routecraft/routecraft";
 
 /**
@@ -67,8 +67,17 @@ function isSkippedProjectDirectory(name: string): boolean {
  */
 function isImportableModule(name: string): boolean {
   if (!MODULE_EXTENSIONS.includes(extname(name))) return false;
-  if (name.endsWith(".d.ts")) return false;
+  if (/\.d\.[cm]?ts$/.test(name)) return false;
   return !/\.(test|spec)\.[^.]+$/.test(name);
+}
+
+/**
+ * Order two paths by code unit, never by locale. `localeCompare`
+ * answers a different question on a different machine, and this order
+ * decides registration order, which decides config precedence.
+ */
+function byPath(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 /**
@@ -121,7 +130,7 @@ function collectModules(
  * is a grouping folder.
  */
 export function discoverCapabilityModules(dir: string): string[] {
-  return collectModules(dir, capabilityFile).sort((a, b) => a.localeCompare(b));
+  return collectModules(dir, capabilityFile).sort(byPath);
 }
 
 /**
@@ -129,7 +138,7 @@ export function discoverCapabilityModules(dir: string): string[] {
  * sentinel form, because a plugin is one module.
  */
 export function discoverPluginModules(dir: string): string[] {
-  return collectModules(dir).sort((a, b) => a.localeCompare(b));
+  return collectModules(dir).sort(byPath);
 }
 
 /**
@@ -138,7 +147,9 @@ export function discoverPluginModules(dir: string): string[] {
  */
 export function displayPath(root: string, path: string): string {
   const rel = relative(root, path);
-  return rel === "" || rel.startsWith("..") ? path : rel;
+  // A leading `..` segment, not a `..` prefix: a directory legitimately
+  // named `..shared` is inside the root and should read as relative.
+  return rel === "" || rel === ".." || rel.startsWith(`..${sep}`) ? path : rel;
 }
 
 /** Filename stem of the project configuration file. */

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -122,7 +122,14 @@ function collectModules(
     // symlinked capability would be dropped without a word. Resolve file
     // links and load them; leave directory links unfollowed, which is
     // what keeps the walk loop-free and matches the markdown walk.
-    if (entry.isFile() || entry.isSymbolicLink()) {
+    if (entry.isFile()) {
+      if (isImportableModule(entry.name)) out.push(child);
+      continue;
+    }
+    if (entry.isSymbolicLink()) {
+      // Only a link needs the follow-the-target stat; a regular file is
+      // already proven to be one, and statting it again would let a file
+      // that vanished mid-walk disappear silently.
       if (isImportableModule(entry.name) && isFile(child)) out.push(child);
       continue;
     }

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -75,9 +75,16 @@ function isImportableModule(name: string): boolean {
  * Order two paths by code unit, never by locale. `localeCompare`
  * answers a different question on a different machine, and this order
  * decides registration order, which decides config precedence.
+ *
+ * Separators are normalised first because `\` and `/` sort differently
+ * against the rest of the alphabet, so a nested module and its sibling
+ * would otherwise swap places between Windows and POSIX. Mirrors the
+ * sort in the markdown walk for the same reason.
  */
 function byPath(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
+  const left = sep === "/" ? a : a.split(sep).join("/");
+  const right = sep === "/" ? b : b.split(sep).join("/");
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 /**
@@ -111,14 +118,19 @@ function collectModules(
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const child = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (isSkippedProjectDirectory(entry.name)) continue;
-      const claimed = claim?.(child);
-      if (claimed !== undefined) out.push(claimed);
-      else out.push(...collectModules(child, claim));
+    // A symlink is neither a file nor a directory to `readdirSync`, so a
+    // symlinked capability would be dropped without a word. Resolve file
+    // links and load them; leave directory links unfollowed, which is
+    // what keeps the walk loop-free and matches the markdown walk.
+    if (entry.isFile() || entry.isSymbolicLink()) {
+      if (isImportableModule(entry.name) && isFile(child)) out.push(child);
       continue;
     }
-    if (entry.isFile() && isImportableModule(entry.name)) out.push(child);
+    if (!entry.isDirectory()) continue;
+    if (isSkippedProjectDirectory(entry.name)) continue;
+    const claimed = claim?.(child);
+    if (claimed !== undefined) out.push(claimed);
+    else out.push(...collectModules(child, claim));
   }
   return out;
 }

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,0 +1,187 @@
+import { readdirSync, statSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+
+/**
+ * Module extensions the project runtime will import. Mirrors what
+ * `craft run` accepts for its entry file.
+ *
+ * @internal
+ */
+export const MODULE_EXTENSIONS = [".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"];
+
+/**
+ * Filename stem that marks a directory as one capability. The
+ * directory is the capability's home: colocated helpers, fixtures and
+ * tests live beside it and are never imported by discovery.
+ *
+ * @internal
+ */
+const CAPABILITY_SENTINEL = "route";
+
+/**
+ * Directories discovery never walks into, at any depth. `__tests__`
+ * and `__fixtures__` hold code that is not a capability;
+ * `node_modules` and dot-folders are not authored project content.
+ *
+ * @internal
+ */
+const SKIPPED_DIRECTORIES = new Set([
+  "node_modules",
+  "__tests__",
+  "__fixtures__",
+  "__mocks__",
+  "__snapshots__",
+]);
+
+/** True when `path` exists and is a directory. */
+export function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** True when `path` exists and is a file. */
+export function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isSkippedDirectory(name: string): boolean {
+  return name.startsWith(".") || SKIPPED_DIRECTORIES.has(name);
+}
+
+/**
+ * True for a module file discovery may import: a supported extension,
+ * not a declaration file, and not a test or spec.
+ *
+ * The test check matches the final `.test.<ext>` / `.spec.<ext>`
+ * segment pair, so `route.test.ts` and `route.bun.test.ts` are both
+ * excluded.
+ */
+export function isImportableModule(name: string): boolean {
+  if (!MODULE_EXTENSIONS.includes(extname(name))) return false;
+  if (name.endsWith(".d.ts")) return false;
+  return !/\.(test|spec)\.[^.]+$/.test(name);
+}
+
+/**
+ * Return the capability sentinel file inside `dir`, if one is there.
+ * A directory holding `route.ts` is one capability and everything else
+ * inside it is private to that capability.
+ */
+function capabilityFile(dir: string): string | undefined {
+  for (const ext of MODULE_EXTENSIONS) {
+    const candidate = join(dir, `${CAPABILITY_SENTINEL}${ext}`);
+    if (isFile(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Walk a `capabilities/` tree and return every module that should be
+ * imported, in path order.
+ *
+ * Two forms are recognised, and they can be mixed in one tree:
+ *
+ * - **Folder form.** A directory holding `route.ts` is one capability.
+ *   The file is imported and the directory is not descended into, so
+ *   colocated tests, fixtures and private helpers are never loaded.
+ * - **Single-file form.** Any other importable module is one
+ *   capability on its own.
+ *
+ * A directory that is neither is a grouping folder (a domain) and is
+ * walked.
+ */
+export function discoverCapabilityModules(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (current: string): void => {
+    const sentinel = capabilityFile(current);
+    if (sentinel !== undefined) {
+      out.push(sentinel);
+      return;
+    }
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const child = join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (isSkippedDirectory(entry.name)) continue;
+        walk(child);
+        continue;
+      }
+      if (entry.isFile() && isImportableModule(entry.name)) out.push(child);
+    }
+  };
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const child = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (isSkippedDirectory(entry.name)) continue;
+      walk(child);
+      continue;
+    }
+    if (entry.isFile() && isImportableModule(entry.name)) out.push(child);
+  }
+  return out.sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Walk a `plugins/` tree and return every module that should be
+ * imported, in path order. Subfolders are grouping only; there is no
+ * sentinel form, because a plugin is one module.
+ */
+export function discoverPluginModules(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const child = join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (isSkippedDirectory(entry.name)) continue;
+        walk(child);
+        continue;
+      }
+      if (entry.isFile() && isImportableModule(entry.name)) out.push(child);
+    }
+  };
+  walk(dir);
+  return out.sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Name a module by its path relative to the project root, for log and
+ * error messages that have to be actionable in a terminal.
+ */
+export function displayPath(root: string, path: string): string {
+  const rel = relative(root, path);
+  return rel === "" || rel.startsWith("..") ? path : rel;
+}
+
+/** Filename stem of the project configuration file. */
+export const CONFIG_STEM = "craft.config";
+
+/**
+ * Locate the project configuration file directly under `root`.
+ * Returns undefined when there is none.
+ */
+export function findConfigFile(root: string): string | undefined {
+  for (const ext of MODULE_EXTENSIONS) {
+    const candidate = join(root, `${CONFIG_STEM}${ext}`);
+    if (isFile(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * True when `value` looks like a `CraftPlugin`: an object carrying a
+ * callable `apply`. Structural rather than branded, matching how the
+ * context itself consumes plugins.
+ */
+export function isPluginInstance(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { apply?: unknown }).apply === "function"
+  );
+}

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -13,7 +13,13 @@ import {
 
 const SUPPORTED_EXTENSIONS = [".mjs", ".js", ".cjs", ".ts"] as const;
 
-type RunResult =
+/**
+ * Result of a CLI command that boots a context. `success: false`
+ * carries the message the CLI prints and the exit code it uses.
+ *
+ * @internal
+ */
+export type RunResult =
   { success: true } | { success: false; code?: number; message: string };
 
 /**
@@ -92,65 +98,72 @@ export async function runCommand(
   }
 }
 
-function configureRoutes(
-  contextBuilder: InstanceType<typeof ContextBuilder>,
-  defaultExport: unknown,
-): RunResult {
+/**
+ * Outcome of interpreting a module's default export as routes. Shared
+ * by `run` (one entry file) and `start` (one capability file at a
+ * time) so both accept exactly the same shapes.
+ *
+ * @internal
+ */
+export type CollectRoutesResult =
+  | { ok: true; routes: (RouteDefinition | AnyRouteBuilder)[] }
+  | { ok: false; reason: string };
+
+/**
+ * Interpret a module's default export as routes. Accepts a single
+ * `RouteBuilder`, a single `RouteDefinition`, or an array of either.
+ * Uses brand-based guards so a builder created by another copy of the
+ * package still passes.
+ *
+ * @internal
+ */
+export function collectRoutes(defaultExport: unknown): CollectRoutesResult {
   if (!defaultExport) {
-    logger.error("No default export found. Expected routes as default export.");
-    return { success: false, code: 1, message: "No default export found" };
+    return {
+      ok: false,
+      reason: "No default export found. Expected routes as default export.",
+    };
   }
-
-  // Handle single RouteBuilder or RouteDefinition (brand-based guards for cross-instance)
   if (isRouteBuilder(defaultExport)) {
-    contextBuilder.routes(defaultExport as AnyRouteBuilder);
-    logger.info("Loaded single RouteBuilder from default export");
-    return { success: true };
+    return { ok: true, routes: [defaultExport as AnyRouteBuilder] };
   }
-
   if (isRouteDefinition(defaultExport)) {
-    contextBuilder.routes(defaultExport as RouteDefinition);
-    logger.info("Loaded single route from default export");
-    return { success: true };
+    return { ok: true, routes: [defaultExport as RouteDefinition] };
   }
-
-  // Handle array of routes
   if (Array.isArray(defaultExport)) {
-    // Check each item, prioritizing RouteBuilder check
     if (
       !defaultExport.every(
         (item) => isRouteBuilder(item) || isRouteDefinition(item),
       )
     ) {
-      logger.error(
-        "All items in default export array must be RouteDefinition or RouteBuilder",
-      );
       return {
-        success: false,
-        code: 1,
-        message: "Invalid items in default export array",
+        ok: false,
+        reason:
+          "All items in the default export array must be a RouteDefinition or a RouteBuilder.",
       };
     }
-
-    defaultExport.forEach((routeOrBuilder) =>
-      contextBuilder.routes(
-        routeOrBuilder as RouteDefinition | AnyRouteBuilder,
-      ),
-    );
-    logger.info(
-      `Loaded ${defaultExport.length} routes from default export array`,
-    );
-    return { success: true };
+    return {
+      ok: true,
+      routes: defaultExport as (RouteDefinition | AnyRouteBuilder)[],
+    };
   }
-
-  // Invalid default export
-  logger.error(
-    "Invalid default export. Expected: RouteDefinition, RouteBuilder, or array of those.",
-  );
   return {
-    success: false,
-    code: 1,
-    message:
+    ok: false,
+    reason:
       "Invalid default export. Expected: RouteDefinition, RouteBuilder, or array of those.",
   };
+}
+
+function configureRoutes(
+  contextBuilder: InstanceType<typeof ContextBuilder>,
+  defaultExport: unknown,
+): RunResult {
+  const collected = collectRoutes(defaultExport);
+  if (!collected.ok) {
+    logger.error(collected.reason);
+    return { success: false, code: 1, message: collected.reason };
+  }
+  collected.routes.forEach((route) => contextBuilder.routes(route));
+  logger.info(`Loaded ${collected.routes.length} route(s) from default export`);
+  return { success: true };
 }

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -10,8 +10,8 @@ import {
   type AnyRouteBuilder,
   type RouteDefinition,
 } from "@routecraft/routecraft";
-
-const SUPPORTED_EXTENSIONS = [".mjs", ".js", ".cjs", ".ts"] as const;
+import { MODULE_EXTENSIONS } from "./project.js";
+import { messageOf } from "./util.js";
 
 /**
  * Result of a CLI command that boots a context. `success: false`
@@ -39,14 +39,11 @@ export async function runCommand(
   const absFilePath = resolve(process.cwd(), filePath);
   const ext = extname(absFilePath);
 
-  // Validate file extension
-  if (
-    !SUPPORTED_EXTENSIONS.includes(ext as (typeof SUPPORTED_EXTENSIONS)[number])
-  ) {
+  if (!MODULE_EXTENSIONS.includes(ext)) {
     return {
       success: false,
       code: 1,
-      message: `Error: Only the following file types are supported: ${SUPPORTED_EXTENSIONS.join(", ")}`,
+      message: `Error: Only the following file types are supported: ${MODULE_EXTENSIONS.join(", ")}`,
     };
   }
 
@@ -83,16 +80,7 @@ export async function runCommand(
 
     return { success: true };
   } catch (error: unknown) {
-    if (error instanceof Error) {
-      logger.error(`Failed to run ${absFilePath}: ${error.message}`);
-      return { success: false, code: 1, message: error.message };
-    }
-    // Non-Error throws (e.g. Bun's ResolveMessage for a missing package)
-    // still carry a message; surface it instead of "Unknown error".
-    const message =
-      typeof error === "object" && error !== null && "message" in error
-        ? String((error as { message: unknown }).message)
-        : String(error);
+    const message = messageOf(error);
     logger.error(`Failed to run ${absFilePath}: ${message}`);
     return { success: false, code: 1, message };
   }

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -107,10 +107,14 @@ export async function startCommand(
     );
   }
 
-  const contentRoot = pickContentRoot(root);
-  logger.info(`Starting project "${root}" (content root: "${contentRoot}").`);
-
   try {
+    // Inside the guard: picking the content root consults the discoverer
+    // registry, which throws on a dependency cycle, and every failure
+    // this command can hit belongs in its RunResult rather than as a
+    // rejection its caller has to catch.
+    const contentRoot = pickContentRoot(root);
+    logger.info(`Starting project "${root}" (content root: "${contentRoot}").`);
+
     const pluginsDir = join(contentRoot, PLUGINS_FOLDER);
     if (isDirectory(pluginsDir)) {
       config = mergeProjectConfig(config, {
@@ -167,6 +171,9 @@ export async function startCommand(
     }
     if (outcome === "timeout") {
       await context.stop();
+      // Same reason as the shutdown path below: a route rejecting during
+      // stop must not turn a diagnosed timeout into an unhandled rejection.
+      await started.catch(() => undefined);
       return fail(
         `No exchange reached a terminal outcome within ${String(timeout)}ms. Nothing in this project produced one; check that a source actually fires, or raise --timeout.`,
       );
@@ -393,17 +400,31 @@ function watchFirstExchange(context: CraftContext): Promise<ExchangeOutcome> {
  */
 function watchStartupErrors(context: CraftContext): () => string[] {
   const failed: string[] = [];
-  context.on("context:error", (event) => {
-    // Listeners receive the event envelope, not the payload: the route
-    // is one level down, under `details`.
-    const id = (
+  const off = context.on("context:error", (event) => {
+    // Listeners receive the event envelope, not the payload: the details
+    // are one level down.
+    const details = (
       event as {
-        details?: { route?: { definition?: { id?: string } } };
+        details?: {
+          route?: { definition?: { id?: string } };
+          exchange?: unknown;
+        };
       }
-    ).details?.route?.definition?.id;
+    ).details;
+    // A route-scoped error carrying an exchange is that exchange
+    // failing, not the route failing to come up. The pipeline emits the
+    // same event for both, and counting a runtime failure as a boot
+    // failure would fail a command whose project started perfectly.
+    if (details?.exchange !== undefined) return;
+    const id = details?.route?.definition?.id;
     if (id !== undefined) failed.push(id);
   });
-  return () => failed;
+  // Reading is the last thing the command does with it, so unsubscribe
+  // there rather than leaving a listener on a context a caller may hold.
+  return () => {
+    off();
+    return failed;
+  };
 }
 
 /**

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -1,0 +1,317 @@
+import { join, resolve } from "node:path";
+import {
+  ContextBuilder,
+  getProjectDiscoverers,
+  logger,
+  mergeProjectConfig,
+  shutdownHandler,
+  RUNNER_ARGV,
+  type CraftConfig,
+  type CraftContext,
+  type CraftPlugin,
+  type AnyRouteBuilder,
+  type RouteDefinition,
+} from "@routecraft/routecraft";
+import { collectRoutes, type RunResult } from "./run.js";
+import {
+  CONFIG_STEM,
+  discoverCapabilityModules,
+  discoverPluginModules,
+  displayPath,
+  findConfigFile,
+  isDirectory,
+  isPluginInstance,
+} from "./project.js";
+
+/**
+ * Folders `craft start` discovers. `capabilities` and `plugins` are
+ * loaded by the CLI itself; the rest carry meaning the CLI does not
+ * have and are handed to a registered project discoverer.
+ */
+const CAPABILITIES_FOLDER = "capabilities";
+const PLUGINS_FOLDER = "plugins";
+
+/**
+ * Convention folders whose contents only an ecosystem package can
+ * interpret. Present on disk with no discoverer registered is an
+ * error, never a silent skip: the symptom would be an agent that is
+ * merely absent.
+ */
+const DISCOVERED_FOLDERS = ["skills", "agents"];
+
+/** Every folder the convention knows, used to pick the content root. */
+const CONVENTION_FOLDERS = [
+  CAPABILITIES_FOLDER,
+  PLUGINS_FOLDER,
+  ...DISCOVERED_FOLDERS,
+];
+
+/** Options accepted by {@link startCommand}. */
+export interface StartOptions {
+  /**
+   * Shut down cleanly once the first exchange reaches a terminal
+   * outcome on any route. For CI smoke checks and one-shot runs.
+   */
+  once?: boolean;
+}
+
+/**
+ * Boot a whole project from the folder convention.
+ *
+ * Where `craft run` executes one entry file, `start` reads
+ * `craft.config.ts` and then discovers what the project declares on
+ * disk: capabilities, plugins, and any folder an ecosystem package has
+ * claimed through `registerProjectDiscoverer` (`agents/` and `skills/`
+ * come from `@routecraft/ai`).
+ *
+ * Code wins and convention fills the gaps. Anything declared in
+ * `craft.config.ts` is left alone; discovery adds what the config did
+ * not. Every discovered agent is logged with the file it came from, so
+ * precedence is visible in a startup log rather than inferred.
+ *
+ * @param dir - Project root, defaulting to the current directory
+ * @param options - Runtime flags
+ */
+export async function startCommand(
+  dir: string | undefined,
+  options: StartOptions = {},
+  cliArgs: string[] = [],
+): Promise<RunResult> {
+  const root = resolve(process.cwd(), dir ?? ".");
+  if (!isDirectory(root)) {
+    return fail(`Project directory "${root}" does not exist.`);
+  }
+
+  const configPath = findConfigFile(root);
+  if (configPath === undefined) {
+    return fail(
+      `No ${CONFIG_STEM}.ts found in "${root}". A project needs one at its root: it is what pulls plugins and ecosystem packages into the module graph. Create it with \`export const craftConfig = defineConfig({ ... })\`, or run a single file with \`craft run <file>\`.`,
+    );
+  }
+
+  let config: CraftConfig;
+  try {
+    config = await loadConfig(configPath);
+  } catch (error: unknown) {
+    return fail(
+      `Failed to load ${displayPath(root, configPath)}: ${messageOf(error)}`,
+    );
+  }
+
+  const contentRoot = pickContentRoot(root);
+  logger.info(`Starting project "${root}" (content root: "${contentRoot}").`);
+
+  try {
+    const pluginsDir = join(contentRoot, PLUGINS_FOLDER);
+    if (isDirectory(pluginsDir)) {
+      config = mergeProjectConfig(config, {
+        plugins: await loadPlugins(root, pluginsDir),
+      });
+    }
+
+    config = await applyDiscoverers(contentRoot, config);
+
+    const builder = new ContextBuilder().with(config);
+
+    const capabilitiesDir = join(contentRoot, CAPABILITIES_FOLDER);
+    if (isDirectory(capabilitiesDir)) {
+      for (const route of await loadCapabilities(root, capabilitiesDir)) {
+        builder.routes(route);
+      }
+    }
+
+    const { context } = await builder.build();
+    context.setStore(RUNNER_ARGV, cliArgs);
+    shutdownHandler(context);
+
+    const firstExchange = options.once
+      ? watchFirstExchange(context)
+      : undefined;
+    await context.start();
+    if (firstExchange === undefined) return { success: true };
+
+    const outcome = await firstExchange;
+    logger.info(`Exchange ${outcome}; shutting down (--once).`);
+    await context.stop();
+    return outcome === "failed"
+      ? fail("The first exchange failed. See the logged error for the cause.")
+      : { success: true };
+  } catch (error: unknown) {
+    return fail(messageOf(error));
+  }
+}
+
+/**
+ * Read the project configuration from its module. The named
+ * `craftConfig` export is the shape the runtime and the scaffolder
+ * both use; a default export is accepted with a warning so the form
+ * that older docs showed is not a silent failure.
+ */
+async function loadConfig(configPath: string): Promise<CraftConfig> {
+  const module = (await import(configPath)) as {
+    craftConfig?: CraftConfig;
+    default?: unknown;
+  };
+  if (module.craftConfig !== undefined) return module.craftConfig;
+  if (isConfigObject(module.default)) {
+    logger.warn(
+      `${configPath}: found a default export but no "craftConfig" export. Rename it to \`export const craftConfig = defineConfig({ ... })\`; the default export is read for compatibility only.`,
+    );
+    return module.default;
+  }
+  logger.warn(
+    `${configPath}: exports neither "craftConfig" nor a config object as default. Continuing with an empty configuration; folder discovery still runs.`,
+  );
+  return {};
+}
+
+function isConfigObject(value: unknown): value is CraftConfig {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { build?: unknown }).build !== "function"
+  );
+}
+
+/**
+ * Choose between the root-level and `src/`-nested layouts. A project
+ * uses one or the other; when both hold convention folders the root
+ * wins and the other is reported rather than silently dropped.
+ */
+function pickContentRoot(root: string): string {
+  const src = join(root, "src");
+  const rootHas = CONVENTION_FOLDERS.some((f) => isDirectory(join(root, f)));
+  const srcHas = CONVENTION_FOLDERS.some((f) => isDirectory(join(src, f)));
+  if (rootHas && srcHas) {
+    logger.warn(
+      `Convention folders exist both at "${root}" and "${src}". Using the root-level layout; the ones under "src" are ignored. Move them into one place.`,
+    );
+  }
+  if (rootHas) return root;
+  return srcHas ? src : root;
+}
+
+/**
+ * Run every registered discoverer whose folder is present, in order,
+ * threading the growing configuration through so a later discoverer
+ * sees what an earlier one contributed.
+ *
+ * A convention folder that needs a discoverer and has none fails here
+ * rather than booting a project with an agent quietly missing.
+ */
+async function applyDiscoverers(
+  contentRoot: string,
+  config: CraftConfig,
+): Promise<CraftConfig> {
+  const discoverers = getProjectDiscoverers();
+  let out = config;
+  for (const { folder, discover } of discoverers) {
+    const directory = join(contentRoot, folder);
+    if (!isDirectory(directory)) continue;
+    out = mergeProjectConfig(out, await discover(directory, out));
+  }
+  const registered = new Set(discoverers.map((d) => d.folder));
+  for (const folder of DISCOVERED_FOLDERS) {
+    if (registered.has(folder)) continue;
+    if (!isDirectory(join(contentRoot, folder))) continue;
+    throw new Error(
+      `"${folder}/" exists at "${contentRoot}" but nothing knows how to load it. Install @routecraft/ai and import it for its side effects from ${CONFIG_STEM}.ts:\n\n  import "@routecraft/ai";\n\nA type-only import (\`import type { ... } from "@routecraft/ai"\`) is erased at compile time and does not register anything, so an import statement that looks correct can still produce this error.`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Import every module under `plugins/` and collect the plugin each one
+ * default-exports.
+ */
+async function loadPlugins(root: string, dir: string): Promise<CraftPlugin[]> {
+  const out: CraftPlugin[] = [];
+  for (const file of discoverPluginModules(dir)) {
+    const where = displayPath(root, file);
+    const module = (await import(file)) as { default?: unknown };
+    const exported = module.default;
+    if (isPluginInstance(exported)) {
+      out.push(exported as CraftPlugin);
+      logger.info(`Plugin: loaded from "${where}".`);
+      continue;
+    }
+    if (typeof exported === "function") {
+      throw new Error(
+        `${where} default-exports a factory, not a plugin instance. A factory needs arguments this runtime cannot invent, so call it in ${CONFIG_STEM}.ts and add the result to \`plugins\`.`,
+      );
+    }
+    throw new Error(
+      `${where} must default-export a plugin (an object with an \`apply\` function). Got ${describe(exported)}.`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Import every capability module and collect the routes each one
+ * default-exports.
+ */
+async function loadCapabilities(
+  root: string,
+  dir: string,
+): Promise<(RouteDefinition | AnyRouteBuilder)[]> {
+  const out: (RouteDefinition | AnyRouteBuilder)[] = [];
+  for (const file of discoverCapabilityModules(dir)) {
+    const where = displayPath(root, file);
+    const module = (await import(file)) as { default?: unknown };
+    const collected = collectRoutes(module.default);
+    if (!collected.ok) {
+      throw new Error(`${where}: ${collected.reason}`);
+    }
+    out.push(...collected.routes);
+    logger.info(
+      `Capability: loaded ${collected.routes.length} route(s) from "${where}".`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Resolve on the first exchange that reaches a terminal outcome on any
+ * route. `--once` treats a failure and a drop as terminal too, so a CI
+ * smoke check reports instead of hanging until it is killed.
+ */
+function watchFirstExchange(
+  context: CraftContext,
+): Promise<"completed" | "failed" | "dropped"> {
+  return new Promise((settle) => {
+    const offs: Array<() => void> = [];
+    const finish =
+      (outcome: "completed" | "failed" | "dropped") => (): void => {
+        for (const off of offs) off();
+        settle(outcome);
+      };
+    offs.push(
+      context.on("route:exchange:completed", finish("completed")),
+      context.on("route:exchange:failed", finish("failed")),
+      context.on("route:exchange:dropped", finish("dropped")),
+    );
+  });
+}
+
+function describe(value: unknown): string {
+  if (value === undefined) return "no default export";
+  if (value === null) return "null";
+  return Array.isArray(value) ? "an array" : typeof value;
+}
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  // Non-Error throws (e.g. Bun's ResolveMessage for a missing package)
+  // still carry a message; surface it instead of "Unknown error".
+  return typeof error === "object" && error !== null && "message" in error
+    ? String((error as { message: unknown }).message)
+    : String(error);
+}
+
+function fail(message: string): RunResult {
+  logger.error(message);
+  return { success: false, code: 1, message };
+}

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -147,48 +147,52 @@ export async function startCommand(
       ? watchFirstExchange(context)
       : undefined;
 
-    // `context.start()` deliberately never resolves while a server
-    // ingress is held open (see Route.start), so `--once` has to race
-    // it rather than await it: awaiting first would mean the flag only
-    // worked on projects that were going to exit anyway.
-    const started = context.start();
-    if (firstExchange === undefined) {
-      await started;
-      return reportStartup(startupErrors());
-    }
+    try {
+      // `context.start()` deliberately never resolves while a server
+      // ingress is held open (see Route.start), so `--once` has to race
+      // it rather than await it: awaiting first would mean the flag only
+      // worked on projects that were going to exit anyway.
+      const started = context.start();
+      if (firstExchange === undefined) {
+        await started;
+        return reportStartup(startupErrors.read());
+      }
 
-    const timeout = options.timeoutMs;
-    const outcome = await Promise.race([
-      firstExchange,
-      // Every route finished on its own before any exchange landed.
-      started.then(() => "drained" as const),
-      ...(timeout === undefined ? [] : [expire(timeout)]),
-    ]);
+      const timeout = options.timeoutMs;
+      const outcome = await Promise.race([
+        firstExchange,
+        // Every route finished on its own before any exchange landed.
+        started.then(() => "drained" as const),
+        ...(timeout === undefined ? [] : [expire(timeout)]),
+      ]);
 
-    if (outcome === "drained") {
-      await started;
-      return reportStartup(startupErrors());
-    }
-    if (outcome === "timeout") {
+      if (outcome === "drained") {
+        await started;
+        return reportStartup(startupErrors.read());
+      }
+      if (outcome === "timeout") {
+        await context.stop();
+        // Same reason as the shutdown path below: a route rejecting during
+        // stop must not turn a diagnosed timeout into an unhandled rejection.
+        await started.catch(() => undefined);
+        return fail(
+          `No exchange reached a terminal outcome within ${String(timeout)}ms. Nothing in this project produced one; check that a source actually fires, or raise --timeout.`,
+        );
+      }
+      logger.info(`Exchange ${outcome}; shutting down (--once).`);
       await context.stop();
-      // Same reason as the shutdown path below: a route rejecting during
-      // stop must not turn a diagnosed timeout into an unhandled rejection.
+      // Attach the start rejection so a route failure during shutdown is
+      // reported rather than surfacing as an unhandled rejection.
       await started.catch(() => undefined);
-      return fail(
-        `No exchange reached a terminal outcome within ${String(timeout)}ms. Nothing in this project produced one; check that a source actually fires, or raise --timeout.`,
-      );
+      if (outcome === "failed") {
+        return fail(
+          "The first exchange failed. See the logged error for the cause.",
+        );
+      }
+      return reportStartup(startupErrors.read());
+    } finally {
+      startupErrors.off();
     }
-    logger.info(`Exchange ${outcome}; shutting down (--once).`);
-    await context.stop();
-    // Attach the start rejection so a route failure during shutdown is
-    // reported rather than surfacing as an unhandled rejection.
-    await started.catch(() => undefined);
-    if (outcome === "failed") {
-      return fail(
-        "The first exchange failed. See the logged error for the cause.",
-      );
-    }
-    return reportStartup(startupErrors());
   } catch (error: unknown) {
     return fail(messageOf(error));
   }
@@ -398,7 +402,10 @@ function watchFirstExchange(context: CraftContext): Promise<ExchangeOutcome> {
  * command reports a clean boot for a project that did not boot, which
  * is the one thing a CI gate must never do.
  */
-function watchStartupErrors(context: CraftContext): () => string[] {
+function watchStartupErrors(context: CraftContext): {
+  read: () => string[];
+  off: () => void;
+} {
   const failed: string[] = [];
   const off = context.on("context:error", (event) => {
     // Listeners receive the event envelope, not the payload: the details
@@ -419,12 +426,11 @@ function watchStartupErrors(context: CraftContext): () => string[] {
     const id = details?.route?.definition?.id;
     if (id !== undefined) failed.push(id);
   });
-  // Reading is the last thing the command does with it, so unsubscribe
-  // there rather than leaving a listener on a context a caller may hold.
-  return () => {
-    off();
-    return failed;
-  };
+  // Disposal is separate from reading because most exit paths report a
+  // failure without reading, and a programmatic caller keeps the context
+  // after the command returns. The caller unsubscribes in a finally so
+  // no path leaves the listener attached.
+  return { read: () => failed, off };
 }
 
 /**

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -2,6 +2,8 @@ import { join, resolve } from "node:path";
 import {
   ContextBuilder,
   getProjectDiscoverers,
+  isRouteBuilder,
+  isRouteDefinition,
   logger,
   mergeProjectConfig,
   shutdownHandler,
@@ -13,6 +15,7 @@ import {
   type RouteDefinition,
 } from "@routecraft/routecraft";
 import { collectRoutes, type RunResult } from "./run.js";
+import { messageOf } from "./util.js";
 import {
   CONFIG_STEM,
   discoverCapabilityModules,
@@ -53,6 +56,13 @@ export interface StartOptions {
    * outcome on any route. For CI smoke checks and one-shot runs.
    */
   once?: boolean;
+  /**
+   * Give up after this many milliseconds and exit non-zero. Without it
+   * a project whose sources never produce an exchange waits forever,
+   * which for a CI gate reports as a job timeout rather than as a
+   * diagnosis.
+   */
+  timeoutMs?: number;
 }
 
 /**
@@ -75,7 +85,6 @@ export interface StartOptions {
 export async function startCommand(
   dir: string | undefined,
   options: StartOptions = {},
-  cliArgs: string[] = [],
 ): Promise<RunResult> {
   const root = resolve(process.cwd(), dir ?? ".");
   if (!isDirectory(root)) {
@@ -109,7 +118,7 @@ export async function startCommand(
       });
     }
 
-    config = await applyDiscoverers(contentRoot, config);
+    config = await applyDiscoverers(root, contentRoot, config);
 
     const builder = new ContextBuilder().with(config);
 
@@ -121,18 +130,44 @@ export async function startCommand(
     }
 
     const { context } = await builder.build();
-    context.setStore(RUNNER_ARGV, cliArgs);
+    // `start` has no trailing-argument passthrough the way `run` does,
+    // so the key is present and empty rather than absent.
+    context.setStore(RUNNER_ARGV, []);
     shutdownHandler(context);
 
-    const firstExchange = options.once
-      ? watchFirstExchange(context)
-      : undefined;
-    await context.start();
-    if (firstExchange === undefined) return { success: true };
+    // `context.start()` deliberately never resolves while a server
+    // ingress is held open (see Route.start), so `--once` has to race
+    // it rather than await it: awaiting first would mean the flag only
+    // worked on projects that were going to exit anyway.
+    const started = context.start();
+    if (!options.once) {
+      await started;
+      return { success: true };
+    }
 
-    const outcome = await firstExchange;
+    const timeout = options.timeoutMs;
+    const outcome = await Promise.race([
+      watchFirstExchange(context),
+      // Every route finished on its own before any exchange landed.
+      started.then(() => "drained" as const),
+      ...(timeout === undefined ? [] : [expire(timeout)]),
+    ]);
+
+    if (outcome === "drained") {
+      await started;
+      return { success: true };
+    }
+    if (outcome === "timeout") {
+      await context.stop();
+      return fail(
+        `No exchange reached a terminal outcome within ${String(timeout)}ms. Nothing in this project produced one; check that a source actually fires, or raise --timeout.`,
+      );
+    }
     logger.info(`Exchange ${outcome}; shutting down (--once).`);
     await context.stop();
+    // Attach the start rejection so a route failure during shutdown is
+    // reported rather than surfacing as an unhandled rejection.
+    await started.catch(() => undefined);
     return outcome === "failed"
       ? fail("The first exchange failed. See the logged error for the cause.")
       : { success: true };
@@ -159,10 +194,9 @@ async function loadConfig(configPath: string): Promise<CraftConfig> {
     );
     return module.default;
   }
-  logger.warn(
-    `${configPath}: exports neither "craftConfig" nor a config object as default. Continuing with an empty configuration; folder discovery still runs.`,
+  throw new Error(
+    `exports neither "craftConfig" nor a config object as default. Add \`export const craftConfig = defineConfig({ ... })\`; without it no plugin or ecosystem package this project needs is in the module graph.`,
   );
-  return {};
 }
 
 function isConfigObject(value: unknown): value is CraftConfig {
@@ -170,8 +204,19 @@ function isConfigObject(value: unknown): value is CraftConfig {
     typeof value === "object" &&
     value !== null &&
     !Array.isArray(value) &&
-    typeof (value as { build?: unknown }).build !== "function"
+    // Brand guards rather than duck-typing `build`: a route default
+    // export is the realistic mistake here, and core already exports
+    // the means to recognise one.
+    !isRouteBuilder(value) &&
+    !isRouteDefinition(value)
   );
+}
+
+/** Resolve to `"timeout"` after `ms`, without holding the event loop open. */
+function expire(ms: number): Promise<"timeout"> {
+  return new Promise((settle) => {
+    setTimeout(() => settle("timeout"), ms).unref?.();
+  });
 }
 
 /**
@@ -201,6 +246,7 @@ function pickContentRoot(root: string): string {
  * rather than booting a project with an agent quietly missing.
  */
 async function applyDiscoverers(
+  projectRoot: string,
   contentRoot: string,
   config: CraftConfig,
 ): Promise<CraftConfig> {
@@ -209,7 +255,10 @@ async function applyDiscoverers(
   for (const { folder, discover } of discoverers) {
     const directory = join(contentRoot, folder);
     if (!isDirectory(directory)) continue;
-    out = mergeProjectConfig(out, await discover(directory, out));
+    out = mergeProjectConfig(
+      out,
+      await discover({ directory, contentRoot, projectRoot, config: out }),
+    );
   }
   const registered = new Set(discoverers.map((d) => d.folder));
   for (const folder of DISCOVERED_FOLDERS) {
@@ -230,7 +279,7 @@ async function loadPlugins(root: string, dir: string): Promise<CraftPlugin[]> {
   const out: CraftPlugin[] = [];
   for (const file of discoverPluginModules(dir)) {
     const where = displayPath(root, file);
-    const module = (await import(file)) as { default?: unknown };
+    const module = await importModule(file, where);
     const exported = module.default;
     if (isPluginInstance(exported)) {
       out.push(exported as CraftPlugin);
@@ -260,7 +309,7 @@ async function loadCapabilities(
   const out: (RouteDefinition | AnyRouteBuilder)[] = [];
   for (const file of discoverCapabilityModules(dir)) {
     const where = displayPath(root, file);
-    const module = (await import(file)) as { default?: unknown };
+    const module = await importModule(file, where);
     const collected = collectRoutes(module.default);
     if (!collected.ok) {
       throw new Error(`${where}: ${collected.reason}`);
@@ -296,19 +345,28 @@ function watchFirstExchange(
   });
 }
 
+/**
+ * Import a discovered module, attributing a failure to the file that
+ * caused it. `start` walks a whole tree, so "which file" is the only
+ * question a bare resolver error leaves unanswered.
+ */
+async function importModule(
+  file: string,
+  where: string,
+): Promise<{ default?: unknown }> {
+  try {
+    return (await import(file)) as { default?: unknown };
+  } catch (error: unknown) {
+    throw new Error(`${where}: failed to import. ${messageOf(error)}`, {
+      cause: error,
+    });
+  }
+}
+
 function describe(value: unknown): string {
   if (value === undefined) return "no default export";
   if (value === null) return "null";
   return Array.isArray(value) ? "an array" : typeof value;
-}
-
-function messageOf(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  // Non-Error throws (e.g. Bun's ResolveMessage for a missing package)
-  // still carry a message; surface it instead of "Unknown error".
-  return typeof error === "object" && error !== null && "message" in error
-    ? String((error as { message: unknown }).message)
-    : String(error);
 }
 
 function fail(message: string): RunResult {

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -135,19 +135,27 @@ export async function startCommand(
     context.setStore(RUNNER_ARGV, []);
     shutdownHandler(context);
 
+    // Both watchers subscribe before the first route runs. `start()`
+    // emits synchronously before it yields, so anything installed after
+    // the call can miss the very events it exists to observe.
+    const startupErrors = watchStartupErrors(context);
+    const firstExchange = options.once
+      ? watchFirstExchange(context)
+      : undefined;
+
     // `context.start()` deliberately never resolves while a server
     // ingress is held open (see Route.start), so `--once` has to race
     // it rather than await it: awaiting first would mean the flag only
     // worked on projects that were going to exit anyway.
     const started = context.start();
-    if (!options.once) {
+    if (firstExchange === undefined) {
       await started;
-      return { success: true };
+      return reportStartup(startupErrors());
     }
 
     const timeout = options.timeoutMs;
     const outcome = await Promise.race([
-      watchFirstExchange(context),
+      firstExchange,
       // Every route finished on its own before any exchange landed.
       started.then(() => "drained" as const),
       ...(timeout === undefined ? [] : [expire(timeout)]),
@@ -155,7 +163,7 @@ export async function startCommand(
 
     if (outcome === "drained") {
       await started;
-      return { success: true };
+      return reportStartup(startupErrors());
     }
     if (outcome === "timeout") {
       await context.stop();
@@ -168,9 +176,12 @@ export async function startCommand(
     // Attach the start rejection so a route failure during shutdown is
     // reported rather than surfacing as an unhandled rejection.
     await started.catch(() => undefined);
-    return outcome === "failed"
-      ? fail("The first exchange failed. See the logged error for the cause.")
-      : { success: true };
+    if (outcome === "failed") {
+      return fail(
+        "The first exchange failed. See the logged error for the cause.",
+      );
+    }
+    return reportStartup(startupErrors());
   } catch (error: unknown) {
     return fail(messageOf(error));
   }
@@ -226,8 +237,16 @@ function expire(ms: number): Promise<"timeout"> {
  */
 function pickContentRoot(root: string): string {
   const src = join(root, "src");
-  const rootHas = CONVENTION_FOLDERS.some((f) => isDirectory(join(root, f)));
-  const srcHas = CONVENTION_FOLDERS.some((f) => isDirectory(join(src, f)));
+  // Registered folders count too, so a project whose only convention
+  // folder comes from an ecosystem package still resolves its layout.
+  // Without them, a `src/`-nested project holding just that folder would
+  // fall back to the root and boot without what the discoverer provides.
+  const folders = [
+    ...CONVENTION_FOLDERS,
+    ...getProjectDiscoverers().map((d) => d.folder),
+  ];
+  const rootHas = folders.some((f) => isDirectory(join(root, f)));
+  const srcHas = folders.some((f) => isDirectory(join(src, f)));
   if (rootHas && srcHas) {
     logger.warn(
       `Convention folders exist both at "${root}" and "${src}". Using the root-level layout; the ones under "src" are ignored. Move them into one place.`,
@@ -251,13 +270,20 @@ async function applyDiscoverers(
   config: CraftConfig,
 ): Promise<CraftConfig> {
   const discoverers = getProjectDiscoverers();
+  const declared = config;
   let out = config;
   for (const { folder, discover } of discoverers) {
     const directory = join(contentRoot, folder);
     if (!isDirectory(directory)) continue;
     out = mergeProjectConfig(
       out,
-      await discover({ directory, contentRoot, projectRoot, config: out }),
+      await discover({
+        directory,
+        contentRoot,
+        projectRoot,
+        config: out,
+        declared,
+      }),
     );
   }
   const registered = new Set(discoverers.map((d) => d.folder));
@@ -322,27 +348,62 @@ async function loadCapabilities(
   return out;
 }
 
+/** How the first exchange ended, for the `--once` shutdown decision. */
+type ExchangeOutcome = "completed" | "failed" | "dropped" | "suspended";
+
 /**
  * Resolve on the first exchange that reaches a terminal outcome on any
- * route. `--once` treats a failure and a drop as terminal too, so a CI
- * smoke check reports instead of hanging until it is killed.
+ * route. `--once` treats a failure, a drop and a suspension as terminal
+ * alongside a completion, so a CI smoke check reports instead of
+ * hanging until it is killed.
+ *
+ * A suspension is terminal for the run that produced it: the exchange
+ * parks durably and `route:exchange:suspended` takes the place of
+ * `:completed`, so waiting for a completion that is not coming is the
+ * same hang under a different name.
+ *
+ * Subscribe before starting the context, never after: `start()` runs a
+ * synchronous prefix before it yields, so a source that produces an
+ * exchange during route startup would fire into a watcher that does not
+ * exist yet.
  */
-function watchFirstExchange(
-  context: CraftContext,
-): Promise<"completed" | "failed" | "dropped"> {
+function watchFirstExchange(context: CraftContext): Promise<ExchangeOutcome> {
   return new Promise((settle) => {
     const offs: Array<() => void> = [];
-    const finish =
-      (outcome: "completed" | "failed" | "dropped") => (): void => {
-        for (const off of offs) off();
-        settle(outcome);
-      };
+    const finish = (outcome: ExchangeOutcome) => (): void => {
+      for (const off of offs) off();
+      settle(outcome);
+    };
     offs.push(
       context.on("route:exchange:completed", finish("completed")),
       context.on("route:exchange:failed", finish("failed")),
       context.on("route:exchange:dropped", finish("dropped")),
+      context.on("route:exchange:suspended", finish("suspended")),
     );
   });
+}
+
+/**
+ * Collect route startup failures.
+ *
+ * `context.start()` settles every route rather than racing them, so it
+ * resolves even when a route threw on the way up. Without this the
+ * command reports a clean boot for a project that did not boot, which
+ * is the one thing a CI gate must never do.
+ */
+function watchStartupErrors(context: CraftContext): () => string[] {
+  const failed: string[] = [];
+  context.on("context:error", (event) => {
+    // Listeners receive the event envelope, not the payload: the route
+    // is one level down, under `details`.
+    const id = (
+      event as {
+        details?: { route?: { definition?: { id?: string } } };
+      }
+    ).details?.route?.definition?.id;
+    if (id !== undefined) failed.push(id);
+  });
+  return () => failed;
 }
 
 /**
@@ -367,6 +428,18 @@ function describe(value: unknown): string {
   if (value === undefined) return "no default export";
   if (value === null) return "null";
   return Array.isArray(value) ? "an array" : typeof value;
+}
+
+/**
+ * Turn collected startup failures into the command's result. A boot
+ * where a route never came up is a failed boot, whatever the surviving
+ * routes went on to do.
+ */
+function reportStartup(failedRoutes: readonly string[]): RunResult {
+  if (failedRoutes.length === 0) return { success: true };
+  return fail(
+    `${String(failedRoutes.length)} route(s) failed to start: ${failedRoutes.join(", ")}. See the logged errors for the cause.`,
+  );
 }
 
 function fail(message: string): RunResult {

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -5,10 +5,20 @@ import { config as loadDotenv } from "dotenv";
 /**
  * Loads environment variables from .env files
  *
+ * An explicit `path` always resolves against the working directory,
+ * because that is what a relative path typed on the command line means.
+ * The conventional `.env` / `.env.local` pair resolves against
+ * `defaultsFrom`, so `craft start ./apps/eywa` picks up that project's
+ * own environment rather than the one beside the shell.
+ *
  * @param path Optional path to .env file. If not specified, loads .env and .env.local (if they exist)
+ * @param defaultsFrom Directory the conventional .env files are read from. Defaults to the working directory
  * @returns The parsed dotenv config result
  */
-export function loadEnvFile(path?: string) {
+export function loadEnvFile(
+  path?: string,
+  defaultsFrom: string = process.cwd(),
+) {
   const dotenvOpts = { quiet: true };
   if (path) {
     // Explicit path provided - load that file only
@@ -31,7 +41,7 @@ export function loadEnvFile(path?: string) {
   // No path provided - load .env, then .env.local (with override)
   // Load .env first
   const envResult = loadDotenv({
-    path: resolve(process.cwd(), ".env"),
+    path: resolve(defaultsFrom, ".env"),
     ...dotenvOpts,
   });
   if (envResult.parsed) {
@@ -44,7 +54,7 @@ export function loadEnvFile(path?: string) {
 
   // Load .env.local next, allowing it to override .env values
   const envLocalResult = loadDotenv({
-    path: resolve(process.cwd(), ".env.local"),
+    path: resolve(defaultsFrom, ".env.local"),
     override: true,
     ...dotenvOpts,
   });

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -66,3 +66,16 @@ export function loadEnvFile(path?: string) {
   }
   return envLocalResult;
 }
+
+/**
+ * Turn a thrown value into a printable message. Non-Error throws (Bun's
+ * `ResolveMessage` for a missing package, most usefully) still carry a
+ * message, so surfacing it beats reporting "Unknown error". Shared by
+ * `run` and `start` because both fail the same ways.
+ */
+export function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return typeof error === "object" && error !== null && "message" in error
+    ? String((error as { message: unknown }).message)
+    : String(error);
+}

--- a/packages/cli/test/start.bun.test.ts
+++ b/packages/cli/test/start.bun.test.ts
@@ -1,0 +1,278 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// Silence logger output. Bun:test has no `importActual`/spread-and-override
+// equivalent for `mock.module`, so spy on the live `logger` singleton
+// directly. Spies are installed once and restored after all tests.
+const { logger } = await import("@routecraft/routecraft");
+const { startCommand } = await import("../src/start");
+
+/**
+ * The discoverer registry is global and shared across every test file
+ * in a `bun test` run, so a sibling package's registration would leak
+ * in here. Snapshot and restore around each case.
+ */
+const REGISTRY_KEY = Symbol.for("routecraft.project-discoverer-registry");
+type Registry = Map<string, unknown>;
+type GlobalWithRegistry = typeof globalThis & { [REGISTRY_KEY]?: Registry };
+
+function snapshotRegistry(): Registry {
+  return new Map((globalThis as GlobalWithRegistry)[REGISTRY_KEY] ?? new Map());
+}
+
+function restoreRegistry(snapshot: Registry): void {
+  (globalThis as GlobalWithRegistry)[REGISTRY_KEY] = new Map(snapshot);
+}
+
+describe("CLI start command", () => {
+  let spies: Array<{ mockRestore: () => void }> = [];
+  let warn: ReturnType<typeof spyOn> | undefined;
+  let snapshot: Registry | undefined;
+  let roots: string[] = [];
+  let counter = 0;
+
+  beforeAll(() => {
+    spies = [
+      spyOn(logger, "info").mockImplementation(() => {}),
+      spyOn(logger, "error").mockImplementation(() => {}),
+      spyOn(logger, "debug").mockImplementation(() => {}),
+    ];
+  });
+
+  afterAll(() => {
+    for (const s of spies) s.mockRestore();
+    spies = [];
+  });
+
+  beforeEach(() => {
+    snapshot = snapshotRegistry();
+    warn = spyOn(logger, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (snapshot) restoreRegistry(snapshot);
+    snapshot = undefined;
+    warn?.mockRestore();
+    warn = undefined;
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+    roots = [];
+  });
+
+  /**
+   * Write a project tree. Lives inside the package so a dynamic import
+   * of a temp file resolves workspace packages by climbing to the root
+   * `node_modules`.
+   */
+  function makeProject(files: Record<string, string>): string {
+    counter += 1;
+    const root = join(import.meta.dir, `tmp-start-${Date.now()}-${counter}`);
+    roots.push(root);
+    for (const [name, content] of Object.entries(files)) {
+      const target = join(root, name);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, content, "utf-8");
+    }
+    return root;
+  }
+
+  const EMPTY_CONFIG = `export const craftConfig = {};\n`;
+
+  function routeFile(id: string): string {
+    return [
+      `import { craft, simple, log } from "@routecraft/routecraft";`,
+      `export default craft().id(${JSON.stringify(id)}).from(simple("hi")).to(log());`,
+      "",
+    ].join("\n");
+  }
+
+  /**
+   * @case A project without a config file fails with an actionable message
+   * @preconditions Directory holding capabilities but no craft.config.ts
+   * @expectedResult Failure naming craft.config.ts and pointing at craft run
+   */
+  test("fails clearly when craft.config.ts is missing", async () => {
+    const root = makeProject({
+      "capabilities/hello/route.ts": routeFile("hello"),
+    });
+    const result = await startCommand(root);
+    expect(result).toMatchObject({ success: false, code: 1 });
+    expect(result.success === false && result.message).toMatch(
+      /No craft\.config\.ts found/,
+    );
+  });
+
+  /**
+   * @case Capabilities load from the folder form and the single-file form
+   * @preconditions A route.ts capability folder, a nested domain, and a bare module
+   * @expectedResult All three routes are registered and the context starts
+   */
+  test("discovers capabilities in both forms", async () => {
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "capabilities/comms/send-email/route.ts": routeFile("send-email"),
+      "capabilities/comms/poll-mail.ts": routeFile("poll-mail"),
+      "capabilities/health.ts": routeFile("health"),
+    });
+    const result = await startCommand(root, { once: true });
+    expect(result).toMatchObject({ success: true });
+  });
+
+  /**
+   * @case Colocated tests, fixtures and helpers inside a capability are never imported
+   * @preconditions A capability folder holding a throwing helper, test and fixture
+   * @expectedResult Start succeeds, proving only route.ts was imported
+   */
+  test("never imports tests, fixtures or helpers inside a capability", async () => {
+    const throws = `throw new Error("this module must never be imported");\n`;
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "capabilities/orders/route.ts": routeFile("orders"),
+      "capabilities/orders/mapper.ts": throws,
+      "capabilities/orders/route.test.ts": throws,
+      "capabilities/orders/route.bun.test.ts": throws,
+      "capabilities/orders/__fixtures__/sample.ts": throws,
+      "capabilities/__tests__/helper.ts": throws,
+    });
+    const result = await startCommand(root, { once: true });
+    expect(result).toMatchObject({ success: true });
+  });
+
+  /**
+   * @case A plugin module default-exporting a factory is a pointed error
+   * @preconditions plugins/health.ts exports a factory function
+   * @expectedResult Failure naming the file and pointing at craft.config.ts
+   */
+  test("errors when a plugin file exports a factory", async () => {
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "plugins/health.ts": `export default () => ({ apply() {} });\n`,
+    });
+    const result = await startCommand(root);
+    expect(result).toMatchObject({ success: false });
+    const message = result.success === false ? result.message : "";
+    expect(message).toMatch(/plugins\/health\.ts/);
+    expect(message).toMatch(/factory, not a plugin instance/);
+    expect(message).toMatch(/craft\.config\.ts/);
+  });
+
+  /**
+   * @case A plugin instance is loaded from the plugins folder
+   * @preconditions plugins/health.ts default-exports an object with apply()
+   * @expectedResult The plugin's apply runs during startup
+   */
+  test("loads a plugin instance from plugins/", async () => {
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "plugins/health.ts": [
+        `import { writeFileSync } from "node:fs";`,
+        `export default { name: "health", apply() { writeFileSync(new URL("./applied.txt", import.meta.url), "yes"); } };`,
+        "",
+      ].join("\n"),
+      "capabilities/health.ts": routeFile("health"),
+    });
+    const result = await startCommand(root, { once: true });
+    expect(result).toMatchObject({ success: true });
+    expect(readFileSync(join(root, "plugins", "applied.txt"), "utf-8")).toBe(
+      "yes",
+    );
+  });
+
+  /**
+   * @case An agents folder with no registered discoverer fails loudly
+   * @preconditions agents/ present, registry cleared of the ai discoverers
+   * @expectedResult Failure naming the folder and the erased type-import trap
+   */
+  test("errors when agents/ has no registered discoverer", async () => {
+    restoreRegistry(new Map());
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "agents/triage.md": `---\nname: triage\ndescription: d\n---\nsystem`,
+    });
+    const result = await startCommand(root);
+    expect(result).toMatchObject({ success: false });
+    const message = result.success === false ? result.message : "";
+    expect(message).toMatch(/@routecraft\/ai/);
+    expect(message).toMatch(/type-only import/);
+  });
+
+  /**
+   * @case A registered discoverer receives the folder and contributes config
+   * @preconditions A discoverer registered for "agents" that records its argument
+   * @expectedResult It is called with the absolute agents directory
+   */
+  test("hands a present folder to its registered discoverer", async () => {
+    const { registerProjectDiscoverer } =
+      await import("@routecraft/routecraft");
+    let seen: string | undefined;
+    registerProjectDiscoverer("agents", async (directory) => {
+      seen = directory;
+      return {};
+    });
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "agents/triage.md": `---\nname: triage\ndescription: d\n---\nsystem`,
+      "capabilities/health.ts": routeFile("health"),
+    });
+    const result = await startCommand(root, { once: true });
+    expect(result).toMatchObject({ success: true });
+    expect(seen).toBe(join(root, "agents"));
+  });
+
+  /**
+   * @case The src-nested layout is discovered like the root-level one
+   * @preconditions Convention folders under src/ with the config at the root
+   * @expectedResult Capabilities under src/ are loaded
+   */
+  test("supports the src-nested layout", async () => {
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "src/capabilities/health/route.ts": routeFile("health"),
+    });
+    const result = await startCommand(root, { once: true });
+    expect(result).toMatchObject({ success: true });
+  });
+
+  /**
+   * @case A default-exported config is accepted with a warning
+   * @preconditions craft.config.ts default-exports the config object
+   * @expectedResult Start succeeds and the warning names the craftConfig export
+   */
+  test("accepts a default-exported config with a warning", async () => {
+    const root = makeProject({
+      "craft.config.ts": `export default { name: "app" };\n`,
+      "capabilities/health.ts": routeFile("health"),
+    });
+    const result = await startCommand(root, { once: true });
+    expect(result).toMatchObject({ success: true });
+    const warned =
+      warn?.mock.calls.map((c: unknown[]) => String(c[0])).join("\n") ?? "";
+    expect(warned).toMatch(/craftConfig/);
+  });
+
+  /**
+   * @case A capability module that exports no routes names the file
+   * @preconditions A barrel-style module with no default export
+   * @expectedResult Failure naming the offending file
+   */
+  test("errors when a capability module exports no routes", async () => {
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "capabilities/index.ts": `export const nothing = 1;\n`,
+    });
+    const result = await startCommand(root);
+    expect(result).toMatchObject({ success: false });
+    expect(result.success === false && result.message).toMatch(
+      /capabilities\/index\.ts/,
+    );
+  });
+});

--- a/packages/cli/test/start.bun.test.ts
+++ b/packages/cli/test/start.bun.test.ts
@@ -121,6 +121,34 @@ describe("CLI start command", () => {
   });
 
   /**
+   * @case A runtime exchange failure is not reported as a failed boot
+   * @preconditions A route that starts cleanly and then fails its exchange,
+   *   beside one that completes
+   * @expectedResult The command does not claim routes failed to start. The
+   *   pipeline emits context:error with a route for a failed exchange too, so
+   *   counting those would fail a command whose project started perfectly
+   */
+  test("does not report a runtime exchange failure as a startup failure", async () => {
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "capabilities/healthy.ts": routeFile("healthy"),
+      "capabilities/throws.ts": [
+        `import { craft, simple, log } from "@routecraft/routecraft";`,
+        `export default craft()`,
+        `  .id("throws")`,
+        `  .from(simple("hi"))`,
+        `  .step(() => { throw new Error("exchange blew up"); })`,
+        `  .to(log());`,
+        "",
+      ].join("\n"),
+    });
+    const result = await startCommand(root, { once: true, timeoutMs: 5_000 });
+    if (result.success === false) {
+      expect(result.message).not.toMatch(/failed to start/);
+    }
+  });
+
+  /**
    * @case A project without a config file fails with an actionable message
    * @preconditions Directory holding capabilities but no craft.config.ts
    * @expectedResult Failure naming craft.config.ts and pointing at craft run

--- a/packages/cli/test/start.bun.test.ts
+++ b/packages/cli/test/start.bun.test.ts
@@ -117,7 +117,12 @@ describe("CLI start command", () => {
     });
     const result = await startCommand(root, { once: true, timeoutMs: 5_000 });
     expect(result).toMatchObject({ success: false, code: 1 });
-    expect(result.success === false && result.message).toMatch(/broken/);
+    // The startup-failure wording, not just the route name: the fixture
+    // file is also called "broken", so matching the name alone would let
+    // an import error pass as proof of startup accounting.
+    expect(result.success === false && result.message).toMatch(
+      /route\(s\) failed to start: broken/,
+    );
   });
 
   /**

--- a/packages/cli/test/start.bun.test.ts
+++ b/packages/cli/test/start.bun.test.ts
@@ -214,8 +214,8 @@ describe("CLI start command", () => {
     const { registerProjectDiscoverer } =
       await import("@routecraft/routecraft");
     let seen: string | undefined;
-    registerProjectDiscoverer("agents", async (directory) => {
-      seen = directory;
+    registerProjectDiscoverer("agents", async (ctx) => {
+      seen = ctx.directory;
       return {};
     });
     const root = makeProject({
@@ -257,6 +257,68 @@ describe("CLI start command", () => {
     const warned =
       warn?.mock.calls.map((c: unknown[]) => String(c[0])).join("\n") ?? "";
     expect(warned).toMatch(/craftConfig/);
+  });
+
+  /**
+   * @case --once settles even when a server ingress holds the context open
+   * @preconditions A project with both a direct() ingress (which never resolves
+   *   its subscription) and a finite source that produces one exchange
+   * @expectedResult startCommand resolves rather than hanging. Awaiting
+   *   context.start() before the exchange watcher would block here forever,
+   *   which is the shape --once exists to avoid.
+   */
+  test("--once settles with a server ingress holding the context open", async () => {
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "capabilities/inbox.ts": [
+        `import { craft, direct, log } from "@routecraft/routecraft";`,
+        `export default craft().id("inbox").from(direct()).to(log());`,
+        "",
+      ].join("\n"),
+      "capabilities/tick.ts": routeFile("tick"),
+    });
+    const result = await startCommand(root, { once: true, timeoutMs: 10_000 });
+    expect(result).toMatchObject({ success: true });
+  });
+
+  /**
+   * @case --timeout turns a project that produces nothing into a diagnosis
+   * @preconditions Only a server ingress, so no exchange ever reaches a
+   *   terminal outcome
+   * @expectedResult Fails non-zero naming the timeout, rather than waiting
+   *   for the CI job to be killed
+   */
+  test("--timeout fails when no exchange arrives", async () => {
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "capabilities/inbox.ts": [
+        `import { craft, direct, log } from "@routecraft/routecraft";`,
+        `export default craft().id("inbox").from(direct()).to(log());`,
+        "",
+      ].join("\n"),
+    });
+    const result = await startCommand(root, { once: true, timeoutMs: 250 });
+    expect(result).toMatchObject({ success: false, code: 1 });
+    expect(result.success === false && result.message).toMatch(
+      /No exchange reached a terminal outcome within 250ms/,
+    );
+  });
+
+  /**
+   * @case A config file exporting neither shape fails rather than booting empty
+   * @preconditions craft.config.ts exports a wrongly-named const
+   * @expectedResult Failure naming the expected export, not a silent empty config
+   */
+  test("errors when craft.config.ts exports neither shape", async () => {
+    const root = makeProject({
+      "craft.config.ts": `export const config = {};\n`,
+      "capabilities/health.ts": routeFile("health"),
+    });
+    const result = await startCommand(root);
+    expect(result).toMatchObject({ success: false });
+    expect(result.success === false && result.message).toMatch(
+      /exports neither "craftConfig" nor a config object/,
+    );
   });
 
   /**

--- a/packages/cli/test/start.bun.test.ts
+++ b/packages/cli/test/start.bun.test.ts
@@ -122,30 +122,28 @@ describe("CLI start command", () => {
 
   /**
    * @case A runtime exchange failure is not reported as a failed boot
-   * @preconditions A route that starts cleanly and then fails its exchange,
-   *   beside one that completes
-   * @expectedResult The command does not claim routes failed to start. The
-   *   pipeline emits context:error with a route for a failed exchange too, so
-   *   counting those would fail a command whose project started perfectly
+   * @preconditions One capability that starts cleanly and then throws inside
+   *   its pipeline. Run without --once so start() drains every route and the
+   *   outcome is the startup verdict rather than a race between exchanges
+   * @expectedResult Success. The pipeline emits context:error carrying a route
+   *   for a failed exchange as well as for a route that never came up, so
+   *   counting both would fail a command whose project started perfectly
    */
   test("does not report a runtime exchange failure as a startup failure", async () => {
     const root = makeProject({
       "craft.config.ts": EMPTY_CONFIG,
-      "capabilities/healthy.ts": routeFile("healthy"),
       "capabilities/throws.ts": [
         `import { craft, simple, log } from "@routecraft/routecraft";`,
         `export default craft()`,
         `  .id("throws")`,
         `  .from(simple("hi"))`,
-        `  .step(() => { throw new Error("exchange blew up"); })`,
+        `  .transform(() => { throw new Error("exchange blew up"); })`,
         `  .to(log());`,
         "",
       ].join("\n"),
     });
-    const result = await startCommand(root, { once: true, timeoutMs: 5_000 });
-    if (result.success === false) {
-      expect(result.message).not.toMatch(/failed to start/);
-    }
+    const result = await startCommand(root);
+    expect(result).toMatchObject({ success: true });
   });
 
   /**

--- a/packages/cli/test/start.bun.test.ts
+++ b/packages/cli/test/start.bun.test.ts
@@ -96,6 +96,31 @@ describe("CLI start command", () => {
   }
 
   /**
+   * @case A route that throws on the way up fails the command
+   * @preconditions One capability whose source throws from its subscribe,
+   *   beside a healthy one
+   * @expectedResult Failure naming the dead route, because context.start()
+   *   settles every route and resolves even when one of them rejected
+   */
+  test("reports a route that failed to start as a failed boot", async () => {
+    const root = makeProject({
+      "craft.config.ts": EMPTY_CONFIG,
+      "capabilities/healthy.ts": routeFile("healthy"),
+      "capabilities/broken.ts": [
+        `import { craft, log } from "@routecraft/routecraft";`,
+        `const exploding = {`,
+        `  subscribe() { throw new Error("source refused to start"); },`,
+        `};`,
+        `export default craft().id("broken").from(exploding).to(log());`,
+        "",
+      ].join("\n"),
+    });
+    const result = await startCommand(root, { once: true, timeoutMs: 5_000 });
+    expect(result).toMatchObject({ success: false, code: 1 });
+    expect(result.success === false && result.message).toMatch(/broken/);
+  });
+
+  /**
    * @case A project without a config file fails with an actionable message
    * @preconditions Directory holding capabilities but no craft.config.ts
    * @expectedResult Failure naming craft.config.ts and pointing at craft run

--- a/packages/routecraft/src/define-config.ts
+++ b/packages/routecraft/src/define-config.ts
@@ -20,7 +20,7 @@ import type { CraftConfig } from "@routecraft/routecraft";
  * import { defineConfig } from "@routecraft/routecraft";
  * import "@routecraft/ai"; // augments CraftConfig with `llm`, `mcp`, etc.
  *
- * export default defineConfig({
+ * export const craftConfig = defineConfig({
  *   cron: { timezone: "UTC" },
  *   llm: { providers: { openai: { apiKey: process.env.OPENAI_API_KEY! } } },
  * });

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -62,6 +62,7 @@ export {
   registerProjectDiscoverer,
   type ProjectDiscoverer,
   type ProjectDiscovererOptions,
+  type ProjectDiscoveryContext,
   type RegisteredProjectDiscoverer,
 } from "./project-discoverer.ts";
 export { type HttpConfig } from "./adapters/http/types.ts";

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -54,6 +54,14 @@ export {
 export { type Capability, registerCapability } from "./capabilities.ts";
 export { defineConfig } from "./define-config.ts";
 export { registerConfigApplier, type ConfigApplier } from "./config-applier.ts";
+export {
+  getProjectDiscoverers,
+  mergeProjectConfig,
+  registerProjectDiscoverer,
+  type ProjectDiscoverer,
+  type ProjectDiscovererOptions,
+  type RegisteredProjectDiscoverer,
+} from "./project-discoverer.ts";
 export { type HttpConfig } from "./adapters/http/types.ts";
 
 // Side-effect: register the config appliers for first-class config keys

--- a/packages/routecraft/src/project-discoverer.ts
+++ b/packages/routecraft/src/project-discoverer.ts
@@ -34,6 +34,17 @@ export interface ProjectDiscoveryContext {
    * earlier. Never mutated.
    */
   readonly config: Readonly<CraftConfig>;
+  /**
+   * The project's own configuration, before any discoverer contributed.
+   *
+   * This is the one that answers "did the project declare this?", which
+   * {@link config} cannot: by the time a later discoverer runs, an
+   * earlier one's fragment is indistinguishable from something the
+   * author wrote. Use it for precedence decisions and for reporting
+   * where a value came from; use `config` to see what is actually in
+   * effect.
+   */
+  readonly declared: Readonly<CraftConfig>;
 }
 
 /**
@@ -175,30 +186,38 @@ export function registerProjectDiscoverer(
  */
 export function getProjectDiscoverers(): readonly RegisteredProjectDiscoverer[] {
   const registered = getRegistry();
+  const pending = [...registered.values()];
   const out: RegisteredProjectDiscoverer[] = [];
   const done = new Set<string>();
-  const visiting = new Set<string>();
 
-  const visit = (entry: RegisteredProjectDiscoverer, trail: string[]): void => {
-    if (done.has(entry.folder)) return;
-    if (visiting.has(entry.folder)) {
+  // Kahn rather than a depth-first walk: emitting a dependency the
+  // moment it is reached would hoist it above independent discoverers
+  // that registered earlier, so an unrelated registration could reorder
+  // two entries that have nothing to do with each other, and ordering
+  // here decides which fragment merges over which. Repeatedly taking
+  // the earliest-registered entry whose dependencies have all run keeps
+  // registration order as the only tiebreak.
+  while (pending.length > 0) {
+    const index = pending.findIndex((entry) =>
+      entry.after.every(
+        // A dependency nobody registered is satisfied: the package that
+        // would have claimed the folder simply is not installed.
+        (folder) => !registered.has(folder) || done.has(folder),
+      ),
+    );
+    if (index === -1) {
       throw rcError("RC5003", undefined, {
-        message: `Project discoverers form a dependency cycle: ${[...trail, entry.folder].join(" -> ")}. One of the "after" declarations has to go; no run order can satisfy a cycle.`,
+        message: `Project discoverers form a dependency cycle among: ${pending
+          .map((entry) => entry.folder)
+          .join(
+            ", ",
+          )}. One of the "after" declarations has to go; no run order can satisfy a cycle.`,
       });
     }
-    visiting.add(entry.folder);
-    for (const dependency of entry.after) {
-      const next = registered.get(dependency);
-      // A dependency nobody registered is satisfied: the package that
-      // would have claimed the folder simply is not installed.
-      if (next) visit(next, [...trail, entry.folder]);
-    }
-    visiting.delete(entry.folder);
+    const [entry] = pending.splice(index, 1) as [RegisteredProjectDiscoverer];
     done.add(entry.folder);
     out.push(entry);
-  };
-
-  for (const entry of registered.values()) visit(entry, []);
+  }
   return out;
 }
 

--- a/packages/routecraft/src/project-discoverer.ts
+++ b/packages/routecraft/src/project-discoverer.ts
@@ -1,0 +1,205 @@
+// Self-reference via the published specifier so ecosystem augmentations
+// (`declare module "@routecraft/routecraft" { interface CraftConfig { ... } }`)
+// propagate into this module's view of `CraftConfig`. Importing through
+// `./context.ts` would resolve to a separate module identity and miss the
+// augmentations.
+import type { CraftConfig } from "@routecraft/routecraft";
+
+/**
+ * Turn a convention folder into a `CraftConfig` fragment.
+ *
+ * A project runner (`craft start`) walks the filesystem and knows which
+ * folders exist; it does not know what the contents mean. A discoverer
+ * supplies that meaning for one folder name, which is how `agents/` and
+ * `skills/` are understood by `@routecraft/ai` without the CLI ever
+ * depending on it.
+ *
+ * `config` is the configuration accumulated so far: the project's own
+ * `craft.config.ts` plus every fragment from a lower-ordered
+ * discoverer. Two things follow from that:
+ *
+ * - **Precedence is the discoverer's job.** Code wins and convention
+ *   fills the gaps, so a discoverer inspects `config` and declines to
+ *   produce anything the project already declared.
+ * - **Discoverers can build on each other.** The `agents` discoverer
+ *   reads the house skills the `skills` discoverer contributed, because
+ *   it runs at a higher order.
+ *
+ * @param directory - Absolute path of the discovered folder
+ * @param config - Configuration accumulated so far, never mutated
+ */
+export type ProjectDiscoverer = (
+  directory: string,
+  config: Readonly<CraftConfig>,
+) => Promise<Partial<CraftConfig>>;
+
+/**
+ * Registration options for {@link registerProjectDiscoverer}.
+ */
+export interface ProjectDiscovererOptions {
+  /**
+   * Run order, ascending, defaulting to `0`. Ties keep registration
+   * order. Set it when a discoverer needs another one's fragment to
+   * already be in `config`: `@routecraft/ai` orders `skills` ahead of
+   * `agents` so an agent bundle can compose the house skills rather
+   * than silently replacing them.
+   */
+  order?: number;
+}
+
+/**
+ * A discoverer as held by the registry.
+ */
+export interface RegisteredProjectDiscoverer {
+  /** Folder name, relative to the project's content root. */
+  folder: string;
+  /** Run order, ascending. */
+  order: number;
+  /** The discoverer itself. */
+  discover: ProjectDiscoverer;
+}
+
+/**
+ * Cross-instance registry. `Symbol.for` so multiple copies of the
+ * package in a workspace share a single registry; without this, a
+ * discoverer registered by one package copy would be invisible to a
+ * runner constructed from another copy.
+ */
+const REGISTRY_KEY: unique symbol = Symbol.for(
+  "routecraft.project-discoverer-registry",
+);
+
+type GlobalWithRegistry = typeof globalThis & {
+  [REGISTRY_KEY]?: Map<string, RegisteredProjectDiscoverer>;
+};
+
+function getRegistry(): Map<string, RegisteredProjectDiscoverer> {
+  const g = globalThis as GlobalWithRegistry;
+  let registry = g[REGISTRY_KEY];
+  if (!registry) {
+    registry = new Map<string, RegisteredProjectDiscoverer>();
+    g[REGISTRY_KEY] = registry;
+  }
+  return registry;
+}
+
+/**
+ * Register a discoverer for one convention folder.
+ *
+ * Ecosystem packages call this at module load time from a side-effect
+ * import, the same way {@link registerConfigApplier} promotes a config
+ * key. Registering the same folder twice replaces the previous
+ * registration: last writer wins.
+ *
+ * Registration happens on **import**, which is worth stating plainly
+ * because it is the failure mode users hit: a project whose
+ * `craft.config.ts` only carries `import type { ... }` from the
+ * package never registers anything, because a type-only import is
+ * erased at compile time.
+ *
+ * @param folder - Folder name relative to the project's content root
+ * @param discoverer - Builds a config fragment from that folder
+ * @param options - Run order
+ *
+ * @example
+ * ```typescript
+ * registerProjectDiscoverer(
+ *   "agents",
+ *   async (dir, config) => ({ agent: { agents: await load(dir, config) } }),
+ *   { order: 20 },
+ * );
+ * ```
+ */
+export function registerProjectDiscoverer(
+  folder: string,
+  discoverer: ProjectDiscoverer,
+  options: ProjectDiscovererOptions = {},
+): void {
+  getRegistry().set(folder, {
+    folder,
+    order: options.order ?? 0,
+    discover: discoverer,
+  });
+}
+
+/**
+ * Get the registered discoverers in run order: ascending `order`, then
+ * registration order for ties.
+ */
+export function getProjectDiscoverers(): readonly RegisteredProjectDiscoverer[] {
+  // Registration order is Map insertion order, and Array.prototype.sort
+  // is stable, so sorting by `order` alone preserves it within a tier.
+  return [...getRegistry().values()].sort((a, b) => a.order - b.order);
+}
+
+/**
+ * True for objects the merge is allowed to recurse into: object
+ * literals and null-prototype records. Class instances, arrays, and
+ * functions are values, not shapes to combine.
+ *
+ * An object carrying own symbol keys is also treated as a value. Those
+ * keys are how the framework brands cross-instance types (a
+ * `ToolSelection` is an object literal with a `Symbol.for` brand), and
+ * a rebuilt copy would be a different thing wearing the same shape.
+ */
+function isMergeableRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value) as object | null;
+  if (proto !== Object.prototype && proto !== null) return false;
+  return Object.getOwnPropertySymbols(value).length === 0;
+}
+
+/**
+ * Merge a discoverer's fragment into a configuration and return a new
+ * object. Neither input is mutated.
+ *
+ * Rules, in order:
+ *
+ * 1. An `undefined` value in the fragment is ignored, so a discoverer
+ *    that produces nothing can return `{}` or omit the key.
+ * 2. Two plain objects merge recursively. This is what puts a
+ *    discovered agent beside a config-declared one instead of
+ *    replacing the whole map.
+ * 3. Two arrays concatenate, base first, which is how a discovered
+ *    plugin joins the ones the project declared.
+ * 4. Anything else: the fragment's value replaces the base's.
+ *
+ * Rule 4 is the reason precedence lives in the discoverer rather than
+ * here. The merge cannot tell an intentional override from an
+ * accidental one; the discoverer can, because it is handed the config
+ * before it decides what to return.
+ */
+export function mergeProjectConfig(
+  base: CraftConfig,
+  fragment: Partial<CraftConfig>,
+): CraftConfig {
+  return mergeRecords(
+    base as Record<string, unknown>,
+    fragment as Record<string, unknown>,
+  ) as CraftConfig;
+}
+
+function mergeRecords(
+  base: Record<string, unknown>,
+  fragment: Record<string, unknown>,
+): Record<string, unknown> {
+  // Spread and `Reflect.ownKeys` rather than `Object.entries` so own
+  // symbol keys survive on both sides; see isMergeableRecord.
+  const out: Record<string, unknown> = { ...base };
+  for (const key of Reflect.ownKeys(fragment) as Array<string | symbol>) {
+    const value = (fragment as Record<string | symbol, unknown>)[key];
+    if (value === undefined) continue;
+    const current = (out as Record<string | symbol, unknown>)[key];
+    if (isMergeableRecord(current) && isMergeableRecord(value)) {
+      (out as Record<string | symbol, unknown>)[key] = mergeRecords(
+        current,
+        value,
+      );
+    } else if (Array.isArray(current) && Array.isArray(value)) {
+      (out as Record<string | symbol, unknown>)[key] = [...current, ...value];
+    } else {
+      (out as Record<string | symbol, unknown>)[key] = value;
+    }
+  }
+  return out;
+}

--- a/packages/routecraft/src/project-discoverer.ts
+++ b/packages/routecraft/src/project-discoverer.ts
@@ -227,28 +227,36 @@ export function getProjectDiscoverers(): readonly RegisteredProjectDiscoverer[] 
  * Everything still pending when the sort deadlocks is blocked, but most
  * of it may be blocked merely by sitting downstream of the cycle. Naming
  * those in the error sends the reader hunting through `after`
- * declarations that are perfectly fine. Repeatedly dropping entries
- * nothing else pending depends on peels away that downstream tail and
- * leaves the entries that depend on each other.
+ * declarations that are perfectly fine.
+ *
+ * A folder is on a cycle exactly when it can reach itself by following
+ * `after` edges, which is the definition rather than an approximation of
+ * it: peeling away entries nothing depends on looks equivalent but keeps
+ * a bridge between two separate cycles, and that bridge is innocent.
  *
  * @internal
  */
 function cycleMembers(
   pending: readonly RegisteredProjectDiscoverer[],
 ): string[] {
-  let members = [...pending];
-  for (;;) {
-    const names = new Set(members.map((entry) => entry.folder));
-    const depended = new Set(
-      members.flatMap((entry) =>
-        entry.after.filter((folder) => names.has(folder)),
-      ),
+  const byFolder = new Map(pending.map((entry) => [entry.folder, entry]));
+  const reaches = (
+    from: string,
+    target: string,
+    seen: Set<string>,
+  ): boolean => {
+    if (seen.has(from)) return false;
+    seen.add(from);
+    const entry = byFolder.get(from);
+    if (!entry) return false;
+    return entry.after.some(
+      (folder) => folder === target || reaches(folder, target, seen),
     );
-    const next = members.filter((entry) => depended.has(entry.folder));
-    if (next.length === members.length) break;
-    members = next;
-  }
-  return members.map((entry) => entry.folder).sort();
+  };
+  return pending
+    .filter((entry) => reaches(entry.folder, entry.folder, new Set()))
+    .map((entry) => entry.folder)
+    .sort();
 }
 
 /**

--- a/packages/routecraft/src/project-discoverer.ts
+++ b/packages/routecraft/src/project-discoverer.ts
@@ -207,11 +207,11 @@ export function getProjectDiscoverers(): readonly RegisteredProjectDiscoverer[] 
     );
     if (index === -1) {
       throw rcError("RC5003", undefined, {
-        message: `Project discoverers form a dependency cycle among: ${pending
-          .map((entry) => entry.folder)
-          .join(
-            ", ",
-          )}. One of the "after" declarations has to go; no run order can satisfy a cycle.`,
+        message: `Project discoverers form a dependency cycle among: ${cycleMembers(
+          pending,
+        ).join(
+          ", ",
+        )}. One of the "after" declarations has to go; no run order can satisfy a cycle.`,
       });
     }
     const [entry] = pending.splice(index, 1) as [RegisteredProjectDiscoverer];
@@ -219,6 +219,36 @@ export function getProjectDiscoverers(): readonly RegisteredProjectDiscoverer[] 
     out.push(entry);
   }
   return out;
+}
+
+/**
+ * Narrow a deadlocked set to the folders actually on a cycle.
+ *
+ * Everything still pending when the sort deadlocks is blocked, but most
+ * of it may be blocked merely by sitting downstream of the cycle. Naming
+ * those in the error sends the reader hunting through `after`
+ * declarations that are perfectly fine. Repeatedly dropping entries
+ * nothing else pending depends on peels away that downstream tail and
+ * leaves the entries that depend on each other.
+ *
+ * @internal
+ */
+function cycleMembers(
+  pending: readonly RegisteredProjectDiscoverer[],
+): string[] {
+  let members = [...pending];
+  for (;;) {
+    const names = new Set(members.map((entry) => entry.folder));
+    const depended = new Set(
+      members.flatMap((entry) =>
+        entry.after.filter((folder) => names.has(folder)),
+      ),
+    );
+    const next = members.filter((entry) => depended.has(entry.folder));
+    if (next.length === members.length) break;
+    members = next;
+  }
+  return members.map((entry) => entry.folder).sort();
 }
 
 /**

--- a/packages/routecraft/src/project-discoverer.ts
+++ b/packages/routecraft/src/project-discoverer.ts
@@ -4,6 +4,37 @@
 // `./context.ts` would resolve to a separate module identity and miss the
 // augmentations.
 import type { CraftConfig } from "@routecraft/routecraft";
+import { rcError } from "./error.ts";
+
+/**
+ * Everything a discoverer is given about the folder it matched and the
+ * project around it.
+ *
+ * Passed as one object rather than positional arguments so the contract
+ * can grow (a logger, a dry-run flag) without breaking every ecosystem
+ * package that implements one, and so a discoverer never has to derive
+ * a path the runner already knows. Deriving `contentRoot` from
+ * `directory` looks harmless but bakes in an invariant the runner does
+ * not promise.
+ */
+export interface ProjectDiscoveryContext {
+  /** Absolute path of the discovered folder. */
+  readonly directory: string;
+  /**
+   * Absolute path of the content root the folder was found under: the
+   * project root, or its `src` when the project uses that layout. A
+   * sibling convention folder lives here.
+   */
+  readonly contentRoot: string;
+  /** Absolute path of the project root, where `craft.config.ts` lives. */
+  readonly projectRoot: string;
+  /**
+   * Configuration accumulated so far: the project's own
+   * `craft.config.ts` plus every fragment from a discoverer that ran
+   * earlier. Never mutated.
+   */
+  readonly config: Readonly<CraftConfig>;
+}
 
 /**
  * Turn a convention folder into a `CraftConfig` fragment.
@@ -14,23 +45,24 @@ import type { CraftConfig } from "@routecraft/routecraft";
  * `skills/` are understood by `@routecraft/ai` without the CLI ever
  * depending on it.
  *
- * `config` is the configuration accumulated so far: the project's own
- * `craft.config.ts` plus every fragment from a lower-ordered
- * discoverer. Two things follow from that:
+ * Two rules follow from being handed the accumulated config:
  *
  * - **Precedence is the discoverer's job.** Code wins and convention
- *   fills the gaps, so a discoverer inspects `config` and declines to
- *   produce anything the project already declared.
- * - **Discoverers can build on each other.** The `agents` discoverer
- *   reads the house skills the `skills` discoverer contributed, because
- *   it runs at a higher order.
+ *   fills the gaps, so a discoverer inspects `ctx.config` and declines
+ *   to produce anything the project already declared.
+ * - **Return the contribution, not the base.** The merge preserves what
+ *   is already there, so a fragment should carry only what the
+ *   discoverer adds. Copying existing values back into the fragment is
+ *   redundant and, for an array-valued field, duplicates entries.
  *
- * @param directory - Absolute path of the discovered folder
- * @param config - Configuration accumulated so far, never mutated
+ * The return type is `Partial<CraftConfig>`, which is shallow: it
+ * cannot express "a partial value nested inside a record". A fragment
+ * that patches one entry of `agent.agents` is still a patch, and may
+ * need a cast at the boundary. That is a limitation of the type, not
+ * permission to return complete values you did not compute.
  */
 export type ProjectDiscoverer = (
-  directory: string,
-  config: Readonly<CraftConfig>,
+  ctx: ProjectDiscoveryContext,
 ) => Promise<Partial<CraftConfig>>;
 
 /**
@@ -38,13 +70,22 @@ export type ProjectDiscoverer = (
  */
 export interface ProjectDiscovererOptions {
   /**
-   * Run order, ascending, defaulting to `0`. Ties keep registration
-   * order. Set it when a discoverer needs another one's fragment to
-   * already be in `config`: `@routecraft/ai` orders `skills` ahead of
-   * `agents` so an agent bundle can compose the house skills rather
-   * than silently replacing them.
+   * Folder names whose fragments must already be in `ctx.config` when
+   * this discoverer runs. Declaring the dependency beats picking a
+   * number: it says which discoverer you need rather than where you
+   * hope to sit, and a third party can target a folder name without
+   * importing a constant it cannot see.
+   *
+   * Two edge semantics, both deliberate:
+   *
+   * - A name nobody registered is a **satisfied** constraint, not an
+   *   error. A discoverer that composes another's output when present
+   *   must still run when that package is absent.
+   * - A cycle is an **error**, raised by {@link getProjectDiscoverers},
+   *   because no run order can satisfy it and silently picking one
+   *   would make the outcome depend on import order.
    */
-  order?: number;
+  after?: readonly string[];
 }
 
 /**
@@ -52,11 +93,11 @@ export interface ProjectDiscovererOptions {
  */
 export interface RegisteredProjectDiscoverer {
   /** Folder name, relative to the project's content root. */
-  folder: string;
-  /** Run order, ascending. */
-  order: number;
+  readonly folder: string;
+  /** Folder names that must run before this one. */
+  readonly after: readonly string[];
   /** The discoverer itself. */
-  discover: ProjectDiscoverer;
+  readonly discover: ProjectDiscoverer;
 }
 
 /**
@@ -87,8 +128,8 @@ function getRegistry(): Map<string, RegisteredProjectDiscoverer> {
  * Register a discoverer for one convention folder.
  *
  * Ecosystem packages call this at module load time from a side-effect
- * import, the same way {@link registerConfigApplier} promotes a config
- * key. Registering the same folder twice replaces the previous
+ * import, the same way `registerConfigApplier` promotes a config key.
+ * Registering the same folder twice replaces the previous
  * registration: last writer wins.
  *
  * Registration happens on **import**, which is worth stating plainly
@@ -99,14 +140,14 @@ function getRegistry(): Map<string, RegisteredProjectDiscoverer> {
  *
  * @param folder - Folder name relative to the project's content root
  * @param discoverer - Builds a config fragment from that folder
- * @param options - Run order
+ * @param options - Declared dependencies on other folders
  *
  * @example
  * ```typescript
  * registerProjectDiscoverer(
  *   "agents",
- *   async (dir, config) => ({ agent: { agents: await load(dir, config) } }),
- *   { order: 20 },
+ *   async (ctx) => ({ agent: { agents: await load(ctx) } }),
+ *   { after: ["skills"] },
  * );
  * ```
  */
@@ -117,19 +158,48 @@ export function registerProjectDiscoverer(
 ): void {
   getRegistry().set(folder, {
     folder,
-    order: options.order ?? 0,
+    after: options.after ?? [],
     discover: discoverer,
   });
 }
 
 /**
- * Get the registered discoverers in run order: ascending `order`, then
- * registration order for ties.
+ * Get the registered discoverers in run order.
+ *
+ * Sorted so every declared `after` dependency runs first, with
+ * registration order preserved between independent entries so the
+ * result is stable. A dependency on a folder nobody registered is
+ * satisfied by definition.
+ *
+ * @throws RC5003 when the declared dependencies form a cycle.
  */
 export function getProjectDiscoverers(): readonly RegisteredProjectDiscoverer[] {
-  // Registration order is Map insertion order, and Array.prototype.sort
-  // is stable, so sorting by `order` alone preserves it within a tier.
-  return [...getRegistry().values()].sort((a, b) => a.order - b.order);
+  const registered = getRegistry();
+  const out: RegisteredProjectDiscoverer[] = [];
+  const done = new Set<string>();
+  const visiting = new Set<string>();
+
+  const visit = (entry: RegisteredProjectDiscoverer, trail: string[]): void => {
+    if (done.has(entry.folder)) return;
+    if (visiting.has(entry.folder)) {
+      throw rcError("RC5003", undefined, {
+        message: `Project discoverers form a dependency cycle: ${[...trail, entry.folder].join(" -> ")}. One of the "after" declarations has to go; no run order can satisfy a cycle.`,
+      });
+    }
+    visiting.add(entry.folder);
+    for (const dependency of entry.after) {
+      const next = registered.get(dependency);
+      // A dependency nobody registered is satisfied: the package that
+      // would have claimed the folder simply is not installed.
+      if (next) visit(next, [...trail, entry.folder]);
+    }
+    visiting.delete(entry.folder);
+    done.add(entry.folder);
+    out.push(entry);
+  };
+
+  for (const entry of registered.values()) visit(entry, []);
+  return out;
 }
 
 /**
@@ -179,6 +249,26 @@ export function mergeProjectConfig(
   ) as CraftConfig;
 }
 
+/**
+ * Write a key without going through a setter. `out[key] = value` would
+ * hit `Object.prototype.__proto__` for a key of that name, silently
+ * dropping the entry and changing the object's prototype; the spread
+ * that seeded `out` defines it as a real own property, so the two
+ * halves of this function have to agree.
+ */
+function define(
+  target: Record<string | symbol, unknown>,
+  key: string | symbol,
+  value: unknown,
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
 function mergeRecords(
   base: Record<string, unknown>,
   fragment: Record<string, unknown>,
@@ -186,19 +276,17 @@ function mergeRecords(
   // Spread and `Reflect.ownKeys` rather than `Object.entries` so own
   // symbol keys survive on both sides; see isMergeableRecord.
   const out: Record<string, unknown> = { ...base };
+  const target = out as Record<string | symbol, unknown>;
   for (const key of Reflect.ownKeys(fragment) as Array<string | symbol>) {
     const value = (fragment as Record<string | symbol, unknown>)[key];
     if (value === undefined) continue;
-    const current = (out as Record<string | symbol, unknown>)[key];
+    const current = target[key];
     if (isMergeableRecord(current) && isMergeableRecord(value)) {
-      (out as Record<string | symbol, unknown>)[key] = mergeRecords(
-        current,
-        value,
-      );
+      define(target, key, mergeRecords(current, value));
     } else if (Array.isArray(current) && Array.isArray(value)) {
-      (out as Record<string | symbol, unknown>)[key] = [...current, ...value];
+      define(target, key, [...current, ...value]);
     } else {
-      (out as Record<string | symbol, unknown>)[key] = value;
+      define(target, key, value);
     }
   }
   return out;

--- a/packages/routecraft/test/project-discoverer.bun.test.ts
+++ b/packages/routecraft/test/project-discoverer.bun.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  getProjectDiscoverers,
+  mergeProjectConfig,
+  registerProjectDiscoverer,
+  type CraftConfig,
+  type RegisteredProjectDiscoverer,
+} from "../src/index.ts";
+
+/**
+ * Access the cross-instance discoverer registry directly so tests can
+ * sandbox registrations and reset between cases. Mirrors the symbol
+ * used in project-discoverer.ts.
+ */
+const REGISTRY_KEY = Symbol.for("routecraft.project-discoverer-registry");
+
+type GlobalWithRegistry = typeof globalThis & {
+  [REGISTRY_KEY]?: Map<string, RegisteredProjectDiscoverer>;
+};
+
+function snapshotRegistry(): Map<string, RegisteredProjectDiscoverer> {
+  const g = globalThis as GlobalWithRegistry;
+  return new Map(g[REGISTRY_KEY] ?? new Map());
+}
+
+function restoreRegistry(
+  snapshot: Map<string, RegisteredProjectDiscoverer>,
+): void {
+  const g = globalThis as GlobalWithRegistry;
+  g[REGISTRY_KEY] = new Map(snapshot);
+}
+
+describe("registerProjectDiscoverer", () => {
+  let snapshot: Map<string, RegisteredProjectDiscoverer> | undefined;
+
+  beforeEach(() => {
+    snapshot = snapshotRegistry();
+  });
+
+  afterEach(() => {
+    if (snapshot) restoreRegistry(snapshot);
+    snapshot = undefined;
+  });
+
+  /**
+   * @case A registered discoverer is retrievable by folder name
+   * @preconditions One discoverer registered for "__testFolder"
+   * @expectedResult getProjectDiscoverers includes it with the default order
+   */
+  test("registers a discoverer for a folder", () => {
+    const discover = async (): Promise<Partial<CraftConfig>> => ({});
+    registerProjectDiscoverer("__testFolder", discover);
+    const found = getProjectDiscoverers().find(
+      (d) => d.folder === "__testFolder",
+    );
+    expect(found).toMatchObject({ folder: "__testFolder", order: 0 });
+    expect(found?.discover).toBe(discover);
+  });
+
+  /**
+   * @case Discoverers run in ascending order regardless of registration order
+   * @preconditions Two discoverers registered high-order first
+   * @expectedResult The lower order comes first in the returned list
+   */
+  test("returns discoverers in ascending order", () => {
+    registerProjectDiscoverer("__testLate", async () => ({}), { order: 20 });
+    registerProjectDiscoverer("__testEarly", async () => ({}), { order: 10 });
+    const folders = getProjectDiscoverers()
+      .map((d) => d.folder)
+      .filter((f) => f.startsWith("__test"));
+    expect(folders).toEqual(["__testEarly", "__testLate"]);
+  });
+
+  /**
+   * @case Equal orders keep registration order
+   * @preconditions Two discoverers registered with no explicit order
+   * @expectedResult The first registered comes first
+   */
+  test("ties keep registration order", () => {
+    registerProjectDiscoverer("__testA", async () => ({}));
+    registerProjectDiscoverer("__testB", async () => ({}));
+    const folders = getProjectDiscoverers()
+      .map((d) => d.folder)
+      .filter((f) => f === "__testA" || f === "__testB");
+    expect(folders).toEqual(["__testA", "__testB"]);
+  });
+
+  /**
+   * @case Re-registering a folder replaces the previous discoverer
+   * @preconditions Same folder registered twice with different functions
+   * @expectedResult Only one entry remains and it is the last registered
+   */
+  test("re-registering a folder replaces the previous one", () => {
+    const second = async (): Promise<Partial<CraftConfig>> => ({});
+    registerProjectDiscoverer("__testDup", async () => ({}));
+    registerProjectDiscoverer("__testDup", second);
+    const matches = getProjectDiscoverers().filter(
+      (d) => d.folder === "__testDup",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.discover).toBe(second);
+  });
+});
+
+describe("mergeProjectConfig", () => {
+  /**
+   * @case Nested plain objects merge rather than replace
+   * @preconditions Base declares one agent, fragment declares another
+   * @expectedResult Both agents survive the merge
+   */
+  test("merges nested plain objects", () => {
+    const base = { name: "app", agent: { agents: { a: 1 } } };
+    const merged = mergeProjectConfig(
+      base as unknown as CraftConfig,
+      {
+        agent: { agents: { b: 2 } },
+      } as unknown as Partial<CraftConfig>,
+    ) as unknown as {
+      agent: { agents: Record<string, number> };
+    };
+    expect(merged.agent.agents).toEqual({ a: 1, b: 2 });
+  });
+
+  /**
+   * @case Arrays concatenate with the base first
+   * @preconditions Base and fragment both carry plugins
+   * @expectedResult Result holds both, base-declared plugins first
+   */
+  test("concatenates arrays", () => {
+    const one = { apply: (): void => {} };
+    const two = { apply: (): void => {} };
+    const merged = mergeProjectConfig({ plugins: [one] }, { plugins: [two] });
+    expect(merged.plugins).toEqual([one, two]);
+  });
+
+  /**
+   * @case A scalar in the fragment replaces the base value
+   * @preconditions Base and fragment both set `name`
+   * @expectedResult The fragment's value wins
+   */
+  test("fragment scalars replace base values", () => {
+    const merged = mergeProjectConfig({ name: "base" }, { name: "fragment" });
+    expect(merged.name).toBe("fragment");
+  });
+
+  /**
+   * @case An undefined fragment value leaves the base untouched
+   * @preconditions Fragment carries the key with an undefined value
+   * @expectedResult The base value survives
+   */
+  test("ignores undefined fragment values", () => {
+    const merged = mergeProjectConfig({ name: "base" }, {
+      name: undefined,
+    } as unknown as Partial<CraftConfig>);
+    expect(merged.name).toBe("base");
+  });
+
+  /**
+   * @case Neither input is mutated
+   * @preconditions Base with a nested object, fragment adding to it
+   * @expectedResult Base still holds only its original nested keys
+   */
+  test("does not mutate its inputs", () => {
+    const base = { agent: { agents: { a: 1 } } } as unknown as CraftConfig;
+    mergeProjectConfig(base, {
+      agent: { agents: { b: 2 } },
+    } as unknown as Partial<CraftConfig>);
+    expect(
+      (base as unknown as { agent: { agents: Record<string, number> } }).agent
+        .agents,
+    ).toEqual({ a: 1 });
+  });
+
+  /**
+   * @case A branded object literal survives the merge intact
+   * @preconditions Both sides hold an object literal carrying a Symbol.for brand
+   * @expectedResult The fragment's object is kept by identity, brand and all
+   */
+  test("does not rebuild objects carrying a symbol brand", () => {
+    const BRAND = Symbol.for("routecraft.test.brand");
+    const selection = { [BRAND]: true, refs: ["a"] };
+    const merged = mergeProjectConfig(
+      {
+        agent: { defaultOptions: { tools: { [BRAND]: true, refs: ["b"] } } },
+      } as unknown as CraftConfig,
+      {
+        agent: { defaultOptions: { tools: selection } },
+      } as unknown as Partial<CraftConfig>,
+    ) as unknown as {
+      agent: { defaultOptions: { tools: typeof selection } };
+    };
+    expect(merged.agent.defaultOptions.tools).toBe(selection);
+    expect(merged.agent.defaultOptions.tools[BRAND]).toBe(true);
+  });
+
+  /**
+   * @case A class instance in the fragment replaces rather than merges
+   * @preconditions Base holds a plain object, fragment holds an instance
+   * @expectedResult The instance survives intact, not spread into a literal
+   */
+  test("replaces non-plain objects instead of merging them", () => {
+    class Selection {
+      readonly kind = "selection";
+    }
+    const instance = new Selection();
+    const merged = mergeProjectConfig(
+      { agent: { defaultOptions: {} } } as unknown as CraftConfig,
+      {
+        agent: { defaultOptions: { tools: instance } },
+      } as unknown as Partial<CraftConfig>,
+    ) as unknown as {
+      agent: { defaultOptions: { tools: Selection } };
+    };
+    expect(merged.agent.defaultOptions.tools).toBe(instance);
+  });
+});

--- a/packages/routecraft/test/project-discoverer.bun.test.ts
+++ b/packages/routecraft/test/project-discoverer.bun.test.ts
@@ -45,7 +45,7 @@ describe("registerProjectDiscoverer", () => {
   /**
    * @case A registered discoverer is retrievable by folder name
    * @preconditions One discoverer registered for "__testFolder"
-   * @expectedResult getProjectDiscoverers includes it with the default order
+   * @expectedResult getProjectDiscoverers includes it with no declared dependency
    */
   test("registers a discoverer for a folder", () => {
     const discover = async (): Promise<Partial<CraftConfig>> => ({});
@@ -53,18 +53,20 @@ describe("registerProjectDiscoverer", () => {
     const found = getProjectDiscoverers().find(
       (d) => d.folder === "__testFolder",
     );
-    expect(found).toMatchObject({ folder: "__testFolder", order: 0 });
+    expect(found).toMatchObject({ folder: "__testFolder", after: [] });
     expect(found?.discover).toBe(discover);
   });
 
   /**
-   * @case Discoverers run in ascending order regardless of registration order
-   * @preconditions Two discoverers registered high-order first
-   * @expectedResult The lower order comes first in the returned list
+   * @case A declared dependency runs first regardless of registration order
+   * @preconditions The dependent discoverer is registered before the one it needs
+   * @expectedResult The dependency comes first in the returned list
    */
-  test("returns discoverers in ascending order", () => {
-    registerProjectDiscoverer("__testLate", async () => ({}), { order: 20 });
-    registerProjectDiscoverer("__testEarly", async () => ({}), { order: 10 });
+  test("returns discoverers in dependency order", () => {
+    registerProjectDiscoverer("__testLate", async () => ({}), {
+      after: ["__testEarly"],
+    });
+    registerProjectDiscoverer("__testEarly", async () => ({}));
     const folders = getProjectDiscoverers()
       .map((d) => d.folder)
       .filter((f) => f.startsWith("__test"));
@@ -72,17 +74,55 @@ describe("registerProjectDiscoverer", () => {
   });
 
   /**
-   * @case Equal orders keep registration order
-   * @preconditions Two discoverers registered with no explicit order
+   * @case Independent discoverers keep registration order
+   * @preconditions Two discoverers with no declared dependency
    * @expectedResult The first registered comes first
    */
-  test("ties keep registration order", () => {
+  test("independent discoverers keep registration order", () => {
     registerProjectDiscoverer("__testA", async () => ({}));
     registerProjectDiscoverer("__testB", async () => ({}));
     const folders = getProjectDiscoverers()
       .map((d) => d.folder)
       .filter((f) => f === "__testA" || f === "__testB");
     expect(folders).toEqual(["__testA", "__testB"]);
+  });
+
+  /**
+   * @case A dependency on a folder nobody registered is satisfied, not an error
+   * @preconditions A discoverer declaring after: ["__testAbsent"], which nothing registers
+   * @expectedResult It still runs; the missing package simply is not installed
+   */
+  test("an unregistered dependency is a satisfied constraint", () => {
+    registerProjectDiscoverer("__testOrphan", async () => ({}), {
+      after: ["__testAbsent"],
+    });
+    expect(
+      getProjectDiscoverers().some((d) => d.folder === "__testOrphan"),
+    ).toBe(true);
+  });
+
+  /**
+   * @case A dependency cycle is an error rather than an arbitrary order
+   * @preconditions Two discoverers each declaring the other in after
+   * @expectedResult getProjectDiscoverers throws RC5003 naming the cycle
+   */
+  test("a dependency cycle throws", () => {
+    registerProjectDiscoverer("__testA", async () => ({}), {
+      after: ["__testB"],
+    });
+    registerProjectDiscoverer("__testB", async () => ({}), {
+      after: ["__testA"],
+    });
+    const error = (() => {
+      try {
+        getProjectDiscoverers();
+        return undefined;
+      } catch (err: unknown) {
+        return err;
+      }
+    })();
+    expect(error).toMatchObject({ rc: "RC5003" });
+    expect((error as Error).message).toMatch(/dependency cycle/);
   });
 
   /**
@@ -169,6 +209,23 @@ describe("mergeProjectConfig", () => {
       (base as unknown as { agent: { agents: Record<string, number> } }).agent
         .agents,
     ).toEqual({ a: 1 });
+  });
+
+  /**
+   * @case A fragment key named __proto__ survives as a real own key
+   * @preconditions A null-prototype fragment carrying an own "__proto__" key
+   * @expectedResult The key is defined on the result rather than routed through
+   *   the prototype setter, and the result's prototype is unchanged
+   */
+  test("a __proto__ key in a fragment is defined, not set", () => {
+    const fragment = Object.create(null) as Record<string, unknown>;
+    fragment["__proto__"] = { polluted: true };
+    const merged = mergeProjectConfig(
+      {} as CraftConfig,
+      fragment as unknown as Partial<CraftConfig>,
+    ) as unknown as Record<string, unknown>;
+    expect(Object.hasOwn(merged, "__proto__")).toBe(true);
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
   });
 
   /**

--- a/packages/routecraft/test/project-discoverer.bun.test.ts
+++ b/packages/routecraft/test/project-discoverer.bun.test.ts
@@ -145,6 +145,37 @@ describe("registerProjectDiscoverer", () => {
   });
 
   /**
+   * @case The cycle error names only the folders actually on the cycle
+   * @preconditions __testB and __testC depend on each other; __testA merely
+   *   depends on __testB and is therefore blocked but innocent
+   * @expectedResult The message names B and C and not A, so the reader is not
+   *   sent hunting through an "after" declaration that is perfectly fine
+   */
+  test("the cycle error excludes discoverers merely blocked by the cycle", () => {
+    registerProjectDiscoverer("__testA", async () => ({}), {
+      after: ["__testB"],
+    });
+    registerProjectDiscoverer("__testB", async () => ({}), {
+      after: ["__testC"],
+    });
+    registerProjectDiscoverer("__testC", async () => ({}), {
+      after: ["__testB"],
+    });
+    const error = (() => {
+      try {
+        getProjectDiscoverers();
+        return undefined;
+      } catch (err: unknown) {
+        return err;
+      }
+    })();
+    const message = (error as Error).message;
+    expect(message).toMatch(/__testB/);
+    expect(message).toMatch(/__testC/);
+    expect(message).not.toMatch(/__testA/);
+  });
+
+  /**
    * @case Re-registering a folder replaces the previous discoverer
    * @preconditions Same folder registered twice with different functions
    * @expectedResult Only one entry remains and it is the last registered

--- a/packages/routecraft/test/project-discoverer.bun.test.ts
+++ b/packages/routecraft/test/project-discoverer.bun.test.ts
@@ -88,6 +88,25 @@ describe("registerProjectDiscoverer", () => {
   });
 
   /**
+   * @case An unrelated dependency does not reorder two independent discoverers
+   * @preconditions A depends on C, then independent B, then C are registered;
+   *   B and C have no dependency between them
+   * @expectedResult B still precedes C, because only their registration order
+   *   relates them; a depth-first walk would hoist C above B on its way to A
+   */
+  test("a dependency does not reorder independent discoverers", () => {
+    registerProjectDiscoverer("__testA", async () => ({}), {
+      after: ["__testC"],
+    });
+    registerProjectDiscoverer("__testB", async () => ({}));
+    registerProjectDiscoverer("__testC", async () => ({}));
+    const folders = getProjectDiscoverers()
+      .map((d) => d.folder)
+      .filter((f) => f.startsWith("__test"));
+    expect(folders).toEqual(["__testB", "__testC", "__testA"]);
+  });
+
+  /**
    * @case A dependency on a folder nobody registered is satisfied, not an error
    * @preconditions A discoverer declaring after: ["__testAbsent"], which nothing registers
    * @expectedResult It still runs; the missing package simply is not installed


### PR DESCRIPTION
Closes #131. Closes #340.

Second and final PR of Lane C, on top of #577 (#324, merged). `craft start` boots a whole project from the folder convention, and an existing Claude Code agent tree drops in without edits.

## What this adds

```bash
craft start [dir] [--env <path>] [--once] [--timeout <ms>]
```

`start` reads `craft.config.ts` through its named `craftConfig` export, then discovers what the project declares on disk: `plugins/`, the registered folder discoverers, and `capabilities/`. Both root-level and `src/`-nested layouts work. Code wins and convention fills the gaps, per field: whatever the config declares is kept and discovery supplies only what it left unset, with one info line per discovered agent naming field provenance.

```text
Agent "zoe": description, system, tools from craft.config.ts,
  blocks.skills from agents/zoe.md + skills + devoptix + npm:@acme/claude-skills/support.
```

## The CLI stays ignorant of AI

Core gains `registerProjectDiscoverer(folder, discoverer, { after })`, mirroring the existing `registerConfigApplier` pattern. `@routecraft/ai` claims `skills/` and `agents/` on import; the CLI owns the filesystem walk and the merge, and never learns what an agent is.

Discoverers declare their own ordering rather than relying on registration order, so the agents discoverer states `after: ["skills"]` and composes house skills instead of racing them. A cycle throws `RC5003` naming its members; a dependency on a folder the project does not have is a satisfied constraint, not an error.

A folder with no registered discoverer fails with an install-and-import hint that names the erased `import type` case, since a type-only import registers nothing while looking perfectly correct at the top of the file.

## Skills resolution

An agent declares its own sources in frontmatter:

```yaml
skills:
  - ./skills                                  # local, relative to the agent file
  - npm:@acme/claude-skills/support           # installed package, subpath into its tree
```

`npm:` refs resolve against installed packages only, so there is no network at boot and no trust surface beyond the dependencies already in `package.json`. `npm:<pkg>/<sub>` tries `<root>/<sub>` then `<root>/skills/<sub>`; `npm:<pkg>` tries `<root>/skills` then the root. A ref resolving to no directory fails the boot with `AI1004` listing every path tried. The full rule and its reasoning are recorded on #131.

Composition order, most specific last: house `skills/` folder, then frontmatter refs in declared order, then the bundle's own `skills/` folder. A name in more than one resolves to the most specific copy and logs both sources.

An agent that declares no skills inherits the house set. Absent means "the house default", never "no skills", so a dropped-in file lands in the ambient behaviour its author expected.

## Claude Code compatibility (#340)

An existing `.claude/agents/` tree loads unchanged: comma-separated `tools:` strings alongside YAML arrays, the `opus` / `sonnet` / `haiku` / `inherit` aliases, and unknown frontmatter keys warned about once rather than treated as fatal. Claude built-ins this runtime does not provide are skipped per agent with a warning, checked against the live registry at dispatch rather than at parse time.

One deliberate departure from drop-in fidelity: `disallowedTools` with no `tools` throws rather than warning. A per-agent list replaces the context default outright rather than narrowing it, so a deny with no allow would leave the agent inheriting the very tools its file denies. A field whose whole purpose is removing capability is not one to fail open on. The error carries the workaround, and #583 tracks the faithful end state.

## Breaking

- `ParsedMarkdown.directory` is renamed to `bundleDirectory`. Its presence is what discriminates a bundle, so the old name invited a future author to set it for a flat document and silently re-arm the bundle identity check.
- `disallowedTools` with no `tools` throws where it previously warned.

## Known limits, both documented

`--once` settles on the first terminal exchange on **any** route, so a heartbeat timer beside the route under test can win the race. Scoping it is #584. And a project with a server ingress never finishes starting by design, which is why `--once` races the first exchange against startup rather than waiting for startup to complete; without that race it would hang forever on any project with an HTTP ingress.

## Follow-ups filed

- #583 honour `disallowedTools` against inherited defaults
- #584 scope `craft start --once` to a single route
- #585 a discoverer fragment type that mirrors the merge semantics

## Verification

`bun run all` green: 2456 pass, 0 fail. Changeset included, all three packages minor. Docs updated across `project-structure`, `cli`, `agentplugin` and `errors`, plus a sweep of 22 pages still showing `export default config` for a config export nothing reads.

Decision records for everything settled during implementation are on #131.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ifZ45mPGwZyNTBP2vbpEG)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `craft start` to boot a project from its folder layout and lets Claude Code agent files run without edits. Latest fixes tighten cycle detection, clean up watchers reliably, and streamline module discovery.

- **New Features**
  - `craft start [dir] [--env <path>] [--once] [--timeout <ms>]` discovers `craft.config.ts` (named `craftConfig`), `plugins/` (modules default-exporting a factory error with a file hint), ecosystem folders, then `capabilities/`; a directory with `route.ts` is one capability and is not descended.
  - Core: `registerProjectDiscoverer(folder, discoverer, { after })` with stable Kahn-sorted ordering; cycles error; missing dependent folders are treated as satisfied. `@routecraft/ai` registers discoverers for `skills/` and `agents/` on import and receives `declared` config for provenance.
  - Skills: support local and `npm:` refs (installed packages only), compose in order (house `skills/`, frontmatter refs, bundle `skills/`); unresolved refs fail with `AI1004`.
  - Claude Code compatibility: tolerant frontmatter (unknown keys warned once), `tools`/`disallowedTools` accept comma-separated forms, model aliases `opus`/`sonnet`/`haiku`/`inherit`, unsupported built-ins skipped with a warning.
  - CLI robustness: `--once` exits after the first terminal exchange (completed, failed, or suspended); `--timeout` requires `--once` with ms ≥ 1 and turns “nothing happened” into a non-zero exit. Watchers subscribe before `start()`; `.env` defaults load from the target project; global log options are applied before logger init. Breaking: config reads named export `craftConfig`; `ParsedMarkdown.directory` renamed to `bundleDirectory`; `disallowedTools` without `tools` now throws.

- **Bug Fixes**
  - Startup correctness: routes that throw during startup now fail the command; startup error tracking no longer counts failed exchanges; suspension is treated as terminal.
  - Ordering and cycles: discoverers sorted with Kahn’s algorithm; cycle messages name only participants; cycle detection now uses the true “can reach itself” definition.
  - Discovery hygiene: deterministic path ordering across platforms, `.d.ts/.d.mts/.d.cts` are not importable, file symlinks followed (directory symlinks skipped), import failures attributed to the file that failed, shared module extension list across commands, and hardened `npm:` traversal guards.
  - Watchers and timeouts: watchers unsubscribe deterministically (result read and in `finally`), `--timeout` attaches startup rejection and enforces `--once`.
  - Config and API: content-root selection counts registered discoverer folders; `ProjectDiscoveryContext` exported; `disallowedTools` entries that match no granted tool now warn; `collectModules` only stats symlinks; tests updated to assert runtime exchange and startup-failure handling correctly.

<sup>Written for commit dc44838db178c283061926e96e3e192ed4f703be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

