### PR TITLE
fix(cli): typecheck the TUI against the React major it ships

### DIFF
--- a/.standards/ci-cd.md
+++ b/.standards/ci-cd.md
@@ -106,6 +106,8 @@ Why this shape:
 
 This is enforced informally by review. When adding a new internal package that other packages depend on, mirror this pattern.
 
+The workspace intentionally carries both React type majors: the CLI ships React 18 through Ink 5, while the docs app runs React 19. Each workspace must resolve the matching `@types/react` major, and this paragraph records that dependency shape because the root manifest cannot carry a comment.
+
 ## 6. Optional peer dependencies (provider SDKs)
 
 External SDKs that a package only needs when a specific feature is used (Vercel AI SDK adapters, `@huggingface/transformers`, `@modelcontextprotocol/server`, `croner`, `cheerio`, etc.) live in `peerDependencies` AND `peerDependenciesMeta.<name>.optional = true`. The adapter dynamically imports them via `loadOptionalPeer` (`packages/routecraft/src/adapters/shared/optional-peer.ts`) and throws **`RC5017`** with an install hint when the import fails. Don't add such deps to `dependencies`; that bloats every install.

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/routecraft.dev": {
       "name": "routecraft.dev",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@algolia/autocomplete-core": "^1.19.9",
         "@headlessui/react": "^2.2.10",
@@ -78,7 +78,7 @@
     },
     "examples": {
       "name": "examples",
-      "version": "0.5.0",
+      "version": "1.0.0",
       "dependencies": {
         "@routecraft/ai": "workspace:*",
         "@routecraft/routecraft": "workspace:*",
@@ -96,7 +96,7 @@
     },
     "packages/ai": {
       "name": "@routecraft/ai",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "ai": "^6.0.246",
@@ -150,13 +150,13 @@
     },
     "packages/cli": {
       "name": "@routecraft/cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "craft": "./dist/index.js",
       },
       "dependencies": {
         "@opentelemetry/sdk-trace-base": "^2.10.0",
-        "@routecraft/routecraft": "^0.5.0",
+        "@routecraft/routecraft": "^0.6.0",
         "agent-browser": "^0.17.1",
         "cheerio": "^1.2.0",
         "commander": "^14.0.3",
@@ -182,7 +182,7 @@
     },
     "packages/create-routecraft": {
       "name": "create-routecraft",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "create-routecraft": "./dist/index.js",
       },
@@ -195,7 +195,7 @@
     },
     "packages/eslint-plugin-routecraft": {
       "name": "@routecraft/eslint-plugin-routecraft",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "devDependencies": {
         "@types/eslint": "^9.6.1",
         "tsup": "^8.5.1",
@@ -208,7 +208,7 @@
     },
     "packages/os": {
       "name": "@routecraft/os",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "devDependencies": {
         "@routecraft/routecraft": "workspace:*",
         "@routecraft/testing": "workspace:*",
@@ -225,7 +225,7 @@
     },
     "packages/prettier-plugin-routecraft": {
       "name": "@routecraft/prettier-plugin-routecraft",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "devDependencies": {
         "prettier": "^3.9.6",
         "tsup": "^8.5.1",
@@ -238,7 +238,7 @@
     },
     "packages/routecraft": {
       "name": "@routecraft/routecraft",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@standard-schema/spec": "^1.1.0",
@@ -273,6 +273,7 @@
       },
       "peerDependencies": {
         "@opentelemetry/sdk-trace-base": "^2.6.0",
+        "better-sqlite3": "^11.0.0",
         "cheerio": "^1.2.0",
         "croner": "^10.0.1",
         "fast-xml-parser": "^5.10.1",
@@ -287,6 +288,7 @@
       },
       "optionalPeers": [
         "@opentelemetry/sdk-trace-base",
+        "better-sqlite3",
         "cheerio",
         "croner",
         "fast-xml-parser",
@@ -302,7 +304,7 @@
     },
     "packages/testing": {
       "name": "@routecraft/testing",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
       },
@@ -318,10 +320,6 @@
     "better-sqlite3",
     "esbuild",
   ],
-  "overrides": {
-    "@types/react": "19.2.18",
-    "@types/react-dom": "19.2.4",
-  },
   "packages": {
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.107", "", { "dependencies": { "@ai-sdk/provider": "3.0.14", "@ai-sdk/provider-utils": "4.0.42" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-aXwAv1v9ezU3lkAvcz4dfuzJb30ioLk0WRhwpuDgCGKN0dEZiNLeDuyVcRqxWRlYc4Zg4Z4rJcZBKmzJTdzrtw=="],
 
@@ -999,7 +997,9 @@
 
     "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
 
-    "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
+    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+
+    "@types/react": ["@types/react@18.3.31", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
 
@@ -2767,6 +2767,10 @@
 
     "@types/papaparse/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
+    "@types/react-dom/@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
+
+    "@types/react-highlight-words/@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
+
     "@types/yauzl/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -2948,6 +2952,8 @@
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "resq/fast-deep-equal": ["fast-deep-equal@2.0.1", "", {}, "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="],
+
+    "routecraft.dev/@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
     "routecraft.dev/react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 

--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
     "better-sqlite3",
     "esbuild"
   ],
-  "overrides": {
-    "@types/react": "19.2.18",
-    "@types/react-dom": "19.2.4"
-  },
   "scripts": {
     "typecheck": "tsc --noEmit && tsc -p tsconfig.bun-test.json --noEmit && tsc -p tsconfig.bun-test.registry.json --noEmit",
     "lint": "eslint .",


### PR DESCRIPTION
## What changed

Removed the root `overrides` for `@types/react` and `@types/react-dom`, then recorded the intentional dual React type majors in `.standards/ci-cd.md`.

Bun honors the existing direct workspace dependencies when the global override is absent. It selects `@types/react@18.3.31` for `packages/cli`, matching React 18 and Ink 5, while it keeps `@types/react@19.2.18` for `apps/routecraft.dev`. The lockfile carries both copies and keeps the docs app's transitive React type consumers on 19.x.

## Resolution proof

Resolved from each workspace with `require.resolve("@types/react/package.json")`:

- `packages/cli`: `node_modules/.bun/@types+react@18.3.31/node_modules/@types/react/package.json`, version `18.3.31`
- `apps/routecraft.dev`: `node_modules/.bun/@types+react@19.2.18/node_modules/@types/react/package.json`, version `19.2.18`

## Verification

- `bun install`: passed, no changes on the final run
- `bun run typecheck`: passed
- `bun run lint`: passed
- `bun run test`: passed, 2,546 Bun tests and the Vitest arm

Closes #559

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typechecks the CLI TUI against React 18 by removing the root React types override. Previously, a global override forced React 19 types everywhere; now each workspace resolves its own `@types/react` major. The CLI uses `@types/react@18.x` to match Ink 5; the docs app stays on `@types/react@19.x`. The lockfile now carries both majors with no runtime impact. Closes #559.

**Review notes**
- Removed root `overrides` for `@types/react` and `@types/react-dom`; documented the dual-major policy in `.standards/ci-cd.md`.
- `bun.lock` reflects per-workspace resolution; `bun install`, `typecheck`, `lint`, and tests pass.
- Do not add a root override again. If a workspace needs a specific React major, declare the matching `@types/react` in that workspace.

<sup>Written for commit 173cbd25b8ad64cef888afa13a82a64697cca1d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

