### PR TITLE
fix(release): read the changelog from where the migration put it

### DIFF
--- a/scripts/finalise-changelog.mjs
+++ b/scripts/finalise-changelog.mjs
@@ -13,11 +13,11 @@
  *
  * Transformation, applied to the first matching heading only:
  *
- *   ## v0.6.0 {% badge color="gray" %}In development{% /badge %}
+ *   ## v0.6.0 <Badge color="gray">In development</Badge>
  *
  * becomes
  *
- *   ## [v0.6.0](https://github.com/routecraftjs/routecraft/releases/tag/v0.6.0) {% badge color="yellow" %}Pre-release{% /badge %}
+ *   ## [v0.6.0](https://github.com/routecraftjs/routecraft/releases/tag/v0.6.0) <Badge color="yellow">Pre-release</Badge>
  *
  *   *August 2026*
  *
@@ -46,16 +46,24 @@ const changelogPath = join(
   rootDir,
   "apps",
   "routecraft.dev",
-  "src",
   "app",
+  "content",
   "changelog",
-  "page.md",
+  "index.mdx",
 );
 
-const source = readFileSync(changelogPath, "utf8");
+let source;
+try {
+  source = readFileSync(changelogPath, "utf8");
+} catch (error) {
+  // The release cannot describe itself without this file, and a silent skip
+  // would publish a version whose changelog still says "In development".
+  console.error(`Could not read the changelog at ${changelogPath}`);
+  throw error;
+}
 
 const inDevHeading =
-  /^## v\d+\.\d+\.\d+(?:-\S+)? \{% badge color="gray" %\}In development\{% \/badge %\}$/m;
+  /^## v\d+\.\d+\.\d+(?:-\S+)? <Badge color="gray">In development<\/Badge>$/m;
 
 if (!inDevHeading.test(source)) {
   console.log("Changelog has no in-development heading; nothing to finalise.");
@@ -70,7 +78,7 @@ const monthLabel = new Date().toLocaleString("en-GB", {
 
 const releasedHeading =
   `## [v${coreVersion}](https://github.com/routecraftjs/routecraft/releases/tag/v${coreVersion})` +
-  ` {% badge color="yellow" %}Pre-release{% /badge %}\n\n*${monthLabel}*`;
+  ` <Badge color="yellow">Pre-release</Badge>\n\n*${monthLabel}*`;
 
 writeFileSync(changelogPath, source.replace(inDevHeading, releasedHeading));
 


### PR DESCRIPTION
The first release after the TanStack migration failed, so no docs image reached GHCR and there is nothing to deploy.

## What broke

`scripts/finalise-changelog.mjs` opened `apps/routecraft.dev/src/app/changelog/page.md` and matched Markdoc badge syntax. The migration deleted that tree, so `version-packages` died immediately after bumping to 0.7.0:

```
Error: ENOENT: no such file or directory, open '.../apps/routecraft.dev/src/app/changelog/page.md'
    at scripts/finalise-changelog.mjs:55:16
```

That took the whole `release` job down, and with it everything downstream ([run 31834931105](https://github.com/routecraftjs/routecraft/actions/runs/31834931105)):

| job | outcome |
|-----|---------|
| `release` | failure |
| `publish-canary` | skipped |
| `build-and-deploy-docs` | skipped |

No Version Packages branch was regenerated, and no GHCR image was built or pushed.

GitHub Pages was not touched: the run has no Pages job, no `deploy-pages` step and no `github-pages` environment, so the live docs still serve the previous release, as intended.

## The fix

- The path points at `app/content/changelog/index.mdx`, where the changelog now lives.
- Both the match and the replacement use the MDX `<Badge>` element instead of Markdoc's `{% badge %}`.
- A missing changelog is reported by path and rethrown rather than skipped. A silent skip would publish a release whose changelog still says "In development".

## Verification

- No in-development heading (today's state): logs `nothing to finalise` and exits 0.
- With `## v0.9.9 <Badge color="gray">In development</Badge>` present: rewritten to `## [v0.6.0](https://github.com/routecraftjs/routecraft/releases/tag/v0.6.0) <Badge color="yellow">Pre-release</Badge>` followed by `*August 2026*`, taking the version from the core package rather than the heading, which is the documented contract.
- Root format, lint and typecheck pass.

The steps before the failure already succeeded on the runner (`changeset version`, then `Synced 2 derived version field(s) to 0.7.0`), so the rest of the chain is exercised by that run.

## Why it was missed

The script sits at the repository root and reads into the app, so a sweep of `apps/routecraft.dev` during the migration never reached it. Swept the root for other references into the deleted tree: the only remaining ones are the `LEGACY` constants in `freeze-docs.ts` and `verify-docs-freeze.ts`, which are correct, since the freeze checks out a pre-migration tag where the docs genuinely lived at `src/app/docs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVHnnUzVVFij34gdzqCDFi)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the release pipeline by pointing `scripts/finalise-changelog.mjs` at the changelog’s new MDX location and matching MDX `<Badge>` syntax. Previously it read the deleted Markdoc file and failed with ENOENT, aborting `version-packages` and downstream jobs.

- Updates path to `apps/routecraft.dev/app/content/changelog/index.mdx` and replaces Markdoc badge handling with `<Badge>`.
- On missing changelog, logs the path and throws to avoid publishing with “In development”; if no in-development heading, exits cleanly with “nothing to finalise”.
- Unblocks `release` and the subsequent `publish-canary` and docs build steps; no app/runtime behavior changes.

<sup>Written for commit 3d24e31bd8d176cfe7981fe668b6074d883bd90e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

