### PR TITLE
fix(ci): pin changesets/action back to v1 for CLI v2 compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      # changesets/action v2 requires Changesets CLI v3; this repo runs CLI
+      # v2. Lift this when the CLI is migrated to v3.
+      - dependency-name: "changesets/action"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "bun"
     directory: "/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,10 @@ jobs:
       # it; .nvmrc pins 24).
       - name: Create release PR or publish to npm
         id: changesets
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
+        # Action v2 requires Changesets CLI v3 and renames its inputs; this
+        # repo runs CLI v2, so v2.x of the action refuses to start. Stay on
+        # v1 until the CLI is migrated (Dependabot ignores the major bump).
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: bun run version-packages
           publish: bun run release


### PR DESCRIPTION
The Release workflow has been failing since #618 bumped `changesets/action` from 1.9.0 to 2.1.0. Run [32121469759](https://github.com/routecraftjs/routecraft/actions/runs/32121469759) (the first release trigger after the bump) failed before versioning or publishing anything:

```
Error: This version of the Changesets action is designed to work with
Changesets CLI v3. Changesets CLI v2 is not supported; use Changesets
action v1 instead, which is compatible with CLI v2.
```

This repo runs `@changesets/cli@2.31.1`. Action v2 also renames its inputs, which surfaced in the same run as a warning that `version`, `publish`, and `createGithubReleases` are no longer valid.

## Changes

- `release.yml`: restore the `changesets/action@a45c4d59 # v1.9.0` pin, the pairing the action's own error prescribes for CLI v2, with a comment recording why the major is held back.
- `dependabot.yml`: ignore major updates for `changesets/action` in the github-actions ecosystem, so the same bump is not reopened next week. The comment says to lift the ignore once the CLI is migrated.

## Follow-up

Upgrading to Changesets CLI v3 plus action v2 is the real fix, but it changes input names and the changelog package pairing, so it deserves its own change with a dry run rather than being rushed while releases are blocked.

## Verification

Workflow-only change; nothing to run locally. The proof is the next Release run on main after merge, which should reach the versioning step and open the Version Packages PR (0.7.0, carrying the named-server ingress changeset from #620).

---
## Summary by cubic
Unblocks releases by pinning `changesets/action` back to v1.9.0 to match `@changesets/cli@2.31.1`. Previously, action v2.1.0 required CLI v3 and renamed inputs, so the Release job failed before versioning; now it should proceed and open the Version Packages PR as before.

**Rollout**
- Dependabot now ignores semver-major updates to `changesets/action` in the GitHub Actions ecosystem until the CLI is upgraded.
- Verify on the next Release run that versioning runs and a Version Packages PR opens. Follow-up: migrate to `@changesets/cli@^3` and `changesets/action@^2`, update input names, and remove the Dependabot ignore.

<sup>Written for commit e574aa568d2e1e8c9a06ad89e85b5804e330fa12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/622?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>