### PR TITLE
fix: heal missed canaries, name the mount topology on an empty server, and stop the IMAP pool throwing when drained

### DIFF
--- a/.changeset/empty-server-names-mounts.md
+++ b/.changeset/empty-server-names-mounts.md
@@ -10,7 +10,7 @@ for it never mounted, not that the config naming it is wrong. The refusal now
 lists every mount and the server it landed on, and reports all empty servers
 together rather than one boot at a time:
 
-```
+```text
 servers.mcp: server has no mounts. Mounted surfaces: http -> servers.public.
 Either remove the unused server, or bind a surface to it. A surface that names
 the server in config but did not mount is usually a plugin that failed to

--- a/.changeset/empty-server-names-mounts.md
+++ b/.changeset/empty-server-names-mounts.md
@@ -1,0 +1,22 @@
+---
+"@routecraft/routecraft": patch
+---
+
+Name the mount topology when a declared server has nothing mounted on it.
+
+`servers.mcp: server has no mounts.` said nothing about what did mount, which
+is the fact a reader needs: an empty server usually means the surface meant
+for it never mounted, not that the config naming it is wrong. The refusal now
+lists every mount and the server it landed on, and reports all empty servers
+together rather than one boot at a time:
+
+```
+servers.mcp: server has no mounts. Mounted surfaces: http -> servers.public.
+Either remove the unused server, or bind a surface to it. A surface that names
+the server in config but did not mount is usually a plugin that failed to
+apply, a misspelt server name, or a plugin version that predates named servers.
+```
+
+The check moved from `HttpMountRegistry.validate()` up to the servers plugin,
+which is the only place that can see across servers. A registry validated
+directly no longer refuses itself for being empty.

--- a/.changeset/imap-pool-drain-null-client.md
+++ b/.changeset/imap-pool-drain-null-client.md
@@ -1,0 +1,16 @@
+---
+"@routecraft/routecraft": patch
+---
+
+An IMAP pool drained mid-connect no longer throws during teardown.
+
+The pool reserves a slot before its connect resolves, since the reservation is
+what bounds the pool size. `drain()` dereferenced every slot's client
+unconditionally, so a shutdown that began while a connection was still being
+established threw `null is not an object`. That is the ordinary shape of a
+shutdown during startup, and the thrown teardown masked whatever had actually
+failed the boot.
+
+Drain now skips a slot that holds no client yet, and an acquire whose connect
+lands after the drain logs its own connection out rather than leaving a socket
+open with nothing referencing it.

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/opsplugin/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/opsplugin/index.mdx
@@ -190,6 +190,31 @@ Note the placement. `.retry()` and `.timeout()` before `.from()` are route-scope
 
 **Bind probe routes only.** For a probe the exchange is the health check by construction. Binding a business route would make every expected refusal (a caller without the scope, a validation error, a business rule saying no) report the dependency down, which is the escalation this design exists to prevent.
 
+### What moves a bound indicator
+
+A bound indicator and its route are separate components that move on different rules, so it is worth seeing both at once. A single failed exchange is enough to report the dependency `down`, with no threshold: on a probe the exchange is the check, and a probe that failed has answered the question.
+
+| Event on the bound route | Indicator | Route | Aggregate |
+| --- | --- | --- | --- |
+| Exchange completes | `up` | `up` | 200 |
+| Exchange fails | `down` | `up`, `details.failures` climbs | 503 |
+| Retry recovers inside the exchange | no change | `up` | 200 |
+| Exchange dropped | no change | `up` | 200 |
+| Breaker open, no `fallback` | `down` | `degraded` | 503 |
+| Breaker open, with `fallback` | `up` | `degraded` | 200 |
+| No exchange within `maxAgeMs` | `down`, `reason: 'stale'` | no change | 503 |
+| Source gave up producing | no change until stale | `down` | 503 |
+
+Three rows earn an explanation.
+
+**A dropped exchange reports nothing.** A drop is a terminal state that suppresses `completed`, but it is not evidence either way: the exchange may have been filtered out before the dependency was ever reached. A verdict read from it would be invented. A bound indicator on a route that only ever drops goes stale, which is the truthful answer.
+
+**An open breaker holds the indicator down.** Each rejected call fails with [`RC5025`](/docs/reference/errors#rc-5025) before the protected work runs, and that rejection is a failed exchange like any other. So the indicator stays `down` for the whole cooldown even though nothing is touching the dependency any more, which is the reading you want: the breaker is open precisely because the dependency was failing.
+
+**A breaker with a `fallback` does not.** The fallback resolves the rejected exchange successfully, so it emits `route:exchange:completed` and reports the indicator `up` while the route still reads `degraded`. On a business route that is correct, because it is serving. On a probe it is a lie, because the fallback answers without ever reaching the dependency. **Do not put a `fallback` on a breaker on a route you have bound an indicator to.**
+
+Source death and staleness stay independent on purpose. A dead scheduler takes the route `down` at once and lets the indicator go stale on its own clock, so "the probe stopped running" and "the dependency is unreachable" never get confused for one another.
+
 ### Pushed by hand
 
 For a probe checking several subsystems, or a business route flagging a dependency mid-flight, push through the handle from any `.process()` or `.error()` step:

--- a/packages/routecraft/src/adapters/mail/client-manager.ts
+++ b/packages/routecraft/src/adapters/mail/client-manager.ts
@@ -19,6 +19,10 @@ import { loadOptionalPeer } from "../shared/optional-peer.ts";
 // ImapPool: fixed-size, mailbox-aware IMAP connection pool for one account
 // ---------------------------------------------------------------------------
 
+function drainedError(): Error {
+  return new Error("IMAP pool drained during shutdown");
+}
+
 /**
  * Fixed-size IMAP connection pool for a single account.
  * Tracks which mailbox each connection has open to avoid unnecessary switches.
@@ -26,7 +30,12 @@ import { loadOptionalPeer } from "../shared/optional-peer.ts";
  */
 export class ImapPool {
   private readonly entries: Array<{
-    client: InstanceType<typeof import("imapflow").ImapFlow>;
+    /**
+     * Null while the slot is reserved and its connect is still in flight.
+     * The reservation is what bounds the pool, so it has to exist before
+     * there is a client to put in it.
+     */
+    client: InstanceType<typeof import("imapflow").ImapFlow> | null;
     inUse: boolean;
     currentMailbox: string | null;
   }> = [];
@@ -34,6 +43,7 @@ export class ImapPool {
     resolve: (client: InstanceType<typeof import("imapflow").ImapFlow>) => void;
     reject: (error: Error) => void;
   }> = [];
+  private drained = false;
   private readonly poolSize: number;
   private readonly imapConfig: {
     host?: string;
@@ -63,9 +73,9 @@ export class ImapPool {
     // 1. Prefer idle connection with same mailbox already open
     if (mailbox) {
       const sameMailbox = this.entries.find(
-        (c) => !c.inUse && c.currentMailbox === mailbox,
+        (c) => c.client !== null && !c.inUse && c.currentMailbox === mailbox,
       );
-      if (sameMailbox) {
+      if (sameMailbox?.client) {
         sameMailbox.inUse = true;
         if (sameMailbox.client.usable) return sameMailbox.client;
         // Dead connection, remove and fall through
@@ -74,8 +84,8 @@ export class ImapPool {
     }
 
     // 2. Any idle connection
-    const idle = this.entries.find((c) => !c.inUse);
-    if (idle) {
+    const idle = this.entries.find((c) => c.client !== null && !c.inUse);
+    if (idle?.client) {
       idle.inUse = true;
       if (idle.client.usable) return idle.client;
       // Dead connection, remove and fall through
@@ -85,15 +95,22 @@ export class ImapPool {
     // 3. Create new if under limit (reserve slot before async connect)
     if (this.entries.length < this.poolSize) {
       const placeholder = {
-        client: null as unknown as InstanceType<
-          typeof import("imapflow").ImapFlow
-        >,
+        client: null as InstanceType<typeof import("imapflow").ImapFlow> | null,
         inUse: true,
         currentMailbox: null,
       };
       this.entries.push(placeholder);
       try {
         const client = await this.createClient();
+        // The pool can be drained while this connect is in flight, which is
+        // the ordinary shape of a shutdown that begins during startup. Drain
+        // has already walked the entries by then, so this connection would
+        // otherwise stay open with nothing left holding a reference to it.
+        if (this.drained) {
+          this.entries.splice(this.entries.indexOf(placeholder), 1);
+          await client.logout().catch(() => {});
+          throw drainedError();
+        }
         placeholder.client = client;
         return client;
       } catch (error) {
@@ -146,13 +163,17 @@ export class ImapPool {
    * Drain all connections. Called during context teardown.
    */
   async drain(): Promise<void> {
-    const drainError = new Error("IMAP pool drained during shutdown");
+    this.drained = true;
+    const drainError = drainedError();
     for (const waiter of this.waitQueue) {
       waiter.reject(drainError);
     }
     this.waitQueue.length = 0;
     for (const entry of this.entries) {
-      await entry.client.logout().catch(() => {});
+      // A slot whose connect has not resolved holds no client yet. That
+      // acquire logs its own connection out when it lands, so skipping it
+      // here leaves nothing open.
+      if (entry.client) await entry.client.logout().catch(() => {});
     }
     this.entries.length = 0;
   }

--- a/packages/routecraft/src/adapters/mail/client-manager.ts
+++ b/packages/routecraft/src/adapters/mail/client-manager.ts
@@ -70,6 +70,12 @@ export class ImapPool {
   async acquire(
     mailbox?: string,
   ): Promise<InstanceType<typeof import("imapflow").ImapFlow>> {
+    // A drained pool never serves again, and every path below would strand
+    // the caller: creating opens a fresh connection mid-shutdown, and
+    // queueing waits on a queue drain() already emptied and will never
+    // revisit, so that promise would never settle at all.
+    if (this.drained) throw drainedError();
+
     // 1. Prefer idle connection with same mailbox already open
     if (mailbox) {
       const sameMailbox = this.entries.find(
@@ -100,6 +106,15 @@ export class ImapPool {
         currentMailbox: null,
       };
       this.entries.push(placeholder);
+      // Both the drained branch and the catch release the reservation, and
+      // the drained branch reaches the catch by throwing. Removal has to be
+      // idempotent: a bare splice(indexOf(x), 1) on an already-removed entry
+      // splices at -1, which silently drops somebody else's slot and leaves
+      // that connection with nothing to close it.
+      const releaseReservation = () => {
+        const index = this.entries.indexOf(placeholder);
+        if (index >= 0) this.entries.splice(index, 1);
+      };
       try {
         const client = await this.createClient();
         // The pool can be drained while this connect is in flight, which is
@@ -107,14 +122,14 @@ export class ImapPool {
         // has already walked the entries by then, so this connection would
         // otherwise stay open with nothing left holding a reference to it.
         if (this.drained) {
-          this.entries.splice(this.entries.indexOf(placeholder), 1);
+          releaseReservation();
           await client.logout().catch(() => {});
           throw drainedError();
         }
         placeholder.client = client;
         return client;
       } catch (error) {
-        this.entries.splice(this.entries.indexOf(placeholder), 1);
+        releaseReservation();
         throw error;
       }
     }

--- a/packages/routecraft/src/plugins/server/plugin.ts
+++ b/packages/routecraft/src/plugins/server/plugin.ts
@@ -97,6 +97,7 @@ export function serversPlugin(definitions: ServerDefinitions): CraftPlugin {
   };
 
   async function bindAll(ctx: CraftContext, state: ServerState): Promise<void> {
+    assertEveryServerMounted(state.registries);
     for (const registry of state.registries.values()) registry.validate();
     for (const [name, definition] of Object.entries(definitions)) {
       const registry = state.registries.get(name)!;
@@ -134,6 +135,48 @@ export function serversPlugin(definitions: ServerDefinitions): CraftPlugin {
       ctx.emit("server:listening", { server: name, host, port: handle.port });
     }
   }
+}
+
+/**
+ * Refuse declared servers that nothing mounted on, naming the whole mount
+ * topology in the message.
+ *
+ * The check lives here rather than on the registry because a registry only
+ * knows its own mounts, and the fact a reader needs is the one it cannot
+ * see: what mounted somewhere else. An empty server almost always means the
+ * surface meant for it never mounted (a plugin that failed to apply, a
+ * misspelt server name, or a plugin predating named servers), and the mount
+ * list is what makes that visible at a glance. Every empty server is
+ * reported at once so an app declaring several does not learn about them one
+ * boot at a time.
+ */
+function assertEveryServerMounted(
+  registries: ReadonlyMap<string, HttpMountRegistry>,
+): void {
+  const empty: string[] = [];
+  const mounted: string[] = [];
+  for (const [name, registry] of registries) {
+    const ids = registry.mountIds();
+    if (ids.length === 0) {
+      empty.push(name);
+      continue;
+    }
+    for (const id of ids) mounted.push(`${id} -> servers.${name}`);
+  }
+  if (empty.length === 0) return;
+  const subject =
+    empty.length === 1
+      ? `servers.${empty[0]}: server has no mounts.`
+      : `servers: ${empty.map((name) => `"${name}"`).join(", ")} have no mounts.`;
+  const topology =
+    mounted.length > 0
+      ? ` Mounted surfaces: ${mounted.join(", ")}.`
+      : " No surface mounted on any server.";
+  throw rcError("RC5003", undefined, {
+    message:
+      `${subject}${topology} Either remove the unused ${empty.length === 1 ? "server" : "servers"}, or bind a surface to ${empty.length === 1 ? "it" : "them"}. ` +
+      "A surface that names the server in config but did not mount is usually a plugin that failed to apply, a misspelt server name, or a plugin version that predates named servers.",
+  });
 }
 
 function validateDefinitions(definitions: ServerDefinitions): void {

--- a/packages/routecraft/src/plugins/server/registry.ts
+++ b/packages/routecraft/src/plugins/server/registry.ts
@@ -205,12 +205,12 @@ export class HttpMountRegistry implements WebIngress {
     this.boundAddress = { host, port };
   }
 
+  /** Mount ids registered on this server, in registration order. */
+  mountIds(): readonly string[] {
+    return [...this.mounts.keys()];
+  }
+
   validate(): void {
-    if (this.mounts.size === 0) {
-      throw rcError("RC5003", undefined, {
-        message: `servers.${this.serverName}: server has no mounts. Remove it or bind a surface to it.`,
-      });
-    }
     const evaluated = [...this.mounts.values()].map((mount) => ({
       mount,
       claims: [...mount.claims()],

--- a/packages/routecraft/test/mail.bun.test.ts
+++ b/packages/routecraft/test/mail.bun.test.ts
@@ -3264,12 +3264,15 @@ describe("ImapPool drain", () => {
    * Build a pool whose connect is under the test's control, so the window
    * between reserving a slot and filling it can be held open.
    */
-  function pausedPool(): {
+  function pausedPool(poolSize?: number): {
     pool: ImapPool;
     connected: (client: unknown) => void;
     failed: (error: Error) => void;
   } {
-    const pool = new ImapPool({ host: "imap.example.test" });
+    const pool = new ImapPool({
+      host: "imap.example.test",
+      ...(poolSize !== undefined ? { poolSize } : {}),
+    });
     let connected!: (client: unknown) => void;
     let failed!: (error: Error) => void;
     const pending = new Promise((resolve, reject) => {
@@ -3320,6 +3323,26 @@ describe("ImapPool drain", () => {
 
     await expect(acquiring).rejects.toThrow(/drained during shutdown/);
     expect(loggedOut).toBe(true);
+  });
+
+  /**
+   * @case A fresh acquire arrives after the pool was drained
+   * @preconditions drain() completed and nothing is in flight
+   * @expectedResult It rejects without ever calling createClient. A drained pool never serves again, so dialling out mid-shutdown only opens a socket to tear down again
+   */
+  test("refuses an acquire that starts after the drain", async () => {
+    const { pool } = pausedPool();
+    let connectAttempts = 0;
+    (pool as unknown as { createClient: () => Promise<unknown> }).createClient =
+      () => {
+        connectAttempts += 1;
+        return new Promise(() => {});
+      };
+
+    await pool.drain();
+
+    await expect(pool.acquire()).rejects.toThrow(/drained during shutdown/);
+    expect(connectAttempts).toBe(0);
   });
 
   /**

--- a/packages/routecraft/test/mail.bun.test.ts
+++ b/packages/routecraft/test/mail.bun.test.ts
@@ -19,6 +19,7 @@ import {
   buildSearchCriteriaSets,
   isMissingPeerError,
 } from "../src/adapters/mail/shared.ts";
+import { ImapPool } from "../src/adapters/mail/client-manager.ts";
 import { rcError } from "../src/error.ts";
 import {
   analyzeHeaders,
@@ -3255,5 +3256,93 @@ describe("isMissingPeerError", () => {
       isMissingPeerError(new Error("Cannot find package 'mailparser'")),
     ).toBe(false);
     expect(isMissingPeerError(undefined)).toBe(false);
+  });
+});
+
+describe("ImapPool drain", () => {
+  /**
+   * Build a pool whose connect is under the test's control, so the window
+   * between reserving a slot and filling it can be held open.
+   */
+  function pausedPool(): {
+    pool: ImapPool;
+    connected: (client: unknown) => void;
+    failed: (error: Error) => void;
+  } {
+    const pool = new ImapPool({ host: "imap.example.test" });
+    let connected!: (client: unknown) => void;
+    let failed!: (error: Error) => void;
+    const pending = new Promise((resolve, reject) => {
+      connected = resolve;
+      failed = reject;
+    });
+    // createClient is private and would otherwise reach the network; the pool
+    // under test is the slot bookkeeping around it, not imapflow.
+    (pool as unknown as { createClient: () => Promise<unknown> }).createClient =
+      () => pending;
+    return { pool, connected, failed };
+  }
+
+  /**
+   * @case Shutdown begins while a pooled connection is still being established
+   * @preconditions An acquire has reserved a slot and its connect has not resolved
+   * @expectedResult drain() resolves rather than throwing. The reserved slot holds no client yet, and dereferencing it turned an ordinary shutdown-during-startup into a teardown failure that masked the real boot error
+   */
+  test("drains a slot whose connect has not resolved", async () => {
+    const { pool, connected } = pausedPool();
+    const acquiring = pool.acquire("INBOX");
+    acquiring.catch(() => {});
+
+    await pool.drain();
+
+    connected({ usable: true, logout: async () => {} });
+    await expect(acquiring).rejects.toThrow(/drained during shutdown/);
+  });
+
+  /**
+   * @case A connection lands after the pool was drained
+   * @preconditions drain() completed while a connect was in flight, then it succeeds
+   * @expectedResult The late connection is logged out by the acquire itself. Drain has already walked the entries, so nothing else holds a reference and the socket would stay open for the life of the process
+   */
+  test("logs out a connection that arrives after the drain", async () => {
+    const { pool, connected } = pausedPool();
+    let loggedOut = false;
+    const acquiring = pool.acquire();
+    acquiring.catch(() => {});
+
+    await pool.drain();
+    connected({
+      usable: true,
+      logout: async () => {
+        loggedOut = true;
+      },
+    });
+
+    await expect(acquiring).rejects.toThrow(/drained during shutdown/);
+    expect(loggedOut).toBe(true);
+  });
+
+  /**
+   * @case An ordinary drain of a live connection
+   * @preconditions One connection acquired and released normally
+   * @expectedResult It is logged out, so the null-slot handling above did not buy itself a skipped logout on the path that matters
+   */
+  test("logs out an established connection", async () => {
+    const { pool, connected } = pausedPool();
+    let loggedOut = false;
+    const acquiring = pool.acquire();
+    connected({
+      usable: true,
+      logout: async () => {
+        loggedOut = true;
+      },
+    });
+    pool.release(
+      (await acquiring) as unknown as Parameters<typeof pool.release>[0],
+    );
+
+    await pool.drain();
+
+    expect(loggedOut).toBe(true);
   });
 });

--- a/packages/routecraft/test/server-ingress.bun.test.ts
+++ b/packages/routecraft/test/server-ingress.bun.test.ts
@@ -145,15 +145,75 @@ describe("named server ingress", () => {
   });
 
   /**
-   * @case A named listener has no mounted surface
-   * @preconditions An empty ingress registry
-   * @expectedResult Validation refuses a useless listener
+   * @case A declared server nothing mounted on names the mounts that did land
+   * @preconditions Two servers declared, http mounts on one, the other is left empty
+   * @expectedResult Startup refuses with RC5003 whose message names the empty
+   *   server AND the surface that mounted elsewhere, so a reader can see the
+   *   intended surface is missing rather than guessing at their own config
    */
-  test("rejects mountless servers", async () => {
-    const context = (await testContext().build()).ctx;
-    expect(() => new HttpMountRegistry("empty", context).validate()).toThrow(
-      /no mounts/,
-    );
+  test("rejects a mountless server and names what did mount", async () => {
+    const t = await testContext()
+      .with({
+        servers: { public: { port: 0 }, mcp: { port: 0 } },
+        http: { server: "public" },
+      })
+      .routes([
+        craft()
+          .id("http-holder")
+          .from(http({ path: "/api" }))
+          .to(noop()),
+      ])
+      .build();
+
+    let caught: unknown;
+    try {
+      await t.ctx.start();
+    } catch (error) {
+      caught = error;
+    } finally {
+      await t.stop();
+    }
+
+    expect((caught as { rc?: string }).rc).toBe("RC5003");
+    const message = (caught as Error).message;
+    expect(message).toContain("servers.mcp: server has no mounts");
+    expect(message).toContain("http -> servers.public");
+    expect(message).toContain("predates named servers");
+  });
+
+  /**
+   * @case Several empty servers are reported together
+   * @preconditions Three servers declared, only one carries a mount
+   * @expectedResult One RC5003 names both empty servers, so an app does not
+   *   learn about them one boot at a time
+   */
+  test("reports every mountless server at once", async () => {
+    const t = await testContext()
+      .with({
+        servers: { public: { port: 0 }, mcp: { port: 0 }, ops: { port: 0 } },
+        http: { server: "public" },
+      })
+      .routes([
+        craft()
+          .id("http-holder")
+          .from(http({ path: "/api" }))
+          .to(noop()),
+      ])
+      .build();
+
+    let caught: unknown;
+    try {
+      await t.ctx.start();
+    } catch (error) {
+      caught = error;
+    } finally {
+      await t.stop();
+    }
+
+    const message = (caught as Error).message;
+    expect(message).toContain('"mcp"');
+    expect(message).toContain('"ops"');
+    expect(message).toContain("http -> servers.public");
   });
 
   /**

--- a/packages/routecraft/test/server-ingress.bun.test.ts
+++ b/packages/routecraft/test/server-ingress.bun.test.ts
@@ -210,6 +210,7 @@ describe("named server ingress", () => {
       await t.stop();
     }
 
+    expect((caught as { rc?: string }).rc).toBe("RC5003");
     const message = (caught as Error).message;
     expect(message).toContain('"mcp"');
     expect(message).toContain('"ops"');

--- a/scripts/prepare-canary-snapshot.mjs
+++ b/scripts/prepare-canary-snapshot.mjs
@@ -6,18 +6,22 @@
  * Scopes the canary snapshot to the packages the push actually changed,
  * while keeping the version line aimed at the next stable release:
  *
- * 1. Diffs `<base-sha>..HEAD` to find the changed public packages. No
- *    public package changed means no canary (`publish=false`).
+ * 1. Diffs `<base-sha>..HEAD` to find the changed public packages.
  * 2. Collects the highest pending bump per package from the changesets on
  *    main, then deletes them: they belong to the next stable release, and
  *    `changeset version --snapshot` would otherwise consume them and pull
  *    every package they mention into every canary.
  * 3. Expands `fixed` groups from .changeset/config.json so the core train
  *    moves together whenever any member changed.
- * 4. Folds in any public package whose current version is absent from the
- *    npm registry: `changeset publish` publishes every locally unpublished
- *    version, snapshot-bumped or not, so a never-released stable version
- *    would otherwise leak onto npm from the canary job.
+ * 4. Folds in any public package the registry is behind on: one whose
+ *    current version is absent (`changeset publish` publishes every locally
+ *    unpublished version, snapshot-bumped or not, so a never-released stable
+ *    version would otherwise leak onto npm from the canary job), and one
+ *    whose newest canary was cut from a commit that predates a change to it.
+ *    The second rule is what makes a missed canary self-healing: scoping to
+ *    a single push means a failed canary job drops that push's packages for
+ *    good, since no later push has them in its diff range.
+ *    Nothing kept after all four steps means no canary (`publish=false`).
  * 5. Writes .changeset/snapshot-canary.md giving each kept package its
  *    pending bump (patch when none), so canaries keep previewing the next
  *    stable version (e.g. 0.6.0-canary-<datetime> while a minor is
@@ -88,12 +92,6 @@ const keep = new Set(
     .map(([name]) => name),
 );
 
-if (keep.size === 0) {
-  console.log("No public package changed; skipping canary.");
-  setOutput("publish=false");
-  process.exit(0);
-}
-
 // 2. Record the highest pending bump per package, then drop the pending
 // changesets so only the synthetic one below drives the snapshot.
 const pendingBump = new Map();
@@ -132,35 +130,99 @@ function expandFixedGroups() {
 }
 expandFixedGroups();
 
-// 4. Fold in public packages whose current version was never published.
-for (const [name, pkg] of packages) {
-  if (keep.has(name)) continue;
+/**
+ * Fetch JSON from the npm registry. A 404 resolves to null so a package that
+ * has never been published reads as absent rather than an error.
+ */
+async function registryJson(path, accept) {
   let res;
   try {
-    res = await fetch(
-      `https://registry.npmjs.org/${encodeURIComponent(name)}`,
-      {
-        headers: { accept: "application/vnd.npm.install-v1+json" },
-        // Fail loudly instead of letting a stalled connection hang the job.
-        signal: AbortSignal.timeout(10_000),
-      },
-    );
+    res = await fetch(`https://registry.npmjs.org/${path}`, {
+      headers: accept ? { accept } : {},
+      // Fail loudly instead of letting a stalled connection hang the job.
+      signal: AbortSignal.timeout(10_000),
+    });
   } catch (err) {
-    throw new Error(`npm registry lookup failed for ${name}`, { cause: err });
+    throw new Error(`npm registry lookup failed for ${path}`, { cause: err });
   }
-  if (res.status !== 404) {
-    if (!res.ok) {
-      throw new Error(`npm registry returned ${res.status} for ${name}`);
-    }
-    const meta = await res.json();
-    if (meta.versions?.[pkg.version]) continue;
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`npm registry returned ${res.status} for ${path}`);
   }
-  console.log(
-    `${name}@${pkg.version} is not on npm; folding it into the canary.`,
+  return await res.json();
+}
+
+/**
+ * The commit the package's newest canary was built from, or null when that
+ * cannot be established. npm records `gitHead` on publish, so the published
+ * canary carries its own base and no state has to be kept on our side.
+ */
+async function publishedCanaryBase(name, meta) {
+  const version = meta["dist-tags"]?.canary;
+  if (!version) return null;
+  const manifest = await registryJson(
+    `${encodeURIComponent(name)}/${encodeURIComponent(version)}`,
   );
-  keep.add(name);
+  const sha = manifest?.gitHead;
+  if (typeof sha !== "string" || !sha) return null;
+  // A shallow or rewritten history cannot resolve it; treat as unknown.
+  try {
+    execFileSync("git", ["cat-file", "-e", `${sha}^{commit}`], {
+      cwd: rootDir,
+      stdio: "ignore",
+    });
+  } catch {
+    return null;
+  }
+  return sha;
+}
+
+function changedSince(sha, dir) {
+  const out = execFileSync(
+    "git",
+    ["diff", "--name-only", sha, "HEAD", "--", `packages/${dir}/`],
+    { cwd: rootDir, encoding: "utf8" },
+  );
+  return out.trim().length > 0;
+}
+
+// 4. Fold in public packages the registry is behind on: never-published
+// versions, and packages changed since their newest canary was cut.
+for (const [name, pkg] of packages) {
+  if (keep.has(name)) continue;
+  const meta = await registryJson(
+    encodeURIComponent(name),
+    "application/vnd.npm.install-v1+json",
+  );
+  if (!meta?.versions?.[pkg.version]) {
+    console.log(
+      `${name}@${pkg.version} is not on npm; folding it into the canary.`,
+    );
+    keep.add(name);
+    continue;
+  }
+  const canaryBase = await publishedCanaryBase(name, meta);
+  if (canaryBase === null) {
+    console.log(
+      `${name} has no resolvable canary base; folding it into the canary.`,
+    );
+    keep.add(name);
+    continue;
+  }
+  if (changedSince(canaryBase, pkg.dir)) {
+    console.log(
+      `${name} changed since its canary at ${canaryBase.slice(0, 7)}; folding it into the canary.`,
+    );
+    keep.add(name);
+  }
 }
 expandFixedGroups();
+
+if (keep.size === 0) {
+  console.log("Registry is level with main; skipping canary.");
+  setOutput("publish=false");
+  process.exit(0);
+}
 
 // 5. Write the synthetic changeset, carrying the pending bump intent.
 const releases = [...keep]

--- a/scripts/prepare-canary-snapshot.mjs
+++ b/scripts/prepare-canary-snapshot.mjs
@@ -231,7 +231,7 @@ const releases = [...keep]
 const snapshotPath = join(changesetDir, "snapshot-canary.md");
 writeFileSync(
   snapshotPath,
-  `---\n${releases.join("\n")}\n---\n\nCanary snapshot of the packages changed in this push.\n`,
+  `---\n${releases.join("\n")}\n---\n\nCanary snapshot of the packages this push changed, plus any the registry was behind on.\n`,
 );
 console.log(readFileSync(snapshotPath, "utf8"));
 setOutput("publish=true");


### PR DESCRIPTION
Closes #624. Closes #625.

Four changes: two fixes for fallout from #620 merging while the release workflow was broken, plus two cherry-picks carried along at request.

## Canary catch-up (#624)

`@routecraft/ai` has been stranded on its 11 August canary since #620's release run failed on the `changesets/action` v2 incompatibility. `scripts/prepare-canary-snapshot.mjs` scopes each canary to the packages one push's diff touched, so a package whose canary job failed is dropped for good: no later push has it in its diff range. The published core describes named servers while the published `ai` predates them, which makes the whole 0.7.0 canary line unadoptable for anything using the MCP HTTP transport.

Each package now also checks the commit its own newest canary was cut from, read back off npm's `gitHead`, and folds itself in when it has changed since. A push carrying no package change runs the catch-up rather than exiting early, since that is exactly the push that follows a failed one.

Dry run against this branch with an empty diff, which is the case that was previously unrecoverable:

```text
@routecraft/ai changed since its canary at ae79872; folding it into the canary.
@routecraft/routecraft changed since its canary at cf46f07; folding it into the canary.
```

`@routecraft/os` is correctly left alone. Merging this is itself the push that triggers the catch-up, so it republishes `ai` as a side effect.

Cherry-picked from `claude/devoptics-health-endpoint-t6x1wt` (`4a99a4e`), with one follow-up: the synthetic changeset's description said "the packages changed in this push", which is no longer the whole story now that catch-up packages ride along.

## Empty-server message (#625)

`servers.mcp: server has no mounts.` said nothing about what *did* mount, so a config that plainly names that server read as a lie. The usual cause is a surface that never mounted, and the mount list is what makes that visible:

```text
servers.mcp: server has no mounts. Mounted surfaces: http -> servers.public.
Either remove the unused server, or bind a surface to it. A surface that names
the server in config but did not mount is usually a plugin that failed to
apply, a misspelt server name, or a plugin version that predates named servers.
```

The check moved from `HttpMountRegistry.validate()` up to `serversPlugin`. A registry only knows its own mounts, so it structurally cannot report the one fact that helps; the plugin holds every registry. That also delivers the issue's secondary ask for free: every empty server is named at once instead of one boot at a time. A registry validated directly no longer refuses itself for being empty, so the test that asserted that now drives the plugin, which is the realistic path anyway.

## IMAP pool drain

Cherry-picked `06357e7`: stops the pool throwing when drained mid-connect. Review of that code surfaced two further problems, fixed here:

- A post-drain `acquire()` only noticed the drain after `createClient()` resolved, so it dialled out during shutdown and, with a connect that never settles, never settled either. Guarded at entry instead. Reverting the guard hangs the new test rather than failing it cleanly, which is the shape of the bug.
- The drained branch removed its placeholder and then threw into the `catch`, which removed it again with `indexOf` now `-1`, so `splice(-1, 1)` dropped an unrelated live slot that `drain()` would never log out. Reservation release is now idempotent. Unreachable once the entry guard lands, but not a thing to leave sitting in the code.

## Ops indicator docs

Cherry-picked `4426e05` from `claude/ops-indicator-docs`: documents what actually moves a bound indicator, including the breaker-cooldown and fallback interactions and why a dropped exchange is deliberately not evidence either way.

## Verification

- `bun run all` green: format, typecheck, lint, build (docs gate included), 2626 tests.
- Node cross-runtime 7/7.
- Canary script exercised by dry run against this branch, output above; `.changeset/` restored afterwards.