### PR TITLE
fix(docs-site): pin the Docker bun version and drop the redundant install that hangs

### DIFF
--- a/apps/routecraft.dev/Dockerfile
+++ b/apps/routecraft.dev/Dockerfile
@@ -1,7 +1,12 @@
 # The build context is the repository root, because the site is a bun workspace
 # member and the lockfile lives there:
 #   docker build -f apps/routecraft.dev/Dockerfile -t routecraft-dev .
-FROM oven/bun:1 AS base
+# Pinned, not floating. The repo runs bun 1.3.11 everywhere else (root
+# package.json `packageManager`, which setup-bun reads in CI), and `oven/bun:1`
+# drifted to 1.3.14, whose `bun install` hangs in "Resolving dependencies"
+# here: the same install, same lockfile and same .npmrc completes on the CI
+# runner in under two minutes. Keep this in step with `packageManager`.
+FROM oven/bun:1.3.11 AS base
 WORKDIR /repo
 
 # --- Dependencies ---

--- a/apps/routecraft.dev/Dockerfile
+++ b/apps/routecraft.dev/Dockerfile
@@ -38,8 +38,12 @@ ENV VITE_DOC_VERSION=$VITE_DOC_VERSION \
     VITE_POSTHOG_KEY=$VITE_POSTHOG_KEY \
     VITE_POSTHOG_HOST=$VITE_POSTHOG_HOST
 
+# No second install: the deps stage above already copied every workspace
+# manifest and the lockfile, so the dependency graph is fully resolved by
+# then, and .dockerignore keeps this COPY from touching node_modules. A
+# manifest arriving only here would fail the deps install outright, since a
+# frozen install needs every member the lockfile names.
 COPY . .
-RUN bun install --frozen-lockfile --ignore-scripts
 WORKDIR /repo/apps/routecraft.dev
 RUN bun run build
 


### PR DESCRIPTION
The docs deploy hangs in the image build and sits there until the job is cancelled. Two runs so far: [32228026028](https://github.com/routecraftjs/routecraft/actions/runs/32228026028/job/95992220730) (hung 07:33 to 09:37) and [32238243594](https://github.com/routecraftjs/routecraft/actions/runs/32238243594/job/96024348418).

```text
#16 [build 2/4] RUN bun install --frozen-lockfile --ignore-scripts
#16 0.119 bun install v1.3.14 (0d9b296a)
#16 0.137 Resolving dependencies
##[error]The operation was canceled.
```

Two changes, either of which stops the hang on its own.

## 1. Pin the base image

`apps/routecraft.dev/Dockerfile` tracked `oven/bun:1`, a floating major tag that has drifted to bun **1.3.14**. Everywhere else the repo pins **1.3.11** through root `packageManager`, which `setup-bun` reads via `bun-version-file: package.json`.

That version is the only controlled difference between the install that works and the one that hangs. In the same failing workflow run, the runner's own `Install dependencies` step runs `bun install --frozen-lockfile` against the same lockfile, the same workspace and the same `.npmrc`, and finishes in 1m48s. Inside the image, the identical command on 1.3.14 never gets past resolution.

The image was the only place a bun version could change without a commit, which is how an upstream release reached CI with nothing in the repo to point at.

## 2. Remove the second install

The `build` stage repeated `bun install --frozen-lockfile` after `COPY . .`. It is the step that hangs, and it was doing nothing: the `deps` stage above it already copies the lockfile and every workspace manifest (`packages`, `apps/routecraft.dev/package.json`, `examples/package.json`), so the dependency graph is settled before any source arrives, and `.dockerignore` keeps the `COPY` from touching `node_modules`.

It was not load-bearing as a safety net either. A manifest that showed up only at `COPY . .` would already have failed the `deps` install, because a frozen install needs every member the lockfile names, which is what the existing comment in that stage says.

Verified by replaying both stages outside Docker, since this session has no Docker daemon:

1. install using only the files the `deps` stage copies: 2753 packages, 1.80s
2. overlay the full tree, no second install: root and app `node_modules` both survive
3. `bun run build` in `apps/routecraft.dev`: exit 0, all 257 pages prerendered, `.output/` produced, no missing-module errors

## What I did not change

I first suspected the root `.npmrc` (`engine-strict=true`), since it reaches the `build` stage through `COPY . .` but never the `deps` stage, and an initial local A/B appeared to confirm it. A controlled repeat with a cold bun cache per arm did not hold up: with `.npmrc` 8.41s, without it 7.41s, both clean. The runner also has that same `.npmrc` and installs fine. So it is not the differentiator and there is nothing to fix there.

## Verification

The real proof is the next docs deploy on main reaching `bun run build` instead of stalling in resolution. Locally:

```bash
docker build -f apps/routecraft.dev/Dockerfile -t routecraft-dev .
```