### PR TITLE
fix(core): wait for an in-flight plugin hook before teardown

### DIFF
--- a/.changeset/plugin-hook-stop-race.md
+++ b/.changeset/plugin-hook-stop-race.md
@@ -24,3 +24,12 @@ teardown-before-completion.
 Both lifecycle walks also re-check for a stop before each plugin, so a stop
 mid-boot no longer applies or starts plugins that teardown has already
 walked past.
+
+**One constraint comes with the wait, documented rather than enforced.** A
+lifecycle hook must not `await` its own `ctx.stop()`: it would wait for a
+shutdown that is waiting for the hook. Both intents keep a working spelling,
+and they differ by a keyword. Use `throw` to abort the boot with a reason,
+which unwinds through the teardown walk and surfaces the error, or call
+`ctx.stop()` without awaiting it to stand the context down without failing
+the boot. Nothing detects the awaited form, so it hangs at boot on the first
+run; the unawaited form is pinned by a test.

--- a/.changeset/plugin-hook-stop-race.md
+++ b/.changeset/plugin-hook-stop-race.md
@@ -1,0 +1,26 @@
+---
+"@routecraft/routecraft": patch
+---
+
+A `stop()` racing boot no longer tears a plugin down while its own lifecycle
+hook is still running.
+
+A stop that arrived while a plugin's `apply()` or `start()` was awaiting
+produced the order enter, teardown, resolve: the plugin was torn down (the
+teardown walk keys off the applied set, so it was never skipped), but
+anything the hook acquired after its last await point was acquired after the
+release meant to cover it, and nothing released it afterwards. A process that
+exits hides this because the OS reclaims; an embedder or a test suite
+building successive contexts in one process keeps the interval or socket.
+
+Shutdown now waits for the in-flight hook before teardown, on a promise
+scoped to the plugin lifecycle hooks alone. It deliberately does not cover
+`run()`, which for an indefinite route resolves only once the context stops.
+The wait is unbounded, matching plugin teardown: a hook that never settles is
+a defective plugin rather than a shutdown-policy question, and interrupting
+instead would require every plugin author to write `start()` so it tolerates
+teardown-before-completion.
+
+Both lifecycle walks also re-check for a stop before each plugin, so a stop
+mid-boot no longer applies or starts plugins that teardown has already
+walked past.

--- a/.standards/plugin-lifecycle.md
+++ b/.standards/plugin-lifecycle.md
@@ -87,6 +87,34 @@ or task to carry it.
   per plugin, so a `stop()` mid-boot stops the walk rather than applying or
   starting plugins nothing will release.
 
+### A hook must not await its own `stop()`
+
+A lifecycle hook may shut the context down. What it must not do is **await**
+that shutdown from inside the hook: the hook then waits for a shutdown that
+is waiting for the hook, and neither ever settles. The wait above is what
+makes this circular, and nothing detects it, so the failure is a silent hang
+at boot rather than an error.
+
+Both intents already have a working spelling, and they mean different things:
+
+| Intent | Spelling | What happens |
+|--------|----------|--------------|
+| Abort the boot with a reason | `throw` | `build()` and `start()` unwind through the teardown walk and the error reaches the operator unchanged |
+| Request shutdown without failing the boot | call `ctx.stop()` and do not await it | the hook settles, the wait sees it settle, and teardown follows in its proper order |
+
+```ts
+async start(ctx) {
+  if (!healthy) throw rcError("RC9901", undefined, { message: "..." });
+  // or, to stand the context down without failing the boot:
+  void ctx.stop();
+}
+```
+
+The constraint is one keyword wide and it is documented rather than enforced.
+Detecting it would need the shutdown to know which async context asked for
+it, which costs more machinery in the lifecycle path than the rule it would
+replace, for a misuse that fails deterministically on the first boot.
+
 ### The build-failure unwind
 
 A failure inside `build()` has the same hole with none of the same escape

--- a/.standards/plugin-lifecycle.md
+++ b/.standards/plugin-lifecycle.md
@@ -74,6 +74,18 @@ or task to carry it.
 - A teardown that throws during the unwind is logged and does not replace
   the start error. The operator needs the cause of the failed boot, not
   whatever the cleanup hit on the way out.
+- A `stop()` that arrives while a lifecycle hook is still awaiting WAITS
+  for that hook before teardown runs, so the order a plugin observes is
+  always `apply`/`start` entered, resolved, then `teardown`. The wait covers
+  the lifecycle hooks alone and never `run()`, which for an indefinite route
+  resolves only at shutdown. It is unbounded for the same reason teardown
+  is: a hook cut short keeps whatever it acquired past its last await point,
+  and interrupting instead would oblige every plugin author to write
+  `start()` so it tolerates teardown-before-completion. A hook that never
+  settles is a defective plugin, not a shutdown-policy question.
+- No hook runs once teardown has walked the applied set. Both walks re-check
+  per plugin, so a `stop()` mid-boot stops the walk rather than applying or
+  starting plugins nothing will release.
 
 ### The build-failure unwind
 

--- a/.standards/plugin-lifecycle.md
+++ b/.standards/plugin-lifecycle.md
@@ -76,7 +76,7 @@ or task to carry it.
   whatever the cleanup hit on the way out.
 - A `stop()` that arrives while a lifecycle hook is still awaiting WAITS
   for that hook before teardown runs, so the order a plugin observes is
-  always `apply`/`start` entered, resolved, then `teardown`. The wait covers
+  always `apply`/`start` entered, settled, then `teardown`. The wait covers
   the lifecycle hooks alone and never `run()`, which for an indefinite route
   resolves only at shutdown. It is unbounded for the same reason teardown
   is: a hook cut short keeps whatever it acquired past its last await point,

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/index.mdx
@@ -92,6 +92,8 @@ Hooks run in registration order and each is awaited before the next plugin's, at
 
 A failure during `build()` unwinds the same way, so a plugin that opened a resource before a later plugin refused does not leak it: `build()` returns no context, so nothing else could ever release it. Only plugins whose `apply()` returned are torn down, and the original error surfaces unchanged even if a teardown throws on the way out.
 
+A `stop()` that lands mid-boot waits for the hook that is still running before it tears that plugin down, so the order a plugin observes is always its hook entered, its hook resolved, then `teardown`. Anything a hook acquires after its last `await` is therefore covered by the release that follows it. The wait is unbounded and covers `apply` and `start` alone, never the route work that only ends at shutdown, and no further hook runs once teardown has begun.
+
 `teardown` receives a second argument describing how far the context got, so a plugin never has to infer it:
 
 | Field | Means |

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/index.mdx
@@ -94,6 +94,17 @@ A failure during `build()` unwinds the same way, so a plugin that opened a resou
 
 A `stop()` that lands mid-boot waits for the hook that is still running before it tears that plugin down, so the order a plugin observes is always its hook entered, its hook settled, then `teardown`. Anything a hook acquires after its last `await` is therefore covered by the release that follows it. The wait is unbounded and covers `apply` and `start` alone, never the route work that only ends at shutdown, and no further hook runs once teardown has begun.
 
+A hook may shut the context down, but it must never `await` its own `stop()`: the hook would wait for a shutdown that is waiting for the hook, and neither settles. Use `throw` to abort the boot with a reason, which unwinds through the teardown walk and surfaces the error, or call `ctx.stop()` without awaiting it to stand the context down without failing the boot. The rule is documented rather than enforced, and awaiting it hangs at boot on the first run.
+
+```ts
+async start(ctx: CraftContext) {
+  // Abort the boot, with the reason reaching the operator:
+  if (!configured) throw new Error("mail credentials missing");
+  // Or request shutdown without failing the boot:
+  void ctx.stop();
+}
+```
+
 `teardown` receives a second argument describing how far the context got, so a plugin never has to infer it:
 
 | Field | Means |

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/index.mdx
@@ -92,7 +92,7 @@ Hooks run in registration order and each is awaited before the next plugin's, at
 
 A failure during `build()` unwinds the same way, so a plugin that opened a resource before a later plugin refused does not leak it: `build()` returns no context, so nothing else could ever release it. Only plugins whose `apply()` returned are torn down, and the original error surfaces unchanged even if a teardown throws on the way out.
 
-A `stop()` that lands mid-boot waits for the hook that is still running before it tears that plugin down, so the order a plugin observes is always its hook entered, its hook resolved, then `teardown`. Anything a hook acquires after its last `await` is therefore covered by the release that follows it. The wait is unbounded and covers `apply` and `start` alone, never the route work that only ends at shutdown, and no further hook runs once teardown has begun.
+A `stop()` that lands mid-boot waits for the hook that is still running before it tears that plugin down, so the order a plugin observes is always its hook entered, its hook settled, then `teardown`. Anything a hook acquires after its last `await` is therefore covered by the release that follows it. The wait is unbounded and covers `apply` and `start` alone, never the route work that only ends at shutdown, and no further hook runs once teardown has begun.
 
 `teardown` receives a second argument describing how far the context got, so a plugin never has to infer it:
 

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -1187,6 +1187,20 @@ export class CraftContext {
       started.reject(err);
       throw err;
     }
+
+    // A stop() that landed while the plugins were applying has already torn
+    // them down. Starting routes now announces boot progress for a context
+    // that is gone: route:starting fires after context:stopped, every route
+    // refuses with RC3001 against its aborted controller, and the boot
+    // summary reports a failed boot for what was a clean shutdown. Waiting
+    // for that shutdown before returning also keeps start() from resolving
+    // while teardown is still running.
+    if (this.hasStopped) {
+      // The shutdown's own failure belongs to whoever called stop().
+      await this.shutdownPromise?.catch(() => undefined);
+      return;
+    }
+
     this.logger.info(
       { routeCount: this.routes.length },
       "Starting Routecraft context",

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -388,6 +388,16 @@ export class CraftContext {
   /** The in-flight start, so concurrent `start()` calls join one boot. */
   private startInFlight: Promise<void> | undefined;
 
+  /**
+   * The plugin lifecycle hook currently awaiting, so a `stop()` that lands
+   * mid-boot can let it finish before teardown runs.
+   *
+   * Scoped to `apply()` and `start()` alone, never `run()`: for an
+   * indefinite route `run()` resolves only once the context stops, so
+   * waiting on it would deadlock the shutdown this ordering exists to serve.
+   */
+  private pluginHookInFlight: Promise<void> | undefined;
+
   /** Latched by `stop()`. A stopped context refuses to start again. */
   private hasStopped = false;
 
@@ -515,6 +525,10 @@ export class CraftContext {
     if (this.pluginsInitialized) return;
     this.pluginsInitialized = true;
     for (const [pluginIndex, plugin] of this.plugins.entries()) {
+      // Same guard as startPlugins(), for the same reason: once teardown has
+      // walked the applied set, a plugin applied after it acquires resources
+      // nothing will ever release.
+      if (this.hasStopped) return;
       try {
         if (
           !plugin ||
@@ -543,12 +557,10 @@ export class CraftContext {
           pluginIndex,
         });
 
-        await (plugin as CraftPlugin).apply(this);
-        this.appliedPlugins.add(pluginIndex);
-
-        this.emit("plugin:applied", {
-          pluginId,
-          pluginIndex,
+        await this.runLifecycleHook(async () => {
+          await (plugin as CraftPlugin).apply(this);
+          this.appliedPlugins.add(pluginIndex);
+          this.emit("plugin:applied", { pluginId, pluginIndex });
         });
       } catch (err) {
         this.logger.error(
@@ -748,12 +760,15 @@ export class CraftContext {
       // hook launched after that begins work nothing will ever stop.
       if (this.hasStopped) return;
       if (typeof plugin.start !== "function") continue;
+      const startHook = plugin.start.bind(plugin);
       const pluginId = this.getPluginId(plugin, pluginIndex);
       try {
         this.emit("plugin:starting", { pluginId, pluginIndex });
-        await plugin.start(this);
-        this.startedPlugins.add(pluginIndex);
-        this.emit("plugin:started", { pluginId, pluginIndex });
+        await this.runLifecycleHook(async () => {
+          await startHook(this);
+          this.startedPlugins.add(pluginIndex);
+          this.emit("plugin:started", { pluginId, pluginIndex });
+        });
       } catch (err) {
         this.logger.error(
           { pluginIndex, pluginId, err },
@@ -763,6 +778,47 @@ export class CraftContext {
         throw err;
       }
     }
+  }
+
+  /**
+   * Run one plugin lifecycle hook, publishing it as the in-flight hook for
+   * as long as it runs.
+   *
+   * The published promise covers the hook and the bookkeeping that records
+   * it, so a shutdown waiting on it sees a plugin either fully applied or
+   * fully absent, never half-recorded.
+   *
+   * @param hook The hook call together with the state it updates on success
+   */
+  private async runLifecycleHook(hook: () => Promise<void>): Promise<void> {
+    const inFlight = hook();
+    this.pluginHookInFlight = inFlight;
+    try {
+      await inFlight;
+    } finally {
+      if (this.pluginHookInFlight === inFlight) {
+        this.pluginHookInFlight = undefined;
+      }
+    }
+  }
+
+  /**
+   * Wait for a plugin lifecycle hook still in flight before teardown runs.
+   *
+   * Waiting rather than interrupting, and unbounded, for the reason plugin
+   * teardown is unbounded: a hook cut off partway keeps whatever it acquired
+   * after its last await point, and no teardown can release what the plugin
+   * had not yet handed over. Interrupting instead would oblige every plugin
+   * author to write `start()` so it tolerates teardown-before-completion, a
+   * contract paid for by every correct plugin to contain a defective one.
+   * A hook that never settles is that defective plugin, not a shutdown
+   * policy question.
+   *
+   * The hook's own rejection belongs to whoever invoked it, which is why
+   * only its settling is observed here.
+   */
+  private async settlePluginHook(): Promise<void> {
+    await this.pluginHookInFlight?.catch(() => undefined);
   }
 
   /**
@@ -1404,6 +1460,11 @@ export class CraftContext {
         );
       }
     }
+
+    // A stop() racing boot lets the hook already awaiting finish first, so
+    // a plugin is never torn down while its own apply() or start() is still
+    // acquiring. Outside that race this settles immediately.
+    await this.settlePluginHook();
 
     // Plugin teardown (plugins with teardown in reverse order, then
     // registerTeardown callbacks). Unbounded on purpose: teardown releases

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -557,6 +557,12 @@ export class CraftContext {
           pluginIndex,
         });
 
+        // Re-checked after the emit, not only at the loop head: handlers run
+        // synchronously, so a subscriber calling stop() lands between the two
+        // and the hook would otherwise start into a shutdown already waiting
+        // for it.
+        if (this.hasStopped) return;
+
         await this.runLifecycleHook(async () => {
           await (plugin as CraftPlugin).apply(this);
           this.appliedPlugins.add(pluginIndex);
@@ -764,6 +770,10 @@ export class CraftContext {
       const pluginId = this.getPluginId(plugin, pluginIndex);
       try {
         this.emit("plugin:starting", { pluginId, pluginIndex });
+        // See initPlugins(): a synchronous subscriber can stop the context
+        // between the loop guard and this call.
+        if (this.hasStopped) return;
+
         await this.runLifecycleHook(async () => {
           await startHook(this);
           this.startedPlugins.add(pluginIndex);

--- a/packages/routecraft/test/plugin-stop-race.bun.test.ts
+++ b/packages/routecraft/test/plugin-stop-race.bun.test.ts
@@ -177,4 +177,71 @@ describe("a stop racing a plugin lifecycle hook", () => {
     expect(outcome).not.toBe(wedged);
     expect(order).toEqual(["start", "teardown"]);
   });
+
+  /**
+   * @case A plugin:starting subscriber stops the context synchronously
+   * @preconditions A handler on the lifecycle event that calls stop() before the hook is invoked
+   * @expectedResult The hook never runs and the shutdown completes. Event handlers dispatch synchronously, so a stop can land between the walk's guard and the hook, and a hook started into a shutdown that now waits for it could hold that shutdown open forever
+   */
+  test("starts no hook when an event handler stops the context", async () => {
+    const order: string[] = [];
+    let stopping: Promise<unknown> | undefined;
+
+    const ctx = new CraftContext({
+      plugins: [
+        {
+          name: "stopped-at-the-event",
+          apply() {},
+          start() {
+            order.push("start:enter");
+          },
+          teardown() {
+            order.push("teardown");
+          },
+        },
+      ],
+    });
+    ctx.on("plugin:starting", () => {
+      order.push("stop");
+      stopping = ctx.stop();
+    });
+
+    await ctx.start().catch(() => undefined);
+    await stopping;
+
+    expect(order).toEqual(["stop", "teardown"]);
+  });
+
+  /**
+   * @case A plugin:applying subscriber stops the context synchronously
+   * @preconditions The same handler shape one phase earlier, on the apply walk
+   * @expectedResult The plugin never applies, so it is not torn down either: teardown releases what apply opened, and this apply never ran
+   */
+  test("applies no plugin when an event handler stops the context", async () => {
+    const order: string[] = [];
+    let stopping: Promise<unknown> | undefined;
+
+    const ctx = new CraftContext({
+      plugins: [
+        {
+          name: "stopped-at-the-event",
+          apply() {
+            order.push("apply:enter");
+          },
+          teardown() {
+            order.push("teardown");
+          },
+        },
+      ],
+    });
+    ctx.on("plugin:applying", () => {
+      order.push("stop");
+      stopping = ctx.stop();
+    });
+
+    await ctx.start().catch(() => undefined);
+    await stopping;
+
+    expect(order).toEqual(["stop"]);
+  });
 });

--- a/packages/routecraft/test/plugin-stop-race.bun.test.ts
+++ b/packages/routecraft/test/plugin-stop-race.bun.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { testContext, type TestContext } from "@routecraft/testing";
+import { craft, direct, noop, type CraftPlugin } from "../src/index.ts";
+import { CraftContext } from "../src/context.ts";
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Wait for a recorded phase, bounded.
+ *
+ * An unbounded poll turns a lifecycle regression into a hung suite instead
+ * of a failure, which is the same blindness a fixed sleep causes from the
+ * other side.
+ */
+const waitFor = async (reached: () => boolean, what: string): Promise<void> => {
+  const deadline = Date.now() + 5_000;
+  while (!reached()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await sleep(5);
+  }
+};
+
+/**
+ * A `stop()` that arrives while a plugin lifecycle hook is still awaiting.
+ *
+ * Teardown keys off the applied set, so the plugin is torn down. The defect
+ * is the order: the hook resolved after its own `teardown()` had run, so
+ * anything it acquired past its last await point was acquired after the
+ * release meant to cover it and nothing ever released it. For a process that
+ * exits the OS reclaims; for an embedder or a test building successive
+ * contexts in one process, the interval or socket simply lives on.
+ *
+ * Shutdown therefore waits for the hook rather than interrupting it, and
+ * waits unbounded, on a promise covering the lifecycle hooks alone. It never
+ * covers `run()`, which for an indefinite route resolves only once the
+ * context stops: waiting on that would deadlock the shutdown this ordering
+ * exists to serve.
+ */
+describe("a stop racing a plugin lifecycle hook", () => {
+  let t: TestContext | undefined;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * How long a gated hook stays in flight.
+   *
+   * This is the hook's own duration, not a synchronisation guess: the test
+   * waits for the hook to be entered before stopping, so the race is
+   * established deterministically and the assertions never depend on when
+   * this elapses. It only has to outlast the moment teardown would otherwise
+   * begin, which for a context with no routes to drain is immediate.
+   */
+  const HOOK_MS = 200;
+
+  /**
+   * @case stop() lands while a plugin's start() is still awaiting
+   * @preconditions A directly constructed context whose plugin start() is still running when stop() arrives
+   * @expectedResult The observed order is enter, resolve, teardown. Teardown running second would release a plugin that is still acquiring, which is the leak this ticket exists for
+   */
+  test("waits for an in-flight start() before tearing that plugin down", async () => {
+    const order: string[] = [];
+
+    // Built by hand and without routes: stage one then has nothing to drain,
+    // so a shutdown that did not wait would reach teardown immediately and
+    // the ordering assertion below would catch it with the whole hook
+    // duration to spare.
+    const ctx = new CraftContext({
+      plugins: [
+        {
+          name: "slow-start",
+          apply() {},
+          async start() {
+            order.push("start:enter");
+            await sleep(HOOK_MS);
+            order.push("start:resolve");
+          },
+          teardown() {
+            order.push("teardown");
+          },
+        },
+      ],
+    });
+
+    const started = ctx.start();
+    started.catch(() => {});
+    await waitFor(
+      () => order.includes("start:enter"),
+      "the start hook to be entered",
+    );
+
+    await ctx.stop();
+    await started;
+
+    expect(order).toEqual(["start:enter", "start:resolve", "teardown"]);
+  });
+
+  /**
+   * @case stop() lands while a plugin's apply() is still awaiting
+   * @preconditions A directly constructed context, two plugins, the first still in apply() when stop() arrives
+   * @expectedResult The first resolves before its teardown, and the second never applies. A plugin applied after teardown has walked the applied set acquires what nothing will release
+   */
+  test("waits for an in-flight apply() and applies no plugin after it", async () => {
+    const order: string[] = [];
+
+    // ContextBuilder.build() awaits initPlugins(), so a gated apply() would
+    // hold the builder itself and the test would never reach its stop().
+    const ctx = new CraftContext({
+      plugins: [
+        {
+          name: "slow-apply",
+          async apply() {
+            order.push("apply:enter");
+            await sleep(HOOK_MS);
+            order.push("apply:resolve");
+          },
+          teardown() {
+            order.push("teardown");
+          },
+        },
+        {
+          name: "later",
+          apply() {
+            order.push("later:apply");
+          },
+        },
+      ],
+    });
+
+    const started = ctx.start();
+    started.catch(() => {});
+    await waitFor(
+      () => order.includes("apply:enter"),
+      "the apply hook to be entered",
+    );
+
+    await ctx.stop();
+    await started.catch(() => undefined);
+
+    expect(order).toEqual(["apply:enter", "apply:resolve", "teardown"]);
+  });
+
+  /**
+   * @case stop() on a started context with indefinite routes and no hook in flight
+   * @preconditions A healthy plugin whose start() has already resolved, and a route whose source runs until the context stops
+   * @expectedResult stop() resolves and teardown runs. The wait is scoped to lifecycle hooks, so it cannot be held open by the route work that only ends at shutdown
+   */
+  test("adds no wait when no hook is in flight", async () => {
+    const order: string[] = [];
+
+    const plugin: CraftPlugin = {
+      name: "prompt-start",
+      apply() {},
+      start() {
+        order.push("start");
+      },
+      teardown() {
+        order.push("teardown");
+      },
+    };
+
+    t = await testContext()
+      .with({ plugins: [plugin] })
+      .routes(craft().id("worker").from(direct()).to(noop()))
+      .build();
+    await t.startAndWaitReady();
+
+    const wedged = Symbol("wedged");
+    const outcome = await Promise.race([
+      t.ctx.stop(),
+      sleep(5_000).then(() => wedged),
+    ]);
+
+    expect(outcome).not.toBe(wedged);
+    expect(order).toEqual(["start", "teardown"]);
+  });
+});

--- a/packages/routecraft/test/plugin-stop-race.bun.test.ts
+++ b/packages/routecraft/test/plugin-stop-race.bun.test.ts
@@ -214,10 +214,10 @@ describe("a stop racing a plugin lifecycle hook", () => {
 
   /**
    * @case A plugin:applying subscriber stops the context synchronously
-   * @preconditions The same handler shape one phase earlier, on the apply walk
-   * @expectedResult The plugin never applies, so it is not torn down either: teardown releases what apply opened, and this apply never ran
+   * @preconditions The same handler shape one phase earlier, on the apply walk, with a route registered
+   * @expectedResult The plugin never applies, so it is not torn down either, and the boot goes no further: a route started here would announce progress for a context that is already gone, and refuse with RC3001 against its aborted controller anyway
    */
-  test("applies no plugin when an event handler stops the context", async () => {
+  test("applies no plugin and starts no route when an event handler stops the context", async () => {
     const order: string[] = [];
     let stopping: Promise<unknown> | undefined;
 
@@ -233,6 +233,12 @@ describe("a stop racing a plugin lifecycle hook", () => {
           },
         },
       ],
+    });
+    ctx.registerRoutes(
+      ...craft().id("worker").from(direct()).to(noop()).build(),
+    );
+    ctx.on("route:starting", () => {
+      order.push("route:starting");
     });
     ctx.on("plugin:applying", () => {
       order.push("stop");

--- a/packages/routecraft/test/plugin-stop-race.bun.test.ts
+++ b/packages/routecraft/test/plugin-stop-race.bun.test.ts
@@ -250,4 +250,39 @@ describe("a stop racing a plugin lifecycle hook", () => {
 
     expect(order).toEqual(["stop"]);
   });
+
+  /**
+   * @case A hook requests shutdown without awaiting it, then finishes its own work
+   * @preconditions A start() hook that calls ctx.stop() unawaited and then keeps working past an await
+   * @expectedResult The hook settles before its teardown, and the shutdown completes. This is the sanctioned spelling for a hook that wants the context down without failing the boot, so it is a guarantee rather than an accident: awaiting the same call would have the hook wait for a shutdown that is waiting for the hook
+   */
+  test("shuts down cleanly when a hook requests it without awaiting", async () => {
+    const order: string[] = [];
+    let stopping: Promise<unknown> | undefined;
+
+    const ctx: CraftContext = new CraftContext({
+      plugins: [
+        {
+          name: "requests-shutdown",
+          apply() {},
+          async start() {
+            order.push("start:enter");
+            stopping = ctx.stop();
+            // Work after the request, so the assertion measures the ordering
+            // rather than a hook that happened to finish first.
+            await sleep(HOOK_MS);
+            order.push("start:resolve");
+          },
+          teardown() {
+            order.push("teardown");
+          },
+        },
+      ],
+    });
+
+    await ctx.start();
+    await stopping;
+
+    expect(order).toEqual(["start:enter", "start:resolve", "teardown"]);
+  });
 });

--- a/packages/routecraft/test/plugin-stop-race.bun.test.ts
+++ b/packages/routecraft/test/plugin-stop-race.bun.test.ts
@@ -280,9 +280,12 @@ describe("a stop racing a plugin lifecycle hook", () => {
       ],
     });
 
+    // Asserted before awaiting the outcome: run() awaits the shutdown before
+    // resolving, so start() returning already means the context is down, and
+    // checking here pins that rather than only the recorded order.
     await ctx.start();
-    await stopping;
-
     expect(order).toEqual(["start:enter", "start:resolve", "teardown"]);
+
+    await stopping;
   });
 });


### PR DESCRIPTION
Closes #640. The last tag-blocker from Bundle B (#638), landing as its own small PR as ruled.

## The defect

A `stop()` that arrived while a plugin's `apply()` or `start()` was awaiting produced the ordering `start:enter`, `teardown`, `start:resolve`.

Teardown itself was never skipped. It keys off `appliedPlugins`, so the plugin was torn down, which is where CodeRabbit's original description of this had the mechanism wrong. What is real is the consequence: anything the hook acquired after its last await point was acquired after the release meant to cover it, and nothing released it afterwards. #638's `hasStopped` guards stop the NEXT hook from launching after a stop; they do nothing for the one already in flight, which is what made the remaining gap visible.

Introduced with the `start()` phase in #602 and never released, so it is fixed before the 0.7.0 tag. Impact is bounded for a process that exits, since the OS reclaims, and real for embedders and tests that build successive contexts in one process: a leaked interval or socket from a torn-down context lives on.

## The fix, as ruled

`stop()` waits for the in-flight hook before teardown, on a promise scoped to the plugin lifecycle hooks alone. It never covers `run()`, which for an indefinite route resolves only once the context stops, so waiting on that would deadlock the shutdown this ordering exists to serve.

Unbounded, deliberately, on the same defect-class line #590 drew for teardown. A hook cut short keeps whatever it acquired, and interrupting instead would oblige every plugin author to write `start()` so it tolerates teardown-before-completion: a heavy contract paid for by every correct plugin to contain the defective one. A hook that never settles is a defective plugin, not a shutdown-policy question.

The published promise covers the hook **and** the bookkeeping that records it, so a shutdown waiting on it sees a plugin either fully applied or fully absent, never half-recorded.

## Beyond the acceptance criteria

`initPlugins()` now re-checks for a stop before each plugin, as `startPlugins()` already did. Without it, tracking the `apply()` hook is half a mechanism: shutdown would wait for the applying plugin, tear down, and `initPlugins()` would carry on applying plugins that the teardown walk has already passed, acquiring what nothing will release. Same defect class, same shape of guard, flagged here because it is one step past what the ticket asked for.

## Verification

Three tests: the `start()` race with the ordering pinned per plugin, the same for `apply()` with the following plugin proven never to apply, and a `stop()` with no hook in flight against a context with indefinite routes, which is the deadlock the ruling warned about.

The first fixture I wrote passed with the fix removed and therefore pinned nothing: it released the gated hook immediately after `stop()`, so the hook resolved during the route drain and the ordering held either way. Rebuilt on a hand-constructed context with no routes, so a shutdown that does not wait reaches teardown immediately and the hook's own duration is the whole margin. Mutation-checked: removing `await this.settlePluginHook()` fails both race tests, restoring it passes all three.

`bun run test` 2745 pass / 0 fail across 190 files. `lint`, `typecheck`, `format`, `build` clean. `bun run limit:size` green (core 115.52 kB of 200 kB).

The ordering guarantee is documented in `.standards/plugin-lifecycle.md` §3 and on the plugins reference page, with a patch changeset.

https://claude.ai/code/session_01Q5oSiEXyMTDL1gRXr4aYJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5oSiEXyMTDL1gRXr4aYJX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits for any in-flight plugin apply()/start() before teardown to prevent teardown-before-settle leaks. Previously a stop during boot could order enter → teardown → settle; now it is enter → settle → teardown, and start() halts at plugins and awaits shutdown.

- stop() awaits one in-flight lifecycle hook; the wait is unbounded, covers apply/start only, and never waits on run().
- Both lifecycle walks re-check hasStopped per plugin and again after emitting plugin:applying/starting so synchronous handlers that call stop() prevent the hook from starting.
- start() exits early when a stop lands mid-apply/start and awaits the shutdown so it does not report progress or resolve while teardown runs.
- Adds runLifecycleHook()/settlePluginHook() so teardown sees a hook fully settled and its bookkeeping applied; no half-recorded state.
- Documents: a lifecycle hook must not await its own ctx.stop(); throw to abort boot or call ctx.stop() without awaiting. Tests cover apply()/start() races, synchronous handler stops, and the unawaited-stop path; a new test asserts the ordering before the outcome. Publishes a patch changeset for `@routecraft/routecraft`.

**Migration**
- Do not await ctx.stop() inside apply()/start(); either throw or call ctx.stop() without awaiting. No other changes required.

<sup>Written for commit bcd0a1d17008ce1701d0cee94450e10b76dac77a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

