### PR TITLE
docs(skills): make process() a recorded last resort in the authoring skills

### DIFF
--- a/skills/create-adapter/SKILL.md
+++ b/skills/create-adapter/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the user asks to:
 - Replace bespoke `process()` calls with a reusable adapter
 - Add a transformer that turns one body shape into another
 
-If the user only needs a one-shot data transformation inside a single capability, use `.transform()` or `.process()` directly instead. If the work is reusable across capabilities, it belongs in an adapter.
+If the user only needs a one-shot data transformation inside a single capability, use `.transform()` with a named function instead (not `.process()`; the create-capability skill records why `.process()` is a last resort). If the work is reusable across capabilities, it belongs in an adapter.
 
 ## Step 1: clarify
 

--- a/skills/create-capability/SKILL.md
+++ b/skills/create-capability/SKILL.md
@@ -28,7 +28,7 @@ Confirm answers to these questions before writing. Ask the user only the ones th
 
 1. **What triggers the capability?** A direct call from another capability? An MCP tool invocation? A webhook (HTTP source)? A timer or cron? A mail inbox? A simple in-memory payload (typical for tests)?
 2. **What is the body shape on input and output?** Bodies are typed end to end; commit to a Zod or other Standard Schema for `input` and `output` if the user knows what they want
-3. **What does the pipeline do?** Linear (one transform, one destination)? Fan-out then fan-in (`split` then `aggregate`)? Branch (`choice`)? Conditional drop (`filter`)? Schema check (`validate`)?
+3. **What does the pipeline do?** Linear (one transform, one destination)? Fan-out then fan-in (`split` then `aggregate`)? Branch (`choice`)? Conditional drop (`filter`)? Schema check (`validate`)? Name each behavior as an operation now; whatever you name here must appear in the chain, not inside a `.process()` body (see the rule in Step 3)
 4. **Does it need batching?** If the source emits many small messages and the work batches naturally, set `.batch({...})` before `.from(...)`
 5. **Does it need resilience?** If failures should retry, time out, or fall back, plan to use the route- or step-scope wrappers (`.error(...)` is built in; others are coming)
 
@@ -65,6 +65,44 @@ export default craft()
   // operations
   .to(/* destination */);
 ```
+
+### The chain is the logic; `.process()` is the last resort
+
+The route chain is read by people who will never read the step internals: reviewers, operators, non-technical stakeholders, and anyone checking a route an AI wrote. Checking the DSL is cheap; checking imperative logic is not. So every behavior that has an operation must appear *as that operation in the chain*, where it can be seen. The anti-pattern this rule exists to kill:
+
+```ts
+// WRONG: a script wearing a route costume. The chain says nothing;
+// all branching, mapping, and even the send hide inside one processor.
+craft()
+  .id("sync-orders")
+  .from(http("/orders"))
+  .process(async (ex) => {
+    if (ex.body.status === "cancelled") return ex;
+    const enriched = await fetchCustomer(ex.body);
+    if (enriched.vip) await notifySales(enriched);
+    await postToErp(enriched);
+    return ex;
+  })
+  .to(noop());
+```
+
+```ts
+// RIGHT: the same behavior, visible in the chain.
+craft()
+  .id("sync-orders")
+  .from(http("/orders"))
+  .filter((ex) => ex.body.status !== "cancelled")
+  .enrich(customerLookup())
+  .choice(when((ex) => ex.body.vip, (b) => b.tap(salesNotifier())))
+  .to(erp());
+```
+
+Concrete rules:
+
+- Branching is `.choice()`, conditional drop is `.filter()`, reshaping is `.transform()`, pulling data in is `.enrich(...)`, side effects are `.tap(...)`, sending is `.to(...)`, fan-out/fan-in is `.split()`/`.aggregate()`, schema checks are `.validate()`/`.input()`. An `if` inside a step body that selects *behavior* is a `.choice()` or `.filter()` that escaped the chain.
+- **`.to(noop())` is a red flag.** If the route ends in `noop()` while a step above performs the real send, the destination is hiding; move it into `.to(...)` (or `.tap(...)` if it is fire-and-forget). `noop()` is legitimate only when the route genuinely produces no outbound effect (its value is the reply body or the enrichment itself).
+- `.process()` is for the rare step no operation expresses (a multi-field stateful interaction with the exchange). Reaching for it because it is familiar imperative code is the failure mode; if a chain of two operations can say the same thing, write the two operations.
+- Before finishing, reread the chain alone and ask: can a reader who opens only `route.ts` say what this capability does, to what, under which conditions, and where results go? If any of those answers lives inside a step body, the chain is not done.
 
 Authoring rules to keep in mind:
 

--- a/skills/create-capability/SKILL.md
+++ b/skills/create-capability/SKILL.md
@@ -87,7 +87,11 @@ craft()
 ```
 
 ```ts
-// RIGHT: the same behavior, visible in the chain.
+// RIGHT: the flow, visible in the chain. The rewrite also surfaces decisions
+// the processor made silently: cancelled orders are now dropped explicitly
+// rather than completing as no-ops, and the sales notification is
+// deliberately fire-and-forget. Imperative steps hide such choices;
+// operations force them into the open, which is part of the point.
 craft()
   .id("sync-orders")
   .from(http("/orders"))


### PR DESCRIPTION
Two-file docs change to the Agent Skills, closing a gap Jaco observed in generated capabilities: agents produce routes shaped `from -> process(everything) -> to(noop())`, with branching, mapping, and even the real send hidden inside one imperative step, which defeats the DSL.

## What changed

**`skills/create-capability/SKILL.md`** gains a section at the head of the authoring rules, "The chain is the logic; `.process()` is the last resort", with a wrong/right example pair (the right example verified against the real `choice(when(...))` API in the tree) and four concrete rules:

- Every behavior that has an operation appears as that operation in the chain: `.filter()` for conditional drops, `.choice()` for branches, `.enrich()` for pull-in, `.tap()` for side effects, `.to()` for the send, `.split()`/`.aggregate()` for fan-out/in. An `if` selecting behavior inside a step body is an escaped `.choice()` or `.filter()`.
- `.to(noop())` is named as a red flag when a step above it performs the real send.
- `.process()` is reserved for the rare step no operation expresses.
- A finishing check: a reader opening only `route.ts` must be able to say what the capability does, to what, under which conditions, and where results go.

Step 1's pipeline question now tells the author that every behavior named there must appear in the chain.

**`skills/create-adapter/SKILL.md`** stops suggesting `.process()` for one-shot transformations; it now points at `.transform()` with a named function and defers to the capability skill's rule.

## Why

The chain is what reviewers, operators, and non-technical readers check, and routes are increasingly written by AI: checking a DSL is cheap, checking imperative logic is not.

No code changes; docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuiwgTH4WMVBgrhyrscdsg)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the route chain the source of truth and documents `.process()` as a last resort, so behavior stays visible in the DSL. The example now explicitly calls out behavior differences surfaced by the rewrite (cancelled orders are dropped; the sales notification is fire-and-forget).

**Doc Changes**
- Adds “The chain is the logic; `.process()` is the last resort” with an anti-pattern (`from -> process(...) -> to(noop())`) and a chain-based rewrite.
- Maps behaviors to operations: `.choice`, `.filter`, `.transform`, `.enrich`, `.tap`, `.to`, `.split`/`.aggregate`, `.validate`/`.input`.
- Flags `.to(noop())` as a red flag when a prior step performs the real send; move the send into `.to(...)` or `.tap(...)`.
- Requires behaviors named during planning to appear in the chain, not inside `.process()`.
- Updates the adapter skill to recommend `.transform()` with a named function for one-shot transformations instead of `.process()`.

**Migration**
- Prefer explicit chain operations over `.process()`; use `.process()` only when no operation fits.
- Move hidden destinations into `.to(...)` and remove `noop()` tails.

<sup>Written for commit 8c59848d2d0cca0f6412073d5efc51dc3f0a1ec8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

