### PR TITLE
chore(ai)!: remove currentTime() and randomUuid() fn factories

### DIFF
--- a/.changeset/remove-currenttime-randomuuid-factories.md
+++ b/.changeset/remove-currenttime-randomuuid-factories.md
@@ -1,0 +1,27 @@
+---
+"@routecraft/ai": minor
+---
+
+**Breaking: `currentTime()` and `randomUuid()` are removed from `@routecraft/ai` (#596).**
+
+Both were fn factories you assigned a tool name in `agentPlugin({ functions })`. Both are gone, with no deprecation cycle: the whole v0 API is unstable, so breaking changes land directly and get declared loudly rather than aged out.
+
+They fail the test every shipped export has to pass. Registering `CurrentTime: currentTime()` costs exactly the same declaration lines as writing the handler inline, so the export saved an import and cost the framework a public symbol to maintain, version and document forever. A clock is three lines of JavaScript. It should be yours, not ours.
+
+**What to write instead.** Declare the fn inline in the same `functions:` block, under the same tool name, and every `tools([...])` reference keeps working unchanged:
+
+```ts
+CurrentTime: {
+  description: "Current date and time in ISO 8601.",
+  input: z.object({}),
+  handler: () => new Date().toISOString(),
+},
+```
+
+The `randomUuid()` replacement is the same shape with `handler: () => crypto.randomUUID()`.
+
+Add `tags: ["read-only", "idempotent"]` (`["read-only"]` for the UUID fn) if you select tools by tag in a `tools((catalog) => ...)` builder, since the removed factories set those tags for you.
+
+**Known external consumer:** eywa registers both today. The migration is the three-line swap above, once per fn, with no change to the agents that reference them.
+
+`directTool(routeId, overrides?)` is unaffected and is now the only fn builder the framework ships.

--- a/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
+++ b/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
@@ -449,9 +449,13 @@ craft()
             <CheatNote>
               Register functions and direct-route tools once via{' '}
               <code>
-                agentPlugin({'{'} functions: {'{'} CurrentTime: {'{'}{' '}
-                description, input, handler {'}'}, greetUser: directTool(
-                {"'"}greet-user{"'"}) {'}'} {'}'})
+                agentPlugin({'{'} functions {'}'})
+              </code>
+              . A fn is an inline object with <code>description</code>,{' '}
+              <code>input</code> and <code>handler</code>; a route-backed tool
+              is{' '}
+              <code>
+                directTool({"'"}greet-user{"'"})
               </code>
               .
             </CheatNote>

--- a/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
+++ b/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
@@ -449,8 +449,9 @@ craft()
             <CheatNote>
               Register functions and direct-route tools once via{' '}
               <code>
-                agentPlugin({'{'} functions: {'{'} CurrentTime: currentTime(),
-                greetUser: directTool({"'"}greet-user{"'"}) {'}'} {'}'})
+                agentPlugin({'{'} functions: {'{'} CurrentTime: {'{'}{' '}
+                description, input, handler {'}'}, greetUser: directTool(
+                {"'"}greet-user{"'"}) {'}'} {'}'})
               </code>
               .
             </CheatNote>

--- a/apps/routecraft.dev/app/content/docs/examples/support-triage/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/examples/support-triage/index.mdx
@@ -82,7 +82,7 @@ export default craft()
 ```
 
 `Direct(<id>)` references a registered capability as a tool; the agent sees its
-`.description()` and `.input()` schema and calls it with validated arguments. `CurrentTime` and
+`.description()` and `.input()` schema and calls it with validated arguments. A bare fn id and
 `MCP(server:tool)` are also valid allowlist entries, and the object form
 `{ name, guard, description }` adds a per-tool [guard](/docs/advanced/securing-capabilities) or
 a per-agent description override. A guard receives the tool input and a context carrying the

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/agentplugin/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/agentplugin/index.mdx
@@ -260,7 +260,7 @@ import { z } from 'zod'
 
 agentPlugin({
   functions: {
-    currentTime: {
+    CurrentTime: {
       description: 'Current UTC timestamp in ISO 8601',
       input: z.object({}),
       handler: async () => new Date().toISOString(),
@@ -320,19 +320,17 @@ const out = await testFn(greet, { name: 'alice' })
 Tags, the `tools([...])` selector, the builder helpers, and the context-level `defaultOptions` bag compose to give an agent a typed, whitelisted set of capabilities.
 
 ```ts
-import {
-  agentPlugin,
-  agent,
-  currentTime,
-  directTool,
-  randomUuid,
-  tools,
-} from '@routecraft/ai'
+import { agentPlugin, agent, directTool, tools } from '@routecraft/ai'
+import { z } from 'zod'
 
 agentPlugin({
   functions: {
-    CurrentTime: currentTime(),                     // built-in (read-only, idempotent)
-    RandomUuid: randomUuid(),                        // built-in (read-only)
+    CurrentTime: {                                  // an inline fn, written in full
+      description: 'Current date and time in ISO 8601.',
+      input: z.object({}),
+      handler: () => new Date().toISOString(),
+      tags: ['read-only', 'idempotent'],
+    },
     sendSlack: { description, input, handler, tags: ['destructive', 'messaging'] },
     fetchOrder: directTool('fetch-order'),          // wraps a direct route as a fn
   },
@@ -452,7 +450,8 @@ Resolution rules:
 | Builder | Use |
 |---|---|
 | `directTool(routeId, overrides?)` | Adapt a registered direct route as a fn. Pulls description, input schema, and tags from the route's discovery bundle by default; `overrides` accepts `description` and `input` to replace either of those (tags pass through unchanged). |
-| `currentTime()` / `randomUuid()` | Built-in fn factories (read-only / idempotent). Assign each a tool name in your `functions:` config, the same way as `directTool`. |
+
+`directTool` is the only fn builder the framework ships. A tool that just wraps a line of JavaScript, such as a clock or a UUID generator, is written inline in `functions:` as shown above: the declaration costs the same as naming a factory, and it stays yours to change.
 
 MCP tools are NOT exposed via a builder. Use the `MCP(server:tool)` / `MCP(server)` grammar (or the raw `mcp__server__tool` form) inside `tools([...])` instead; the registry populated by `defineConfig.mcp` is the source of truth.
 
@@ -708,7 +707,7 @@ For compile-time autocomplete of fn ids in the agent `tools: [...]` field (follo
 // src/types/routecraft.d.ts
 declare module '@routecraft/ai' {
   interface FnRegistry {
-    currentTime: true
+    CurrentTime: true
     sendSlackMessage: true
   }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,12 @@ export default [
       "**/node_modules/**",
       "**/dist/**",
       "coverage/**",
+      // Agent worktrees are nested checkouts of this repository. Linting one
+      // reports every file in it a second time, against a config it did not
+      // come from, and fails the parent repo's gate for changes that are not
+      // the parent's. `.gitignore` does not cover this: flat config does not
+      // read it.
+      ".claude/**",
       ".husky/_/**",
       "bun.lock",
       "**/.next/**",

--- a/packages/ai/src/agent/tools/builders.ts
+++ b/packages/ai/src/agent/tools/builders.ts
@@ -6,11 +6,9 @@ import {
   rcError,
   type Capability,
   type CraftContext,
-  type KnownTag,
   type Principal,
 } from "@routecraft/routecraft";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { randomUUID } from "node:crypto";
 import type {
   FnHandlerContext,
   FnOptions,
@@ -47,60 +45,6 @@ function cloneFrozenPrincipal(rp: ReadonlyPrincipal): Principal {
     out.claims = structuredClone(rp.claims) as Record<string, unknown>;
   return isAuthentic(rp) ? markAuthentic(out) : out;
 }
-
-/**
- * JSON Schema describing an empty object. Closed for additional
- * properties so the LLM can't confuse models that have more fields.
- */
-const EMPTY_OBJECT_JSON_SCHEMA = {
-  type: "object" as const,
-  properties: {},
-  additionalProperties: false,
-};
-
-/**
- * Standard Schema implementation of an empty input object. Used by the
- * built-in fn factories so this module stays free of a Zod runtime dependency
- * (per CLAUDE.md "Use Standard Schema, not Zod/Valibot directly in
- * shared code").
- *
- * Exposes both `~standard.validate` (mandatory per the spec) and the
- * non-standard `~standard.jsonSchema.{input,output}` extension that
- * the Vercel AI SDK bridge consumes, so this hand-rolled schema can
- * back tools and structured-output specs alongside Zod / Valibot
- * schemas without special-casing.
- */
-const emptyObjectSchema: StandardSchemaV1<unknown, Record<string, never>> = {
-  "~standard": {
-    version: 1,
-    vendor: "routecraft",
-    validate(value) {
-      if (
-        value === null ||
-        typeof value !== "object" ||
-        Array.isArray(value) ||
-        Object.keys(value as object).length > 0
-      ) {
-        return {
-          issues: [
-            {
-              message: "Expected an empty object {}.",
-            },
-          ],
-        };
-      }
-      return { value: {} as Record<string, never> };
-    },
-    // Non-standard `jsonSchema` extension consumed by the AI SDK bridge.
-    // Cast away from the strict StandardSchemaV1 shape since the spec
-    // doesn't include this field; library schemas (Zod, Valibot) ship it
-    // as an extension and the bridge looks it up defensively.
-    jsonSchema: {
-      input: () => EMPTY_OBJECT_JSON_SCHEMA,
-      output: () => EMPTY_OBJECT_JSON_SCHEMA,
-    },
-  } as StandardSchemaV1<unknown, Record<string, never>>["~standard"],
-};
 
 /**
  * Per-call overrides accepted by the builder helpers. Lets the caller
@@ -288,48 +232,4 @@ function abortError(routeId: string, reason: unknown): Error {
   );
   err.name = "AbortError";
   return err;
-}
-
-/**
- * Built-in fn factory: returns the current UTC timestamp in ISO 8601
- * format. Takes no configuration. Assign it a tool name in your
- * `agentPlugin({ functions: { ... } })` config, the same way you use
- * `directTool(...)`.
- *
- * @example
- * ```ts
- * agentPlugin({
- *   functions: {
- *     CurrentTime: currentTime(),
- *     fetchOrder: directTool("fetch-order"),
- *   },
- * });
- * ```
- */
-export function currentTime(): FnOptions {
-  return {
-    description: "Returns the current UTC timestamp in ISO 8601 format.",
-    input: emptyObjectSchema,
-    handler: () => new Date().toISOString(),
-    tags: ["read-only", "idempotent"] satisfies KnownTag[],
-  };
-}
-
-/**
- * Built-in fn factory: generates a fresh random UUID v4. Takes no
- * configuration. Assign it a tool name in your
- * `agentPlugin({ functions: { ... } })` config.
- *
- * @example
- * ```ts
- * agentPlugin({ functions: { RandomUuid: randomUuid() } });
- * ```
- */
-export function randomUuid(): FnOptions {
-  return {
-    description: "Generates a fresh random UUID v4.",
-    input: emptyObjectSchema,
-    handler: () => randomUUID(),
-    tags: ["read-only"] satisfies KnownTag[],
-  };
 }

--- a/packages/ai/src/agent/tools/index.ts
+++ b/packages/ai/src/agent/tools/index.ts
@@ -1,9 +1,4 @@
-export {
-  currentTime,
-  directTool,
-  randomUuid,
-  type ToolBuilderOverrides,
-} from "./builders.ts";
+export { directTool, type ToolBuilderOverrides } from "./builders.ts";
 export {
   DEFERRED_FN_BRAND,
   isDeferredFn,

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -271,7 +271,7 @@ export function isToolSelection(value: unknown): value is ToolSelection {
  * ```ts
  * agent({
  *   tools: tools([
- *     "currentTime",
+ *     "CurrentTime",
  *     "fetchOrder",
  *     "Direct(cancel-order)",
  *     "MCP(github:create_issue)",

--- a/packages/ai/src/block/resolve.ts
+++ b/packages/ai/src/block/resolve.ts
@@ -384,8 +384,9 @@ const EMPTY_OBJECT_JSON_SCHEMA = {
 
 /**
  * Standard Schema implementation of an empty input object for loader
- * tools. Mirrors the shape used by `currentTime` / `randomUuid` so the
- * AI SDK bridge's JSON-schema lookup works uniformly.
+ * tools. Exposes the non-standard `~standard.jsonSchema` extension
+ * alongside `validate` so the AI SDK bridge's JSON-schema lookup works
+ * uniformly with library schemas such as Zod and Valibot.
  *
  * @internal
  */

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -167,9 +167,7 @@ export type {
 // the `MCP(server:tool)` / `mcp__server__tool` grammar inside
 // `tools(...)`.
 export {
-  currentTime,
   directTool,
-  randomUuid,
   tools,
   type AgentToolDescriptor,
   type AgentToolPolicy,

--- a/packages/ai/test/agent-bus-events.bun.test.ts
+++ b/packages/ai/test/agent-bus-events.bun.test.ts
@@ -5,12 +5,11 @@ import { z } from "zod";
 import {
   agent,
   agentPlugin,
-  currentTime,
-  randomUuid,
   llmPlugin,
   tools,
   type AgentDelta,
 } from "../src/index.ts";
+import { currentTimeFn, randomUuidFn } from "./helpers/fn-fixtures.ts";
 import type { LlmResult } from "../src/llm/types.ts";
 
 // Mock the LLM dispatcher so the test stays hermetic. The mock
@@ -97,7 +96,7 @@ describe("agent context-bus events", () => {
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
           agentPlugin({
-            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+            functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
           }),
         ],
       })
@@ -486,7 +485,7 @@ describe("agent context-bus events", () => {
       .with({
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
-          agentPlugin({ functions: { CurrentTime: currentTime() } }),
+          agentPlugin({ functions: { CurrentTime: currentTimeFn } }),
         ],
       })
       .routes(
@@ -542,7 +541,7 @@ describe("agent context-bus events", () => {
                 system: "Be concise.",
               },
             },
-            functions: { CurrentTime: currentTime() },
+            functions: { CurrentTime: currentTimeFn },
           }),
         ],
       })

--- a/packages/ai/test/agent-runtime.bun.test.ts
+++ b/packages/ai/test/agent-runtime.bun.test.ts
@@ -5,12 +5,11 @@ import { z } from "zod";
 import {
   agent,
   agentPlugin,
-  currentTime,
-  randomUuid,
   llmPlugin,
   tools,
   type AgentResult,
 } from "../src/index.ts";
+import { currentTimeFn, randomUuidFn } from "./helpers/fn-fixtures.ts";
 import type { LlmResult } from "../src/llm/types.ts";
 
 // Mock the LLM dispatcher so the runtime tests stay hermetic. Each
@@ -87,7 +86,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
           agentPlugin({
-            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+            functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
           }),
         ],
       })
@@ -126,7 +125,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
           agentPlugin({
-            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+            functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
           }),
         ],
       })
@@ -261,7 +260,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
           agentPlugin({
-            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+            functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
             defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
@@ -292,7 +291,7 @@ describe("agent runtime: tool wiring through callLlm", () => {
         plugins: [
           llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
           agentPlugin({
-            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+            functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
             defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],

--- a/packages/ai/test/helpers/fn-fixtures.ts
+++ b/packages/ai/test/helpers/fn-fixtures.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/**
+ * Trivial read-only fns used as registry fixtures by the selection,
+ * defaults, runtime and bus-event suites. Those suites care about how a
+ * registered fn is selected, defaulted, dispatched and reported, not about
+ * what it computes, so they need a fn with a description, an empty input
+ * schema and tags, and nothing more.
+ *
+ * One copy, because the suites assert on these tags and descriptions; a
+ * drifted twin would let a selection regression hide in whichever suite
+ * kept the stale copy.
+ */
+export const currentTimeFn = {
+  description: "Returns the current UTC timestamp in ISO 8601 format.",
+  input: z.object({}),
+  handler: () => new Date().toISOString(),
+  tags: ["read-only", "idempotent"],
+};
+
+/** Companion fixture giving the suites a second read-only fn to select between. */
+export const randomUuidFn = {
+  description: "Generates a fresh random UUID v4.",
+  input: z.object({}),
+  handler: () => crypto.randomUUID(),
+  tags: ["read-only"],
+};

--- a/packages/ai/test/tools-builders.bun.test.ts
+++ b/packages/ai/test/tools-builders.bun.test.ts
@@ -9,15 +9,7 @@ import {
   log,
 } from "@routecraft/routecraft";
 import { testContext, type TestContext } from "@routecraft/testing";
-import {
-  agentPlugin,
-  currentTime,
-  randomUuid,
-  directTool,
-  tools,
-  type FnEntry,
-  type FnOptions,
-} from "../src/index.ts";
+import { agentPlugin, directTool, tools, type FnEntry } from "../src/index.ts";
 import { isDeferredFn } from "../src/agent/tools/types.ts";
 import { ADAPTER_FN_REGISTRY } from "../src/fn/store.ts";
 
@@ -448,51 +440,6 @@ describe("tool builders - directTool dispatch", () => {
     }
     expect(isRoutecraftError(caught)).toBe(true);
     expect((caught as { rc?: string }).rc).toBe("RC5023");
-  });
-});
-
-describe("tool builders - built-in fn factories", () => {
-  /**
-   * @case currentTime() and randomUuid() factories return eager FnOptions
-   * @preconditions Call the factories directly
-   * @expectedResult Both return objects with description / schema / handler / tags
-   */
-  test("currentTime() and randomUuid() return eager fns", () => {
-    expect(currentTime()).toBeDefined();
-    expect(isDeferredFn(currentTime())).toBe(false);
-    const ct = currentTime() as FnOptions;
-    expect(typeof ct.description).toBe("string");
-    expect(typeof ct.handler).toBe("function");
-    expect(ct.tags).toContain("read-only");
-
-    expect(randomUuid()).toBeDefined();
-    const ru = randomUuid() as FnOptions;
-    expect(typeof ru.description).toBe("string");
-    expect(typeof ru.handler).toBe("function");
-  });
-
-  /**
-   * @case CurrentTime handler returns an ISO 8601 timestamp string
-   * @preconditions Call currentTime().handler({}, ctx)
-   * @expectedResult Returns a parseable ISO string within a second of now
-   */
-  test("CurrentTime handler returns a fresh ISO timestamp", async () => {
-    const ct = currentTime() as FnOptions<Record<string, never>, string>;
-    const before = Date.now();
-    const out = await ct.handler(
-      {},
-      {
-        logger: undefined as unknown as Parameters<
-          typeof ct.handler
-        >[1]["logger"],
-        abortSignal: new AbortController().signal,
-        suspend: refuseSuspend,
-      },
-    );
-    const after = Date.now();
-    const parsed = Date.parse(out);
-    expect(parsed).toBeGreaterThanOrEqual(before);
-    expect(parsed).toBeLessThanOrEqual(after);
   });
 });
 

--- a/packages/ai/test/tools-default.bun.test.ts
+++ b/packages/ai/test/tools-default.bun.test.ts
@@ -4,11 +4,10 @@ import { testContext, type TestContext } from "@routecraft/testing";
 import {
   agent,
   agentPlugin,
-  currentTime,
-  randomUuid,
   tools,
   type AgentRegisteredOptions,
 } from "../src/index.ts";
+import { currentTimeFn, randomUuidFn } from "./helpers/fn-fixtures.ts";
 import {
   ADAPTER_AGENT_DEFAULT_OPTIONS,
   ADAPTER_AGENT_REGISTRY,
@@ -32,7 +31,7 @@ describe("agentPlugin defaultOptions storage", () => {
       .with({
         plugins: [
           agentPlugin({
-            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+            functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
             defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
@@ -74,7 +73,7 @@ describe("agentPlugin defaultOptions storage", () => {
       .with({
         plugins: [
           agentPlugin({
-            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+            functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
           }),
         ],
       })
@@ -95,8 +94,8 @@ describe("agentPlugin defaultOptions storage", () => {
           plugins: [
             agentPlugin({
               functions: {
-                CurrentTime: currentTime(),
-                RandomUuid: randomUuid(),
+                CurrentTime: currentTimeFn,
+                RandomUuid: randomUuidFn,
               },
               defaultOptions: { tools: tools(["CurrentTime"]) },
             }),
@@ -144,7 +143,7 @@ describe("agentPlugin defaultOptions storage", () => {
             defaultOptions: { model: "anthropic:claude-opus-4-7" },
           }),
           agentPlugin({
-            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+            functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
             defaultOptions: { tools: tools(["CurrentTime"]) },
           }),
         ],
@@ -214,7 +213,7 @@ describe("agentPlugin per-agent tools field", () => {
       .with({
         plugins: [
           agentPlugin({
-            functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+            functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
             agents: {
               researcher: {
                 description: "Research workflow coordinator.",

--- a/packages/ai/test/tools-selection.bun.test.ts
+++ b/packages/ai/test/tools-selection.bun.test.ts
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { z } from "zod";
 import { craft, direct, isRoutecraftError, log } from "@routecraft/routecraft";
 import { testContext, type TestContext } from "@routecraft/testing";
-import { agentPlugin, currentTime, randomUuid, tools } from "../src/index.ts";
+import { agentPlugin, tools } from "../src/index.ts";
+import { currentTimeFn, randomUuidFn } from "./helpers/fn-fixtures.ts";
 import { isToolSelection } from "../src/agent/tools/selection.ts";
 
 async function buildCtx(opts: {
@@ -47,11 +48,11 @@ describe("tools() resolver - bare references", () => {
   /**
    * @case Bare fn name resolves against the fn registry
    * @preconditions agentPlugin functions includes CurrentTime; resolve tools(["CurrentTime"])
-   * @expectedResult Single ResolvedTool named "CurrentTime" with description and handler from currentTime()
+   * @expectedResult Single ResolvedTool named "CurrentTime" with description and handler from currentTimeFn
    */
   test("bare fn name resolves to a registered fn", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+      functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
     });
     const resolved = tools(["CurrentTime"]).resolve(t.ctx);
     expect(resolved).toHaveLength(1);
@@ -141,7 +142,7 @@ describe("tools() resolver - bare references", () => {
    */
   test("unknown bare name throws RC5003", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+      functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
     });
     let caught: unknown;
     try {
@@ -182,7 +183,7 @@ describe("tools() resolver - { name, guard }", () => {
    */
   test("{ name, guard } attaches the guard", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+      functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
     });
     const guard = mock();
     const [resolved] = tools([{ name: "CurrentTime", guard }]).resolve(t.ctx);
@@ -197,7 +198,7 @@ describe("tools() resolver - { name, guard }", () => {
    */
   test("{ name } rejects empty string", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+      functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
     });
     expect(() => tools([{ name: "" }]).resolve(t!.ctx)).toThrow(/non-empty/i);
   });
@@ -209,7 +210,7 @@ describe("tools() resolver - { name, guard }", () => {
    */
   test("{ name, description } overrides description per binding", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+      functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
     });
     const [resolved] = tools([
       {
@@ -222,7 +223,7 @@ describe("tools() resolver - { name, guard }", () => {
     // Registry entry stays canonical: a second binding without the
     // override sees the original description.
     const [resolved2] = tools(["CurrentTime"]).resolve(t.ctx);
-    expect(resolved2.description).toBe(currentTime().description);
+    expect(resolved2.description).toBe(currentTimeFn.description);
     expect(resolved2.description).not.toBe(resolved.description);
   });
 
@@ -233,7 +234,7 @@ describe("tools() resolver - { name, guard }", () => {
    */
   test("{ name, description } rejects empty string", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+      functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
     });
     expect(() =>
       tools([{ name: "CurrentTime", description: "" }]).resolve(t!.ctx),
@@ -247,7 +248,7 @@ describe("tools() resolver - { name, guard }", () => {
    */
   test("{ name, guard, description } applies both overrides", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+      functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
     });
     const guard = mock();
     const [resolved] = tools([
@@ -276,7 +277,7 @@ describe("tools() resolver - misc", () => {
    */
   test("duplicate explicit refs are deduplicated", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime(), RandomUuid: randomUuid() },
+      functions: { CurrentTime: currentTimeFn, RandomUuid: randomUuidFn },
     });
     const resolved = tools(["CurrentTime", "CurrentTime"]).resolve(t.ctx);
     expect(resolved).toHaveLength(1);
@@ -289,7 +290,7 @@ describe("tools() resolver - misc", () => {
    */
   test("tools() throws on object items lacking name", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime() },
+      functions: { CurrentTime: currentTimeFn },
     });
     expect(() =>
       tools([{ guard: () => undefined } as never]).resolve(t!.ctx),
@@ -312,8 +313,8 @@ describe("tools() resolver - builder form", () => {
   test("builder can filter fns by tag from the catalog", async () => {
     t = await buildCtx({
       functions: {
-        CurrentTime: currentTime(),
-        RandomUuid: randomUuid(),
+        CurrentTime: currentTimeFn,
+        RandomUuid: randomUuidFn,
         wipe: {
           description: "Wipe data.",
           input: z.object({}),
@@ -341,8 +342,8 @@ describe("tools() resolver - builder form", () => {
   test("builder mixes explicit refs with catalog-derived names", async () => {
     t = await buildCtx({
       functions: {
-        CurrentTime: currentTime(),
-        RandomUuid: randomUuid(),
+        CurrentTime: currentTimeFn,
+        RandomUuid: randomUuidFn,
         wipe: {
           description: "Wipe data.",
           input: z.object({}),
@@ -397,7 +398,7 @@ describe("tools() resolver - builder form", () => {
    */
   test("builder errors are wrapped in RC5003", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime() },
+      functions: { CurrentTime: currentTimeFn },
     });
     expect(() =>
       tools(() => {
@@ -413,7 +414,7 @@ describe("tools() resolver - builder form", () => {
    */
   test("builder must return an array", async () => {
     t = await buildCtx({
-      functions: { CurrentTime: currentTime() },
+      functions: { CurrentTime: currentTimeFn },
     });
     expect(() => tools((() => ({})) as never).resolve(t!.ctx)).toThrow(
       /builder must return an array/,


### PR DESCRIPTION
Lane H. Closes #596.

## What goes

`currentTime()` and `randomUuid()`, the two built-in agent fn factories, plus the empty-object Standard Schema they shared. `directTool(routeId, overrides?)` is unaffected and is now the only fn builder the framework ships.

Both fail the test every shipped export has to pass. Registering `CurrentTime: currentTime()` costs exactly the same declaration lines as writing the handler inline, so the export saved an import while costing the framework a public symbol to maintain, version and document forever. A clock is three lines of JavaScript and it should be the author's.

Removal rather than deprecation, because the whole v0 API is unstable: breaking changes land directly and are declared loudly instead of being aged out through a cycle the policy does not run.

## What an author writes instead

Same tool name, same `functions:` block, and every `tools([...])` reference keeps working unchanged:

```ts
CurrentTime: {
  description: "Current date and time in ISO 8601.",
  input: z.object({}),
  handler: () => new Date().toISOString(),
},
```

The changeset carries the same for the UUID fn, and notes that `tags: ["read-only", "idempotent"]` now has to be written explicitly if a `tools((catalog) => ...)` builder selects by tag, since the removed factories set those for you.

## Tests kept rather than deleted

The dedicated factory tests go. The selection, defaults, runtime and bus-event suites keep their coverage against a new inline fixture in `test/helpers/fn-fixtures.ts`, because those tests are about how a registered fn is selected, defaulted, dispatched and reported, not about where the fn came from. Deleting them would have lost real coverage for an unrelated reason.

## Deliberately untouched

- **`apps/routecraft.dev/baseline/`.** Twelve files there mention the factories. It is a captured snapshot of released production pages, read by `compare-baseline.ts` to catch content silently lost in rendering. It is deliberately stale against `main` and no CI job consumes it, so editing it to match would defeat its purpose.
- **`docs/migrating/0.4-to-0.5`.** It records these as added in that release. That is history; the removal is announced in the 0.7.0 migration note instead. This is the only surviving `currentTime()` reference in the tree, by design.
- **`examples/`.** It declares its own `currentTime` fn inline and never imported the factory. Only the name coincided.
- **`agent/plugin.ts` and `fn/types.ts`.** Their examples were already inline declarations rather than factory calls, so they needed no change.

Every other surviving hit for `CurrentTime` is the tool *name*, which was never what was being removed.

## The second commit

`chore(lint): ignore nested agent worktrees`, unrelated to the removal but fixed here because this branch was open and it had just broken two verification runs.

An agent worktree is created at `.claude/worktrees/<id>/`, inside the repository, so eslint walked it as part of the parent tree and reported every file in it a second time against a config it did not come from. `.gitignore` already covers `.claude` and does not help, because flat config does not read `.gitignore`. Verified: `bun run lint` now exits 0 in the parent repo with a nested worktree present, where it previously reported 6340 problems across 58 files, all of them inside the worktree.

## Verification

`bun run all` green at `7267489`: **2918 pass, 1 skip, 0 fail, 197 files**, exit 0.

Two fewer tests than `main`, which is the expected delta: the two dedicated factory tests are gone and nothing else moved.

## Known external consumer

eywa registers both factories today. The migration is the three-line swap above, once per fn, with no change to the agents that reference them.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WuiwgTH4WMVBgrhyrscdsg)_