### PR TITLE
fix(docs): read the catalogue rows the release freeze survives

### DIFF
--- a/apps/routecraft.dev/scripts/generate-raw-docs.ts
+++ b/apps/routecraft.dev/scripts/generate-raw-docs.ts
@@ -310,35 +310,39 @@ function extractBlurb(cleaned: string): string {
   return ''
 }
 
+/** One row of a reference catalogue: the page name and its one-line summary. */
+interface CatalogueEntry {
+  name: string
+  description: string
+}
+
 /**
- * The reference catalogues, rendered as link sections for llms.txt.
+ * Render one reference catalogue as a link section for llms.txt.
  *
  * The leaf pages (28 adapters, 42 operations, 8 plugins) are not in
  * `navigation`, so the NAV_ORDER walk below never reaches them and the index
  * linked only the five catalogue pages. A model then paid two fetches to learn
  * that `http` or `concurrency` exists.
  *
- * The rows come from `app/lib/generated/docs-*.ts`, which
+ * Callers pass rows from `app/lib/generated/docs-*.ts`, which
  * `scripts/generate-docs-catalogue` writes one step earlier in the same
  * `generate` chain. That is the same source the rendered reference tables use,
  * so an entry reaches the site and this index together or neither.
  *
- * Read the generated modules rather than `_data/*.json` directly. The release
+ * Pass the generated modules rather than `_data/*.json` directly. The release
  * freeze replaces `app/content/docs` with a checkout of the released tag, and a
  * tag predating `_data` carries no data files at all; the catalogue generator
  * already resolves that through its `fallbackRows` path, and reading the JSON
- * here would bypass it and crash the release build (it did).
+ * here would bypass it and crash the release build (it did). An empty
+ * catalogue therefore returns an empty string rather than an empty heading,
+ * and the caller filters it out.
  *
- * RELEASED CHANNEL ONLY, hence `latest`. The `next` channel describes API that
- * has not shipped, and llms.txt has no `-next` sibling by design (see the note
- * above the canary bundle), so publishing next's rows would advertise
- * unreleased adapters to every model that lands on the index.
+ * RELEASED CHANNEL ONLY, hence the `latest` rows at every call site. The `next`
+ * channel describes API that has not shipped, and llms.txt has no `-next`
+ * sibling by design (see the note above the canary bundle), so publishing
+ * next's rows would advertise unreleased adapters to every model that lands on
+ * the index.
  */
-interface CatalogueEntry {
-  name: string
-  description: string
-}
-
 function catalogueSection(
   heading: string,
   entries: readonly CatalogueEntry[],

--- a/apps/routecraft.dev/scripts/generate-raw-docs.ts
+++ b/apps/routecraft.dev/scripts/generate-raw-docs.ts
@@ -19,6 +19,9 @@ import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Glob } from 'bun'
 import { cleanMdx } from '../app/lib/clean-mdx'
+import { adaptersByChannel } from '../app/lib/generated/docs-adapters'
+import { operationsByChannel } from '../app/lib/generated/docs-operations'
+import { pluginsByChannel } from '../app/lib/generated/docs-plugins'
 import { navigation } from '../app/lib/navigation'
 import { parseFrontmatter } from '../app/lib/frontmatter'
 
@@ -315,14 +318,21 @@ function extractBlurb(cleaned: string): string {
  * linked only the five catalogue pages. A model then paid two fetches to learn
  * that `http` or `concurrency` exists.
  *
- * The rows come from the same `_data/*.json` that feeds the rendered tables
- * (via `scripts/generate-docs-catalogue` and `app/lib/generated/docs-*.ts`), so
- * an entry added there reaches the site and this index together or neither.
+ * The rows come from `app/lib/generated/docs-*.ts`, which
+ * `scripts/generate-docs-catalogue` writes one step earlier in the same
+ * `generate` chain. That is the same source the rendered reference tables use,
+ * so an entry reaches the site and this index together or neither.
  *
- * RELEASED CHANNEL ONLY. `docs-next/_data` describes API that has not shipped;
- * llms.txt has no `-next` sibling by design (see the note above the canary
- * bundle), so reading the wrong directory would advertise unreleased adapters
- * to every model that lands on the index.
+ * Read the generated modules rather than `_data/*.json` directly. The release
+ * freeze replaces `app/content/docs` with a checkout of the released tag, and a
+ * tag predating `_data` carries no data files at all; the catalogue generator
+ * already resolves that through its `fallbackRows` path, and reading the JSON
+ * here would bypass it and crash the release build (it did).
+ *
+ * RELEASED CHANNEL ONLY, hence `latest`. The `next` channel describes API that
+ * has not shipped, and llms.txt has no `-next` sibling by design (see the note
+ * above the canary bundle), so publishing next's rows would advertise
+ * unreleased adapters to every model that lands on the index.
  */
 interface CatalogueEntry {
   name: string
@@ -331,15 +341,11 @@ interface CatalogueEntry {
 
 function catalogueSection(
   heading: string,
-  file: string,
+  entries: readonly CatalogueEntry[],
   route: string,
   preamble: string,
 ): string {
-  const raw = fs.readFileSync(
-    path.join(ROOT, 'app', 'content', 'docs', '_data', file),
-    'utf8',
-  )
-  const entries = JSON.parse(raw) as CatalogueEntry[]
+  if (entries.length === 0) return ''
   const links = entries.map(
     (e) =>
       `- [${e.name}](${BASE_URL}/raw/docs/reference/${route}/${e.name.toLowerCase()}.md): ${e.description}`,
@@ -372,19 +378,19 @@ const llmsTxt =
     ...llmsSections,
     catalogueSection(
       'Adapters',
-      'adapters.json',
+      adaptersByChannel.latest,
       'adapters',
       'Every connector Routecraft ships. Read this list before writing an integration: the one you need may already exist.',
     ),
     catalogueSection(
       'Operations',
-      'operations.json',
+      operationsByChannel.latest,
       'operations',
       'Every verb in the route DSL. Read this list before reaching for imperative code in a step body: concurrency limits, throttling, retries, caching and branching are operations, not things to hand-roll.',
     ),
     catalogueSection(
       'Plugins',
-      'plugins.json',
+      pluginsByChannel.latest,
       'plugins',
       'Runtime extensions configured once on the context.',
     ),
@@ -393,7 +399,11 @@ const llmsTxt =
       `- [Full Documentation (single file)](${BASE_URL}/llms-full.txt): All documentation concatenated into one markdown file for bulk ingestion`,
       `- [Changelog](${BASE_URL}/raw/changelog.md)`,
     ].join('\n'),
-  ].join('\n\n') + '\n'
+  ]
+    // A catalogue with no rows yields '', which would otherwise join into a
+    // blank gap. A frozen tag predating `_data` is exactly that case.
+    .filter((part) => part !== '')
+    .join('\n\n') + '\n'
 
 const llmsPath = path.join(ROOT, 'public', 'llms.txt')
 fs.writeFileSync(llmsPath, llmsTxt, 'utf8')


### PR DESCRIPTION
Fixes the release build broken by #663. One file: `apps/routecraft.dev/scripts/generate-raw-docs.ts`.

## What broke

#663 added adapter, operation and plugin sections to `llms.txt`, generated from `app/content/docs/_data/*.json`. That path does not survive the release freeze.

`scripts/freeze-docs.ts` replaces `app/content/docs` with a checkout of the released tag, and a tag predating `_data` carries no data files at all. The release build died on `ENOENT`:

```
ENOENT: no such file or directory, open '.../apps/routecraft.dev/app/content/docs/_data/adapters.json'
    at catalogueSection (scripts/generate-raw-docs.ts:338:18)
```

CI never freezes, so it passed on the PR and on main. The freeze only happens in the release job, which is why this got through.

`scripts/generate-docs-catalogue.ts` already documents this case at line 31 ("Releases tagged before `_data` existed freeze a docs tree with no data files at all") and handles it through its `fallbackRows` path. Reading the JSON directly bypassed it.

## The fix

Read `app/lib/generated/docs-*.ts` instead. `generate-docs-catalogue` runs one step earlier in the same `generate` chain, resolves the missing-data case, and writes channel-keyed rows.

Three consequences, all improvements over what #663 did:

- **The fallback is inherited rather than reimplemented.** No second copy of the freeze logic to keep in step.
- **The index and the rendered reference tables now read the same source**, so they cannot disagree.
- **The channel choice is visible at the call site.** `adaptersByChannel.latest` rather than a `'docs'` path segment. Still latest-only for the reason in the comment: `next` describes unshipped API and `llms.txt` has no `-next` sibling by design.

A catalogue with no rows now yields no section rather than an empty one, and the assembly filters empty parts so nothing leaves a blank gap.

## Verification

**Reproduced the failure mode**: emptied the generated rows to stand in for a frozen tag with no `_data`, then regenerated. No crash, the three sections absent, no stray blank lines.

**With rows present the output is unchanged**, 182 lines, byte-identical to what #663 produced.

`bun run all`: exit 0, 2960 pass, 1 skip, 0 fail across 204 files.

## Note

Until this merges, any release attempt fails the same way. If you would rather revert #663 and re-land it whole, say so and I will prepare that instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WuiwgTH4WMVBgrhyrscdsg)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release build crashing when a frozen docs tag predates `_data`; the `llms.txt` catalogue now reads the generated `docs-*.ts` modules instead of the raw JSON.

**Bug Fixes**
- Reading `_data/*.json` directly died with `ENOENT` in release builds, where the freeze replaces `app/content/docs` with a tag checkout that predates `_data`; CI never freezes, so it only surfaced in the release job.
- `generate-docs-catalogue` runs earlier in the same chain and already resolves the missing-data case, so the fallback is inherited rather than reimplemented.
- The index and the rendered reference tables now read the same source, so they cannot disagree.
- A catalogue with no rows yields no section instead of an empty one, and empty parts are filtered out, so a frozen tag produces no blank gaps.
- The channel stays latest-only, now spelled out at the call site via `adaptersByChannel.latest`; publishing `next` would advertise unshipped API.
- Output is byte-identical when rows are present, and any release attempt fails the same way until this merges.

<sup>Written for commit 30cbc58447d65ca503b856737591656f3009994e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

