### PR TITLE
Apply clock tolerance to stream expiry checks

### DIFF
--- a/.changeset/export-timing-safe-string-equal.md
+++ b/.changeset/export-timing-safe-string-equal.md
@@ -1,0 +1,9 @@
+---
+"@routecraft/routecraft": minor
+---
+
+`timingSafeStringEqual` is now exported from the package root.
+
+A custom `validator` is the supported way to admit a request on a shared secret, and it works on every surface that takes one, the MCP server included. Until now nobody outside the package could write that comparison safely: `===` on a secret returns as soon as two bytes differ, and the time it took is a measurement an attacker can repeat to recover the secret a byte at a time. The framework had the constant-time comparison already and kept it to itself.
+
+The documented custom-validator example on `ValidatorAuthOptions` now uses it, so the pattern a reader copies is the safe one.

--- a/.changeset/ops-client-wire-error-code.md
+++ b/.changeset/ops-client-wire-error-code.md
@@ -1,0 +1,7 @@
+---
+"@routecraft/cli": patch
+---
+
+A failed dispatch now shows the framework error code the instance returned.
+
+An error body carrying no `message` was reported only as "The instance answered 500", which made a route that refused the caller's own credential (`RC5038`) indistinguishable from one that crashed. The code belongs to a bounded, documented vocabulary and is safe to show, so it is shown, with a pointer to the reference page that explains it.

--- a/.changeset/settings-blank-values.md
+++ b/.changeset/settings-blank-values.md
@@ -1,0 +1,9 @@
+---
+"@routecraft/cli": patch
+---
+
+A blank flag or environment value no longer counts as supplied when resolving settings.
+
+`--url "$CRAFT_URL"` with the variable unset expands to an empty string, and an exported `CRAFT_URL=` arrives the same way. Both used to win the precedence they never earned and override the settings file with nothing, so the CLI addressed an empty URL, or presented a bearer with nothing after it and reported that the credential was rejected. The value is trimmed rather than merely tested, so one pasted with a trailing newline is not refused with nothing to suggest the whitespace is why.
+
+A blank written into a settings file is unchanged and still refused: that is the one source a blank can only reach by hand, and explaining it is more use than silently falling back.

--- a/.changeset/streaming-expiry-clock-tolerance.md
+++ b/.changeset/streaming-expiry-clock-tolerance.md
@@ -8,6 +8,6 @@ The stream expiry check now applies the clock tolerance that admitted the creden
 
 The resolved tolerance now rides on the admit verdict, beside the principal and the credential it already carried, so anything re-checking that credential inherits the boundary by construction rather than by remembering to pass an argument. Resolving it a second time from config at each consumer would reproduce the same class of bug the moment the two resolutions drifted.
 
-The timer sleeps to the deadline the tolerance moves rather than to `exp`, since waking inside the window would find the credential good and re-arm on the fifty millisecond floor for the rest of it.
+The timer sleeps to the deadline the tolerance moves rather than to `exp`, since waking inside the window would find the credential good and re-arm on the fifty-millisecond floor for the rest of it.
 
 Revoking the stream also no longer depends on the notification succeeding. The signal called `onExpired` and then aborted, so a notifier that threw took the abort with it: on the synchronous arm the throw escaped and the caller got no signal, and on the timer path it was an uncaught exception with the abort never running, leaving the expired credential's stream open. The abort now runs first and a throw from the callback is swallowed.

--- a/.changeset/streaming-expiry-clock-tolerance.md
+++ b/.changeset/streaming-expiry-clock-tolerance.md
@@ -1,0 +1,11 @@
+---
+"@routecraft/routecraft": patch
+---
+
+The stream expiry check now applies the clock tolerance that admitted the credential.
+
+`isPrincipalExpired` documents itself as the single source of the expiry boundary, and the checkpoint that closes a stream when its credential lapses called it without the tolerance the admitting verification had applied. So a client inside the tolerance window looped: admission admitted it, the stream armed, found the credential expired by its own stricter boundary, and closed, and the client reconnected into the same pair of answers.
+
+The resolved tolerance now rides on the admit verdict, beside the principal and the credential it already carried, so anything re-checking that credential inherits the boundary by construction rather than by remembering to pass an argument. Resolving it a second time from config at each consumer would reproduce the same class of bug the moment the two resolutions drifted.
+
+The timer sleeps to the deadline the tolerance moves rather than to `exp`, since waking inside the window would find the credential good and re-arm on the fifty millisecond floor for the rest of it.

--- a/.changeset/streaming-expiry-clock-tolerance.md
+++ b/.changeset/streaming-expiry-clock-tolerance.md
@@ -9,3 +9,5 @@ The stream expiry check now applies the clock tolerance that admitted the creden
 The resolved tolerance now rides on the admit verdict, beside the principal and the credential it already carried, so anything re-checking that credential inherits the boundary by construction rather than by remembering to pass an argument. Resolving it a second time from config at each consumer would reproduce the same class of bug the moment the two resolutions drifted.
 
 The timer sleeps to the deadline the tolerance moves rather than to `exp`, since waking inside the window would find the credential good and re-arm on the fifty millisecond floor for the rest of it.
+
+Revoking the stream also no longer depends on the notification succeeding. The signal called `onExpired` and then aborted, so a notifier that threw took the abort with it: on the synchronous arm the throw escaped and the caller got no signal, and on the timer path it was an uncaught exception with the abort never running, leaving the expired credential's stream open. The abort now runs first and a throw from the callback is swallowed.

--- a/packages/cli/src/ops-client.ts
+++ b/packages/cli/src/ops-client.ts
@@ -175,7 +175,7 @@ export function createOpsClient(settings: ResolvedSettings): OpsClient {
     }
     throw new OpsClientError(
       "error",
-      wire.message ?? `The instance answered ${String(response.status)}.`,
+      wire.message ?? describeWireError(wire, response.status),
       response.status,
       wire,
     );
@@ -322,6 +322,24 @@ function classifyTransportFailure(
     "unreachable",
     `Could not reach a running instance at ${address}: ${messageOf(error)}\nStart one with 'craft start', or point at another instance with --url.`,
   );
+}
+
+/**
+ * Describe an error body that carries no message.
+ *
+ * The framework's error code belongs to a bounded, documented vocabulary and
+ * is safe to show, so it is shown: without it a route that refused the
+ * caller's own credential (`RC5038`) is indistinguishable from one that
+ * crashed, and the operator is told only that the instance answered 500.
+ */
+function describeWireError(wire: WireError, status: number): string {
+  const answered = `The instance answered ${String(status)}`;
+  if (wire.error === undefined && wire.code === undefined)
+    return `${answered}.`;
+  const parts = [wire.error, wire.code].filter(
+    (part): part is string => part !== undefined,
+  );
+  return `${answered}: ${parts.join(" ")}. See https://routecraft.dev/docs/reference/errors for what the code means.`;
 }
 
 /** A non-JSON error body, carried as the reason so it still reaches the reader. */

--- a/packages/cli/src/settings.ts
+++ b/packages/cli/src/settings.ts
@@ -109,6 +109,24 @@ const ENV_FORMAT = "CRAFT_FORMAT";
 export class SettingsError extends Error {}
 
 /**
+ * A blank flag or environment value, read as not supplied.
+ *
+ * `--url "$CRAFT_URL"` with the variable unset, and an exported `CRAFT_URL=`,
+ * both arrive as an empty string; treating one as supplied lets it win the
+ * precedence it never earned and silently override the settings file with
+ * nothing. Trimmed rather than merely tested, so a value pasted with a
+ * trailing newline is not refused as invalid with nothing to suggest the
+ * whitespace is why.
+ *
+ * A blank value written into a settings file is not this: somebody typed it
+ * there, and the refusal is what tells them.
+ */
+export function supplied(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed === undefined || trimmed === "" ? undefined : trimmed;
+}
+
+/**
  * Read one settings file, or `undefined` when it is not there.
  *
  * A missing file is the normal case and says nothing. A file that exists
@@ -177,9 +195,11 @@ export function resolveSettings(
 
   const pick = <K extends keyof CraftSettings>(
     key: K,
-    fromFlag: string | undefined,
-    fromEnv: string | undefined,
+    flag: string | undefined,
+    env: string | undefined,
   ): Resolved<NonNullable<CraftSettings[K]>> | undefined => {
+    const fromFlag = supplied(flag);
+    const fromEnv = supplied(env);
     if (fromFlag !== undefined) {
       return {
         value: fromFlag as NonNullable<CraftSettings[K]>,
@@ -239,6 +259,16 @@ export function resolveSettings(
   if (token !== undefined && typeof token.value !== "string") {
     throw new SettingsError(
       `The token from the ${token.source} must be a string.`,
+    );
+  }
+  // The file half of the blank rule, and the reason it is checked here: a
+  // blank flag or environment value never reaches this point, so a blank
+  // token can only have been written into a file by hand. Left alone it
+  // presents `Bearer` with nothing after it and the operator is told their
+  // credential was rejected.
+  if (token !== undefined && token.value.trim() === "") {
+    throw new SettingsError(
+      `The token from the ${describeSource(token)} is empty. Put a credential there, or remove the key.`,
     );
   }
 

--- a/packages/cli/test/settings.bun.test.ts
+++ b/packages/cli/test/settings.bun.test.ts
@@ -207,6 +207,72 @@ describe("CLI settings resolution", () => {
   });
 
   /**
+   * @case An empty environment variable is not a credential
+   * @preconditions CRAFT_TOKEN exported empty, as an unset variable in a shell profile leaves it, with a token in the project file
+   * @expectedResult The file's token wins. Read as present, the empty value makes the client present a bearer with nothing after it, and the operator is told their credential was rejected when they never supplied one
+   */
+  test("ignores a blank environment value", () => {
+    const root = scratch("token: from_file\n");
+
+    const settings = resolveSettings({
+      home,
+      cwd: root,
+      env: { CRAFT_TOKEN: "" },
+    });
+
+    expect(settings.token?.value).toBe("from_file");
+    expect(settings.token?.source).toBe("project file");
+  });
+
+  /**
+   * @case An empty flag is not a value either
+   * @preconditions --token and --url given as empty strings, which is what `--token "$UNSET"` expands to
+   * @expectedResult Both fall through: no credential at all, and the default address rather than an empty one
+   */
+  test("ignores a blank flag", () => {
+    const root = mkdtempSync(join(tmpdir(), "craft-settings-blank-"));
+    roots.push(root);
+
+    const settings = resolveSettings({
+      home,
+      cwd: root,
+      env: {},
+      token: "",
+      url: "   ",
+    });
+
+    expect(settings.token).toBeUndefined();
+    expect(settings.url.value).toBe(DEFAULT_URL);
+    expect(settings.url.source).toBe("default");
+  });
+
+  /**
+   * @case A blank value written into a file is still an error
+   * @preconditions A settings file carrying `url:` with nothing after it
+   * @expectedResult SettingsError. Somebody typed it and left it, so quietly using the default would hide the mistake rather than explain it, which is the opposite of what the blank-flag rule is for
+   */
+  test("still refuses a blank url in a settings file", () => {
+    const root = scratch("url: ''\n");
+
+    expect(() => resolveSettings({ home, cwd: root, env: {} })).toThrow(
+      SettingsError,
+    );
+  });
+
+  /**
+   * @case A blank token written into a file is refused, not presented
+   * @preconditions A settings file carrying an empty token string
+   * @expectedResult SettingsError. It is the one source a blank can only reach by hand, and presenting it makes the client send a bearer with nothing after it, which is the misdiagnosis this whole rule exists to remove
+   */
+  test("refuses a blank token in a settings file", () => {
+    const root = scratch('token: ""\n');
+
+    expect(() => resolveSettings({ home, cwd: root, env: {} })).toThrow(
+      SettingsError,
+    );
+  });
+
+  /**
    * @case A missing settings file is the normal case and says nothing
    * @preconditions A working directory with no .routecraft directory at all
    * @expectedResult Defaults, with no error: not having a personal settings file is how most invocations run

--- a/packages/routecraft/src/auth/expiry.ts
+++ b/packages/routecraft/src/auth/expiry.ts
@@ -16,9 +16,13 @@ import type { Principal } from "./types.ts";
  * concept (an API key behind a custom validator) is a legitimate result, and
  * requiring `exp` belongs to the verifier layer (section 1), never here.
  *
- * This predicate is the single source of the boundary; `authorize()` (RC5020)
- * and the HTTP bearer middleware both call it so the two checkpoints on the
- * same credential can never disagree by a second.
+ * This predicate is the single source of the boundary. Three checkpoints call
+ * it: `authorize()` (RC5020), the HTTP bearer middleware, and
+ * {@link principalExpirySignal}, which closes a stream when the credential
+ * that admitted it lapses. All three pass the same `clockToleranceSec`, which
+ * is what keeps them from disagreeing by a second on one credential; calling
+ * this predicate while dropping its tolerance argument buys the appearance of
+ * that guarantee without the substance.
  */
 export function isPrincipalExpired(
   principal: Pick<Principal, "expiresAt">,
@@ -58,10 +62,17 @@ const MAX_TIMEOUT_MS = 2_147_483_647;
  * for the life of the stream. Clamped, a distant expiry simply sleeps in
  * stages.
  *
+ * The tolerance is the one the verification that admitted this credential
+ * applied, carried on the admit verdict and passed in here. Without it a
+ * client inside the tolerance window loops: admission admits, the stream arms
+ * and finds the credential expired by its own stricter boundary, closes, and
+ * the client reconnects into the same pair of answers.
+ *
  * @param principal - The admitted principal, or undefined for an
  *   unauthenticated request
- * @param onExpired - Called once when the credential is found to have lapsed,
- *   before the signal aborts, for the surface to report it
+ * @param options.clockToleranceSec - Skew the admitting verification allowed
+ * @param options.onExpired - Called once when the credential is found to have
+ *   lapsed, before the signal aborts, for the surface to report it
  * @returns The signal and a `cancel` to release the timer when the response
  *   ends, or `undefined` when the principal carries no expiry, since a
  *   credential that does not expire granting a stream that does not expire is
@@ -69,20 +80,33 @@ const MAX_TIMEOUT_MS = 2_147_483_647;
  */
 export function principalExpirySignal(
   principal: Pick<Principal, "expiresAt" | "subject"> | undefined,
-  onExpired?: (principal: Pick<Principal, "subject">) => void,
+  options: {
+    /**
+     * Required, like the field on the verdict it comes from: a default of
+     * `0` here is the stricter boundary that closed a stream the door had
+     * just admitted, and an optional field is how a fourth caller reaches
+     * for it without noticing.
+     */
+    clockToleranceSec: number;
+    onExpired?: (principal: Pick<Principal, "subject">) => void;
+  },
 ): { signal: AbortSignal; cancel: () => void } | undefined {
   const expiresAt = principal?.expiresAt;
   if (principal === undefined || expiresAt === undefined) return undefined;
 
+  const { clockToleranceSec } = options;
   const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const arm = (): void => {
-    if (isPrincipalExpired(principal)) {
-      onExpired?.(principal);
+    if (isPrincipalExpired(principal, clockToleranceSec)) {
+      options.onExpired?.(principal);
       controller.abort(new Error("Credential expired"));
       return;
     }
-    const remaining = expiresAt * 1000 - Date.now();
+    // The deadline the tolerance actually moves, not `exp` itself: sleeping
+    // to `exp` inside a tolerance window would wake, find the credential
+    // still good, and re-arm on the 50ms floor for the whole window.
+    const remaining = (expiresAt + clockToleranceSec) * 1000 - Date.now();
     timer = setTimeout(arm, Math.min(Math.max(remaining, 50), MAX_TIMEOUT_MS));
   };
   arm();

--- a/packages/routecraft/src/auth/expiry.ts
+++ b/packages/routecraft/src/auth/expiry.ts
@@ -72,7 +72,8 @@ const MAX_TIMEOUT_MS = 2_147_483_647;
  *   unauthenticated request
  * @param options.clockToleranceSec - Skew the admitting verification allowed
  * @param options.onExpired - Called once when the credential is found to have
- *   lapsed, before the signal aborts, for the surface to report it
+ *   lapsed, for the surface to report it. Runs after the signal aborts, and
+ *   a throw from it is swallowed: revocation does not depend on it
  * @returns The signal and a `cancel` to release the timer when the response
  *   ends, or `undefined` when the principal carries no expiry, since a
  *   credential that does not expire granting a stream that does not expire is
@@ -99,8 +100,19 @@ export function principalExpirySignal(
   let timer: ReturnType<typeof setTimeout> | undefined;
   const arm = (): void => {
     if (isPrincipalExpired(principal, clockToleranceSec)) {
-      options.onExpired?.(principal);
+      // Abort first, and never behind the notification: revoking the stream
+      // is this function's contract and telling someone about it is a
+      // courtesy, so a notifier that throws must not be able to keep an
+      // expired credential's stream open.
       controller.abort(new Error("Credential expired"));
+      try {
+        options.onExpired?.(principal);
+      } catch {
+        // Swallowed rather than rethrown because there is nowhere to report
+        // it: the notifier is the surface's own logger, and on the timer
+        // path a throw here is an uncaught exception that takes the process
+        // down over a log line.
+      }
       return;
     }
     // The deadline the tolerance actually moves, not `exp` itself: sleeping

--- a/packages/routecraft/src/auth/timing-safe.ts
+++ b/packages/routecraft/src/auth/timing-safe.ts
@@ -1,18 +1,21 @@
 import { timingSafeEqual } from "node:crypto";
 
 /**
- * Constant-time equality for two signature/digest strings.
+ * Constant-time equality for a secret and a candidate presented by a caller.
+ *
+ * Reach for this wherever a request is admitted by comparing something it
+ * carried against something the process knows: a shared secret behind a
+ * custom `validator`, a signature, a digest. `===` on those returns as soon
+ * as two bytes differ, and the time it took is a measurement an attacker can
+ * repeat to recover the secret one byte at a time.
  *
  * Wraps `timingSafeEqual` with the explicit length guard it requires: a
  * length mismatch is an ordinary rejection, not an exception. Length itself
  * is not treated as secret; digest lengths are fixed per algorithm, so a
  * mismatch only reveals that the candidate is malformed.
  *
- * Shared by the JWT HMAC validator, the webhook-signature verifier, and the
- * resume-token signer so the security-critical comparison exists exactly
- * once.
- *
- * @internal
+ * @param expected - The value the process knows
+ * @param candidate - The value the caller presented
  */
 export function timingSafeStringEqual(
   expected: string,

--- a/packages/routecraft/src/auth/types.ts
+++ b/packages/routecraft/src/auth/types.ts
@@ -236,6 +236,18 @@ export type OAuthTokenVerifier = (
  *     return { kind: "custom", scheme: "bearer", subject: user.id };
  *   }
  * }
+ *
+ * // A single shared secret. Compare it in constant time: `===` returns as
+ * // soon as two bytes differ, and that timing is measurable.
+ * import { timingSafeStringEqual } from "@routecraft/routecraft";
+ * auth: {
+ *   validator: (token) => {
+ *     if (!timingSafeStringEqual(process.env.OPS_SECRET!, token)) {
+ *       throw new Error("unknown token");
+ *     }
+ *     return { kind: "custom", scheme: "bearer", subject: "ops" };
+ *   }
+ * }
  * ```
  */
 export interface ValidatorAuthOptions {

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -24,6 +24,7 @@ export {
 } from "./auth/error-classification.ts";
 export { isPrincipalExpired } from "./auth/expiry.ts";
 export { isRestored, markRestored } from "./auth/restored.ts";
+export { timingSafeStringEqual } from "./auth/timing-safe.ts";
 export type {
   ActorMatcher,
   ClaimMappers,

--- a/packages/routecraft/src/plugins/http/auth.ts
+++ b/packages/routecraft/src/plugins/http/auth.ts
@@ -38,6 +38,15 @@ export type AuthResult =
        * in an error, or persist it outside the request lifetime.
        */
       credential: string;
+      /**
+       * Clock skew the verification that admitted this credential allowed.
+       *
+       * Carried on the verdict rather than re-derived from config by each
+       * consumer, because anything re-checking the same credential later (a
+       * stream that outlives its admission) must apply the same boundary.
+       * Two resolutions of one setting can drift; an inherited value cannot.
+       */
+      clockToleranceSec: number;
     }
   | { kind: "absent"; scheme: string }
   | {
@@ -287,6 +296,9 @@ export function createAuthMiddleware(
           kind: "admit",
           principal: markAuthentic(syntheticApiKeyPrincipal(raw, auth.scopes)),
           credential: raw,
+          // An api key is compared, never dated: this path applies no
+          // tolerance, so anything inheriting the verdict applies none either.
+          clockToleranceSec: 0,
         };
       }
       try {
@@ -298,6 +310,7 @@ export function createAuthMiddleware(
           kind: "admit",
           principal: markAuthentic(principal),
           credential: raw,
+          clockToleranceSec: 0,
         };
       } catch {
         return reject("invalid api key", "apiKey");
@@ -345,6 +358,7 @@ export function createAuthMiddleware(
           kind: "admit",
           principal: markAuthentic(principal),
           credential: token,
+          clockToleranceSec,
         };
       } catch (error) {
         return reject(classifyRejectionReason(error), "bearer", error);

--- a/packages/routecraft/src/plugins/http/dispatcher.ts
+++ b/packages/routecraft/src/plugins/http/dispatcher.ts
@@ -248,6 +248,10 @@ export function createDispatcher(
     //    route that declares `.authorize()` (`requiresPrincipal`), which
     //    can only make itself stricter, never looser.
     let principal: Principal | undefined;
+    // Kept beside the principal rather than re-read from config later: the
+    // stream expiry check below re-examines this very credential, and the
+    // boundary it applies has to be the one that admitted it.
+    let clockToleranceSec = 0;
     if (opts.walled || entry.requiresPrincipal) {
       const result = await resolveAuth();
       if (!result) {
@@ -277,6 +281,7 @@ export function createDispatcher(
         return response;
       } else {
         principal = result.principal;
+        clockToleranceSec = result.clockToleranceSec;
       }
     }
 
@@ -401,11 +406,14 @@ export function createDispatcher(
         // already exists. A principal with no `expiresAt` is left alone,
         // because a credential with no expiry granting an unexpiring stream
         // is the operator's choice honoured rather than a gap.
-        const expiry = principalExpirySignal(principal, ({ subject }) => {
-          log.info(
-            { subject, routeId: entry.routeId, path: pathname },
-            "http source: closing stream, the admitted credential has expired",
-          );
+        const expiry = principalExpirySignal(principal, {
+          clockToleranceSec,
+          onExpired: ({ subject }) => {
+            log.info(
+              { subject, routeId: entry.routeId, path: pathname },
+              "http source: closing stream, the admitted credential has expired",
+            );
+          },
         });
         const body = streamResponseBody(plan.body, {
           signal: anySignal(req.signal, opts.shutdownSignal, expiry?.signal),

--- a/packages/routecraft/src/plugins/ops/mount.ts
+++ b/packages/routecraft/src/plugins/ops/mount.ts
@@ -203,7 +203,9 @@ export function createManagementHandler(
       // No event and no wire message: the close IS the signal, and inventing
       // an auth:rejected reason for it would put a value outside the bounded
       // vocabulary onto a surface an operator counts refusals from.
-      const expiry = principalExpirySignal(verdict.principal);
+      const expiry = principalExpirySignal(verdict.principal, {
+        clockToleranceSec: verdict.clockToleranceSec,
+      });
       const closes = anySignal(req.signal, expiry?.signal);
       return sseResponse(tailEvents(api, closes), closes, () => {
         expiry?.cancel();

--- a/packages/routecraft/src/plugins/ops/tier.ts
+++ b/packages/routecraft/src/plugins/ops/tier.ts
@@ -23,7 +23,22 @@ import type { OpsTier, OpsTiers } from "./types";
  */
 export type TierVerdict =
   | { kind: "disabled" }
-  | { kind: "admit"; principal?: Principal }
+  | {
+      kind: "admit";
+      principal?: Principal;
+      /**
+       * Clock skew the verification that admitted this caller allowed,
+       * carried through so a tail re-checking the same credential applies
+       * the boundary that let it in rather than a stricter one of its own.
+       *
+       * Required, like the field it comes from: an optional one would be a
+       * re-derivation with nicer syntax, and the value a consumer would
+       * reach for is `?? 0`, which is exactly the stricter boundary that
+       * closed a stream the door had just admitted. A verdict with no
+       * principal carries `0` honestly, because no credential was checked.
+       */
+      clockToleranceSec: number;
+    }
   | { kind: "unauthenticated"; scheme: string }
   | { kind: "rejected"; response: Response }
   | { kind: "insufficient"; missing: string; scheme: string };
@@ -49,11 +64,17 @@ export async function admitToTier(
   if (tier === undefined || tier === false) return { kind: "disabled" };
 
   if (tier === true) {
-    if (!context.auth.configured) return { kind: "admit" };
+    if (!context.auth.configured) {
+      return { kind: "admit", clockToleranceSec: 0 };
+    }
     const result = await context.authenticate();
     return result?.kind === "admit"
-      ? { kind: "admit", principal: result.principal }
-      : { kind: "admit" };
+      ? {
+          kind: "admit",
+          principal: result.principal,
+          clockToleranceSec: result.clockToleranceSec,
+        }
+      : { kind: "admit", clockToleranceSec: 0 };
   }
 
   const result = await context.authenticate();
@@ -79,7 +100,11 @@ export async function admitToTier(
       scheme: result.principal.scheme,
     };
   }
-  return { kind: "admit", principal: result.principal };
+  return {
+    kind: "admit",
+    principal: result.principal,
+    clockToleranceSec: result.clockToleranceSec,
+  };
 }
 
 /** Whether any tier is scope-gated, and so actually enforces a wall. */

--- a/packages/routecraft/test/auth/expiry.bun.test.ts
+++ b/packages/routecraft/test/auth/expiry.bun.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isPrincipalExpired,
+  principalExpirySignal,
+} from "../../src/auth/expiry.ts";
+
+/**
+ * The expiry boundary and the signal that closes a stream on it.
+ *
+ * The property under test is agreement: three checkpoints look at one
+ * credential, and a checkpoint that applies a stricter boundary than the one
+ * that admitted the credential produces a loop rather than a refusal, since
+ * the client reconnects, is admitted again, and is closed again.
+ */
+
+/** A principal whose credential lapsed `secondsAgo` seconds ago. */
+function lapsed(secondsAgo: number): { expiresAt: number; subject: string } {
+  return {
+    expiresAt: Math.floor(Date.now() / 1000) - secondsAgo,
+    subject: "operator",
+  };
+}
+
+/** Let the event loop run the timer callbacks that are already due. */
+function settle(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("principalExpirySignal", () => {
+  /**
+   * @case A credential inside the admitting tolerance is left alone
+   * @preconditions A principal five seconds past exp, armed with the sixty second tolerance that admitted it
+   * @expectedResult The signal is not aborted, because the checkpoint that closes a stream must apply the boundary that opened it
+   */
+  test("honours the tolerance that admitted the credential", () => {
+    const expiry = principalExpirySignal(lapsed(5), { clockToleranceSec: 60 });
+
+    expect(expiry?.signal.aborted).toBe(false);
+    expiry?.cancel();
+  });
+
+  /**
+   * @case The same credential without a tolerance closes at once
+   * @preconditions The same principal, armed with no tolerance
+   * @expectedResult Aborted on arm. This is the disagreement the tolerance exists to remove, asserted directly so the pair reads as one fact
+   */
+  test("closes the same credential when no tolerance is given", () => {
+    const expiry = principalExpirySignal(lapsed(5), { clockToleranceSec: 0 });
+
+    expect(expiry?.signal.aborted).toBe(true);
+  });
+
+  /**
+   * @case The timer wakes on the deadline the tolerance moved, not on exp
+   * @preconditions A principal exactly at exp, armed with a tolerance of one second
+   * @expectedResult Open immediately and closed once the window passes. Sleeping to `exp` would wake inside the window, find the credential good, and re-arm on the fifty millisecond floor for the rest of it
+   */
+  test("closes once the tolerance window itself passes", async () => {
+    const expiry = principalExpirySignal(lapsed(0), { clockToleranceSec: 1 });
+    expect(expiry?.signal.aborted).toBe(false);
+
+    await settle(1_300);
+
+    expect(expiry?.signal.aborted).toBe(true);
+    expiry?.cancel();
+  });
+
+  /**
+   * @case The surface is told before the signal aborts
+   * @preconditions An already lapsed principal with an onExpired callback
+   * @expectedResult The callback receives the subject, so a surface can log which credential closed its stream without reaching for the credential itself
+   */
+  test("reports the subject before aborting", () => {
+    const seen: string[] = [];
+
+    const expiry = principalExpirySignal(lapsed(10), {
+      clockToleranceSec: 0,
+      onExpired: ({ subject }) => seen.push(subject),
+    });
+
+    expect(seen).toEqual(["operator"]);
+    expect(expiry?.signal.aborted).toBe(true);
+  });
+
+  /**
+   * @case A credential with no expiry gets no signal at all
+   * @preconditions A principal carrying no expiresAt, and no principal at all
+   * @expectedResult Undefined in both cases: a credential that does not expire granting a stream that does not expire is the operator's choice honoured, not a gap
+   */
+  test("returns nothing to arm when there is no expiry", () => {
+    expect(
+      principalExpirySignal({ subject: "operator" }, { clockToleranceSec: 0 }),
+    ).toBeUndefined();
+    expect(
+      principalExpirySignal(undefined, { clockToleranceSec: 0 }),
+    ).toBeUndefined();
+  });
+
+  /**
+   * @case The predicate and the signal agree on the same inputs
+   * @preconditions One principal and one tolerance, put to both the predicate and the signal
+   * @expectedResult The signal's armed state matches the predicate's answer at each of the three positions around the boundary, which is what "single source of the boundary" has to mean in practice
+   */
+  test("arms exactly when the predicate says expired", () => {
+    for (const [secondsAgo, tolerance] of [
+      [5, 60],
+      [5, 0],
+      [120, 60],
+    ] as const) {
+      const principal = lapsed(secondsAgo);
+      const expiry = principalExpirySignal(principal, {
+        clockToleranceSec: tolerance,
+      });
+
+      expect(expiry?.signal.aborted).toBe(
+        isPrincipalExpired(principal, tolerance),
+      );
+      expiry?.cancel();
+    }
+  });
+});

--- a/packages/routecraft/test/auth/expiry.bun.test.ts
+++ b/packages/routecraft/test/auth/expiry.bun.test.ts
@@ -67,11 +67,11 @@ describe("principalExpirySignal", () => {
   });
 
   /**
-   * @case The surface is told before the signal aborts
+   * @case The surface is told which credential closed its stream
    * @preconditions An already lapsed principal with an onExpired callback
    * @expectedResult The callback receives the subject, so a surface can log which credential closed its stream without reaching for the credential itself
    */
-  test("reports the subject before aborting", () => {
+  test("reports the subject to the surface", () => {
     const seen: string[] = [];
 
     const expiry = principalExpirySignal(lapsed(10), {
@@ -80,6 +80,26 @@ describe("principalExpirySignal", () => {
     });
 
     expect(seen).toEqual(["operator"]);
+    expect(expiry?.signal.aborted).toBe(true);
+  });
+
+  /**
+   * @case The notifier throws
+   * @preconditions An already lapsed principal whose onExpired callback throws, as a surface's own logger can
+   * @expectedResult The signal still aborts and nothing escapes. Revoking the stream is the contract and the notification is a courtesy, so ordering the abort behind it made an expired credential's stream survive a bad log line, and on the timer path an uncaught exception took the process with it
+   */
+  test("revokes even when the notifier throws", () => {
+    let called = false;
+
+    const expiry = principalExpirySignal(lapsed(10), {
+      clockToleranceSec: 0,
+      onExpired: () => {
+        called = true;
+        throw new Error("the surface's logger failed");
+      },
+    });
+
+    expect(called).toBe(true);
     expect(expiry?.signal.aborted).toBe(true);
   });
 

--- a/packages/routecraft/test/auth/timing-safe.bun.test.ts
+++ b/packages/routecraft/test/auth/timing-safe.bun.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { timingSafeStringEqual } from "../../src/index.ts";
+
+describe("timingSafeStringEqual", () => {
+  /**
+   * @case The secret and the presented candidate are identical
+   * @preconditions Two equal strings
+   * @expectedResult True. The helper is a comparison first; the constant-time property is worthless if it does not admit the right credential
+   */
+  test("admits an identical candidate", () => {
+    expect(timingSafeStringEqual("s3cret-value", "s3cret-value")).toBe(true);
+  });
+
+  /**
+   * @case The candidate differs at the first byte
+   * @preconditions Two strings of equal length differing from the start
+   * @expectedResult False, and by the same path a candidate differing at the last byte takes, which is the whole point of the helper
+   */
+  test("refuses a candidate of the same length", () => {
+    expect(timingSafeStringEqual("s3cret-value", "X3cret-value")).toBe(false);
+    expect(timingSafeStringEqual("s3cret-value", "s3cret-valuX")).toBe(false);
+  });
+
+  /**
+   * @case The candidate is a different length from the secret
+   * @preconditions A candidate longer, shorter, and empty against the same secret
+   * @expectedResult False rather than a thrown error. `timingSafeEqual` rejects unequal buffer lengths by throwing, and a caller comparing a caller-supplied value must get an ordinary rejection instead
+   */
+  test("refuses a candidate of a different length without throwing", () => {
+    expect(timingSafeStringEqual("s3cret-value", "s3cret-value-longer")).toBe(
+      false,
+    );
+    expect(timingSafeStringEqual("s3cret-value", "s3cret")).toBe(false);
+    expect(timingSafeStringEqual("s3cret-value", "")).toBe(false);
+  });
+
+  /**
+   * @case Multi-byte characters compare by bytes, not by code units
+   * @preconditions Two strings whose UTF-8 encodings differ but whose lengths in code units match
+   * @expectedResult False. The comparison runs over the encoded buffers, so a secret carrying non-ASCII is compared as it is transmitted
+   */
+  test("compares the encoded bytes", () => {
+    expect(timingSafeStringEqual("café", "cafe")).toBe(false);
+    expect(timingSafeStringEqual("café", "café")).toBe(true);
+  });
+});

--- a/packages/routecraft/test/ops-events.bun.test.ts
+++ b/packages/routecraft/test/ops-events.bun.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   bootServer,
   readUntilClosed,
+  signHs256,
   testContext,
   type TestContext,
 } from "@routecraft/testing";
@@ -10,6 +11,7 @@ import {
   apiKey,
   craft,
   direct,
+  jwt,
   noop,
   opsPlugin,
   type HttpAuth,
@@ -274,6 +276,38 @@ describe("the ops event tail", () => {
     expect(res.status).toBe(200);
 
     expect(await readUntilClosed(res)).toBe(true);
+  });
+
+  /**
+   * @case A credential inside the admitting clock tolerance keeps its tail open
+   * @preconditions A validator allowing 60 seconds of skew, admitting a token whose exp passed five seconds ago; the events tier gated on the scope that token carries
+   * @expectedResult The tail is still open after the arm, because the stream applies the boundary that admitted the credential. Applying a stricter one would close every stream a client inside the window opens, and the client would reconnect into the same pair of answers
+   */
+  test("does not close a credential the door admitted within its tolerance", async () => {
+    const secret = "ops-events-tolerance-secret-please-change-me";
+    const port = await start({
+      auth: jwt({
+        secret,
+        issuer: "https://idp.test",
+        audience: "https://api.test",
+        clockToleranceSec: 60,
+      }),
+      tiers: { events: "ops:events" },
+    });
+    const token = signHs256({
+      secret,
+      claims: {
+        scope: "ops:events",
+        exp: Math.floor(Date.now() / 1000) - 5,
+      },
+    });
+
+    const res = await fetch(`http://127.0.0.1:${port}/ops/events`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await readUntilClosed(res, 500)).toBe(false);
   });
 
   /**


### PR DESCRIPTION
## Summary

Fixes a loop where clients inside the clock tolerance window would repeatedly reconnect. The stream expiry check now applies the same clock tolerance that admitted the credential, rather than a stricter boundary of its own.

## Key Changes

- **Stream expiry alignment**: `principalExpirySignal()` now accepts `clockToleranceSec` in an options object and applies it when checking expiry, matching the boundary that admitted the credential
- **Verdict carries tolerance**: `TierVerdict` and `AuthResult` now include `clockToleranceSec` so consumers inherit the admitting boundary by construction rather than re-deriving it from config
- **Timer deadline adjustment**: The expiry timer now sleeps to `(expiresAt + clockToleranceSec) * 1000` instead of `expiresAt * 1000`, so it wakes after the tolerance window closes, not inside it
- **Settings blank-value handling**: Empty flags and environment variables no longer override settings files; a blank written into a file is still rejected as an error
- **Export `timingSafeStringEqual`**: Now exported from package root for use in custom validators, with updated documentation and examples
- **Error reporting**: Failed ops dispatches now show the framework error code when no message is present, making credential rejections distinguishable from crashes
- **Test coverage**: Added comprehensive tests for expiry signal behavior, timing-safe comparison, and blank settings values

## Implementation Details

The core issue was that `isPrincipalExpired()` is documented as the single source of the expiry boundary, but three checkpoints call it: `authorize()`, the HTTP bearer middleware, and the stream expiry signal. Without the tolerance on the signal, a client admitted within the window would be immediately closed by the stream, causing a reconnect loop.

The fix threads `clockToleranceSec` through the verdict types so it travels with the principal and credential it already carried. This ensures any re-check of the same credential applies the same boundary by inheritance rather than by remembering to pass an argument—eliminating the class of bug where two resolutions of one setting drift.

The timer adjustment prevents it from waking inside the tolerance window and re-arming on the 50ms floor for the remainder of it.

https://claude.ai/code/session_0188Lm7JdQn6CnUutaPJxbLE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the reconnect loop for clients inside the clock tolerance window: the stream expiry check now applies the same tolerance that admitted the credential, and the expiry timer wakes after the window closes instead of inside it.

**Stream expiry**

- `principalExpirySignal()` now requires `clockToleranceSec` and applies it to both the expiry check and the timer deadline.
- `TierVerdict` and `AuthResult` carry `clockToleranceSec`, so any re-check of the same credential inherits the admitting boundary instead of re-deriving it.
- The stream aborts before the expiry notifier runs, and a throw from the notifier is swallowed, so a bad log line can't keep an expired credential's stream open.

**Other fixes**

- Empty flags and environment variables no longer count as supplied, so they can't override a settings file with nothing; blank values written into a settings file are still refused.
- Failed ops dispatches now show the framework error code when the body has no message, distinguishing a credential rejection from a crash.
- `timingSafeStringEqual` is now exported from the package root so custom validators can compare shared secrets in constant time.

<sup>Written for commit 891ebee9f5ef0e2ffb5de78b8af621a67374090b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

