### PR TITLE
fix(testing): an exchange that fails is not a route that failed to start

### DIFF
--- a/.changeset/testing-exchange-failure-not-start-failure.md
+++ b/.changeset/testing-exchange-failure-not-start-failure.md
@@ -1,0 +1,13 @@
+---
+"@routecraft/testing": patch
+---
+
+`startAndWaitReady()` no longer rejects when a startup exchange fails while another source is still coming up.
+
+`awaitRoutesReady` rejected on any `context:error`, which treated two different things as one: a route or plugin that failed to START, and an exchange that failed while RUNNING. The distinction was already in the payload, since the pipeline attaches the exchange it was executing and every start-path emitter leaves it undefined, so the guard now settles only on the bare form.
+
+The conflation made a whole shape of route untestable. A route with a startup-firing source (`simple()` alongside a `cron()`, the usual way to run a scheduled probe once at boot) emits its first exchange immediately, while a sibling source that readies behind a lazy driver import does not. `route:started` waits for every source, so a failing startup exchange lands first, and the caller got a rejection out of `startAndWaitReady()` rather than a started context. The failure was in `errors` the whole time; a test asserting on it never reached the assertion.
+
+It also read as a flake rather than as this. Which side won depended on whether the sibling's driver import was already warm, so the same test passed alone, passed in one file order, and failed in another.
+
+A route or plugin that genuinely fails to start still rejects, and still fails fast rather than timing out with no cause named.

--- a/.standards/testing.md
+++ b/.standards/testing.md
@@ -155,6 +155,10 @@ Rules:
 - Always assign to a single `let t` declared in the `describe` scope; the `afterEach` then handles teardown unconditionally.
 - Always `await t.stop()`; not awaiting leaks timers, http servers, and background tasks across tests.
 - Prefer `t.test()` over `t.startAndWaitReady()` when you want the routes to actually run. Use `startAndWaitReady` for tests that drive interaction through direct endpoints or that assert on plugin-init side effects.
+- `startAndWaitReady()` rejects when a route or plugin fails to START, and not when an
+  exchange fails while running. A route with a startup-firing source can emit a failing
+  exchange before `route:started`, which waits on every source; that failure lands in
+  `t.errors` and is asserted on there, exactly as it would be after `t.test()`.
 
 ## 6. Asserting on `RoutecraftError`
 

--- a/packages/testing/src/test-context.ts
+++ b/packages/testing/src/test-context.ts
@@ -231,6 +231,22 @@ export class TestContext {
       }) as unknown as EventHandler<EventName>);
       const offError = ctx.on("context:error", (payload) => {
         if (settled) return;
+        // An exchange that failed is not a route that failed to start, and
+        // the payload already separates them: the pipeline attaches the
+        // exchange it was running, while every start-path emitter (plugin
+        // construction, plugin start(), route start, context start) leaves
+        // it undefined. Only the bare form settles this promise.
+        //
+        // Rejecting on both made a whole shape of route untestable. A route
+        // with a startup-firing source whose exchange can legitimately fail
+        // emits that failure while a slower sibling source is still coming
+        // up, so it lands BEFORE `route:started`, and the caller got a
+        // rejection out of `startAndWaitReady()` instead of a started
+        // context. The failure was already collected in `errors`, so a test
+        // asserting on it never reached the assertion. Which side of the
+        // race won depended on whether the sibling's driver import was
+        // warm, so it read as an intermittent failure rather than as this.
+        if (payload.details.exchange !== undefined) return;
         cleanup();
         reject(payload.details.error);
       });

--- a/packages/testing/test/test-context-readiness.bun.test.ts
+++ b/packages/testing/test/test-context-readiness.bun.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  craft,
+  noop,
+  simple,
+  type Source,
+  type Subscription,
+} from "@routecraft/routecraft";
+import { testContext, type TestContext } from "@routecraft/testing";
+
+/**
+ * The smallest Standard Schema that accepts anything, so a multi-source route
+ * can declare the shared input contract `.from()` requires without this
+ * package taking on a validation library for two tests.
+ */
+const anything = {
+  "~standard": {
+    version: 1 as const,
+    vendor: "routecraft-testing",
+    validate: (value: unknown) => ({ value }),
+  },
+};
+
+/**
+ * A source that never signals readiness on its own, standing in for one whose
+ * driver import has not resolved yet (the cron adapter readies only once
+ * `croner` loads). A route pairing this with `simple` reports started only
+ * once this one is released, which is the window every case below exercises.
+ */
+class LateSource implements Source<unknown> {
+  readonly adapterId = "test.adapter.late";
+  private release?: () => void;
+
+  async subscribe(sub: Subscription<unknown>): Promise<void> {
+    await new Promise<void>((resolve) => {
+      this.release = () => {
+        sub.ready();
+        resolve();
+      };
+    });
+  }
+
+  /** Signals readiness, as the real driver import resolving would. */
+  ready(): void {
+    this.release?.();
+  }
+}
+
+let t: TestContext;
+
+afterEach(async () => {
+  await t?.stop();
+});
+
+describe("startAndWaitReady and context:error", () => {
+  /**
+   * @case A startup exchange fails while a sibling source is still coming up
+   * @preconditions A route with two sources, one firing immediately into a
+   *   step that throws and one that has not signalled readiness yet, so the
+   *   pipeline failure lands before `route:started`
+   * @expectedResult The start resolves once the late source readies, and the
+   *   failure is collected in `errors`. Rejecting here would make any route
+   *   with a startup-firing source untestable the moment one of its
+   *   exchanges could legitimately fail, and the caller would never reach
+   *   the assertion that the failure is what it wanted to check.
+   */
+  test("does not reject when an exchange fails before the route starts", async () => {
+    const late = new LateSource();
+    const route = craft()
+      .id("fails-at-startup")
+      .input({ body: anything })
+      .from(simple.value({}), late)
+      .transform(() => {
+        throw new Error("the credential is missing");
+      })
+      .to(noop());
+
+    t = await testContext({ routesReadyTimeout: "5s" }).routes([route]).build();
+    const ready = t.startAndWaitReady();
+    // Released after the failing exchange has had the event loop, which is
+    // the ordering that made this intermittent: whichever of the two got
+    // there first decided whether the test saw a rejection.
+    setTimeout(() => late.ready(), 50);
+    await ready;
+    await t.drain();
+
+    expect(String(t.errors)).toContain("the credential is missing");
+  });
+
+  /**
+   * @case A plugin that throws from its start hook
+   * @preconditions The same shape of failure, minus an exchange, which is
+   *   what the payload uses to tell the two apart
+   * @expectedResult Still rejects. The narrowing above must not cost the
+   *   guard its actual job, which is failing fast on a context that will
+   *   never serve rather than timing out with no cause named.
+   */
+  test("still rejects when a plugin fails to start", async () => {
+    const route = craft().id("healthy").from(simple.value({})).to(noop());
+    const exploding = {
+      apply: () => {},
+      start: () => {
+        throw new Error("plugin start blew up");
+      },
+    };
+
+    // Held locally rather than on the shared `t`: `stop()` re-awaits the
+    // start promise, so the teardown would rethrow this same failure.
+    const failing = await testContext({ routesReadyTimeout: "5s" })
+      .with({ plugins: [exploding] })
+      .routes([route])
+      .build();
+
+    await expect(failing.startAndWaitReady()).rejects.toThrow(
+      "plugin start blew up",
+    );
+    await failing.stop().catch(() => {});
+  });
+});


### PR DESCRIPTION
## Summary

`awaitRoutesReady` rejected on any `context:error`, which collapsed two different things into one: a route or plugin that failed to **start**, and an exchange that failed while **running**.

The distinction was already in the payload. The pipeline attaches the exchange it was executing, and every start-path emitter leaves it undefined, so the guard now settles only on the bare form:

```ts
if (payload.details.exchange !== undefined) return;
```

## Why it matters

The conflation made a whole shape of route untestable. A route with a startup-firing source (`simple()` alongside a `cron()`, which is the usual way to run a scheduled probe once at boot) emits its first exchange immediately, while a sibling source that readies behind a lazy driver import does not. `route:started` waits for every source, so the failing startup exchange lands first and the caller got a rejection out of `startAndWaitReady()` rather than a started context. The failure was sitting in `errors` the whole time; a test asserting on it never reached its assertion.

It also read as a flake rather than as this. Which side won depended on whether the sibling's driver import was already warm, so the same test passed alone, passed in one file order, and failed in another. That is how it surfaced: two `probe-claude-auth` tests in a downstream app failing only in full-suite order.

A route or plugin that genuinely fails to start still rejects, and still fails fast rather than timing out with no cause named.

## Test Plan

Two new tests in `packages/testing/test/test-context-readiness.bun.test.ts` cover both sides of the distinction: a failing startup exchange must not reject readiness, and a genuine start failure must still reject. Both pass.

`bun run all` is green on this head (lint, format, typecheck, build, bun and vitest suites).

`.standards/testing.md` gains a note on the distinction, and there is a changeset marking this a patch to `@routecraft/testing`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3yVVzrZYdjZUUkvnzscdb)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`startAndWaitReady()` in `@routecraft/testing` no longer rejects when a startup exchange fails while another source is still coming up; only a route or plugin that genuinely fails to start rejects. Previously any `context:error` collapsed the two, making a whole shape of route untestable, and the race between the failing exchange and a slower sibling read as an intermittent flake instead of the real cause.

**Tests**
- Two new tests pin both directions: a failing startup exchange must not reject readiness, and a plugin whose start hook throws must still reject.
- `bun run all` is green on this head (lint, format, typecheck, build, bun and vitest suites).

**Docs**
- `.standards/testing.md` gains a note on the distinction, and a changeset marks this a patch to `@routecraft/testing`.

<sup>Written for commit 786aa8775706ee7d60fb5e18ef14611dc13b7f1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

