### PR TITLE
fix(ai): type prompt callbacks from route input

### DIFF
--- a/.changeset/typed-ai-prompt-inputs.md
+++ b/.changeset/typed-ai-prompt-inputs.md
@@ -1,0 +1,5 @@
+---
+"@routecraft/ai": minor
+---
+
+`llm()` and `agent()` prompt callbacks, like `embedding()`, can be parameterized with the route body type so typed input schemas are available without casts.

--- a/apps/routecraft.dev/app/content/docs/examples/support-triage/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/examples/support-triage/index.mdx
@@ -64,12 +64,14 @@ are the only tools the model can call.
 import { craft, mail } from '@routecraft/routecraft'
 import { agent, tools } from '@routecraft/ai'
 
+type SupportEmail = { text: string }
+
 export default craft()
   .id('triage-support')
   .description('Triage an incoming support email')
   .from(mail('INBOX', { unseen: true, markSeen: true }))
   .to(
-    agent({
+    agent<SupportEmail>({
       model: 'anthropic:claude-sonnet-4-6',
       system:
         'You are a support triage assistant. Look the sender up, decide a priority (P1 urgent, P2 normal, P3 low), and post one concise internal brief. Do not reply to the customer.',

--- a/apps/routecraft.dev/app/content/docs/examples/support-triage/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/examples/support-triage/index.mdx
@@ -64,7 +64,7 @@ are the only tools the model can call.
 import { craft, mail } from '@routecraft/routecraft'
 import { agent, tools } from '@routecraft/ai'
 
-type SupportEmail = { text: string }
+type SupportEmail = { text?: string }
 
 export default craft()
   .id('triage-support')
@@ -77,7 +77,7 @@ export default craft()
         'You are a support triage assistant. Look the sender up, decide a priority (P1 urgent, P2 normal, P3 low), and post one concise internal brief. Do not reply to the customer.',
       user: (ex) =>
         `From: ${ex.headers['routecraft.mail.from']}\n` +
-        `Subject: ${ex.headers['routecraft.mail.subject']}\n\n${ex.body.text}`,
+        `Subject: ${ex.headers['routecraft.mail.subject']}\n\n${ex.body.text ?? ''}`,
       tools: tools(['Direct(lookup-customer)', 'Direct(post-brief)']),
     }),
   )

--- a/apps/routecraft.dev/app/content/docs/migrating/0.4-to-0.5/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/migrating/0.4-to-0.5/index.mdx
@@ -310,7 +310,9 @@ embedding("openai:text-embedding-3-small", {})
 **After (0.5.0):**
 
 ```ts
-embedding("openai:text-embedding-3-small", {
+type Message = { text: string }
+
+embedding<Message>("openai:text-embedding-3-small", {
   using: (ex) => ex.body.text,
 })
 ```

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/embedding/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/embedding/index.mdx
@@ -20,7 +20,7 @@ type Document = { content: string; title: string; description: string }
 craft()
   .id('embed-document')
   .from<Document>(source)
-  .enrich(embedding<Document>('openai:text-embedding-3-small', {
+  .enrich(embedding('openai:text-embedding-3-small', {
     using: (ex) => ex.body.content,
   }))
   .to(vectorStore)
@@ -28,7 +28,7 @@ craft()
 // (use only() to keep the document, e.g. only((r) => r.embedding, 'embedding'))
 
 // Embed a combination of fields
-.enrich(embedding<Document>('ollama:nomic-embed-text', {
+.enrich(embedding('ollama:nomic-embed-text', {
   using: (ex) => `${ex.body.title} ${ex.body.description}`,
 }))
 ```

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/embedding/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/embedding/index.mdx
@@ -15,10 +15,12 @@ Generate vector embeddings from text. Requires `embeddingPlugin()` in your conte
 ```ts
 import { embedding } from '@routecraft/ai'
 
+type Document = { content: string; title: string; description: string }
+
 craft()
   .id('embed-document')
-  .from(source)
-  .enrich(embedding('openai:text-embedding-3-small', {
+  .from<Document>(source)
+  .enrich(embedding<Document>('openai:text-embedding-3-small', {
     using: (ex) => ex.body.content,
   }))
   .to(vectorStore)
@@ -26,7 +28,7 @@ craft()
 // (use only() to keep the document, e.g. only((r) => r.embedding, 'embedding'))
 
 // Embed a combination of fields
-.enrich(embedding('ollama:nomic-embed-text', {
+.enrich(embedding<Document>('ollama:nomic-embed-text', {
   using: (ex) => `${ex.body.title} ${ex.body.description}`,
 }))
 ```

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/llm/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/llm/index.mdx
@@ -21,7 +21,7 @@ type Document = { content: string; text: string }
 craft()
   .id('summarise')
   .from<Document>(source)
-  .enrich(llm<undefined, Document>('anthropic:claude-haiku-4-5-20251001', {
+  .enrich(llm('anthropic:claude-haiku-4-5-20251001', {
     system: 'Summarise the following in one sentence.',
     user: (ex) => ex.body.content,
   }))
@@ -40,7 +40,7 @@ const sentimentSchema = z.object({
 craft()
   .id('classify')
   .from<Document>(source)
-  .enrich(llm<undefined, Document>('openai:gpt-4o', {
+  .enrich(llm('openai:gpt-4o', {
     system: 'Classify the sentiment of the text.',
     user: (ex) => ex.body.text,
     output: sentimentSchema,

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/llm/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/llm/index.mdx
@@ -21,7 +21,7 @@ type Document = { content: string; text: string }
 craft()
   .id('summarise')
   .from<Document>(source)
-  .enrich(llm<Document>('anthropic:claude-haiku-4-5-20251001', {
+  .enrich(llm<undefined, Document>('anthropic:claude-haiku-4-5-20251001', {
     system: 'Summarise the following in one sentence.',
     user: (ex) => ex.body.content,
   }))
@@ -40,7 +40,7 @@ const sentimentSchema = z.object({
 craft()
   .id('classify')
   .from<Document>(source)
-  .enrich(llm<Document>('openai:gpt-4o', {
+  .enrich(llm<undefined, Document>('openai:gpt-4o', {
     system: 'Classify the sentiment of the text.',
     user: (ex) => ex.body.text,
     output: sentimentSchema,

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/llm/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/llm/index.mdx
@@ -15,11 +15,13 @@ Call a language model and get text or structured output. Requires `llmPlugin()` 
 ```ts
 import { llm } from '@routecraft/ai'
 
+type Document = { content: string; text: string }
+
 // Text output
 craft()
   .id('summarise')
-  .from(source)
-  .enrich(llm('anthropic:claude-haiku-4-5-20251001', {
+  .from<Document>(source)
+  .enrich(llm<Document>('anthropic:claude-haiku-4-5-20251001', {
     system: 'Summarise the following in one sentence.',
     user: (ex) => ex.body.content,
   }))
@@ -37,8 +39,8 @@ const sentimentSchema = z.object({
 
 craft()
   .id('classify')
-  .from(source)
-  .enrich(llm('openai:gpt-4o', {
+  .from<Document>(source)
+  .enrich(llm<Document>('openai:gpt-4o', {
     system: 'Classify the sentiment of the text.',
     user: (ex) => ex.body.text,
     output: sentimentSchema,

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -28,7 +28,7 @@ import type { AgentOptions, AgentResult } from "./types.ts";
  *
  * @internal
  */
-export function validateAgentOptions(options: AgentOptions): void {
+export function validateAgentOptions<T>(options: AgentOptions<T>): void {
   // `system` accepts the same string-or-function shape as `llm({ system })`.
   // For the static form, require non-empty so misconfiguration ("" or
   // missing) surfaces at construction. The function form is validated at
@@ -343,26 +343,26 @@ function validateBlocksLevel(
  *   .to(direct("reply"));
  * ```
  */
-export function agent(
-  options: AgentOptions & { stream: true },
-): Enricher<unknown, AgentStream>;
+export function agent<T = unknown>(
+  options: AgentOptions<T> & { stream: true },
+): Enricher<T, AgentStream>;
 // `{ stream?: false }` rather than a bare `AgentOptions`, matching the
 // `chunked` precedent on the file-family adapters: the option law admits
 // exactly two overloads, literal `true` and absent-or-`false`, so a widened
 // `stream: someBoolean` is a compile error instead of a call that claims
 // `AgentResult` and hands back an iterable.
-export function agent(
-  options: AgentOptions & { stream?: false },
-): Enricher<unknown, AgentResult>;
+export function agent<T = unknown>(
+  options: AgentOptions<T> & { stream?: false },
+): Enricher<T, AgentResult>;
 export function agent(name: string): Enricher<unknown, AgentResult>;
 export function agent(
   name: string,
   perCall: AgentByNameOverrides,
 ): Enricher<unknown, AgentResult>;
-export function agent(
-  arg: AgentOptions | string,
+export function agent<T = unknown>(
+  arg: AgentOptions<T> | string,
   perCall?: AgentByNameOverrides,
-): Enricher<unknown, AgentResult | AgentStream> {
+): Enricher<T, AgentResult | AgentStream> {
   if (typeof arg === "string") {
     if (arg.trim() === "") {
       throw rcError("RC5003", undefined, {
@@ -370,7 +370,7 @@ export function agent(
       });
     }
     return tagAdapter(
-      new AgentEnricherAdapter({
+      new AgentEnricherAdapter<T>({
         kind: "by-name",
         name: arg,
         ...(perCall ? { perCall } : {}),
@@ -384,7 +384,7 @@ export function agent(
   }
   validateAgentOptions(arg);
   return tagAdapter(
-    new AgentEnricherAdapter({ kind: "inline", options: arg }),
+    new AgentEnricherAdapter<T>({ kind: "inline", options: arg }),
     agent,
     factoryArgs(arg),
   );

--- a/packages/ai/src/agent/enricher.ts
+++ b/packages/ai/src/agent/enricher.ts
@@ -68,8 +68,8 @@ export interface AgentByNameOverrides {
  * Discriminated state: inline options or a registry name.
  * @internal
  */
-export type AgentBinding =
-  | { kind: "inline"; options: AgentOptions }
+export type AgentBinding<T = unknown> =
+  | { kind: "inline"; options: AgentOptions<T> }
   | {
       kind: "by-name";
       name: string;
@@ -92,13 +92,13 @@ export type AgentBinding =
  * store (`ADAPTER_AGENT_REGISTRY`) at dispatch time, throwing a clear
  * error if the name is unknown.
  */
-export class AgentEnricherAdapter implements Enricher<
-  unknown,
+export class AgentEnricherAdapter<T = unknown> implements Enricher<
+  T,
   AgentResult | AgentStream
 > {
   readonly adapterId = "routecraft.adapter.agent";
 
-  constructor(public readonly binding: AgentBinding) {
+  constructor(public readonly binding: AgentBinding<T>) {
     // A tool handler may park the run (ctx.suspend / SuspendError), so the
     // suspend-site walk assigns this adapter's hosting step a re-entrant
     // site at build time. Routes that never suspend pay nothing for it.
@@ -106,7 +106,7 @@ export class AgentEnricherAdapter implements Enricher<
   }
 
   async fetch(
-    exchange: Exchange<unknown>,
+    exchange: Exchange<T>,
     stepCtx?: StepSignalContext,
   ): Promise<AgentResult | AgentStream> {
     const context = getExchangeContext(exchange);
@@ -210,7 +210,7 @@ export class AgentEnricherAdapter implements Enricher<
       exchange,
     );
 
-    const session = new AgentSession({
+    const session = new AgentSession<T>({
       options: merged,
       modelConfig: config,
       modelName,
@@ -268,7 +268,7 @@ export class AgentEnricherAdapter implements Enricher<
   /** Pull the agent options for this dispatch, either inline or from the registry. */
   private resolveOptions(
     context: CraftContext | undefined,
-  ): AgentOptions | AgentRegisteredOptions {
+  ): AgentOptions<T> | AgentRegisteredOptions<T> {
     if (this.binding.kind === "inline") return this.binding.options;
 
     if (!context) {
@@ -294,7 +294,7 @@ export class AgentEnricherAdapter implements Enricher<
         message: `Agent "${this.binding.name}" not found in registry. Known agents: ${known}.`,
       });
     }
-    return found;
+    return found as AgentRegisteredOptions<T>;
   }
 
   /**
@@ -327,10 +327,10 @@ export class AgentEnricherAdapter implements Enricher<
  *
  * @internal
  */
-function mergeWithDefaults(
-  base: AgentOptions | AgentRegisteredOptions,
+function mergeWithDefaults<T>(
+  base: AgentOptions<T> | AgentRegisteredOptions<T>,
   context: CraftContext | undefined,
-): AgentOptions | AgentRegisteredOptions {
+): AgentOptions<T> | AgentRegisteredOptions<T> {
   const defaults = context?.getStore(ADAPTER_AGENT_DEFAULT_OPTIONS);
   if (!defaults) return base;
   const out = { ...base };
@@ -432,8 +432,8 @@ function mergeUserAndLoaderTools(
  *
  * @internal
  */
-function resolveAgentTools(
-  options: AgentOptions | AgentRegisteredOptions,
+function resolveAgentTools<T>(
+  options: AgentOptions<T> | AgentRegisteredOptions<T>,
   context: CraftContext | undefined,
   agentId: string | undefined,
   dispatchIdentity: AgentDispatchIdentity | undefined,
@@ -669,11 +669,11 @@ function toDescriptor(tool: ResolvedTool): AgentToolDescriptor | undefined {
  *
  * @internal
  */
-function appendPrincipalToSystem(
+function appendPrincipalToSystem<T>(
   baseSystem: string,
-  principalOption: boolean | AgentPrincipalRenderer | undefined,
+  principalOption: boolean | AgentPrincipalRenderer<T> | undefined,
   principal: Principal | undefined,
-  exchange: Exchange<unknown>,
+  exchange: Exchange<T>,
 ): string {
   if (principalOption === undefined || principalOption === false) {
     return baseSystem;

--- a/packages/ai/src/agent/session.ts
+++ b/packages/ai/src/agent/session.ts
@@ -85,9 +85,9 @@ const DEFAULT_MAX_TURNS = 20;
  *
  * @internal
  */
-export interface AgentSessionInput {
+export interface AgentSessionInput<T = unknown> {
   /** Agent options after merging with `defaultOptions`. `model` resolved. */
-  readonly options: AgentOptions | AgentRegisteredOptions;
+  readonly options: AgentOptions<T> | AgentRegisteredOptions<T>;
   /** Provider config for the resolved model. */
   readonly modelConfig: LlmModelConfig;
   /** Provider-specific model name (after `parseProviderModel`). */
@@ -119,7 +119,7 @@ export interface AgentSessionInput {
    * model's output with request-scoped state (headers, principal,
    * correlation id) when deciding whether to accept or retry.
    */
-  readonly exchange: Exchange<unknown>;
+  readonly exchange: Exchange<T>;
   /**
    * Dispatch identity used to emit `route:<routeId>:agent:*` events
    * on the context bus. Undefined for synthetic exchanges with no
@@ -244,8 +244,8 @@ export class AgentCancellationCause extends Error {
  *
  * @internal
  */
-export class AgentSession {
-  constructor(public readonly input: AgentSessionInput) {}
+export class AgentSession<T = unknown> {
+  constructor(public readonly input: AgentSessionInput<T>) {}
 
   /**
    * Run the synchronous tool-calling loop until the model emits a
@@ -859,9 +859,9 @@ function toAgentResult(
  *
  * @internal
  */
-export function buildUserPrompt(
-  options: AgentOptions | AgentRegisteredOptions,
-  exchange: Exchange<unknown>,
+export function buildUserPrompt<T>(
+  options: AgentOptions<T> | AgentRegisteredOptions<T>,
+  exchange: Exchange<T>,
 ): string {
   return options.user !== undefined
     ? resolvePrompt(options.user, exchange)

--- a/packages/ai/src/agent/types.ts
+++ b/packages/ai/src/agent/types.ts
@@ -23,8 +23,10 @@ import type { ToolSelection } from "./tools/selection.ts";
  * applies to both the `agent` and `llm` destinations: pass a static
  * string for fixed prompts, or a function that derives the prompt from
  * the incoming exchange.
+ *
+ * @template T - Body type available to the prompt callback
  */
-export type AgentUserPromptSource = LlmPromptSource;
+export type AgentUserPromptSource<T = unknown> = LlmPromptSource<T>;
 
 /**
  * Custom renderer for the agent's `## Caller` section. Receives the
@@ -37,10 +39,12 @@ export type AgentUserPromptSource = LlmPromptSource;
  * renderer owns its own escaping and MUST NOT surface `claims`,
  * `userinfoClaims`, or anything bearer-derived (see
  * `.standards/security.md` § 3a).
+ *
+ * @template T - Body type available to the renderer
  */
-export type AgentPrincipalRenderer = (
+export type AgentPrincipalRenderer<T = unknown> = (
   principal: Principal | undefined,
-  exchange: Exchange<unknown>,
+  exchange: Exchange<T>,
 ) => string;
 
 /**
@@ -133,8 +137,10 @@ export interface AgentDefaultOptions extends LlmSamplingOptions {
  * `topP`, the penalties and `reasoning`) is the same one `llm()` takes and
  * means the same thing here. Unset, it resolves to the framework defaults an
  * `llm()` step gets, so an agent that says nothing behaves as it always has.
+ *
+ * @template T - Body type available to callbacks in this option object
  */
-export interface AgentOptions extends LlmSamplingOptions {
+export interface AgentOptions<T = unknown> extends LlmSamplingOptions {
   /**
    * Model reference of the form "providerId:modelName". The provider
    * must be registered via `llmPlugin({ providers })`. Optional when
@@ -150,7 +156,7 @@ export interface AgentOptions extends LlmSamplingOptions {
    * Load from disk yourself when you want to source the static form
    * from a file (e.g. `readFileSync("./prompt.md", "utf-8")`).
    */
-  system: LlmPromptSource;
+  system: LlmPromptSource<T>;
 
   /**
    * Optional override for the user prompt. Either a static string or
@@ -158,7 +164,7 @@ export interface AgentOptions extends LlmSamplingOptions {
    * (mirrors `llm({ user })`). Defaults to the exchange body (string
    * as-is, JSON for objects, `String()` otherwise) when omitted.
    */
-  user?: LlmPromptSource;
+  user?: LlmPromptSource<T>;
 
   /**
    * Tools the agent is allowed to call. Build via
@@ -234,7 +240,7 @@ export interface AgentOptions extends LlmSamplingOptions {
    * still enforced by `.authorize()` and guards; this block is
    * informational context for the model, not an authorization gate.
    */
-  principal?: boolean | AgentPrincipalRenderer;
+  principal?: boolean | AgentPrincipalRenderer<T>;
 
   /**
    * Cap on tool-calling turns for the Vercel AI SDK loop. Each turn
@@ -283,7 +289,7 @@ export interface AgentOptions extends LlmSamplingOptions {
    */
   validate?: (
     result: AgentResult,
-    ctx: { exchange: Exchange<unknown>; turnsUsed: number },
+    ctx: { exchange: Exchange<T>; turnsUsed: number },
   ) => void | string | Promise<void | string>;
 
   /**
@@ -353,7 +359,7 @@ export interface AgentOptions extends LlmSamplingOptions {
  * by-name reuse. Registered agents carry their own description because they
  * are not backed by a route. The id is the record key in the plugin config.
  */
-export interface AgentRegisteredOptions extends AgentOptions {
+export interface AgentRegisteredOptions<T = unknown> extends AgentOptions<T> {
   /**
    * Human-readable description. Surfaces in observability and is used as the
    * tool description when the agent is exposed to other agents.

--- a/packages/ai/src/llm/enricher.ts
+++ b/packages/ai/src/llm/enricher.ts
@@ -56,37 +56,39 @@ async function parseStructuredTextFallback(
  * resolves the provider from the plugin store, merges options, and calls the provider with the model name.
  * Use with .enrich(llm("providerId:modelName", options)) or .to(llm(...)).
  *
+ * @template T - Body type available to prompt callbacks.
  * @template S - Output schema type when an `output` schema is provided; narrows result.output for downstream typing.
  */
 export class LlmEnricherAdapter<
   S extends StandardSchemaV1 | undefined = undefined,
+  T = unknown,
 >
   implements
-    Enricher<unknown, LlmResultWithOutput<S>>,
-    MergedOptions<LlmOptionsMerged>
+    Enricher<T, LlmResultWithOutput<S>>,
+    MergedOptions<LlmOptionsMerged<T>>
 {
   readonly adapterId = "routecraft.adapter.llm";
 
   constructor(
     private readonly modelId: string,
-    options: LlmOptions = {},
+    options: LlmOptions<T> = {},
   ) {
-    this.options = options as Partial<LlmOptionsMerged>;
+    this.options = options as Partial<LlmOptionsMerged<T>>;
   }
 
-  public options: Partial<LlmOptionsMerged>;
+  public options: Partial<LlmOptionsMerged<T>>;
 
-  mergedOptions(context: CraftContext): LlmOptionsMerged {
+  mergedOptions(context: CraftContext): LlmOptionsMerged<T> {
     const store = context.getStore(ADAPTER_LLM_OPTIONS);
     return {
       temperature: DEFAULT_TEMPERATURE,
       maxTokens: DEFAULT_MAX_TOKENS,
       ...store,
       ...this.options,
-    } as LlmOptionsMerged;
+    } as LlmOptionsMerged<T>;
   }
 
-  async fetch(exchange: Exchange<unknown>): Promise<LlmResultWithOutput<S>> {
+  async fetch(exchange: Exchange<T>): Promise<LlmResultWithOutput<S>> {
     const context = getExchangeContext(exchange);
     const { config, modelName } = resolveModel(this.modelId, context);
     const merged = this.mergedOptions(context!);

--- a/packages/ai/src/llm/llm.ts
+++ b/packages/ai/src/llm/llm.ts
@@ -15,8 +15,8 @@ import type { RegisteredLlmModelId } from "../registry.ts";
  * @param options - Optional overrides (system, user, temperature, maxTokens, output, etc.). User prompt defaults to exchange.body.
  */
 export function llm<
-  T = unknown,
   S extends StandardSchemaV1 | undefined = undefined,
+  T = unknown,
 >(
   modelId: RegisteredLlmModelId,
   options?: LlmOptions<T> & { output?: S },

--- a/packages/ai/src/llm/llm.ts
+++ b/packages/ai/src/llm/llm.ts
@@ -14,12 +14,15 @@ import type { RegisteredLlmModelId } from "../registry.ts";
  * @param modelId - "providerId:modelName"; the provider is resolved from the plugin, the model name is sent to the provider.
  * @param options - Optional overrides (system, user, temperature, maxTokens, output, etc.). User prompt defaults to exchange.body.
  */
-export function llm<S extends StandardSchemaV1 | undefined = undefined>(
+export function llm<
+  T = unknown,
+  S extends StandardSchemaV1 | undefined = undefined,
+>(
   modelId: RegisteredLlmModelId,
-  options?: LlmOptions & { output?: S },
-): Enricher<unknown, LlmResultWithOutput<S>> {
+  options?: LlmOptions<T> & { output?: S },
+): Enricher<T, LlmResultWithOutput<S>> {
   return tagAdapter(
-    new LlmEnricherAdapter<S>(modelId, options),
+    new LlmEnricherAdapter<S, T>(modelId, options),
     llm,
     factoryArgs(modelId, options),
   );

--- a/packages/ai/src/llm/shared.ts
+++ b/packages/ai/src/llm/shared.ts
@@ -138,9 +138,9 @@ export function resolveModel(
 }
 
 /** Resolves a prompt source (string or function) against an exchange. Empty source returns "". */
-export function resolvePrompt(
-  source: LlmPromptSource | undefined,
-  exchange: Exchange<unknown>,
+export function resolvePrompt<T = unknown>(
+  source: LlmPromptSource<T> | undefined,
+  exchange: Exchange<T>,
 ): string {
   if (source === undefined || source === "") return "";
   if (typeof source === "function") return source(exchange);
@@ -148,7 +148,9 @@ export function resolvePrompt(
 }
 
 /** Default user-prompt derivation: string body as-is, JSON for objects, String() otherwise. */
-export function resolveUserPromptDefault(exchange: Exchange<unknown>): string {
+export function resolveUserPromptDefault<T = unknown>(
+  exchange: Exchange<T>,
+): string {
   const body = exchange.body;
   if (typeof body === "string") return body;
   if (body === null || body === undefined) return "";

--- a/packages/ai/src/llm/types.ts
+++ b/packages/ai/src/llm/types.ts
@@ -185,9 +185,11 @@ export type LlmProviderOptionsMap = Required<LlmPluginProviders>;
 
 /**
  * Resolve system or user prompt from exchange (string or function).
+ *
+ * @template T - Body type available to the prompt callback
  */
-export type LlmPromptSource =
-  string | ((exchange: Exchange<unknown>) => string);
+export type LlmPromptSource<T = unknown> =
+  string | ((exchange: Exchange<T>) => string);
 
 /**
  * Normalised reasoning effort, the portable way to ask a model to think more
@@ -245,9 +247,14 @@ export interface LlmSamplingOptions {
   providerOptions?: LlmRawProviderOptions;
 }
 
-export interface LlmOptions extends LlmSamplingOptions {
-  system?: LlmPromptSource;
-  user?: LlmPromptSource;
+/**
+ * Options for an LLM call.
+ *
+ * @template T - Body type available to system and user prompt callbacks.
+ */
+export interface LlmOptions<T = unknown> extends LlmSamplingOptions {
+  system?: LlmPromptSource<T>;
+  user?: LlmPromptSource<T>;
   /**
    * Optional output schema (Standard Schema). When set, the adapter requests
    * provider-level structured output and validates the result. Supported by
@@ -271,8 +278,8 @@ export type LlmSamplingOptionsMerged = Required<
   Omit<LlmSamplingOptions, "temperature" | "maxTokens">;
 
 /** Internal merged type for adapter and store. */
-export type LlmOptionsMerged = LlmSamplingOptionsMerged &
-  Omit<LlmOptions, keyof LlmSamplingOptions>;
+export type LlmOptionsMerged<T = unknown> = LlmSamplingOptionsMerged &
+  Omit<LlmOptions<T>, keyof LlmSamplingOptions>;
 
 /**
  * Token usage reported by the provider. Mirrors the Vercel AI SDK

--- a/packages/ai/test/llm-type-safety.bun.test.ts
+++ b/packages/ai/test/llm-type-safety.bun.test.ts
@@ -40,11 +40,23 @@ describe("LLM adapter type safety", () => {
   });
 
   /**
-   * @case A route input schema types the exchange passed to AI callbacks
-   * @preconditions `.input({ body })` precedes llm(), agent(), and embedding() callbacks
+   * @case The legacy schema type parameter remains the first llm() generic
+   * @preconditions llm<typeof schema>(modelId, { output: schema })
+   * @expectedResult The output schema narrows the result without changing the body type
+   */
+  test("llm preserves the legacy output schema type parameter", () => {
+    const schema = z.object({ answer: z.string() });
+    expectTypeOf(
+      llm<typeof schema>("ollama:x", { output: schema }),
+    ).toMatchTypeOf<Enricher<unknown, LlmResultWithOutput<typeof schema>>>();
+  });
+
+  /**
+   * @case An explicit body type parameter types the exchange passed to AI callbacks
+   * @preconditions llm<undefined, Body>(), agent<Body>(), and embedding<Body>() supply the body type
    * @expectedResult Each callback can read the declared body fields without a cast
    */
-  test("route input type flows into llm, agent, and embedding callbacks", () => {
+  test("explicit body type flows into llm, agent, and embedding callbacks", () => {
     const body = z.object({ content: z.string(), text: z.string() });
     type Body = z.infer<typeof body>;
     const source = simple({ content: "hello", text: "hello" });
@@ -53,7 +65,7 @@ describe("LLM adapter type safety", () => {
       .input({ body })
       .from(source)
       .to(
-        llm<Body>("ollama:my-model", {
+        llm<undefined, Body>("ollama:my-model", {
           user: (exchange) => exchange.body.content,
         }),
       );

--- a/packages/ai/test/llm-type-safety.bun.test.ts
+++ b/packages/ai/test/llm-type-safety.bun.test.ts
@@ -90,4 +90,43 @@ describe("LLM adapter type safety", () => {
         }),
       );
   });
+
+  /**
+   * @case A route input type flows into AI callbacks through `.enrich()`
+   * @preconditions `.input({ body })` precedes llm(), agent(), and embedding() without type arguments
+   * @expectedResult Each callback can read the declared body fields without a cast
+   */
+  test("route input type flows into enrich callbacks without generics", () => {
+    const body = z.object({ content: z.string(), text: z.string() });
+    const source = simple({ content: "hello", text: "hello" });
+
+    craft()
+      .input({ body })
+      .from(source)
+      .enrich(
+        llm("ollama:my-model", {
+          user: (exchange) => exchange.body.content,
+        }),
+      );
+
+    craft()
+      .input({ body })
+      .from(source)
+      .enrich(
+        agent({
+          model: "ollama:my-model",
+          system: (exchange) => `Summarise ${exchange.body.text}`,
+          user: (exchange) => exchange.body.content,
+        }),
+      );
+
+    craft()
+      .input({ body })
+      .from(source)
+      .enrich(
+        embedding("openai:text-embedding-3-small", {
+          using: (exchange) => exchange.body.content,
+        }),
+      );
+  });
 });

--- a/packages/ai/test/llm-type-safety.bun.test.ts
+++ b/packages/ai/test/llm-type-safety.bun.test.ts
@@ -1,5 +1,8 @@
 import { describe, expectTypeOf, test } from "bun:test";
 import { z } from "zod";
+import { craft, simple } from "@routecraft/routecraft";
+import { agent } from "../src/agent/agent.ts";
+import { embedding } from "../src/embedding/embedding.ts";
 import { llm } from "../src/llm/llm.ts";
 import type { LlmResult, LlmResultWithOutput } from "../src/llm/types.ts";
 import type { Enricher } from "@routecraft/routecraft";
@@ -34,5 +37,45 @@ describe("LLM adapter type safety", () => {
     expectTypeOf<Expected["output"]>().toMatchTypeOf<
       { answer: string } | undefined
     >();
+  });
+
+  /**
+   * @case A route input schema types the exchange passed to AI callbacks
+   * @preconditions `.input({ body })` precedes llm(), agent(), and embedding() callbacks
+   * @expectedResult Each callback can read the declared body fields without a cast
+   */
+  test("route input type flows into llm, agent, and embedding callbacks", () => {
+    const body = z.object({ content: z.string(), text: z.string() });
+    type Body = z.infer<typeof body>;
+    const source = simple({ content: "hello", text: "hello" });
+
+    craft()
+      .input({ body })
+      .from(source)
+      .to(
+        llm<Body>("ollama:my-model", {
+          user: (exchange) => exchange.body.content,
+        }),
+      );
+
+    craft()
+      .input({ body })
+      .from(source)
+      .to(
+        agent<Body>({
+          model: "ollama:my-model",
+          system: (exchange) => `Summarise ${exchange.body.text}`,
+          user: (exchange) => exchange.body.content,
+        }),
+      );
+
+    craft()
+      .input({ body })
+      .from(source)
+      .enrich(
+        embedding<Body>("openai:text-embedding-3-small", {
+          using: (exchange) => exchange.body.content,
+        }),
+      );
   });
 });


### PR DESCRIPTION
## Related issue  Fixes #668  ## Background  Routes can declare a body schema with `.input({ body })`, but prompt callbacks passed to `llm()` and `agent()` were typed with `Exchange<unknown>`. This forced users to lose type safety or add casts when reading fields from the route input.  ## What changed  - Added an optional body type parameter to `LlmPromptSource`, `LlmOptions`, and the LLM adapter flow. - Added the same body type flow to inline `agent()` options, principal renderers, validation callbacks, and agent sessions. - Kept the existing `llm()` output-schema type parameter first; body types use the second parameter, preserving calls such as `llm<typeof schema>(...)`.
- Kept existing defaults and by-name agent behavior compatible by defaulting the new type to `unknown`. - Added compile-time regression coverage for typed `llm()`, `agent()`, and `embedding()` callbacks. - Updated the four affected documentation examples and added a minor changeset for `@routecraft/ai`.  The change is type-only at runtime. Existing calls continue to work without a type argument.  ## Validation  - `bun test packages/ai/test/llm-type-safety.bun.test.ts packages/ai/test/agent-prompt-source.bun.test.ts packages/ai/test/embedding.bun.test.ts` (14 passed) - Windows equivalent of the repository full Bun test command (Git for Windows `xargs`, command-line-safe batches): 419 passed, 13 failed, and 2 errors across 432 tests. The failures are unrelated Windows or local-environment issues: symlink permissions, path-separator assertions, SQLite teardown/fixture isolation, and XML timing. - `bun run lint` (passed) - `bun run typecheck` (passed) - `bun run build` (passed) - Prettier check on all changed files (passed) - `git diff --check` (passed) - `bun run changeset status` (completed with the repository's existing cross-package version-range warnings; the new `@routecraft/ai` minor changeset was detected)  The repository-native full test script cannot run on this Windows host because `xargs` is not installed; its Bun test portion was rerun with Git for Windows `xargs` in command-line-safe batches. The focused tests and all static checks were rerun and passed.  ## AI disclosure  This pull request was prepared with assistance from OpenAI Codex. The implementation, tests, documentation changes, and validation results were reviewed before submission.  

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #668 by threading the route body type through `llm()` and `agent()` prompt callbacks, so callbacks receive the typed body instead of `Exchange<unknown>` and no longer need casts. The new type parameter defaults to `unknown`, so existing calls compile unchanged; this is a type-only change at runtime.

**Changes**
- `llm()` keeps its output schema as the first generic parameter; the body type is the second, preserving `llm<typeof schema>()` calls.
- Added compile-time tests covering explicit body generics and route input inference through `.enrich()` without generics.
- Updated four documentation examples and added a minor changeset for `@routecraft/ai`.

<sup>Written for commit cbb697b705ab9c4e1181983cfb92e45f157e0f59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

  