### PR TITLE
fix(testing): expose context logger spy

### DIFF
--- a/.changeset/context-logger-spy.md
+++ b/.changeset/context-logger-spy.md
@@ -1,0 +1,5 @@
+---
+"@routecraft/testing": minor
+---
+
+Expose context-level logger calls through a separately restored `t.contextLogger` spy.

--- a/packages/ai/test/agent-tool-policy.bun.test.ts
+++ b/packages/ai/test/agent-tool-policy.bun.test.ts
@@ -270,7 +270,7 @@ describe("agentPlugin({ toolPolicy }): admission control", () => {
       registerAgent: true,
     });
     await registeredAgentTools(t);
-    const denials = t.logger.warn.mock.calls.filter(
+    const denials = t.contextLogger.warn.mock.calls.filter(
       (c: unknown[]) =>
         typeof c[1] === "string" && c[1].includes("denied by agentPlugin"),
     );
@@ -294,7 +294,7 @@ describe("agentPlugin({ toolPolicy }): admission control", () => {
   test("an inline agent's denial is still attributable", async () => {
     t = await buildCtx({ policies: [{ fn: true, direct: true, mcp: false }] });
     await inlineAgentTools(t);
-    const denial = t.logger.warn.mock.calls.find(
+    const denial = t.contextLogger.warn.mock.calls.find(
       (c: unknown[]) =>
         typeof c[1] === "string" && c[1].includes("denied by agentPlugin"),
     );
@@ -453,7 +453,7 @@ describe("agentPlugin({ toolPolicy }): predicates and composition", () => {
     // Per the boundary convention in .standards/error-and-logging-policy.md
     // the thrown message becomes the log message, so match on that
     // rather than on a framework-authored string.
-    const errors = t.logger.error.mock.calls.filter(
+    const errors = t.contextLogger.error.mock.calls.filter(
       (c: unknown[]) => c[1] === "policy predicate blew up",
     );
     expect(errors.length).toBe(2);
@@ -509,7 +509,7 @@ describe("agentPlugin({ toolPolicy }): predicates and composition", () => {
       ],
     });
     await inlineAgentTools(t);
-    const warns = t.logger.warn.mock.calls.filter(
+    const warns = t.contextLogger.warn.mock.calls.filter(
       (c: unknown[]) =>
         typeof c[1] === "string" && c[1].includes("denied by agentPlugin"),
     );

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -1169,16 +1169,18 @@ describe("McpServer", () => {
 
           const msg =
             "Auth rejected: missing or malformed Authorization header";
-          const debugCall = t.logger.debug.mock.calls.find((c) => c[1] === msg);
+          const debugCall = t.contextLogger.debug.mock.calls.find(
+            (c) => c[1] === msg,
+          );
           expect(debugCall).toBeDefined();
           expect(debugCall?.[0]).toMatchObject({
             reason: "missing_header",
             scheme: "bearer",
             source: "mcp",
           });
-          expect(t.logger.warn.mock.calls.some((c) => c[1] === msg)).toBe(
-            false,
-          );
+          expect(
+            t.contextLogger.warn.mock.calls.some((c) => c[1] === msg),
+          ).toBe(false);
           expect(rejections.some((r) => r["reason"] === "missing_header")).toBe(
             true,
           );
@@ -1213,14 +1215,16 @@ describe("McpServer", () => {
           expect(res.statusCode).toBe(401);
 
           const msg = "Auth rejected: unsupported authorization scheme";
-          const debugCall = t.logger.debug.mock.calls.find((c) => c[1] === msg);
+          const debugCall = t.contextLogger.debug.mock.calls.find(
+            (c) => c[1] === msg,
+          );
           expect(debugCall).toBeDefined();
           expect(debugCall?.[0]).toMatchObject({
             reason: "unsupported_scheme",
           });
-          expect(t.logger.warn.mock.calls.some((c) => c[1] === msg)).toBe(
-            false,
-          );
+          expect(
+            t.contextLogger.warn.mock.calls.some((c) => c[1] === msg),
+          ).toBe(false);
         });
 
         /**
@@ -1251,7 +1255,7 @@ describe("McpServer", () => {
           expect(res.statusCode).toBe(401);
 
           const expiredMsg = "Auth rejected: token expired";
-          const debugCall = t.logger.debug.mock.calls.find(
+          const debugCall = t.contextLogger.debug.mock.calls.find(
             (c) => c[1] === expiredMsg,
           );
           expect(debugCall).toBeDefined();
@@ -1261,7 +1265,7 @@ describe("McpServer", () => {
             source: "mcp",
           });
           expect(
-            t.logger.warn.mock.calls.some(
+            t.contextLogger.warn.mock.calls.some(
               (c) => c[1] === "Auth rejected: token validation failed",
             ),
           ).toBe(false);
@@ -1292,7 +1296,7 @@ describe("McpServer", () => {
           expect(res.statusCode).toBe(401);
 
           const failedMsg = "Auth rejected: token validation failed";
-          const warnCall = t.logger.warn.mock.calls.find(
+          const warnCall = t.contextLogger.warn.mock.calls.find(
             (c) => c[1] === failedMsg,
           );
           expect(warnCall).toBeDefined();
@@ -1302,7 +1306,7 @@ describe("McpServer", () => {
             source: "mcp",
           });
           expect(
-            t.logger.debug.mock.calls.some(
+            t.contextLogger.debug.mock.calls.some(
               (c) => c[1] === "Auth rejected: token expired",
             ),
           ).toBe(false);
@@ -2991,7 +2995,7 @@ describe("McpServer", () => {
           );
 
           const expiredMsg = "Auth rejected: token expired";
-          const debugCall = t.logger.debug.mock.calls.find(
+          const debugCall = t.contextLogger.debug.mock.calls.find(
             (c) => c[1] === expiredMsg,
           );
           expect(debugCall).toBeDefined();
@@ -2999,7 +3003,7 @@ describe("McpServer", () => {
             reason: "expired",
           });
           expect(
-            t.logger.warn.mock.calls.some(
+            t.contextLogger.warn.mock.calls.some(
               (c) => c[1] === "Auth rejected: token validation failed",
             ),
           ).toBe(false);
@@ -3031,7 +3035,7 @@ describe("McpServer", () => {
           );
 
           const failedMsg = "Auth rejected: token validation failed";
-          const warnCall = t.logger.warn.mock.calls.find(
+          const warnCall = t.contextLogger.warn.mock.calls.find(
             (c) => c[1] === failedMsg,
           );
           expect(warnCall).toBeDefined();
@@ -3039,7 +3043,7 @@ describe("McpServer", () => {
             reason: "invalid_token",
           });
           expect(
-            t.logger.debug.mock.calls.some(
+            t.contextLogger.debug.mock.calls.some(
               (c) => c[1] === "Auth rejected: token expired",
             ),
           ).toBe(false);
@@ -3078,7 +3082,7 @@ describe("McpServer", () => {
           expect(res.statusCode).toBe(500);
           expect(res.headers["www-authenticate"]).toBeUndefined();
           expect(
-            t.logger.warn.mock.calls.some(
+            t.contextLogger.warn.mock.calls.some(
               (c) => c[1] === "Auth rejected: token validation failed",
             ),
           ).toBe(true);
@@ -3925,7 +3929,7 @@ describe("McpServer", () => {
       expect(String(declined[0]!["reason"])).toContain("declined the request");
       expect(failed).toHaveLength(0);
       expect(completed).toHaveLength(0);
-      expect(t.logger.error.mock.calls).toHaveLength(0);
+      expect(t.contextLogger.error.mock.calls).toHaveLength(0);
     });
 
     /**
@@ -4053,7 +4057,7 @@ describe("McpServer", () => {
       expect(failed).toHaveLength(1);
       expect(failed[0]).toMatchObject({ tool: "unchecked" });
       expect(String(failed[0]!["error"])).toContain("output schema");
-      expect(t.logger.error.mock.calls.length).toBeGreaterThan(0);
+      expect(t.contextLogger.error.mock.calls.length).toBeGreaterThan(0);
     });
 
     /**

--- a/packages/ai/test/tools-name-contract.bun.test.ts
+++ b/packages/ai/test/tools-name-contract.bun.test.ts
@@ -214,7 +214,7 @@ describe("MCP client tool-name validation", () => {
     const resolved = tools(["MCP(github)"]).resolve(t.ctx);
     expect(resolved.map((r) => r.name)).toEqual(["mcp__github__list_issues"]);
 
-    const warned = t.logger.warn.mock.calls.some(
+    const warned = t.contextLogger.warn.mock.calls.some(
       (c: unknown[]) =>
         typeof c[1] === "string" &&
         c[1].includes("not usable as a provider tool name"),
@@ -257,7 +257,7 @@ describe("MCP client tool-name validation", () => {
     t.ctx.setStore(MCP_TOOL_REGISTRY, registry);
 
     const warnCount = () =>
-      t!.logger.warn.mock.calls.filter(
+      t!.contextLogger.warn.mock.calls.filter(
         (c: unknown[]) =>
           typeof c[1] === "string" &&
           c[1].includes("not usable as a provider tool name"),
@@ -302,7 +302,7 @@ describe("MCP client tool-name validation", () => {
     t.ctx.setStore(MCP_TOOL_REGISTRY, registry);
 
     expect(tools(["MCP(a__b)"]).resolve(t.ctx)).toEqual([]);
-    const warned = t.logger.warn.mock.calls.some(
+    const warned = t.contextLogger.warn.mock.calls.some(
       (c: unknown[]) =>
         typeof c[1] === "string" &&
         c[1].includes("makes the generated tool name ambiguous"),
@@ -349,7 +349,7 @@ describe("MCP client tool-name validation", () => {
     t.ctx.setStore(MCP_TOOL_REGISTRY, registry);
 
     expect(tools(["MCP(github)"]).resolve(t.ctx)).toEqual([]);
-    const warned = t.logger.warn.mock.calls.some(
+    const warned = t.contextLogger.warn.mock.calls.some(
       (c: unknown[]) =>
         typeof c[1] === "string" &&
         c[1].includes(`over the provider limit of ${TOOL_NAME_MAX_LENGTH}`),

--- a/packages/routecraft/test/adapters/event-adapter.bun.test.ts
+++ b/packages/routecraft/test/adapters/event-adapter.bun.test.ts
@@ -294,7 +294,7 @@ describe("Event Source Adapter", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(
-      t.logger.warn.mock.calls.some(
+      t.contextLogger.warn.mock.calls.some(
         ([fields, message]) =>
           message === "Handler error" &&
           (fields as { adapter?: string; err?: { message?: string } })
@@ -304,7 +304,7 @@ describe("Event Source Adapter", () => {
       ),
     ).toBe(true);
     expect(
-      t.logger.error.mock.calls.some(
+      t.contextLogger.error.mock.calls.some(
         ([, message]) => message === "Handler error",
       ),
     ).toBe(false);
@@ -340,7 +340,7 @@ describe("Event Source Adapter", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(
-      t.logger.warn.mock.calls.some(
+      t.contextLogger.warn.mock.calls.some(
         ([fields, message]) =>
           message === "Routecraft handler error" &&
           (

--- a/packages/routecraft/test/enablement.bun.test.ts
+++ b/packages/routecraft/test/enablement.bun.test.ts
@@ -821,7 +821,7 @@ describe("route enablement", () => {
       .build();
     await t.startAndWaitReady();
 
-    const logged = t.logger.error.mock.calls.some(
+    const logged = t.contextLogger.error.mock.calls.some(
       (call: unknown[]) =>
         typeof call[0] === "object" &&
         call[0] !== null &&

--- a/packages/routecraft/test/suspension-sweeper.bun.test.ts
+++ b/packages/routecraft/test/suspension-sweeper.bun.test.ts
@@ -8,7 +8,6 @@ import {
   direct,
   noop,
   type CraftConfig,
-  type CraftContext,
   type EventName,
   type NewSuspension,
   type SuspensionCasResult,
@@ -68,36 +67,6 @@ function overdue(
     ...overrides,
   };
 }
-
-interface LogLine {
-  readonly bindings: Record<string, unknown>;
-  readonly message: string;
-}
-
-type CapturedLogs = Record<"info" | "warn" | "error", LogLine[]>;
-
-/**
- * Record the context logger's output.
- *
- * The sweeper reports through `context.logger` rather than a route logger,
- * so the spy logger the harness installs for route-scoped assertions does
- * not see it.
- */
-function captureLogs(context: CraftContext): CapturedLogs {
-  const lines: CapturedLogs = { info: [], warn: [], error: [] };
-  for (const level of ["info", "warn", "error"] as const) {
-    context.logger[level] = ((
-      bindings: Record<string, unknown>,
-      message: string,
-    ) => {
-      lines[level].push({ bindings, message });
-    }) as unknown as (typeof context.logger)[typeof level];
-  }
-  return lines;
-}
-
-const said = (lines: LogLine[], fragment: string): LogLine | undefined =>
-  lines.find((line) => line.message.includes(fragment));
 
 /**
  * The expiry sweeper.
@@ -303,7 +272,6 @@ describe("the suspension sweeper", () => {
           .to(noop()),
       ])
       .build();
-    const logs = captureLogs(t.ctx);
     await t.startAndWaitReady();
 
     for (let index = 0; index < 150; index++) {
@@ -314,7 +282,13 @@ describe("the suspension sweeper", () => {
     expect(await sweeper.sweep()).toBe(150);
 
     expect(reasked).toHaveLength(150);
-    expect(said(logs.info, "Still retiring expired suspensions")).toBeDefined();
+    expect(
+      t.contextLogger.info.mock.calls.some(
+        ([, message]) =>
+          typeof message === "string" &&
+          message.includes("Still retiring expired suspensions"),
+      ),
+    ).toBe(true);
     expect(await store.findExpired(new Date(), 100)).toHaveLength(0);
   });
 
@@ -391,7 +365,6 @@ describe("the suspension sweeper", () => {
           .to(noop()),
       ])
       .build();
-    const logs = captureLogs(t.ctx);
     await t.startAndWaitReady();
 
     for (const id of ["sus-a", "sus-b", "sus-c"]) {
@@ -404,9 +377,11 @@ describe("the suspension sweeper", () => {
     expect((await store.get("sus-a"))?.status).toBe("expired");
     expect((await store.get("sus-b"))?.status).toBe("suspended");
     expect((await store.get("sus-c"))?.status).toBe("expired");
-    expect(said(logs.error, "Failed to retire")?.bindings).toMatchObject({
-      suspensionId: "sus-b",
-    });
+    const failedRetirement = t.contextLogger.error.mock.calls.find(
+      ([, message]) =>
+        typeof message === "string" && message.includes("Failed to retire"),
+    );
+    expect(failedRetirement?.[0]).toMatchObject({ suspensionId: "sus-b" });
   });
 
   /**
@@ -427,7 +402,6 @@ describe("the suspension sweeper", () => {
           .to(noop()),
       ])
       .build();
-    const logs = captureLogs(t.ctx);
     await t.startAndWaitReady();
 
     await store.create(overdue("sus-ghost", { routeId: "retired-route" }));
@@ -436,9 +410,12 @@ describe("the suspension sweeper", () => {
     expect(await sweeper.sweep()).toBe(0);
 
     expect((await store.get("sus-ghost"))?.status).toBe("suspended");
-    expect(
-      said(logs.warn, "which this context does not have")?.bindings,
-    ).toMatchObject({ routeId: "retired-route" });
+    const missingRoute = t.contextLogger.warn.mock.calls.find(
+      ([, message]) =>
+        typeof message === "string" &&
+        message.includes("which this context does not have"),
+    );
+    expect(missingRoute?.[0]).toMatchObject({ routeId: "retired-route" });
   });
 
   /**
@@ -514,15 +491,17 @@ describe("the suspension sweeper", () => {
           .to(noop()),
       ])
       .build();
-    const logs = captureLogs(t.ctx);
     await t.startAndWaitReady();
 
     expect((await store.get("sus-a"))?.status).toBe("expired");
     expect((await store.get("sus-b"))?.status).toBe("expired");
     expect(reasked).toHaveLength(2);
-    expect(said(logs.info, "Suspension store scanned")?.bindings).toMatchObject(
-      { retiredOnStart: 2 },
+    const startupScan = t.contextLogger.info.mock.calls.find(
+      ([, message]) =>
+        typeof message === "string" &&
+        message.includes("Suspension store scanned"),
     );
+    expect(startupScan?.[0]).toMatchObject({ retiredOnStart: 2 });
   });
 
   /**
@@ -547,13 +526,21 @@ describe("the suspension sweeper", () => {
           .to(noop()),
       ])
       .build();
-    const logs = captureLogs(t.ctx);
     await t.startAndWaitReady();
 
-    expect(said(logs.info, "Suspension store scanned")?.bindings).toMatchObject(
-      { stranded: 1 },
+    const startupScan = t.contextLogger.info.mock.calls.find(
+      ([, message]) =>
+        typeof message === "string" &&
+        message.includes("Suspension store scanned"),
     );
-    expect(said(logs.warn, "nothing will retry them")).toBeDefined();
+    expect(startupScan?.[0]).toMatchObject({ stranded: 1 });
+    expect(
+      t.contextLogger.warn.mock.calls.some(
+        ([, message]) =>
+          typeof message === "string" &&
+          message.includes("nothing will retry them"),
+      ),
+    ).toBe(true);
     expect((await store.get("sus-stranded"))?.status).toBe("resumed");
   });
 

--- a/packages/routecraft/test/suspension-sweeper.bun.test.ts
+++ b/packages/routecraft/test/suspension-sweeper.bun.test.ts
@@ -68,6 +68,16 @@ function overdue(
   };
 }
 
+type LogCall = readonly unknown[];
+
+const said = (
+  calls: readonly LogCall[],
+  fragment: string,
+): LogCall | undefined =>
+  calls.find(
+    ([, message]) => typeof message === "string" && message.includes(fragment),
+  );
+
 /**
  * The expiry sweeper.
  *
@@ -283,12 +293,11 @@ describe("the suspension sweeper", () => {
 
     expect(reasked).toHaveLength(150);
     expect(
-      t.contextLogger.info.mock.calls.some(
-        ([, message]) =>
-          typeof message === "string" &&
-          message.includes("Still retiring expired suspensions"),
+      said(
+        t.contextLogger.info.mock.calls,
+        "Still retiring expired suspensions",
       ),
-    ).toBe(true);
+    ).toBeDefined();
     expect(await store.findExpired(new Date(), 100)).toHaveLength(0);
   });
 
@@ -377,9 +386,9 @@ describe("the suspension sweeper", () => {
     expect((await store.get("sus-a"))?.status).toBe("expired");
     expect((await store.get("sus-b"))?.status).toBe("suspended");
     expect((await store.get("sus-c"))?.status).toBe("expired");
-    const failedRetirement = t.contextLogger.error.mock.calls.find(
-      ([, message]) =>
-        typeof message === "string" && message.includes("Failed to retire"),
+    const failedRetirement = said(
+      t.contextLogger.error.mock.calls,
+      "Failed to retire",
     );
     expect(failedRetirement?.[0]).toMatchObject({ suspensionId: "sus-b" });
   });
@@ -410,10 +419,9 @@ describe("the suspension sweeper", () => {
     expect(await sweeper.sweep()).toBe(0);
 
     expect((await store.get("sus-ghost"))?.status).toBe("suspended");
-    const missingRoute = t.contextLogger.warn.mock.calls.find(
-      ([, message]) =>
-        typeof message === "string" &&
-        message.includes("which this context does not have"),
+    const missingRoute = said(
+      t.contextLogger.warn.mock.calls,
+      "which this context does not have",
     );
     expect(missingRoute?.[0]).toMatchObject({ routeId: "retired-route" });
   });
@@ -496,10 +504,9 @@ describe("the suspension sweeper", () => {
     expect((await store.get("sus-a"))?.status).toBe("expired");
     expect((await store.get("sus-b"))?.status).toBe("expired");
     expect(reasked).toHaveLength(2);
-    const startupScan = t.contextLogger.info.mock.calls.find(
-      ([, message]) =>
-        typeof message === "string" &&
-        message.includes("Suspension store scanned"),
+    const startupScan = said(
+      t.contextLogger.info.mock.calls,
+      "Suspension store scanned",
     );
     expect(startupScan?.[0]).toMatchObject({ retiredOnStart: 2 });
   });
@@ -528,19 +535,14 @@ describe("the suspension sweeper", () => {
       .build();
     await t.startAndWaitReady();
 
-    const startupScan = t.contextLogger.info.mock.calls.find(
-      ([, message]) =>
-        typeof message === "string" &&
-        message.includes("Suspension store scanned"),
+    const startupScan = said(
+      t.contextLogger.info.mock.calls,
+      "Suspension store scanned",
     );
     expect(startupScan?.[0]).toMatchObject({ stranded: 1 });
     expect(
-      t.contextLogger.warn.mock.calls.some(
-        ([, message]) =>
-          typeof message === "string" &&
-          message.includes("nothing will retry them"),
-      ),
-    ).toBe(true);
+      said(t.contextLogger.warn.mock.calls, "nothing will retry them"),
+    ).toBeDefined();
     expect((await store.get("sus-stranded"))?.status).toBe("resumed");
   });
 

--- a/packages/testing/src/test-context.ts
+++ b/packages/testing/src/test-context.ts
@@ -97,7 +97,8 @@ export interface TestOptions {
 /**
  * Test-friendly wrapper around CraftContext. Runs the real context but manages
  * lifecycle (start, wait routes ready, drain, stop) and collects errors.
- * t.logger is a spy logger for asserting on log calls.
+ * t.logger is a route-scoped spy logger and t.contextLogger captures logs made
+ * directly by the context.
  */
 export class TestContext {
   readonly ctx: CraftContext;
@@ -105,6 +106,8 @@ export class TestContext {
   readonly client: CraftClient;
   /** Spy logger; e.g. t.logger.info.mock.calls, or expect(t.logger.info).toHaveBeenCalledWith(...) with an injected runner mock factory */
   readonly logger: SpyLogger;
+  /** Spy logger for calls made directly on the context logger. */
+  readonly contextLogger: SpyLogger;
   readonly errors: RoutecraftError[] = [];
   private readonly routesReadyTimeoutMs: number;
 
@@ -117,12 +120,14 @@ export class TestContext {
     client: CraftClient,
     options?: TestContextOptions & {
       spyLogger?: SpyLogger;
+      contextLogger?: SpyLogger;
       restoreLoggerChild?: () => void;
     },
   ) {
     this.ctx = ctx;
     this.client = client;
     this.logger = options?.spyLogger ?? createNoopSpyLogger();
+    this.contextLogger = options?.contextLogger ?? createNoopSpyLogger();
     if (options?.restoreLoggerChild)
       this.restoreLoggerChild = options.restoreLoggerChild;
     rejectStaleOptions(options, "testContext");
@@ -429,11 +434,18 @@ export class TestContextBuilder {
 
   async build(): Promise<TestContext> {
     const spyLogger = createSpyLogger(this.spyFactory);
+    const contextLogger = createSpyLogger(this.spyFactory);
     const originalChild = logger.child.bind(logger);
     const childSpy = this.spyFactory();
-    childSpy.mockImplementation(
-      () => spyLogger as unknown as ReturnType<typeof logger.child>,
-    );
+    childSpy.mockImplementation((bindings) => {
+      const isRouteLogger =
+        bindings !== null &&
+        typeof bindings === "object" &&
+        "route" in bindings;
+      return (isRouteLogger
+        ? spyLogger
+        : contextLogger) as unknown as ReturnType<typeof logger.child>;
+    });
     logger.child = childSpy as unknown as typeof logger.child;
     // Restore the patched child on build failure: the restore hook is only
     // handed to TestContext after a successful build, so without this a
@@ -460,12 +472,14 @@ export class TestContextBuilder {
 
     const options: TestContextOptions & {
       spyLogger: SpyLogger;
+      contextLogger: SpyLogger;
       restoreLoggerChild: () => void;
     } = {
       ...(this.routesReadyTimeoutMs !== undefined
         ? { routesReadyTimeout: this.routesReadyTimeoutMs }
         : {}),
       spyLogger,
+      contextLogger,
       restoreLoggerChild: () => {
         logger.child = originalChild;
       },
@@ -481,6 +495,7 @@ export class TestContextBuilder {
  * calls in the jest-compatible `mock.calls` shape. Pass `{ fn }` with your
  * runner's mock factory (`vi.fn` from Vitest, `mock` from bun:test) when you
  * want `expect(t.logger.info).toHaveBeenCalledWith(...)` matcher support.
+ * Use `t.contextLogger` for calls made directly by the context logger.
  *
  * @example
  * const builder = testContext();

--- a/packages/testing/src/test-context.ts
+++ b/packages/testing/src/test-context.ts
@@ -435,7 +435,7 @@ export class TestContextBuilder {
   async build(): Promise<TestContext> {
     const spyLogger = createSpyLogger(this.spyFactory);
     const contextLogger = createSpyLogger(this.spyFactory);
-    const originalChild = logger.child.bind(logger);
+    const originalChild = logger.child;
     const childSpy = this.spyFactory();
     childSpy.mockImplementation((bindings) => {
       const isRouteLogger =

--- a/packages/testing/test/context-logger.bun.test.ts
+++ b/packages/testing/test/context-logger.bun.test.ts
@@ -48,6 +48,7 @@ describe("context logger spy", () => {
    * @expectedResult logger.child returns a framework logger rather than a test spy after teardown
    */
   test("restores logger.child after teardown", async () => {
+    const originalChild = logger.child;
     t = await testContext()
       .routes(
         craft().id("context-logger-restore").from(simple("hello")).to(noop()),
@@ -56,6 +57,6 @@ describe("context logger spy", () => {
 
     await t.stop();
 
-    expect(logger.child).not.toBe(t.logger.child);
+    expect(logger.child).toBe(originalChild);
   });
 });

--- a/packages/testing/test/context-logger.bun.test.ts
+++ b/packages/testing/test/context-logger.bun.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { craft, logger, noop, simple } from "@routecraft/routecraft";
+import { testContext, type TestContext } from "@routecraft/testing";
+
+describe("context logger spy", () => {
+  let t: TestContext | undefined;
+
+  afterEach(async () => {
+    if (t) await t.stop();
+    t = undefined;
+  });
+
+  /**
+   * @case Context-level and route-level logger calls are recorded by separate spies
+   * @preconditions A test context is built with one route; each logger receives a distinct marker
+   * @expectedResult t.contextLogger captures ctx.logger calls while t.logger captures route logger calls without cross-contamination
+   */
+  test("separates context and route logger calls", async () => {
+    t = await testContext()
+      .routes(craft().id("context-logger").from(simple("hello")).to(noop()))
+      .build();
+
+    expect(t.ctx.logger as unknown).toBe(t.contextLogger);
+    expect(t.contextLogger).not.toBe(t.logger);
+    expect(t.ctx.logger.warn).toBe(t.contextLogger.warn);
+    expect(t.ctx.logger.warn).not.toBe(t.logger.warn);
+
+    t.ctx.logger.warn({ source: "context" }, "context-level");
+    t.ctx.getRoutes()[0]?.logger.info({ source: "route" }, "route-level");
+
+    expect(t.contextLogger.warn.mock.calls).toContainEqual([
+      { source: "context" },
+      "context-level",
+    ]);
+    expect(t.logger.info.mock.calls).toContainEqual([
+      { source: "route" },
+      "route-level",
+    ]);
+    expect(t.contextLogger.info.mock.calls).not.toContainEqual([
+      { source: "route" },
+      "route-level",
+    ]);
+  });
+
+  /**
+   * @case Stopping a context restores the global logger child implementation
+   * @preconditions A test context has installed its context and route logger spies
+   * @expectedResult logger.child returns a framework logger rather than a test spy after teardown
+   */
+  test("restores logger.child after teardown", async () => {
+    t = await testContext()
+      .routes(
+        craft().id("context-logger-restore").from(simple("hello")).to(noop()),
+      )
+      .build();
+
+    await t.stop();
+
+    expect(logger.child).not.toBe(t.logger.child);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #603.

## Problem

`testContext()` previously routed every `logger.child()` call to the route-scoped `t.logger` spy. Context-level calls made through `t.ctx.logger` therefore could not be asserted independently, and the suspension sweeper test used a local monkey-patching workaround.

## Changes

- Add a separately typed `t.contextLogger` spy for context-level logger calls.
- Keep route and exchange logger calls on `t.logger` by distinguishing route bindings during the harness `logger.child` patch.
- Restore the global `logger.child` implementation on build failure and context teardown as before.
- Replace the suspension sweeper's `captureLogs()` / `said()` workaround with `t.contextLogger` assertions.
- Migrate existing context-level logger assertions to `t.contextLogger` while leaving route-scoped assertions on `t.logger`.
- Add the requested minor changeset for `@routecraft/testing`.

## Compatibility

Existing `t.logger` assertions continue to cover route-scoped calls. Tests that need context-level calls can use the new `t.contextLogger` property; no runtime production logger behavior is changed outside the test harness.

## Tests

- `bun test packages/testing/test/context-logger.bun.test.ts packages/routecraft/test/suspension-sweeper.bun.test.ts` — 23 passed.
- `bun run typecheck` — passed.
- `bun run lint` — passed.
- `bun x prettier --check packages/testing/src/test-context.ts packages/testing/test/context-logger.bun.test.ts packages/routecraft/test/suspension-sweeper.bun.test.ts .changeset/context-logger-spy.md` — passed.
- `bun x madge --circular .` — passed; no circular dependency found.
- `bun run build` — passed.
- `bun x changeset status` — passed; it reports existing workspace dependency-range warnings.
- `bun run format` — not clean on the current Windows checkout because the repository baseline has 899 files outside this change that fail the configured Prettier check; all changed files pass the focused check above.
- `bun run test` — blocked by the repository's Unix shell script invoking unavailable Windows commands (`xargs` and `test`); the Vitest leg completed with no test files.
- `bun test packages/testing/test/spy-logger.bun.test.ts` — 6 passed, with one pre-existing Windows `file://` fixture path `ENOENT` error.

## AI disclosure

Prepared with AI assistance. The implementation, tests, diff, and validation results were reviewed against the issue requirements.
