### PR TITLE
docs(standards): the AI package does not hold the agent tools

### DIFF
--- a/.standards/package-boundaries.md
+++ b/.standards/package-boundaries.md
@@ -138,7 +138,9 @@ Note on determinism: MCP is a thin protocol over HTTP and is usable from any rou
 
 ## 6. AI and the MCP client: `@routecraft/ai`
 
-`@routecraft/ai` holds the genuinely AI parts: `llm()`, `agent()`, embeddings, the provider seam (OpenAI, Anthropic, Gemini, OpenRouter, Ollama, custom, plus future Mistral/Cohere/DeepSeek/Bedrock/Vertex via the Vercel AI SDK), and the agent tools (`WebFetch`, `WebSearch`, `Bash`). It is an ecosystem package, not core, and depends on the Vercel AI SDK; docs must not present it as core.
+`@routecraft/ai` holds the genuinely AI parts: `llm()`, `agent()`, embeddings, and the provider seam (OpenAI, Anthropic, Gemini, OpenRouter, Ollama, custom, plus future Mistral/Cohere/DeepSeek/Bedrock/Vertex via the Vercel AI SDK). It is an ecosystem package, not core, and depends on the Vercel AI SDK; docs must not present it as core.
+
+It does NOT hold the agent tools. `WebFetch`, `WebSearch` and `Bash` are Claude Code's tool names, and the agent loader only tolerates them: a reference to one this runtime does not provide is dropped with a warning so an agent file written for a coding harness still boots, where a genuinely unknown name stays a hard error (`CLAUDE_BUILTIN_TOOLS` in `packages/ai/src/agent/loader.ts`). The one host primitive among them that does ship is `shell()` in `@routecraft/os`, which is there because isolated subprocess execution carries an invariant nothing else can carry, not because an agent wants a tool. Everything else an agent reaches for is a route the app composes and registers under that name, per 6.1. The reference `WebFetch` and `WebSearch` routes ship in the `craft-harness` template (#588), with the domain allowlist as a must-set placeholder so no scaffold carries silent default egress.
 
 **Open decision:** the `mcp()` client is a transport over a protocol, not an AI feature. By the section 2 rule (standards live in core), the MCP client transport arguably belongs in **core**, so a plain non-AI route can use `mcp()` without importing the AI module, leaving only the AI-specific pieces in `@routecraft/ai`. Recorded here as undecided; resolve before v1.
 

--- a/.standards/package-boundaries.md
+++ b/.standards/package-boundaries.md
@@ -196,7 +196,7 @@ Three kinds of module. The 8-to-12 bound governs only the first group.
 | Package | Today / planned | Disposition |
 |---|---|---|
 | `@routecraft/routecraft` | core: framework + standards | keep; add graphql; consider absorbing the MCP client (section 6) |
-| `@routecraft/ai` | llm, agent, mcp, embeddings, providers, agent tools | keep |
+| `@routecraft/ai` | llm, agent, mcp, embeddings, providers; agent tools are composed routes, not package code (section 6) | keep |
 | `@routecraft/os` | system-native: shell (isolated), browser, ... | keep; absorbs `@routecraft/browser` |
 | `@routecraft/browser` | browser automation | merge into `@routecraft/os`, deprecate the name |
 | `@routecraft/google` | Google ecosystem | on first adapter (#370) |

--- a/packages/ai/src/agent/loader.ts
+++ b/packages/ai/src/agent/loader.ts
@@ -105,10 +105,12 @@ const MODEL_ALIASES: Record<string, LlmModelId> = {
  * is still a hard error, because that is a typo or a missing
  * registration rather than a known gap.
  *
- * The check runs against the live catalog, so the moment Routecraft
- * registers a fn under one of these names (`WebFetch` in #341,
- * `WebSearch` in #342, `Bash` in #343) it resolves normally and no
- * entry has to be removed from this list.
+ * The check runs against the live catalog, so the moment an app, or
+ * the `craft-harness` template (#588), registers a route under one of
+ * these names it resolves normally and no entry has to be removed
+ * from this list. Routecraft ships none of them itself: a tool an
+ * agent reaches for is composed per `.standards/package-boundaries.md`
+ * section 6.1, not built into the framework.
  */
 const CLAUDE_BUILTIN_TOOLS = new Set([
   "Bash",


### PR DESCRIPTION
## What

Two documentation corrections, no behaviour change.

- `.standards/package-boundaries.md` section 6: the AI package does not hold agent tools such as WebFetch or WebSearch. Those ship as routes in the craft-harness template (#588), composed from what the framework already provides, in line with section 6.1's worked example.
- `packages/ai/src/agent/loader.ts`: the JSDoc above the built-in tool list now says the same, so a reader of the loader is not told the package carries tools it does not.

## Why

Both places implied the AI package ships agent tools. That contradicted the placement rule the same standard states one subsection later, and it misled an agent working in this repo into asserting the tools were built in. The prose now matches the code and the placement rule.

## Verification

Docs and a comment only. `bun run lint` on the touched package file passes; the loader test file runs unchanged.

https://claude.ai/code/session_01Y3yVVzrZYdjZUUkvnzscdb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3yVVzrZYdjZUUkvnzscdb)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The standards doc and loader JSDoc previously implied `@routecraft/ai` ships agent tools; both now say it only tolerates the Claude Code tool names `WebFetch`, `WebSearch`, and `Bash`, and that apps compose routes with those names.

- The section 8 module map also listed agent tools in the `@routecraft/ai` row; it now names them as composed routes, matching section 6.
- Reference routes ship in the `craft-harness` template, and `shell()` in `@routecraft/os` remains the only host primitive that ships.

Docs and comment only; no behavior change.

<sup>Written for commit ff9aa332b60d4dae1514a55e412e1fe12fb0950e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

