### PR TITLE
fix(ai): say a tool error once when the RC message already carries the cause

### DIFF
--- a/.changeset/mcp-tool-error-once.md
+++ b/.changeset/mcp-tool-error-once.md
@@ -1,0 +1,5 @@
+---
+"@routecraft/ai": patch
+---
+
+A failed MCP tool call no longer repeats its own message. An ordinary error thrown inside a route reached the client as `Error: X: X`, because the framework wraps it with its message as the RC message and the error itself as the cause, and the cause was appended regardless; a cause is now appended only when it says something the message does not.

--- a/packages/ai/src/mcp/server.ts
+++ b/packages/ai/src/mcp/server.ts
@@ -133,17 +133,29 @@ function toolErrorLogMessage(error: unknown): string {
 }
 
 /**
- * Client-facing message for a failed tool call: includes the RC cause
- * (e.g. schema field errors) but never stack traces or internal details.
+ * Client-facing message for a failed tool call: the RC message plus the
+ * cause when the cause adds something, and never stack traces or internal
+ * details.
+ *
+ * Each piece of text appears once. A plain error thrown by a step reaches
+ * here as RC5001 with the error itself as the cause and its message as the
+ * RC message, and several core sites embed the cause's text in the RC
+ * message they build, so appending the cause blindly repeated the same
+ * text in every such tool error. Derived from the error alone so a caller
+ * cannot hand it a message the containment test was never meant for.
  */
-function toolErrorUserMessage(error: unknown, logMsg: string): string {
-  if (isRoutecraftError(error)) {
-    const cause = (error as { cause?: Error }).cause;
-    if (cause?.message) {
-      return `${logMsg}: ${cause.message}`;
-    }
-  }
-  return logMsg;
+function toolErrorUserMessage(error: unknown): string {
+  const message = toolErrorLogMessage(error);
+  if (!isRoutecraftError(error)) return message;
+  const cause = (error as { cause?: Error }).cause?.message;
+  if (!cause || message.includes(cause)) return message;
+  if (cause.includes(message)) return cause;
+  return `${message}: ${cause}`;
+}
+
+/** The wire result for a tool call that did not answer, a decline or a failure. */
+function toolErrorResult(text: string): McpToolCallResult {
+  return { content: [{ type: "text", text: `Error: ${text}` }], isError: true };
 }
 
 /** Resolved options with defaults applied (internal use). */
@@ -1334,10 +1346,7 @@ export class McpServer {
       reason: message,
     });
 
-    return {
-      content: [{ type: "text", text: `Error: ${message}` }],
-      isError: true,
-    };
+    return toolErrorResult(message);
   }
 
   /**
@@ -1369,12 +1378,7 @@ export class McpServer {
           tool: toolName,
           error: err.message,
         });
-        return {
-          isError: true,
-          content: [
-            { type: "text", text: `Error: Tool not found: ${toolName}` },
-          ],
-        };
+        return toolErrorResult(err.message);
       }
 
       this.context.logger.debug(
@@ -1469,15 +1473,7 @@ export class McpServer {
         error: logMsg,
       });
 
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: ${toolErrorUserMessage(error, logMsg)}`,
-          },
-        ],
-        isError: true,
-      };
+      return toolErrorResult(toolErrorUserMessage(error));
     }
   }
 
@@ -1571,10 +1567,7 @@ export class McpServer {
         ? `Proxied tool "${proxied.exposedName}" could not be called.`
         : logMsg;
 
-      return {
-        content: [{ type: "text", text: `Error: ${clientText}` }],
-        isError: true,
-      };
+      return toolErrorResult(clientText);
     }
   }
 }

--- a/packages/ai/test/helpers/mcp-tool-call.ts
+++ b/packages/ai/test/helpers/mcp-tool-call.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "../../src/mcp/server.ts";
 /** Shape of the tool result the server hands back to a client. */
 export type ToolResult = {
   content: Array<{ type: string; text: string }>;
-  structuredContent?: Record<string, unknown>;
+  structuredContent?: unknown;
   isError?: boolean;
 };
 

--- a/packages/ai/test/helpers/mcp-tool-call.ts
+++ b/packages/ai/test/helpers/mcp-tool-call.ts
@@ -1,0 +1,25 @@
+import type { McpServer } from "../../src/mcp/server.ts";
+
+/** Shape of the tool result the server hands back to a client. */
+export type ToolResult = {
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+};
+
+/** Call a tool the way the SDK does, bypassing the JSON-RPC transport. */
+export async function callTool(
+  srv: McpServer,
+  tool: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  return (await (
+    srv as unknown as {
+      handleToolCall(
+        tool: string,
+        args: Record<string, unknown>,
+        principal: undefined,
+      ): Promise<ToolResult>;
+    }
+  ).handleToolCall(tool, args, undefined)) as ToolResult;
+}

--- a/packages/ai/test/mcp-server.bun.test.ts
+++ b/packages/ai/test/mcp-server.bun.test.ts
@@ -22,6 +22,7 @@ import { buildAuthHeaders } from "../src/mcp/build-auth-headers.ts";
 import { z } from "zod";
 import http from "node:http";
 import { rpcBody } from "./fixtures/rpc-body.ts";
+import { callTool } from "./helpers/mcp-tool-call.ts";
 
 const MCP_STORE_KEY =
   MCP_PLUGIN_REGISTERED as keyof import("@routecraft/routecraft").StoreRegistry;
@@ -3735,31 +3736,114 @@ describe("McpServer", () => {
     });
   });
 
+  describe("tool failure text", () => {
+    /**
+     * @case A step throws a plain Error
+     * @preconditions A tool route whose transform throws new Error("Nuclino API 404: Item not found"); the pipeline wraps it as RC5001 with the error as its cause and the error's message as the RC message
+     * @expectedResult The tool result text carries that message exactly once, where every route-raised tool error used to read as "message: message"
+     */
+    test("says a plain step error once", async () => {
+      const srv = await serve([
+        craft()
+          .id("thrower")
+          .description("Throws a plain error from its transform")
+          .from<{ value: string }>(mcp())
+          .transform(() => {
+            throw new Error("Nuclino API 404: Item not found");
+          }),
+      ]);
+
+      const result = await callTool(srv, "thrower", { value: "hi" });
+
+      expect(result.isError).toBe(true);
+      const text = result.content[0]!.text;
+      expect(text).toStartWith("Error: ");
+      expect(text.match(/Nuclino API 404: Item not found/g)).toHaveLength(1);
+    });
+
+    /**
+     * @case A RoutecraftError whose cause says something its message does not
+     * @preconditions A tool route throws rcError("RC5001", new Error("field total is required"), { message: "Validation failed" })
+     * @expectedResult The text carries the message and then the cause, each once: a cause that adds information still reaches the client, which is how schema field errors get there
+     */
+    test("still appends a cause that adds information", async () => {
+      const srv = await serve([
+        craft()
+          .id("validator")
+          .description("Throws an RC error with an informative cause")
+          .from<{ value: string }>(mcp())
+          .transform(() => {
+            throw rcError("RC5001", new Error("field total is required"), {
+              message: "Validation failed",
+            });
+          }),
+      ]);
+
+      const result = await callTool(srv, "validator", { value: "hi" });
+
+      expect(result.isError).toBe(true);
+      const text = result.content[0]!.text;
+      expect(text.match(/Validation failed/g)).toHaveLength(1);
+      expect(text.match(/field total is required/g)).toHaveLength(1);
+      expect(text.indexOf("Validation failed")).toBeLessThan(
+        text.indexOf("field total is required"),
+      );
+    });
+
+    /**
+     * @case A RoutecraftError whose message already embeds its cause's text
+     * @preconditions A tool route throws rcError("RC5001", new Error("total"), { message: "Validation failed for total" }), the shape several core sites build
+     * @expectedResult The cause is not appended, so "total" appears once: containment, not equality, is the rule
+     */
+    test("does not append a cause the message already contains", async () => {
+      const srv = await serve([
+        craft()
+          .id("embedder")
+          .description("Throws an RC error whose message embeds the cause")
+          .from<{ value: string }>(mcp())
+          .transform(() => {
+            throw rcError("RC5001", new Error("total"), {
+              message: "Validation failed for total",
+            });
+          }),
+      ]);
+
+      const result = await callTool(srv, "embedder", { value: "hi" });
+
+      const text = result.content[0]!.text;
+      expect(text).toContain("Validation failed for total");
+      expect(text.match(/total/g)).toHaveLength(1);
+    });
+
+    /**
+     * @case A cause whose text already contains the RC message
+     * @preconditions A tool route throws rcError("RC5001", new Error("Validation failed: field total is required"), { message: "Validation failed" })
+     * @expectedResult The cause is returned whole and the message is not prefixed to it, so "Validation failed" appears once and the detail survives
+     */
+    test("returns a cause that contains the message, once", async () => {
+      const srv = await serve([
+        craft()
+          .id("prefixed")
+          .description("Throws an RC error whose cause extends the message")
+          .from<{ value: string }>(mcp())
+          .transform(() => {
+            throw rcError(
+              "RC5001",
+              new Error("Validation failed: field total is required"),
+              { message: "Validation failed" },
+            );
+          }),
+      ]);
+
+      const result = await callTool(srv, "prefixed", { value: "hi" });
+
+      const text = result.content[0]!.text;
+      expect(text.match(/Validation failed/g)).toHaveLength(1);
+      expect(text).toContain("field total is required");
+    });
+  });
+
   describe("advertised output enforcement", () => {
-    /** Shape of the tool result the server hands back to a client. */
-    type ToolResult = {
-      content: Array<{ type: string; text: string }>;
-      structuredContent?: Record<string, unknown>;
-      isError?: boolean;
-    };
-
-    /** Call a tool the way the SDK does, bypassing the JSON-RPC transport. */
-    async function callTool(
-      srv: McpServer,
-      tool: string,
-      args: Record<string, unknown>,
-    ): Promise<ToolResult> {
-      return (await (
-        srv as unknown as {
-          handleToolCall(
-            tool: string,
-            args: Record<string, unknown>,
-            principal: undefined,
-          ): Promise<ToolResult>;
-        }
-      ).handleToolCall(tool, args, undefined)) as ToolResult;
-    }
-
     /**
      * Serve one tool straight from the local registry, with a handler that
      * returns `body` without a route behind it. Isolates the MCP boundary

--- a/packages/ai/test/mcp-suspended.bun.test.ts
+++ b/packages/ai/test/mcp-suspended.bun.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/mcp/types.ts";
 import { agent, llmPlugin, mcp } from "../src/index.ts";
 import { scriptedLlm } from "./helpers/scripted-llm.ts";
+import { callTool } from "./helpers/mcp-tool-call.ts";
 
 // The agent-bearing advertisement test constructs (never dispatches) an
 // agent route, but the barrel is mocked anyway so this file cannot leak a
@@ -32,29 +33,6 @@ const MCP_STORE_KEY =
 
 const Approval = z.object({ approved: z.boolean() });
 const Payout = z.object({ paid: z.boolean() });
-
-type ToolResult = {
-  content: Array<{ type: string; text: string }>;
-  structuredContent?: Record<string, unknown>;
-  isError?: boolean;
-};
-
-/** Call a tool the way the SDK does, bypassing the JSON-RPC transport. */
-async function callTool(
-  srv: McpServer,
-  tool: string,
-  args: Record<string, unknown>,
-): Promise<ToolResult> {
-  return (await (
-    srv as unknown as {
-      handleToolCall(
-        tool: string,
-        args: Record<string, unknown>,
-        principal: undefined,
-      ): Promise<ToolResult>;
-    }
-  ).handleToolCall(tool, args, undefined)) as ToolResult;
-}
 
 describe("MCP carries Suspended (#581)", () => {
   let t: TestContext | undefined;


### PR DESCRIPTION
## Summary

A plain error thrown by a step reaches the MCP boundary as RC5001 with the error as its cause and the error's own message as the RC message (`processError` in `pipeline/executor.ts`). `toolErrorUserMessage` appended the cause regardless, so every route-raised tool error read twice: `Error: Nuclino API 404: Item not found: Nuclino API 404: Item not found`.

The client text now says each piece once: a cause the message already contains is not appended (several core sites build the RC message by embedding the cause, so equality would not do), a cause that itself contains the message is returned whole, and anything else is appended as before, so schema field errors keep reaching the client.

## What changed

- `packages/ai/src/mcp/server.ts`: `toolErrorUserMessage(error)` derives both strings from the error alone, so a caller cannot hand it a message the containment test was never meant for. The four hand-built `isError` result literals share one `toolErrorResult()`.
- `packages/ai/test/mcp-server.bun.test.ts`: four tests under "tool failure text" (plain error once; informative cause appended; contained cause not appended; cause containing the message returned whole), asserting on occurrence counts rather than full strings per `.standards/testing.md` section 6. The first fails without the fix with exactly the doubled text above.
- `packages/ai/test/helpers/mcp-tool-call.ts`: the `callTool` shim that `mcp-server` and `mcp-suspended` each carried a copy of.
- `.changeset/mcp-tool-error-once.md`: patch for `@routecraft/ai`.

Wire text is the only artefact that changed: the `plugin:mcp:tool:failed` payload and the boundary log still carry the RC message, which remains a substring of the wire text in every case, so an operator can still correlate a client's report to the log line.

## Checks

`bun test packages/ai/test`: 854 pass, 1 skip, 0 fail. `bun run typecheck`, eslint on the touched files and prettier all exit 0.

Motivated by https://github.com/devoptixnl/app.devoptix.nl/pull/255, where the doubled text surfaced on every Nuclino failure.

https://claude.ai/code/session_01Y3yVVzrZYdjZUUkvnzscdb