### PR TITLE
fix(html): text extraction keeps escaped markup and whitespace

### DIFF
--- a/.changeset/html-text-keeps-escaped-markup.md
+++ b/.changeset/html-text-keeps-escaped-markup.md
@@ -1,14 +1,33 @@
 ---
-"@routecraft/routecraft": patch
+"@routecraft/routecraft": minor
 ---
 
-`html()` text extraction no longer deletes escaped markup (#719).
+`html()` text extraction changes what it returns: escaped markup is no longer deleted, and whitespace inside the match is no longer collapsed (#719).
 
-`extract: "text"`, `"innerText"` and `"textContent"` ran a tag-stripping regex over text cheerio had already decoded. At that point there is no markup left to strip, so the regex could only match content the page had escaped on purpose: `<pre>type X = Array&lt;string&gt;;</pre>` came back as `type X = Array;`, with no signal to the caller that anything had been dropped.
+`extract: "text"`, `"innerText"` and `"textContent"` ran a tag-stripping regex over text cheerio had already decoded. At that point there is no markup left to strip, so the regex could only match content the page had escaped on purpose: `<pre>type X = Array&lt;string&gt;;</pre>` came back as `type X = Array;`, with no signal to the caller that anything had been dropped. Removing it changes two things, on all three roles that extract (transformer, source, enricher).
 
-**Behaviour change.** Two things are different for the three text extract modes:
+**Whitespace inside the match now survives.** This is the half that reaches the most routes. The stripping step also collapsed every run of whitespace to a single space, so any page with ordinary indentation was being flattened:
 
-- Escaped markup survives. `Array&lt;string&gt;` now extracts as `Array<string>` rather than `Array`.
-- Whitespace inside the match is preserved. The stripping step also collapsed every run of whitespace to a single space, which flattened a `<pre>` to one line; a multi-line code sample now keeps its newlines and indentation. Leading and trailing whitespace is still trimmed.
+```
+<div class="card">
+  <h2>Getting started</h2>
+  <p>Install the   package
+     and run it.</p>
+</div>
+
+before: "Getting started Install the package and run it."
+after:  "Getting started\n  Install the   package\n     and run it."
+```
+
+Only the ends are trimmed, per matched element in the array case. A `<pre>` therefore keeps its newlines and indentation too, which is the code-sample case that motivated the fix.
+
+**Escaped markup now survives.** `Array&lt;string&gt;` extracts as `Array<string>` rather than `Array`. The value is decoded and unsanitised: a page that escaped a payload gets it back as live markup, so escape it at the sink before writing extracted text into HTML or into any line-structured format.
+
+**You are affected if** a route compares extracted text to a literal, keys or hashes on it, validates it against a schema, or writes it to a line-oriented sink. There is no compile error and no new option to notice. Collapse it in the route where you want the old shape:
+
+```ts
+.transform(html({ selector: '.card', extract: 'text' }))
+.transform((text: string) => text.replace(/\s+/g, ' '))
+```
 
 `<style>` and `<script>` subtrees are still removed from text extraction, which is the part that genuinely needed handling. `extract: "html"`, `"outerHtml"` and `"attr"` are unchanged.

--- a/.changeset/html-text-keeps-escaped-markup.md
+++ b/.changeset/html-text-keeps-escaped-markup.md
@@ -26,8 +26,8 @@ Only the ends are trimmed, per matched element in the array case. A `<pre>` ther
 **You are affected if** a route compares extracted text to a literal, keys or hashes on it, validates it against a schema, or writes it to a line-oriented sink. There is no compile error and no new option to notice. Collapse it in the route where you want the old shape:
 
 ```ts
-.transform(html({ selector: '.card', extract: 'text' }))
-.transform((text: string) => text.replace(/\s+/g, ' '))
+.transform(html<unknown, string>({ selector: '.card', extract: 'text' }))
+.transform((text) => text.replace(/\s+/g, ' '))
 ```
 
 `<style>` and `<script>` subtrees are still removed from text extraction, which is the part that genuinely needed handling. `extract: "html"`, `"outerHtml"` and `"attr"` are unchanged.

--- a/.changeset/html-text-keeps-escaped-markup.md
+++ b/.changeset/html-text-keeps-escaped-markup.md
@@ -1,0 +1,14 @@
+---
+"@routecraft/routecraft": patch
+---
+
+`html()` text extraction no longer deletes escaped markup (#719).
+
+`extract: "text"`, `"innerText"` and `"textContent"` ran a tag-stripping regex over text cheerio had already decoded. At that point there is no markup left to strip, so the regex could only match content the page had escaped on purpose: `<pre>type X = Array&lt;string&gt;;</pre>` came back as `type X = Array;`, with no signal to the caller that anything had been dropped.
+
+**Behaviour change.** Two things are different for the three text extract modes:
+
+- Escaped markup survives. `Array&lt;string&gt;` now extracts as `Array<string>` rather than `Array`.
+- Whitespace inside the match is preserved. The stripping step also collapsed every run of whitespace to a single space, which flattened a `<pre>` to one line; a multi-line code sample now keeps its newlines and indentation. Leading and trailing whitespace is still trimmed.
+
+`<style>` and `<script>` subtrees are still removed from text extraction, which is the part that genuinely needed handling. `extract: "html"`, `"outerHtml"` and `"attr"` are unchanged.

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/html/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/html/index.mdx
@@ -123,11 +123,11 @@ Passing both `append: true` and `delete: true` throws `RC5003` at construction.
 **Extract types:**
 - `text` / `innerText` / `textContent`: Plain text content, with `<style>` and `<script>` subtrees removed and the result trimmed. `innerText` and `textContent` are aliases of `text`; there is no layout server-side to tell them apart.
 
-  Two things to know about the value you get back. Entities are decoded, so a page that escapes markup (`Array&lt;string&gt;`) yields it as written (`Array<string>`); the result is unsanitised, and it is the route's job to escape it at the sink before writing it into HTML or into a line-structured format. And whitespace inside the match survives, so a `<pre>` keeps its line breaks and an ordinary indented page yields the source indentation and newlines between its elements. Collapse it in the route when you want one line:
+  Two things to know about the value you get back. Entities are decoded, so a page that escapes markup (`Array&lt;string&gt;`) yields it as written (`Array<string>`); the result is unsanitised, and it is the route's job to escape it at the sink before writing it into HTML or into a line-structured format. And whitespace inside the match survives, so a `<pre>` keeps its line breaks and an ordinary indented page yields the source indentation and newlines between its elements. Collapse it in the route when you want one line. A selector that matches a single element yields a string, and the second type parameter names that, so the transform after it does not have to handle the array case:
 
   ```ts
-  .transform(html({ selector: '.card', extract: 'text' }))
-  .transform((text: string) => text.replace(/\s+/g, ' '))
+  .transform(html<unknown, string>({ selector: '.card', extract: 'text' }))
+  .transform((text) => text.replace(/\s+/g, ' '))
   ```
 - `html`: Inner HTML content
 - `attr`: Attribute value (requires `attr` option)

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/html/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/html/index.mdx
@@ -121,7 +121,14 @@ All transformer options above (except `from` / `to`, which only apply to the tra
 Passing both `append: true` and `delete: true` throws `RC5003` at construction.
 
 **Extract types:**
-- `text` / `innerText` / `textContent`: Plain text content, with `<style>` and `<script>` subtrees removed and the result trimmed. Entities are decoded, so a page that escapes markup (`Array&lt;string&gt;`) yields it as written (`Array<string>`). Whitespace inside the match is preserved, so a `<pre>` keeps its line breaks.
+- `text` / `innerText` / `textContent`: Plain text content, with `<style>` and `<script>` subtrees removed and the result trimmed. `innerText` and `textContent` are aliases of `text`; there is no layout server-side to tell them apart.
+
+  Two things to know about the value you get back. Entities are decoded, so a page that escapes markup (`Array&lt;string&gt;`) yields it as written (`Array<string>`); the result is unsanitised, and it is the route's job to escape it at the sink before writing it into HTML or into a line-structured format. And whitespace inside the match survives, so a `<pre>` keeps its line breaks and an ordinary indented page yields the source indentation and newlines between its elements. Collapse it in the route when you want one line:
+
+  ```ts
+  .transform(html({ selector: '.card', extract: 'text' }))
+  .transform((text: string) => text.replace(/\s+/g, ' '))
+  ```
 - `html`: Inner HTML content
 - `attr`: Attribute value (requires `attr` option)
 - `outerHtml`: Element including its tag

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/html/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/html/index.mdx
@@ -121,7 +121,7 @@ All transformer options above (except `from` / `to`, which only apply to the tra
 Passing both `append: true` and `delete: true` throws `RC5003` at construction.
 
 **Extract types:**
-- `text` / `innerText` / `textContent`: Plain text content (strips HTML tags, removes `<style>` and `<script>`)
+- `text` / `innerText` / `textContent`: Plain text content, with `<style>` and `<script>` subtrees removed and the result trimmed. Entities are decoded, so a page that escapes markup (`Array&lt;string&gt;`) yields it as written (`Array<string>`). Whitespace inside the match is preserved, so a `<pre>` keeps its line breaks.
 - `html`: Inner HTML content
 - `attr`: Attribute value (requires `attr` option)
 - `outerHtml`: Element including its tag

--- a/packages/routecraft/src/adapters/html/shared.ts
+++ b/packages/routecraft/src/adapters/html/shared.ts
@@ -58,12 +58,8 @@ export async function extractHtml<T, R>(
   const $el = $(selector);
   const length = $el.length;
 
-  const isTextExtract =
-    extract === "text" || extract === "innerText" || extract === "textContent";
   const textFrom = ($node: ReturnType<typeof $>) =>
-    isTextExtract
-      ? $node.clone().find("style, script").remove().end().text().trim()
-      : $node.text().trim();
+    $node.clone().find("style, script").remove().end().text().trim();
 
   const getOne = (): string => {
     if (

--- a/packages/routecraft/src/adapters/html/shared.ts
+++ b/packages/routecraft/src/adapters/html/shared.ts
@@ -28,14 +28,6 @@ export function getHtml<T>(
   return getBodyText(body, from, "html");
 }
 
-/** Strip HTML tags so only plain text remains. Used as a safeguard for text extraction. */
-export function stripHtmlTags(s: string): string {
-  return s
-    .replace(/<[^>]*>/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
 /**
  * Core HTML extraction logic shared by transformer and source adapters.
  *
@@ -79,7 +71,7 @@ export async function extractHtml<T, R>(
       extract === "innerText" ||
       extract === "textContent"
     )
-      return stripHtmlTags(textFrom($el));
+      return textFrom($el);
     if (extract === "html") return $el.html()?.trim() ?? "";
     if (extract === "attr") return $el.attr(attr!) ?? "";
     if (extract === "outerHtml") return $el.prop("outerHTML") ?? "";
@@ -94,7 +86,7 @@ export async function extractHtml<T, R>(
         extract === "innerText" ||
         extract === "textContent"
       )
-        values.push(stripHtmlTags(textFrom($e)));
+        values.push(textFrom($e));
       else if (extract === "html") values.push($e.html()?.trim() ?? "");
       else if (extract === "attr") values.push($e.attr(attr!) ?? "");
       else if (extract === "outerHtml") values.push($e.prop("outerHTML") ?? "");

--- a/packages/routecraft/src/adapters/html/types.ts
+++ b/packages/routecraft/src/adapters/html/types.ts
@@ -12,7 +12,8 @@ export interface HtmlOptions<T = unknown, R = unknown> {
   selector?: string;
   /**
    * What to extract. Default: "text".
-   * - text: cheerio .text() (all descendant text), trimmed
+   * - text: cheerio .text() (all descendant text), trimmed, with
+   *   `style` and `script` subtrees removed
    * - html: inner HTML (cheerio .html())
    * - attr: attribute value (requires attr option)
    * - outerHtml: element including its tag (cheerio .prop('outerHTML'))

--- a/packages/routecraft/src/adapters/html/types.ts
+++ b/packages/routecraft/src/adapters/html/types.ts
@@ -17,8 +17,14 @@ export interface HtmlOptions<T = unknown, R = unknown> {
    * - html: inner HTML (cheerio .html())
    * - attr: attribute value (requires attr option)
    * - outerHtml: element including its tag (cheerio .prop('outerHTML'))
-   * - innerText: text only, no HTML (cheerio .text()); server-side no layout so same as textContent
-   * - textContent: text only, no HTML (cheerio .text())
+   * - innerText: same as textContent; server-side there is no layout
+   * - textContent: identical to "text"
+   *
+   * The three text modes return the page's text decoded and unsanitised.
+   * Entities are resolved, so a page that escaped markup yields it as
+   * written, and whitespace inside the match survives: only the ends are
+   * trimmed. Escape the value at the sink before writing it into HTML or
+   * into any line-structured format.
    */
   extract?:
     "text" | "html" | "attr" | "outerHtml" | "innerText" | "textContent";

--- a/packages/routecraft/test/html.bun.test.ts
+++ b/packages/routecraft/test/html.bun.test.ts
@@ -303,6 +303,128 @@ describe("HTML Adapter", () => {
       const body = s.received[0].body as HtmlResult;
       expect(body).toBe("type X = Array&lt;string&gt;;");
     });
+
+    /**
+     * @case An ordinary indented page yields its source whitespace
+     * @preconditions Selector matches a container whose children are indented across several lines, extract: "text"
+     * @expectedResult Inner newlines and indentation are returned as the source has them; only the ends are trimmed
+     */
+    test("returns source whitespace from an indented container", async () => {
+      const s = spy();
+      const htmlString =
+        '<div class="card">\n  <h2>Getting started</h2>\n  <p>Install the   package\n     and run it.</p>\n</div>';
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-text-indented-prose")
+            .from(simple(htmlString))
+            .transform(html({ selector: ".card", extract: "text" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const body = s.received[0].body as HtmlResult;
+      expect(body).toBe(
+        "Getting started\n  Install the   package\n     and run it.",
+      );
+    });
+
+    /**
+     * @case Source whitespace survives on the multi-match path
+     * @preconditions Selector matches several list items, one of them wrapped across lines, extract: "text"
+     * @expectedResult Each entry is trimmed at its ends but keeps the newline and indentation inside it
+     */
+    test("returns source whitespace in every entry of a multi-match result", async () => {
+      const s = spy();
+      const htmlString =
+        "<ul>\n  <li>One</li>\n  <li>Two\n      wrapped</li>\n</ul>";
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-text-indented-multi")
+            .from(simple(htmlString))
+            .transform(html({ selector: "li", extract: "text" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const body = s.received[0].body as HtmlResult;
+      expect(body).toEqual(["One", "Two\n      wrapped"]);
+    });
+
+    /**
+     * @case The source role extracts through the same corrected text path
+     * @preconditions An HTML file holds entity-escaped markup, read with .from(html({ path, extract: "text" }))
+     * @expectedResult The escaped markup survives, proving the fix reaches the deferred source parse and not only the transformer
+     */
+    test("source role keeps escaped markup in extracted text", async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "html-test-"));
+      const testFile = path.join(tempDir, "escaped.html");
+      await fs.writeFile(
+        testFile,
+        "<html><body><pre>type X = Array&lt;string&gt;;</pre></body></html>",
+      );
+
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-source-escaped-markup")
+            .from(html({ path: testFile, selector: "pre", extract: "text" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const body = s.received[0].body as HtmlResult;
+      expect(body).toBe("type X = Array<string>;");
+
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    /**
+     * @case The enricher role extracts through the same corrected text path
+     * @preconditions An HTML file holds entity-escaped markup, read with .enrich(html({ path, selector }))
+     * @expectedResult The escaped markup survives on the enriched field
+     */
+    test("enricher role keeps escaped markup in extracted text", async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "html-test-"));
+      const testFile = path.join(tempDir, "escaped-enrich.html");
+      await fs.writeFile(
+        testFile,
+        "<html><body><pre>type X = Array&lt;string&gt;;</pre></body></html>",
+      );
+
+      const s = spy();
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-enrich-escaped-markup")
+            .from(simple<{ keep: boolean }>({ keep: true }))
+            .enrich(
+              html({ path: testFile, selector: "pre", extract: "text" }),
+              only((code: HtmlResult) => code, "code"),
+            )
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const body = s.received[0].body as { code: string };
+      expect(body.code).toBe("type X = Array<string>;");
+
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
   });
 
   describe("default and from option", () => {

--- a/packages/routecraft/test/html.bun.test.ts
+++ b/packages/routecraft/test/html.bun.test.ts
@@ -177,6 +177,18 @@ describe("HTML Adapter", () => {
   });
 
   describe("text extraction fidelity", () => {
+    let tempDir: string;
+
+    afterEach(async () => {
+      if (tempDir) {
+        try {
+          await fs.rm(tempDir, { recursive: true, force: true });
+        } catch {
+          // Ignore cleanup errors
+        }
+      }
+    });
+
     /**
      * @case Escaped markup inside a <pre> survives text extraction
      * @preconditions Body is HTML whose text content contains entity-escaped angle brackets, extract: "text"
@@ -364,7 +376,7 @@ describe("HTML Adapter", () => {
      * @expectedResult The escaped markup survives, proving the fix reaches the deferred source parse and not only the transformer
      */
     test("source role keeps escaped markup in extracted text", async () => {
-      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "html-test-"));
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "html-test-"));
       const testFile = path.join(tempDir, "escaped.html");
       await fs.writeFile(
         testFile,
@@ -386,8 +398,6 @@ describe("HTML Adapter", () => {
 
       const body = s.received[0].body as HtmlResult;
       expect(body).toBe("type X = Array<string>;");
-
-      await fs.rm(tempDir, { recursive: true, force: true });
     });
 
     /**
@@ -396,7 +406,7 @@ describe("HTML Adapter", () => {
      * @expectedResult The escaped markup survives on the enriched field
      */
     test("enricher role keeps escaped markup in extracted text", async () => {
-      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "html-test-"));
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "html-test-"));
       const testFile = path.join(tempDir, "escaped-enrich.html");
       await fs.writeFile(
         testFile,
@@ -422,8 +432,6 @@ describe("HTML Adapter", () => {
 
       const body = s.received[0].body as { code: string };
       expect(body.code).toBe("type X = Array<string>;");
-
-      await fs.rm(tempDir, { recursive: true, force: true });
     });
   });
 

--- a/packages/routecraft/test/html.bun.test.ts
+++ b/packages/routecraft/test/html.bun.test.ts
@@ -176,6 +176,135 @@ describe("HTML Adapter", () => {
     });
   });
 
+  describe("text extraction fidelity", () => {
+    /**
+     * @case Escaped markup inside a <pre> survives text extraction
+     * @preconditions Body is HTML whose text content contains entity-escaped angle brackets, extract: "text"
+     * @expectedResult The decoded angle brackets and the content between them are returned intact
+     */
+    test("keeps escaped markup in extracted text", async () => {
+      const s = spy();
+      const htmlString = "<pre>type X = Array&lt;string&gt;;</pre>";
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-text-escaped-markup")
+            .from(simple(htmlString))
+            .transform(html({ selector: "pre", extract: "text" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const body = s.received[0].body as HtmlResult;
+      expect(body).toBe("type X = Array<string>;");
+    });
+
+    /**
+     * @case A multi-line <pre> keeps its line breaks under text extraction
+     * @preconditions Body is HTML with a <pre> spanning several lines and indented, extract: "text"
+     * @expectedResult Newlines and inner indentation are preserved; only leading and trailing whitespace is trimmed
+     */
+    test("preserves newlines and indentation in extracted text", async () => {
+      const s = spy();
+      const htmlString = "<pre>function f() {\n  return 1;\n}</pre>";
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-text-multiline")
+            .from(simple(htmlString))
+            .transform(html({ selector: "pre", extract: "text" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const body = s.received[0].body as HtmlResult;
+      expect(body).toBe("function f() {\n  return 1;\n}");
+    });
+
+    /**
+     * @case <style> and <script> subtrees are still excluded from text extraction
+     * @preconditions Selector matches a container holding style, script and visible text, extract: "text"
+     * @expectedResult Only the visible text is returned; neither CSS nor script source appears
+     */
+    test("still removes style and script content from extracted text", async () => {
+      const s = spy();
+      const htmlString =
+        '<div class="wrap"><style>.hide { display: none; }</style><p>Visible</p><script>alert("hi");</script></div>';
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-text-style-script")
+            .from(simple(htmlString))
+            .transform(html({ selector: ".wrap", extract: "text" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const body = s.received[0].body as HtmlResult;
+      expect(body).toBe("Visible");
+    });
+
+    /**
+     * @case Escaped markup survives on the multi-match path
+     * @preconditions Selector matches several elements, each containing entity-escaped angle brackets, extract: "text"
+     * @expectedResult Every array entry carries its decoded angle brackets intact
+     */
+    test("keeps escaped markup in every entry of a multi-match result", async () => {
+      const s = spy();
+      const htmlString =
+        "<pre>List&lt;T&gt;</pre><pre>Promise&lt;void&gt;</pre><pre>a &lt; b</pre>";
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-text-escaped-multi")
+            .from(simple(htmlString))
+            .transform(html({ selector: "pre", extract: "text" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const body = s.received[0].body as HtmlResult;
+      expect(body).toEqual(["List<T>", "Promise<void>", "a < b"]);
+    });
+
+    /**
+     * @case extract "html" is unaffected by the text-extraction change
+     * @preconditions Same escaped-markup body as the text case, extract: "html"
+     * @expectedResult The raw inner HTML is returned with its entities still encoded
+     */
+    test("extract html still returns the raw encoded markup", async () => {
+      const s = spy();
+      const htmlString = "<pre>type X = Array&lt;string&gt;;</pre>";
+
+      t = await testContext()
+        .routes(
+          craft()
+            .id("html-html-escaped-markup")
+            .from(simple(htmlString))
+            .transform(html({ selector: "pre", extract: "html" }))
+            .to(s),
+        )
+        .build();
+
+      await t.ctx.start();
+
+      const body = s.received[0].body as HtmlResult;
+      expect(body).toBe("type X = Array&lt;string&gt;;");
+    });
+  });
+
   describe("default and from option", () => {
     /**
      * @case By default uses body.body when body is object (e.g. after http())


### PR DESCRIPTION
Closes #719

## What was wrong

`extractHtml` ran `stripHtmlTags` over text that cheerio's `.text()` had already decoded. At that point there is no markup left to strip, so the regex had no true positives: the only thing it could match was content the page had escaped on purpose, and it deleted it silently.

```
<pre>type X = Array&lt;string&gt;;</pre>   extract "text"
before: "type X = Array;"
after:  "type X = Array<string>;"
```

It bit hardest on the pages text extraction is usually pointed at. Any documentation page with a generic in a code sample lost part of it, and the caller had no way to tell.

## The fix

Both call sites drop the wrapper and `stripHtmlTags` is deleted. `textFrom` already removes `style` and `script` subtrees, which is the part that genuinely needs handling. `stripHtmlTags` was exported but had no other caller in the monorepo and did not reach the built `dist/index.d.ts`, so removing it is not a public API removal. `"html"`, `"outerHtml"` and `"attr"` are untouched.

A third commit removes an unreachable branch the fix exposed: `textFrom`'s two call sites both sit inside an inline test for the three text modes, so its non-text arm could never run. Behaviour-neutral.

## The behaviour change

Two changes, on the three text extract modes, in all three roles that extract.

**Whitespace inside the match now survives, and this is the half that reaches the most routes.** `stripHtmlTags` also collapsed every run of whitespace to a single space, so any indented page was flattened, not just a `<pre>`:

```
<div class="card">
  <h2>Getting started</h2>
  <p>Install the   package
     and run it.</p>
</div>

before: "Getting started Install the package and run it."
after:  "Getting started\n  Install the   package\n     and run it."
```

Only the ends are trimmed, per matched element in the array case. A `<pre>` therefore keeps its newlines and indentation, which is the code-sample case that motivated the issue.

**Escaped markup now survives, decoded and unsanitised.** A page that escaped a payload gets it back as live markup, so extracted text is escaped at the sink before being written into HTML or a line-structured format. This is documentation rather than a control: the removed regex was never a sanitiser, and `extract: "html"` and `"outerHtml"` always passed raw markup through untouched.

You are affected if a route compares extracted text to a literal, keys or hashes on it, validates it against a schema, or writes it to a line-oriented sink. There is no compile error and no new option to notice. The changeset carries the one-line route recipe for callers who want the old shape.

The changeset is `minor`, not `patch`. A documented behaviour that existing routes assert on changes byte for byte with no compile error, which `.standards/api-stability.md` line 18 puts in the 0.x breaking window.

## Tests

Nine added in `packages/routecraft/test/html.bun.test.ts`, all under `describe("text extraction fidelity")`, each with the `@case` / `@preconditions` / `@expectedResult` JSDoc. Seven fail before the fix; two guard behaviour that must not change, so they pass on both sides. Verified by reinstating the stripping on the fixed source and running them.

Failing before the fix:

| Test | Before | After |
|---|---|---|
| keeps escaped markup in extracted text | `"type X = Array;"` | `"type X = Array<string>;"` |
| preserves newlines and indentation in extracted text | `"function f() { return 1; }"` | `"function f() {\n  return 1;\n}"` |
| keeps escaped markup in every entry of a multi-match result | `["List", "Promise", "a < b"]` | `["List<T>", "Promise<void>", "a < b"]` |
| returns source whitespace from an indented container | one collapsed line | source indentation and newlines |
| returns source whitespace in every entry of a multi-match result | `["One", "Two wrapped"]` | `["One", "Two\n      wrapped"]` |
| source role keeps escaped markup in extracted text | `"type X = Array;"` | `"type X = Array<string>;"` |
| enricher role keeps escaped markup in extracted text | `"type X = Array;"` | `"type X = Array<string>;"` |

Passing on both sides, by design:

| Test | Pins |
|---|---|
| still removes style and script content from extracted text | the guard that stays |
| extract html still returns the raw encoded markup | that `"html"` is untouched |

Role coverage is deliberate. `extractHtml` is reached from `transformer.ts:17`, `source.ts:54` and `enricher.ts:51`; the destination role writes rather than extracts and does not reach it. The source role goes through the deferred parse, so a transformer assertion was not proof the fix was shared, and it now has its own test.

No existing test asserted the collapsed-whitespace or stripped-markup behaviour, so no existing expectation was changed.

## Docs

The reference page said text extraction "strips HTML tags", which was both the defect and, after this change, no longer what the code does. It now states the decoding, the unsanitised result, the whitespace behaviour prose-case-first, and the route recipe. The `extract` JSDoc said `innerText` and `textContent` return "text only, no HTML", which a page that escapes markup disproves; they are now named as aliases of `text` with the same decoding and escaping note.

## Review round

cubic round one on `ad3d542`, settled in `c2da605`: the route recipe in the docs and the changeset did not compile against `HtmlResult` and now names the single-match result with the second type parameter; the two role tests hoist their temp directory cleanup into `afterEach` so a failing assertion no longer leaks it.

## Gate

```
bun run all
GATE_EXIT=0
3288 pass, 0 fail, 1 skip
Ran 3289 tests across 227 files
```

https://claude.ai/code/session_0161n3sMyEnXdAwC8qTy6yaJ