### PR TITLE
docs(cheat-sheet): correct adapter calls that do not compile

### DIFF
--- a/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
+++ b/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
@@ -381,9 +381,8 @@ RC9xxx  Testing`}</CheatCode>
             title="Context &amp; plugins"
           >
             <CheatCode>{`const ctx = await new ContextBuilder()
-  .add({
-    crm: { timezone: 'UTC' },
-    direct: { channelType: 'memory' },
+  .with({
+    crm: { timezone: 'UTC' },   // your own augmented key
     mail: { accounts: { /* ... */ } },
     plugins: [myPlugin],
   })
@@ -411,6 +410,7 @@ const myPlugin: CraftPlugin = {
 // Basic call (user prompt defaults to body)
 craft()
   .id('text-in')
+  .input({ body: z.object({ text: z.string() }) })
   .from(direct())
   .to(llm('anthropic:claude-sonnet-4-6', {
     system: 'Summarize concisely',
@@ -439,6 +439,7 @@ craft()
 
 craft()
   .id('assistant')
+  .input({ body: z.object({ message: z.string() }) })
   .from(direct())
   .to(agent({
     model: 'anthropic:claude-sonnet-4-6',

--- a/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
+++ b/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
@@ -157,22 +157,24 @@ await ctx.stop()`}</CheatCode>
   { timezone: 'America/New_York' }))
 
 // In-process direct endpoint
-.from(direct('my-endpoint'))
+.from(direct())  // endpoint = route .id()
 
 // IMAP mail (push via IDLE)
 .from(mail('INBOX',
   { unseen: true, markSeen: true }))
 
 // In-process EventEmitter
-.from(event({ eventName: 'order' }))
+.from(event('route:error'))
+.from(event('exchange:*'))  // wildcards
 
 // File and file-format sources
 .from(file({ path: './data.txt' }))
 .from(directory({ path: './inbox' }))
-.from(json({ file: './data.json' }))
-.from(jsonl({ file: './events.jsonl' }))
-.from(csv({ file: './rows.csv' }))
-.from(html({ html: '<table>...</table>' }))`}</CheatCode>
+.from(json({ path: './data.json' }))
+.from(jsonl({ path: './events.jsonl' }))
+.from(csv({ path: './rows.csv' }))
+.from(html({ path: './page.html',
+  selector: 'h1' }))`}</CheatCode>
           </CheatSection>
 
           <CheatSection
@@ -202,9 +204,9 @@ await ctx.stop()`}</CheatCode>
 
 // Write file or file format
 .to(file({ path: './out.txt' }))
-.to(json({ file: './out.json' }))
-.to(jsonl({ file: './out.jsonl' }))
-.to(csv({ file: './out.csv' }))
+.to(json({ path: './out.json' }))
+.to(jsonl({ path: './out.jsonl' }))
+.to(csv({ path: './out.csv' }))
 
 // Send email via SMTP (payload from the exchange body)
 .transform(body => ({
@@ -289,8 +291,10 @@ craft()
 }))
 
 // Merge helpers
-.enrich(dest, only('meta'))
-.enrich(dest, replace())`}</CheatCode>
+.enrich(dest, only((m: Meta) => m, 'meta'))
+
+// Run the fetch, keep the original body
+.enrich(dest, none())`}</CheatCode>
           </CheatSection>
 
           <CheatSection
@@ -305,7 +309,8 @@ craft()
 import { schema } from '@routecraft/routecraft'
 
 craft()
-  .from(direct('input'))
+  .id('input')
+  .from(direct())
   .validate(schema(z.object({
     email: z.string().email(),
     age: z.number().min(18),
@@ -405,7 +410,8 @@ const myPlugin: CraftPlugin = {
 
 // Basic call (user prompt defaults to body)
 craft()
-  .from(direct('text-in'))
+  .id('text-in')
+  .from(direct())
   .to(llm('anthropic:claude-sonnet-4-6', {
     system: 'Summarize concisely',
     user: ex => ex.body.text,
@@ -433,7 +439,7 @@ craft()
 
 craft()
   .id('assistant')
-  .from(direct('chat-in'))
+  .from(direct())
   .to(agent({
     model: 'anthropic:claude-sonnet-4-6',
     system: 'You are a helpful assistant.',

--- a/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
+++ b/apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx
@@ -412,7 +412,8 @@ craft()
   .id('text-in')
   .input({ body: z.object({ text: z.string() }) })
   .from(direct())
-  .to(llm('anthropic:claude-sonnet-4-6', {
+  // explicit body type at .to() until #694
+  .to(llm<undefined, { text: string }>('anthropic:claude-sonnet-4-6', {
     system: 'Summarize concisely',
     user: ex => ex.body.text,
     temperature: 0.2,
@@ -441,7 +442,8 @@ craft()
   .id('assistant')
   .input({ body: z.object({ message: z.string() }) })
   .from(direct())
-  .to(agent({
+  // explicit body type at .to() until #694
+  .to(agent<{ message: string }>({
     model: 'anthropic:claude-sonnet-4-6',
     system: 'You are a helpful assistant.',
     user: ex => ex.body.message,

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/directory/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/directory/index.mdx
@@ -45,7 +45,8 @@ craft()
 ```ts
 // An agent capability: list candidate files, read them, return the matches
 craft()
-  .from(direct('search-notes'))
+  .id('search-notes')
+  .from(direct())
   .to(directory({ path: './notes', recursive: true }))   // body becomes DirectoryEntry[]
   .transform((entries) => entries.filter((e) => e.ext === '.md'))
   .split((ex) => ex.body)
@@ -57,7 +58,8 @@ craft()
 
 // List a directory whose path depends on the exchange
 craft()
-  .from(direct('inspect-dir'))
+  .id('inspect-dir')
+  .from(direct())
   .enrich(
     directory({ path: (ex) => ex.body.dir }),
     only((entries: DirectoryEntry[]) => entries, 'candidates'),

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/http/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/http/index.mdx
@@ -844,7 +844,7 @@ const revalidateAndFollow = (path) =>
 craft()
   .id('fetch-page')
   .input({ body: z.object({ url: AllowedUrl }) })
-  .from(direct('fetch-page'))
+  .from(direct())
   .enrich(http({ url: (ex) => ex.body.url, redirect: 'manual' }))
   .choice(when(isRedirect, revalidateAndFollow))
   .to(log())

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/shell/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/shell/index.mdx
@@ -17,7 +17,7 @@ import { shell, untrusted } from '@routecraft/os'
 
 craft()
   .id('clone-repo')
-  .from(direct('clone'))
+  .from(direct())
   .enrich(shell('git', (ex) => ['clone', untrusted(ex.body.url), '/work'], {
     network: true,
     timeout: 60_000,

--- a/packages/routecraft/src/adapters/directory/index.ts
+++ b/packages/routecraft/src/adapters/directory/index.ts
@@ -88,7 +88,8 @@ export function directory(
  *
  * // List a directory mid-route, e.g. inside a direct() capability
  * craft()
- *   .from(direct("search-notes"))
+ *   .id("search-notes")
+ *   .from(direct())
  *   .to(directory({ path: "./notes", recursive: true }))
  *   .transform((entries) => entries.filter((e) => e.ext === ".md"))
  *   .to(log());


### PR DESCRIPTION
## TLDR

The cheat sheet on routecraft.dev taught fifteen adapter calls that do not exist or do not compile against the installed packages, on a pinned surface that publishes to released docs. Each is corrected and was verified by compiling it as a real route, and the same wrong `direct()` source form is corrected where it recurs in four reference pages and one JSDoc example. Docs and one comment, no code change.

**Breaking for route authors:** no

## Before and after

- **Before:** copying a snippet from the cheat sheet failed to typecheck for `json`, `jsonl`, `csv`, `html`, `event`, `direct` as a source, `only`, `replace`, the context builder, the direct channel config, and both AI examples.
- **After:** every block on the page compiles as a real route except the enrich block, which uses a `dest` placeholder by design.

## DSL

What changed, as it reads on the page now:

```ts
.from(direct())                 // endpoint = route .id(), not direct('name'), which is the client form
.from(event('route:error'))     // a filter string or array, not { eventName }
.from(json({ path: './data.json' }))          // path, not file; same for jsonl, csv, and the three destinations
.from(html({ path: './page.html', selector: 'h1' }))   // no html: option; the source needs path and selector
.enrich(dest, only((m: Meta) => m, 'meta'))   // an extractor function, not a key string
.enrich(dest, none())                          // replace() is not exported
context().with({ ... })                        // .with(), not .add(); channelType takes a class, so the 'memory' line is gone (it is the default)

.input({ body: z.object({ text: z.string() }) })
.from(direct())
// explicit body type at .to() until #694
.to(llm<undefined, { text: string }>('anthropic:claude-sonnet-4-6', { user: (ex) => ex.body.text }))
```

---

## Why

Found by the #719 lane's interrogation lens on four lines, then the whole file was read on Jaco's word and every block compiled. The `direct('name')` finding has the most reach: it returns an enricher, not a source (`packages/routecraft/src/adapters/direct/index.ts`, overloads at lines 65-72), and the cheat sheet taught the wrong form in four places while the direct reference page states the source form correctly. The shell reference example even paired `.id('clone-repo')` with `direct('clone')`, an id and an endpoint that never matched; the source form makes them one thing.

## What changed

- `apps/routecraft.dev/app/content/cheat-sheet/CheatSheet.tsx`: fifteen corrections across four commits.
- `reference/adapters/directory` (two sites), `reference/adapters/http`, `reference/adapters/shell`, and the JSDoc example in `packages/routecraft/src/adapters/directory/index.ts`: the source form of `direct()`.
- `.to(direct('my-endpoint'))` is the correct client form and is untouched, as are `file`, `directory`, `timer`, `cron`, `mail`, `simple`, `log`, `debug`, `noop`, `http`, the schema block, and the split, choice and mcp blocks, which all compiled clean.
- The `docs-next`, `public/raw` and `llms-full` trees are gitignored build output regenerated by `bun run generate`; the tracked `baseline/` is what the acceptance suite compares against and deliberately keeps the old lines.

## Verified

Every block on the page compiles as a real route against the installed packages under `--strict`, except the enrich block, which uses a `dest` placeholder by design and is shape-verified against a typed enricher. The AI examples carry an explicit body type at `.to()` because of #694: `.to()` resolves its Destination overload before its Enricher overload, so a prompt callback is fixed at `Exchange<unknown>` even when `.input()` sets the body; `.enrich()` has nothing ahead of it and infers. The context block's `crm` key is an augmented-config illustration and is marked as such. A grep for `.from(direct(` with any quote style is empty across `app/content/docs`, `packages/*/src`, `packages/*/test`, `examples/` and `skills/`.

## Tests

None added; there is no test surface for the cheat sheet's fenced snippets. Gate: `bun run all` exit 0, 3292 pass, 0 fail.

## Docs and changeset

The pages themselves. No changeset: the docs site is not a published package, and the JSDoc change is comment-only.

## Review

Lane Y, four commits on a fresh branch from main at `5fce5a6`. cubic: no findings on the first two commits, re-running on the head. CodeRabbit: no actionable comments and minimal merge risk on the second commit, rate-limited before the last two; its docstring-coverage warning is declined, since this is a documentation diff and the repo's comment policy forbids what it asks for.

## Leftovers

None. #694 is the open issue that removes the explicit generics when it lands.

https://claude.ai/code/session_0161n3sMyEnXdAwC8qTy6yaJ