### PR TITLE
docs: enable it, never own it; one Closes per line in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ rule under the fixed headings. Delete the guidance comments before opening.
 
 ## TLDR
 
-<!-- One to three sentences: what a route author gets or loses, and why. End with the ticket: "Closes #123". -->
+<!-- One to three sentences: what a route author gets or loses, and why. End with the tickets it closes, one `Closes #N` per line: GitHub honours only the first number in a comma-separated list. -->
 
 **Breaking for route authors:** <!-- yes or no; a behaviour or type an existing route asserts on changes -->
 

--- a/.standards/README.md
+++ b/.standards/README.md
@@ -8,7 +8,7 @@ Internal development standards for Routecraft contributors (human and AI). These
 
 | Document | Scope |
 |----------|-------|
-| [Positioning](./positioning.md) | What Routecraft is for: the connective layer between agents, MCP servers and systems, never a reimplementation of what it connects. Protocol, operation or product as the fast test; the three questions behind it; and the instruction to raise a misplaced feature before building it |
+| [Positioning](./positioning.md) | What Routecraft is for: the connective layer between agents, MCP servers and systems, never a reimplementation of what it connects. Enable a capability, never own it, with the Docker sandbox as the bar; protocol, operation or product as the fast test; the three questions behind it; the four homes a capability can land in; a named consumer as the demand test; and the instruction to raise a misplaced feature before building it, as a challenge rather than a veto |
 | [Adapter Architecture](./adapter-architecture.md) | Patterns, file structure, facade, authoring guide, skeletons, and anti-patterns for adapters |
 | [Exchange State Model](./exchange-state-model.md) | Where state lives on an exchange (`body`/`headers` vs derivations like `id`/`principal`/`logger`), halt/continue serialization contract, getter pattern for cross-cutting concerns |
 | [Naming Policy](./naming-policy.md) | Source/Destination vs Server/Client naming, schema field names (`input`/`output`), prompt-source field names |

--- a/.standards/positioning.md
+++ b/.standards/positioning.md
@@ -24,7 +24,7 @@ The framework's job is to make hard things easy to build. It is not the thing th
 
 The distinction is about where code lives, not about ambition. Routecraft must **enable** a route to drive a remote execution environment. It must never **own** the fleet, the provisioning policy, the quota or the bill. The same sentence holds for browser automation, memory, message delivery and every other capability some vendor already sells: the framework carries the seam, and the seam is measured by how much effort it removes from the person building on it.
 
-Two shipped cases fix the bar.
+Two cases fix the bar.
 
 - **Docker in the built-in sandbox clears it.** Writing a custom isolation adapter from scratch was always possible, and still is. Adding Docker to the shipped sandbox removed a large amount of effort from everyone who builds an agent on the framework. That is the shape a framework addition should have.
 - **A helper that saves ten lines does not.** It is defensible in isolation every time, and the accumulation of such helpers is what turns a framework into the thing that does things. The answer to it is an example, a documentation page and a blog post: readers copy it, learn how it is done, and the framework does not carry it.
@@ -33,7 +33,7 @@ When a bought service eventually costs more than building would, the answer is a
 
 ## 4. Protocol, operation, or product
 
-The fast test, and the one to reach for first. Everything falls into one of three kinds, and the kind decides the answer before any further reasoning:
+The fast classification test, applied once section 3 is cleared. Everything falls into one of three kinds, and the kind decides the answer before any further reasoning:
 
 - **A protocol** (HTTP, MCP, WebSocket, AMQP, MQTT, SSE, OAuth, a codec). **Build it.** A protocol reaches every system that speaks it, so the work pays off across every integration that will ever exist. This is why protocol-level work outranks everything else in the framework.
 - **A cross-cutting operation** (retry, cache, throttle, timeout, circuit breaker, split, dedupe, error handling). **Build it.** Every connector benefits from it, and the framework is the only place it can sit where an author reading a route can see it and change it.

--- a/.standards/positioning.md
+++ b/.standards/positioning.md
@@ -18,19 +18,32 @@ The reason is not purity. Anything rebuilt here is a worse version of the produc
 
 The practical form of the rule: **if a capability could plausibly be bought, rented, or installed as its own product, it does not belong inside a `@routecraft/*` package.** It belongs behind `mcp()`, behind `http()`, or behind an adapter that wraps somebody else's client.
 
-## 3. Protocol, operation, or product
+## 3. Enable it, never own it
+
+The framework's job is to make hard things easy to build. It is not the thing that does them.
+
+The distinction is about where code lives, not about ambition. Routecraft must **enable** a route to drive a remote execution environment. It must never **own** the fleet, the provisioning policy, the quota or the bill. The same sentence holds for browser automation, memory, message delivery and every other capability some vendor already sells: the framework carries the seam, and the seam is measured by how much effort it removes from the person building on it.
+
+Two shipped cases fix the bar.
+
+- **Docker in the built-in sandbox clears it.** Writing a custom isolation adapter from scratch was always possible, and still is. Adding Docker to the shipped sandbox removed a large amount of effort from everyone who builds an agent on the framework. That is the shape a framework addition should have.
+- **A helper that saves ten lines does not.** It is defensible in isolation every time, and the accumulation of such helpers is what turns a framework into the thing that does things. The answer to it is an example, a documentation page and a blog post: readers copy it, learn how it is done, and the framework does not carry it.
+
+When a bought service eventually costs more than building would, the answer is a product built and sold beside the framework. It still does not go into a `@routecraft/*` package.
+
+## 4. Protocol, operation, or product
 
 The fast test, and the one to reach for first. Everything falls into one of three kinds, and the kind decides the answer before any further reasoning:
 
 - **A protocol** (HTTP, MCP, WebSocket, AMQP, MQTT, SSE, OAuth, a codec). **Build it.** A protocol reaches every system that speaks it, so the work pays off across every integration that will ever exist. This is why protocol-level work outranks everything else in the framework.
 - **A cross-cutting operation** (retry, cache, throttle, timeout, circuit breaker, split, dedupe, error handling). **Build it.** Every connector benefits from it, and the framework is the only place it can sit where an author reading a route can see it and change it.
-- **A product or a vendor** (a chat platform, a memory store, a mail provider, a search API, a CRM). **Connect it.** Somebody sells it, maintains it, and employs people to make it better than we can. Our contribution is the adapter or the MCP pointer, an example, and the routes that compose it.
+- **A product or a vendor** (a chat platform, a memory store, a mail provider, a search API, a CRM, a sandbox provider). **Connect it.** Somebody sells it, maintains it, and employs people to make it better than we can. Our contribution is the adapter or the MCP pointer, an example, and the routes that compose it.
 
 The default when a thing does not obviously sort: **if it has an HTTP API or an MCP server, the answer is connect.**
 
 A worked non-example. A Telegram connector looks like framework work and is not: Telegram publishes an API, anyone can integrate with it in an afternoon, and building it here buys reach with one vendor's users at the cost of maintaining their surface forever. It is legitimate work, and it is low priority next to any protocol or operation. The same reasoning retires most requests of the form "Routecraft should support X".
 
-## 4. The three questions
+## 5. The three questions
 
 Before any addition to a `@routecraft/*` package, in order:
 
@@ -42,19 +55,30 @@ A no to question 1, or a no to both halves of question 2, ends it. Question 3 go
 
 The questions and the three kinds agree, and are two views of the same rule. When they seem to disagree, the kind is usually being misread: a capability that feels like an operation but names a vendor is a product.
 
-## 5. Where a capability lands
+## 6. Where a capability lands
 
-Three homes, in order of preference:
+Four homes, in order of preference:
 
 1. **Somebody else's service**, reached with `mcp()` or `http()`. Nothing ships, and nothing is maintained.
-2. **The `craft-harness` template, or the author's own app**, as composed routes. The guardrails are visible and the author owns them.
-3. **A `@routecraft/*` package**, only when all three questions pass.
+2. **The author's own app**, as composed routes. The guardrails are visible and the author owns them. The `craft-harness` template is one such app: a local personal agent, which is its whole job, and not the place a remote or fleet-shaped capability grows.
+3. **A route library shared across apps**, published as an ordinary package and included by configuration. Anything a second app or a second customer would otherwise rewrite belongs here rather than in the framework.
+4. **A `@routecraft/*` package**, only when all three questions pass and the addition clears the bar in section 3.
 
 Preferring the first is not modesty. A framework that reaches more systems is worth more than one that owns more code.
 
-## 6. Raise it during development, not at review
+A design that cannot be split across these four, piece by piece, is not finished.
+
+## 7. Who counts as demand
+
+The bar in section 3 asks how much effort an addition removes, and effort is removed from somebody. That somebody is a named consumer with a concrete need: an app being built on the framework today, or a workshop that has to run next week. It is never a headcount. A young framework has few users, and a headcount test would reject every addition ever made, the Docker sandbox included on the day it was proposed.
+
+So a proposal names its consumer. "Nobody is asking for this" is a valid reason to decline. "Only one app is asking for this" is not, when that app is real and the effort is real.
+
+## 8. Raise it during development, not at review
 
 This is a live check rather than a document to cite afterwards. A contributor or agent building something that fails question 1 or 2 should say so **before writing the code**, name which question fails, and propose the composed-route or third-party shape instead. A feature that arrives at review already built is one that costs a rewrite to place correctly, and the rewrite usually does not happen.
+
+The check is a challenge, not a veto. Whoever holds this standard says "this crosses the line" out loud, every time, and is answered. The consumer may overrule with a stated reason; the overrule stands, the reason is recorded with the change, and what the standard's holder watches is the pattern of overrules rather than the single case. A crossing let through silently is the failure. The crossing itself is not.
 
 Two cases are already on the record, and both began as proposed framework features:
 

--- a/.standards/positioning.md
+++ b/.standards/positioning.md
@@ -29,7 +29,7 @@ Two cases fix the bar.
 - **Docker in the built-in sandbox clears it.** Writing a custom isolation adapter from scratch was always possible, and still is. Adding Docker to the shipped sandbox removed a large amount of effort from everyone who builds an agent on the framework. That is the shape a framework addition should have.
 - **A helper that saves ten lines does not.** It is defensible in isolation every time, and the accumulation of such helpers is what turns a framework into the thing that does things. The answer to it is an example, a documentation page and a blog post: readers copy it, learn how it is done, and the framework does not carry it.
 
-When a bought service eventually costs more than building would, the answer is a product built and sold beside the framework. It still does not go into a `@routecraft/*` package.
+When a bought service eventually costs more than building would, the answer is a product built and sold beside the framework. It still does not go into a `@routecraft/*` package. From the framework's side that product is home 1 in section 6: a service reached with `mcp()` or `http()`, whoever happens to run it.
 
 ## 4. Protocol, operation, or product
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Type-safe integration and automation framework. Monorepo with Bun workspaces (>=
 
 Detailed coding standards for contributors live in `.standards/`:
 
-- [Positioning](.standards/positioning.md) -- what Routecraft is for and what it is not: the framework enables a capability and never owns it; protocols and cross-cutting operations earn framework time, products and vendors get connected; the three questions before any addition, the four homes a capability lands in, and a named consumer as the demand test
+- [Positioning](.standards/positioning.md) -- what Routecraft is for and what it is not: the framework enables a capability and never owns it; protocols and cross-cutting operations earn framework time, products and vendors get connected; the three questions before any addition, the four homes a capability lands in, a named consumer as the demand test, and the check as a challenge a consumer may overrule with a recorded reason, never a veto
 - [Adapter Architecture](.standards/adapter-architecture.md) -- patterns, file structure, facade, authoring guide
 - [Exchange State Model](.standards/exchange-state-model.md) -- where state lives on an exchange (`body`/`headers` vs derivations), halt/continue contract
 - [Naming Policy](.standards/naming-policy.md) -- Source/Destination vs Server/Client conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Type-safe integration and automation framework. Monorepo with Bun workspaces (>=
 
 Detailed coding standards for contributors live in `.standards/`:
 
-- [Positioning](.standards/positioning.md) -- what Routecraft is for and what it is not: protocols and cross-cutting operations earn framework time, products and vendors get connected; the three questions before any addition
+- [Positioning](.standards/positioning.md) -- what Routecraft is for and what it is not: the framework enables a capability and never owns it; protocols and cross-cutting operations earn framework time, products and vendors get connected; the three questions before any addition, the four homes a capability lands in, and a named consumer as the demand test
 - [Adapter Architecture](.standards/adapter-architecture.md) -- patterns, file structure, facade, authoring guide
 - [Exchange State Model](.standards/exchange-state-model.md) -- where state lives on an exchange (`body`/`headers` vs derivations), halt/continue contract
 - [Naming Policy](.standards/naming-policy.md) -- Source/Destination vs Server/Client conventions


### PR DESCRIPTION
## TLDR

Two documentation changes. The positioning standard gains the doctrine decided on 5 September: Routecraft makes hard things easy to build and is not the thing that does them, with the Docker sandbox as the bar for what earns framework time. The pull request template now tells authors to write one `Closes #N` per line, because GitHub only honours the first number in a comma-separated list. No tickets closed.

**Breaking for route authors:** no

## Before and after

- **Before:** Positioning had three homes for a capability and a demand test that read as a headcount; the PR template invited a comma-separated `Closes` list that silently dropped every ticket after the first.
- **After:** Positioning states enable-never-own, the bar with two shipped cases, four homes including a shared route library, a named consumer as the demand test, and the check as a challenge with a recorded overrule; the template asks for one `Closes #N` per line.

## DSL

No DSL change.

---

## Why

Two proposals this week (remote execution environments, a coding-agent backend) needed a written rule for where a capability lands before a spike could be judged. The existing standard answered "is it framework work" but not "what does the framework owe a hard capability it should not own", and its demand language could be read as rejecting anything only one app asks for. The `Closes` gap was found when a merged PR left its second ticket open.

## What changed

- `.standards/positioning.md`: new section 3 (enable it, never own it, with the Docker sandbox and the ten-line helper as the two calibration cases), section 6 gains a fourth home (a route library shared across apps) and names the `craft-harness` template's job, new section 7 (who counts as demand), section 8 gains the challenge-not-veto rule. Existing sections renumbered; no external anchors pointed at them.
- `.standards/README.md` and `CLAUDE.md`: the one-line summaries of the positioning standard updated to match.
- `.github/pull_request_template.md`: one `Closes #N` per line.

## Tests

None. Documentation only.

## Docs and changeset

Standards and template only. No changeset: nothing published changes.

## Review

None yet.

## Leftovers

The same doctrine is recorded in the operator memory decision it came from; promoting it into the company playbook is a separate, non-repository task.

https://claude.ai/code/session_0161n3sMyEnXdAwC8qTy6yaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0161n3sMyEnXdAwC8qTy6yaJ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the positioning standard to codify the "enable it, never own it" doctrine, and fixes the PR template so GitHub closes every ticket a PR references.

- The standard makes the enable-never-own bar the first gate before the protocol/operation/product test, uses the Docker sandbox as the shipped calibration case, adds a shared route library as a fourth home for capabilities, replaces the headcount demand test with a named consumer, and frames the placement check as a challenge with a recorded overrule rather than a veto. A product sold beside the framework still counts as an external service reached with `mcp()` or `http()`.
- The template now asks for one `Closes #N` per line, because GitHub only honours the first number in a comma-separated list.
- Documentation only; no behavior or type changes.

<sup>Written for commit 17feca4de08e717474608af2e06f6ca952bb7e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

