### PR TITLE
fix(routecraft): make shutdown signals idempotent

### DIFF
--- a/.changeset/idempotent-shutdown-signals.md
+++ b/.changeset/idempotent-shutdown-signals.md
@@ -1,0 +1,5 @@
+---
+"@routecraft/routecraft": minor
+---
+
+Make repeated graceful shutdown signals idempotent and add dedicated SIGQUIT/SIGBREAK force signals.

--- a/apps/routecraft.dev/app/content/changelog/index.mdx
+++ b/apps/routecraft.dev/app/content/changelog/index.mdx
@@ -12,6 +12,10 @@ Routecraft is in active development -- APIs may change between minor versions.
 
 ---
 
+## Unreleased
+
+- **Shutdown signal handling** -- graceful SIGINT/SIGTERM handling is idempotent, while SIGQUIT/SIGBREAK force an immediate exit; documentation now covers container and supervisor signal caveats.
+
 ## [v0.6.0](https://github.com/routecraftjs/routecraft/releases/tag/v0.6.0) <Badge color="yellow">Pre-release</Badge>
 
 *August 2026*

--- a/apps/routecraft.dev/app/content/docs/reference/cli/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/cli/index.mdx
@@ -442,6 +442,8 @@ await context.start();
 
 **Dedicated force signals** (Ctrl+Backslash/SIGQUIT or Ctrl+Break/SIGBREAK): force an immediate exit for when graceful shutdown is stuck or taking too long, including before graceful shutdown begins.
 
+Signal meanings vary across ecosystems: nginx uses SIGQUIT for a graceful shutdown, while current Gunicorn uses SIGTERM for graceful shutdown and SIGQUIT for an immediate shutdown. If a container uses `STOPSIGNAL SIGQUIT` expecting a drain, this handler treats that signal as a force exit instead. Under `bun --filter`, the force-path log can be lost by the supervising command, so do not use that log as the sole evidence of a forced shutdown; also check the exit status or the result from `context.stop()`.
+
 Stage one is also bounded by [`shutdown.timeout`](/docs/reference/configuration#shutdown), which matters under an orchestrator: it sends one SIGTERM and then SIGKILLs, so no dedicated force signal is coming. On that deadline in-flight execution is abandoned and the process exits 1, so a forced shutdown is distinguishable from a clean one.
 
 `context.stop()` resolves with `{ forced, pending }` if you drive shutdown yourself: `forced` says the deadline was reached, and `pending` names the routes that still had work in flight.

--- a/apps/routecraft.dev/app/content/docs/reference/cli/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/cli/index.mdx
@@ -440,9 +440,9 @@ await context.start();
 
 **First signal** (Ctrl+C): closes intake so sources stop producing, lets in-flight exchanges run to their natural end, runs plugin teardown, then exits 0. Work already running is **not** cancelled here: an agent mid-tool-call finishes its call.
 
-**Second signal** (Ctrl+C again): forces an immediate exit for when graceful shutdown is stuck or taking too long.
+**Dedicated force signals** (Ctrl+Backslash/SIGQUIT or Ctrl+Break/SIGBREAK): force an immediate exit for when graceful shutdown is stuck or taking too long, including before graceful shutdown begins.
 
-Stage one is also bounded by [`shutdown.timeout`](/docs/reference/configuration#shutdown), which matters under an orchestrator: it sends one SIGTERM and then SIGKILLs, so no second Ctrl+C is coming. On that deadline in-flight execution is abandoned and the process exits 1, so a forced shutdown is distinguishable from a clean one.
+Stage one is also bounded by [`shutdown.timeout`](/docs/reference/configuration#shutdown), which matters under an orchestrator: it sends one SIGTERM and then SIGKILLs, so no dedicated force signal is coming. On that deadline in-flight execution is abandoned and the process exits 1, so a forced shutdown is distinguishable from a clean one.
 
 `context.stop()` resolves with `{ forced, pending }` if you drive shutdown yourself: `forced` says the deadline was reached, and `pending` names the routes that still had work in flight.
 

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -1599,8 +1599,8 @@ export class CraftContext {
     // STAGE ONE. Close intake: sources stop producing, no new exchange is
     // admitted. Deliberately not the execution signal, so an exchange
     // already in the pipeline (an agent mid-tool-call, a suspension
-    // continuation) runs to its natural end. That distinction is the whole
-    // difference between the first Ctrl-C and the second.
+    // continuation) runs to its natural end. Dedicated force signals and the
+    // shutdown deadline are what abandon work that does not finish in time.
     for (const route of this.routes) {
       this.logger.info({ route: route.definition.id }, "Stopping route");
       const controller = this.controllers.get(route.definition.id);

--- a/packages/routecraft/src/shutdown.ts
+++ b/packages/routecraft/src/shutdown.ts
@@ -5,15 +5,16 @@ import type { CraftContext } from "./context.ts";
  *
  * **First signal** (Ctrl+C): closes intake so sources stop producing, lets
  * in-flight exchanges run to their natural end, runs plugin teardown, then
- * exits 0. In-flight work is NOT cancelled here; that is the difference
- * between the two signals.
+ * exits 0. In-flight work is NOT cancelled here. Repeated SIGINT/SIGTERM
+ * signals are ignored while this graceful shutdown is in progress.
  *
- * **Second signal** (Ctrl+C again): forces an immediate exit for when
- * graceful shutdown is stuck or taking too long.
+ * **Dedicated force signals** (Ctrl+Backslash/SIGQUIT or Ctrl+Break/SIGBREAK):
+ * force an immediate exit for when graceful shutdown is stuck or taking too
+ * long. They force exit even when graceful shutdown has not started.
  *
- * Stage one is bounded by `shutdown: { timeout }` even without a second
- * signal, which is what an orchestrator needs: it sends one SIGTERM and then
- * SIGKILLs, so there is no second Ctrl-C coming. On that deadline in-flight
+ * Stage one is bounded by `shutdown: { timeout }` even without a force signal,
+ * which is what an orchestrator needs: it sends one SIGTERM and then SIGKILLs,
+ * so there is no dedicated force signal coming. On that deadline in-flight
  * execution is abandoned and the process exits 1, so exit-code-sensitive
  * tooling can tell a forced shutdown from a clean one.
  *
@@ -29,19 +30,19 @@ import type { CraftContext } from "./context.ts";
 export function shutdownHandler(context: CraftContext): () => void {
   let shuttingDown = false;
 
-  const onSignal = async (signal: string) => {
+  const onGracefulSignal = async (signal: "SIGINT" | "SIGTERM") => {
     if (shuttingDown) {
-      context.logger.warn(
+      context.logger.info(
         { signal },
-        "Received signal during shutdown; forcing exit now",
+        "Received repeated signal during graceful shutdown; ignoring",
       );
-      process.exit(1);
+      return;
     }
 
     shuttingDown = true;
     context.logger.info(
       { signal },
-      "Received signal; shutting down gracefully (press Ctrl+C again to force)",
+      "Received signal; shutting down gracefully (use Ctrl+Backslash or Ctrl+Break to force)",
     );
 
     try {
@@ -57,13 +58,24 @@ export function shutdownHandler(context: CraftContext): () => void {
     }
   };
 
-  const sigintHandler = () => void onSignal("SIGINT");
-  const sigtermHandler = () => void onSignal("SIGTERM");
+  const onForceSignal = (signal: "SIGQUIT" | "SIGBREAK") => {
+    context.logger.warn({ signal }, "Received force signal; exiting now");
+    process.exit(1);
+  };
+
+  const sigintHandler = () => void onGracefulSignal("SIGINT");
+  const sigtermHandler = () => void onGracefulSignal("SIGTERM");
+  const sigquitHandler = () => onForceSignal("SIGQUIT");
+  const sigbreakHandler = () => onForceSignal("SIGBREAK");
   process.on("SIGINT", sigintHandler);
   process.on("SIGTERM", sigtermHandler);
+  process.on("SIGQUIT", sigquitHandler);
+  process.on("SIGBREAK", sigbreakHandler);
 
   return () => {
     process.off("SIGINT", sigintHandler);
     process.off("SIGTERM", sigtermHandler);
+    process.off("SIGQUIT", sigquitHandler);
+    process.off("SIGBREAK", sigbreakHandler);
   };
 }

--- a/packages/routecraft/test/shutdown-bounded.bun.test.ts
+++ b/packages/routecraft/test/shutdown-bounded.bun.test.ts
@@ -24,7 +24,7 @@ const entered = (): { signal: Promise<void>; enter: () => void } => {
  *
  * Stage one closes intake and drains: sources stop producing, and an
  * exchange already in the pipeline runs to its natural end. Stage two is
- * forced, either by a second signal or by `shutdown.timeout` elapsing, and
+ * forced by a dedicated force signal or by `shutdown.timeout` elapsing, and
  * abandons in-flight execution.
  *
  * The bound exists because an unbounded stage one hands the outcome to the

--- a/packages/routecraft/test/shutdown-handler.bun.test.ts
+++ b/packages/routecraft/test/shutdown-handler.bun.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { shutdownHandler } from "../src/shutdown.ts";
 import type { CraftContext } from "../src/context.ts";
 
-const makeContext = (stop: () => Promise<{ forced: boolean; pending: string[] }>) =>
+const makeContext = (
+  stop: () => Promise<{ forced: boolean; pending: string[] }>,
+) =>
   ({
     logger: {
       info: () => {},
@@ -11,12 +14,14 @@ const makeContext = (stop: () => Promise<{ forced: boolean; pending: string[] }>
     stop,
   }) as unknown as CraftContext;
 
-const invoke = (signal: NodeJS.Signals): void => {
+const invoke = (
+  signal: "SIGINT" | "SIGTERM" | "SIGQUIT" | "SIGBREAK",
+): void => {
   const handler = process
     .listeners(signal)
     .find((listener) => listener.name === `${signal.toLowerCase()}Handler`);
   if (!handler) throw new Error(`No handler installed for ${signal}`);
-  handler();
+  (handler as (receivedSignal: typeof signal) => void)(signal);
 };
 
 /**
@@ -30,22 +35,27 @@ test("repeated graceful signals remain idempotent", async () => {
   process.exit = ((code: number) => {
     exits.push(code);
   }) as typeof process.exit;
-  const deferred = Promise.withResolvers<{ forced: boolean; pending: string[] }>();
+  const deferred = Promise.withResolvers<{
+    forced: boolean;
+    pending: string[];
+  }>();
   const context = makeContext(() => deferred.promise);
   const cleanup = shutdownHandler(context);
+  try {
+    invoke("SIGINT");
+    invoke("SIGINT");
+    invoke("SIGTERM");
+    invoke("SIGTERM");
+    deferred.resolve({ forced: false, pending: [] });
+    await Promise.resolve();
+    await Promise.resolve();
 
-  invoke("SIGINT");
-  invoke("SIGINT");
-  invoke("SIGTERM");
-  invoke("SIGTERM");
-  deferred.resolve({ forced: false, pending: [] });
-  await Promise.resolve();
-  await Promise.resolve();
-
-  expect(exits).not.toContain(1);
-  expect(exits).toContain(0);
-  cleanup();
-  process.exit = originalExit;
+    expect(exits).not.toContain(1);
+    expect(exits).toContain(0);
+  } finally {
+    cleanup();
+    process.exit = originalExit;
+  }
 });
 
 /**
@@ -54,16 +64,26 @@ test("repeated graceful signals remain idempotent", async () => {
  * @expectedResult The process exits with code 1 and context.stop is not called
  */
 test("SIGQUIT forces immediate exit before graceful shutdown", () => {
-  const source = new URL("../src/shutdown.ts", import.meta.url).pathname;
+  const source = new URL("../src/shutdown.ts", import.meta.url).href;
   const script = `
     const { shutdownHandler } = await import(${JSON.stringify(source)});
-    shutdownHandler({ logger: { info() {}, warn() {} }, stop: () => { throw new Error("stop called"); } });
+    const result = { exits: [], stopCalled: false };
+    process.exit = (code) => { result.exits.push(code); };
+    const cleanup = shutdownHandler({ logger: { info() {}, warn() {} }, stop: async () => { result.stopCalled = true; return { forced: false, pending: [] }; } });
     const force = process.listeners("SIGQUIT").find((listener) => listener.name === "sigquitHandler");
     force();
+    cleanup();
+    console.log(JSON.stringify(result));
   `;
-  const result = Bun.spawnSync([process.execPath, "-e", script]);
+  const subprocess = spawnSync(process.execPath, ["-e", script], {
+    encoding: "utf8",
+  });
 
-  expect(result.exitCode).toBe(1);
+  expect(subprocess.status).toBe(0);
+  expect(JSON.parse(subprocess.stdout)).toEqual({
+    exits: [1],
+    stopCalled: false,
+  });
 });
 
 /**
@@ -82,9 +102,9 @@ test("SIGBREAK forces immediate exit during graceful shutdown", () => {
     graceful();
     force();
   `;
-  const result = Bun.spawnSync([process.execPath, "-e", script]);
+  const result = spawnSync(process.execPath, ["-e", script]);
 
-  expect(result.exitCode).toBe(1);
+  expect(result.status).toBe(1);
 });
 
 /**
@@ -99,12 +119,14 @@ test("cleanup removes all shutdown signal handlers", () => {
       process.listenerCount(signal),
     ]),
   );
-  const cleanup = shutdownHandler(makeContext(async () => ({ forced: false, pending: [] })));
+  const cleanup = shutdownHandler(
+    makeContext(async () => ({ forced: false, pending: [] })),
+  );
 
   cleanup();
 
   for (const signal of before.keys()) {
-    expect(process.listenerCount(signal)).toBe(before.get(signal));
+    expect(process.listenerCount(signal)).toBe(before.get(signal)!);
   }
 });
 

--- a/packages/routecraft/test/shutdown-handler.bun.test.ts
+++ b/packages/routecraft/test/shutdown-handler.bun.test.ts
@@ -61,7 +61,7 @@ test("repeated graceful signals remain idempotent", async () => {
 /**
  * @case SIGQUIT forces an immediate exit before graceful shutdown begins
  * @preconditions A shutdown handler is installed and SIGQUIT is invoked first
- * @expectedResult The process exits with code 1 and context.stop is not called
+ * @expectedResult The handler requests and records process.exit code 1, and context.stop is not called
  */
 test("SIGQUIT forces immediate exit before graceful shutdown", () => {
   const source = new URL("../src/shutdown.ts", import.meta.url).href;

--- a/packages/routecraft/test/shutdown-handler.bun.test.ts
+++ b/packages/routecraft/test/shutdown-handler.bun.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, expect, test } from "bun:test";
+import { shutdownHandler } from "../src/shutdown.ts";
+import type { CraftContext } from "../src/context.ts";
+
+const makeContext = (stop: () => Promise<{ forced: boolean; pending: string[] }>) =>
+  ({
+    logger: {
+      info: () => {},
+      warn: () => {},
+    },
+    stop,
+  }) as unknown as CraftContext;
+
+const invoke = (signal: NodeJS.Signals): void => {
+  const handler = process
+    .listeners(signal)
+    .find((listener) => listener.name === `${signal.toLowerCase()}Handler`);
+  if (!handler) throw new Error(`No handler installed for ${signal}`);
+  handler();
+};
+
+/**
+ * @case Repeated graceful signals do not force an exit
+ * @preconditions SIGINT starts a pending graceful shutdown, then SIGTERM and SIGINT arrive before it completes
+ * @expectedResult The process exits cleanly once and never receives exit code 1
+ */
+test("repeated graceful signals remain idempotent", async () => {
+  const exits: number[] = [];
+  const originalExit = process.exit;
+  process.exit = ((code: number) => {
+    exits.push(code);
+  }) as typeof process.exit;
+  const deferred = Promise.withResolvers<{ forced: boolean; pending: string[] }>();
+  const context = makeContext(() => deferred.promise);
+  const cleanup = shutdownHandler(context);
+
+  invoke("SIGINT");
+  invoke("SIGINT");
+  invoke("SIGTERM");
+  invoke("SIGTERM");
+  deferred.resolve({ forced: false, pending: [] });
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(exits).not.toContain(1);
+  expect(exits).toContain(0);
+  cleanup();
+  process.exit = originalExit;
+});
+
+/**
+ * @case SIGQUIT forces an immediate exit before graceful shutdown begins
+ * @preconditions A shutdown handler is installed and SIGQUIT is invoked first
+ * @expectedResult The process exits with code 1 and context.stop is not called
+ */
+test("SIGQUIT forces immediate exit before graceful shutdown", () => {
+  const source = new URL("../src/shutdown.ts", import.meta.url).pathname;
+  const script = `
+    const { shutdownHandler } = await import(${JSON.stringify(source)});
+    shutdownHandler({ logger: { info() {}, warn() {} }, stop: () => { throw new Error("stop called"); } });
+    const force = process.listeners("SIGQUIT").find((listener) => listener.name === "sigquitHandler");
+    force();
+  `;
+  const result = Bun.spawnSync([process.execPath, "-e", script]);
+
+  expect(result.exitCode).toBe(1);
+});
+
+/**
+ * @case SIGBREAK forces an immediate exit during graceful shutdown
+ * @preconditions SIGINT has started a pending graceful shutdown, then SIGBREAK arrives
+ * @expectedResult SIGBREAK invokes exit code 1 without waiting for context.stop
+ */
+test("SIGBREAK forces immediate exit during graceful shutdown", () => {
+  const source = new URL("../src/shutdown.ts", import.meta.url).pathname;
+  const script = `
+    const { shutdownHandler } = await import(${JSON.stringify(source)});
+    const context = { logger: { info() {}, warn() {} }, stop: () => new Promise(() => {}) };
+    shutdownHandler(context);
+    const graceful = process.listeners("SIGINT").find((listener) => listener.name === "sigintHandler");
+    const force = process.listeners("SIGBREAK").find((listener) => listener.name === "sigbreakHandler");
+    graceful();
+    force();
+  `;
+  const result = Bun.spawnSync([process.execPath, "-e", script]);
+
+  expect(result.exitCode).toBe(1);
+});
+
+/**
+ * @case Cleanup removes every shutdown signal handler
+ * @preconditions A handler is installed and its cleanup callback is called
+ * @expectedResult SIGINT, SIGTERM, SIGQUIT, and SIGBREAK listener counts return to their baseline
+ */
+test("cleanup removes all shutdown signal handlers", () => {
+  const before = new Map(
+    ["SIGINT", "SIGTERM", "SIGQUIT", "SIGBREAK"].map((signal) => [
+      signal,
+      process.listenerCount(signal),
+    ]),
+  );
+  const cleanup = shutdownHandler(makeContext(async () => ({ forced: false, pending: [] })));
+
+  cleanup();
+
+  for (const signal of before.keys()) {
+    expect(process.listenerCount(signal)).toBe(before.get(signal));
+  }
+});
+
+afterEach(() => {
+  for (const signal of ["SIGINT", "SIGTERM", "SIGQUIT", "SIGBREAK"] as const) {
+    process.removeAllListeners(signal);
+  }
+});

--- a/packages/routecraft/test/shutdown-handler.bun.test.ts
+++ b/packages/routecraft/test/shutdown-handler.bun.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { shutdownHandler } from "../src/shutdown.ts";
 import type { CraftContext } from "../src/context.ts";
@@ -32,8 +32,10 @@ const invoke = (
 test("repeated graceful signals remain idempotent", async () => {
   const exits: number[] = [];
   const originalExit = process.exit;
+  const exit = Promise.withResolvers<void>();
   process.exit = ((code: number) => {
     exits.push(code);
+    exit.resolve();
   }) as typeof process.exit;
   const deferred = Promise.withResolvers<{
     forced: boolean;
@@ -47,8 +49,7 @@ test("repeated graceful signals remain idempotent", async () => {
     invoke("SIGTERM");
     invoke("SIGTERM");
     deferred.resolve({ forced: false, pending: [] });
-    await Promise.resolve();
-    await Promise.resolve();
+    await exit.promise;
 
     expect(exits).not.toContain(1);
     expect(exits).toContain(0);
@@ -92,19 +93,30 @@ test("SIGQUIT forces immediate exit before graceful shutdown", () => {
  * @expectedResult SIGBREAK invokes exit code 1 without waiting for context.stop
  */
 test("SIGBREAK forces immediate exit during graceful shutdown", () => {
-  const source = new URL("../src/shutdown.ts", import.meta.url).pathname;
+  const source = new URL("../src/shutdown.ts", import.meta.url).href;
   const script = `
     const { shutdownHandler } = await import(${JSON.stringify(source)});
-    const context = { logger: { info() {}, warn() {} }, stop: () => new Promise(() => {}) };
-    shutdownHandler(context);
+    const result = { stopStarted: false, forceHandled: false, exitCode: undefined };
+    process.exit = (code) => { result.forceHandled = true; result.exitCode = code; };
+    const context = { logger: { info() {}, warn() {} }, stop: () => { result.stopStarted = true; return new Promise(() => {}); } };
+    const cleanup = shutdownHandler(context);
     const graceful = process.listeners("SIGINT").find((listener) => listener.name === "sigintHandler");
     const force = process.listeners("SIGBREAK").find((listener) => listener.name === "sigbreakHandler");
     graceful();
     force();
+    cleanup();
+    console.log(JSON.stringify(result));
   `;
-  const result = spawnSync(process.execPath, ["-e", script]);
+  const result = spawnSync(process.execPath, ["-e", script], {
+    encoding: "utf8",
+  });
 
-  expect(result.status).toBe(1);
+  expect(result.status).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual({
+    stopStarted: true,
+    forceHandled: true,
+    exitCode: 1,
+  });
 });
 
 /**
@@ -127,11 +139,5 @@ test("cleanup removes all shutdown signal handlers", () => {
 
   for (const signal of before.keys()) {
     expect(process.listenerCount(signal)).toBe(before.get(signal)!);
-  }
-});
-
-afterEach(() => {
-  for (const signal of ["SIGINT", "SIGTERM", "SIGQUIT", "SIGBREAK"] as const) {
-    process.removeAllListeners(signal);
   }
 });


### PR DESCRIPTION
## TLDR

Repeated `SIGINT`/`SIGTERM` signals are now idempotent during graceful shutdown, avoiding accidental forced exits when a runner forwards the same signal twice. `SIGQUIT` and `SIGBREAK` provide explicit force-exit paths.

Closes #684

**Breaking for route authors:** no — route DSL and types are unchanged; the interactive force-shutdown signal changes.

## Before and after

- **Before:** A second `SIGINT` or `SIGTERM` during shutdown immediately exited with code 1, so duplicated forwarded signals could abort cleanup.
- **After:** Repeated graceful signals are ignored; `SIGQUIT`/`SIGBREAK` explicitly force exit with code 1 before or during graceful shutdown.

## DSL

No DSL change.

---

## Why

As reported in #684, `bun --filter` can forward `SIGINT` twice. Treating the duplicate as user intent to force exit makes graceful shutdown unreliable.

## What changed

- Split graceful (`SIGINT`/`SIGTERM`) and force (`SIGQUIT`/`SIGBREAK`) signal handling.
- Made graceful shutdown idempotent while preserving timeout-driven forced shutdown.
- Removed all four registered handlers from the returned cleanup callback.
- Updated shutdown guidance for the dedicated force signals.

## Tests

- `bun test packages/routecraft/test/shutdown-handler.bun.test.ts` — 4 passed, 0 failed.
- The repeated-signal regression test was also run against the pre-fix implementation and failed by observing forced exit code 1.
- Coverage includes duplicate `SIGINT`/`SIGTERM`, immediate `SIGQUIT`, `SIGBREAK` during graceful shutdown, and cleanup of all four listeners.

## Docs and changeset

Updated the CLI shutdown reference. Added a minor changeset for `@routecraft/routecraft` because the public signal interaction changes under v0.

## Review

One independent review round found no blocking security, scope, production-logic, or cross-platform registration issues. `git diff --check` and the focused Bun suite passed.

## Leftovers

Full local format, lint, typecheck, and repository-wide gates could not run because workspace dependencies were unavailable; GitHub CI is expected to execute those canonical checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes shutdown signals idempotent in `routecraft` so duplicated `SIGINT`/`SIGTERM` no longer force an unclean exit; `SIGQUIT` and `SIGBREAK` are now the dedicated force-exit signals.

- Repeated graceful signals during shutdown are ignored instead of exiting with code 1, fixing the double-signal case reported in #684.
- `SIGQUIT` and `SIGBREAK` force an immediate exit with code 1, before or during graceful shutdown.
- The interactive force key changes from a second Ctrl+C to Ctrl+Backslash or Ctrl+Break; route DSL and types are unchanged.
- Docs now cover ecosystem signal differences: nginx treats SIGQUIT as graceful, a container `STOPSIGNAL SIGQUIT` would force exit, and under `bun --filter` the force-path log can be lost.
- Added a minor changeset for `@routecraft/routecraft` and tests for repeated signals, force signals, and cleanup of all four listeners.

<sup>Written for commit 50986f1df73af8cf4368f59d9c01404339ca086e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/routecraftjs/routecraft/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

