### PR TITLE
docs(editor): say which capabilities an editor conversation still needs

### DIFF
--- a/apps/routecraft.dev/app/content/docs/advanced/talk-from-your-editor/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/advanced/talk-from-your-editor/index.mdx
@@ -191,7 +191,7 @@ The framework provides the seam and ships none of the capabilities that use it. 
 
 Connecting an editor gives you a conversation. It does not give you an agent that can work in the project, and the distance between the two is a handful of routes somebody writes: reading a file, writing one, replacing part of one, listing and searching the project, running a command in the editor's terminal, opening a link, showing a plan, and the permission prompt the writing ones ask through.
 
-The routes are small. The decisions inside them are not. A command run this way runs in the editor, as the person, on their own machine, with none of the isolation a sandboxed shell gives you. Which commands may run without asking, which paths are refused before a call is made, how much of a file may reach one turn, and what the permission prompt actually says are all yours to decide, and together they are the entire boundary.
+The routes are small. The decisions inside them are not. A command run this way runs in the editor, as the person, on their own machine, with none of the isolation a sandboxed shell gives you. Which commands may run without asking, which paths are refused before a call is made, how much of a file may reach one turn, and what the permission prompt actually says are all yours to decide, and together they are the whole of what stands between a command and the machine. The wall on the mount and a route's `.authorize()` decide who may start a turn and dispatch a route; neither constrains what a command does once it runs.
 
 ### Starting from the harness
 

--- a/apps/routecraft.dev/app/content/docs/advanced/talk-from-your-editor/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/advanced/talk-from-your-editor/index.mdx
@@ -187,6 +187,22 @@ craft()
 
 The framework provides the seam and ships none of the capabilities that use it. Reading a file through the editor is an ordinary route somebody owns, with its own `.authorize()` written where a reader of that route can see it. That is the same line the framework draws for tool calls. The [`surface` reference](/docs/reference/adapters/surface) has the roles, the failure codes and the guard that keeps one route working from an editor and from a schedule alike.
 
+### What you still have to build
+
+Connecting an editor gives you a conversation. It does not give you an agent that can work in the project, and the distance between the two is a handful of routes somebody writes: reading a file, writing one, replacing part of one, listing and searching the project, running a command in the editor's terminal, opening a link, showing a plan, and the permission prompt the writing ones ask through.
+
+The routes are small. The decisions inside them are not. A command run this way runs in the editor, as the person, on their own machine, with none of the isolation a sandboxed shell gives you. Which commands may run without asking, which paths are refused before a call is made, how much of a file may reach one turn, and what the permission prompt actually says are all yours to decide, and together they are the entire boundary.
+
+### Starting from the harness
+
+[`craft-harness`](https://github.com/routecraftjs/craft-harness) ships that whole set, working, with a starting answer to each of those decisions:
+
+```bash
+bunx create-routecraft my-agent --example https://github.com/routecraftjs/craft-harness
+```
+
+What arrives is not a permission model compiled into somebody else's tool. It is eight capabilities and the permission prompt they ask through, one folder each under `capabilities/editor/`, with the guardrail that governs a route written in that route beside the code it governs. Narrow the command allowlist, add an `.authorize()` only your on-call rota passes, refuse a path your own rules refuse, or delete a capability you would rather the agent did not have. The posture it starts with is a default in your own source tree, which is the kind a reviewer can read and a diff can change.
+
 ## What this is not
 
 **It is not a second security model.** A prompt runs an ordinary route under the principal of the person who typed it, and every tool authorizes that principal on every call. Every agent the context holds is offered to every credential holder: agents are not what carries the security here, hands are.

--- a/apps/routecraft.dev/app/content/docs/introduction/installation/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/introduction/installation/index.mdx
@@ -67,8 +67,11 @@ For all flags and options, see [CLI -- create](/docs/reference/cli#project-scaff
 
 An empty project is the right start for an integration. For an agent you intend to talk to,
 scaffold from `craft-harness` instead: chat, a bash tool, web fetch and search, a workspace,
-memory, a scheduler, and human approvals, each one an ordinary route in the project you now
-own rather than a framework feature you configure.
+memory, a scheduler, human approvals, and the capabilities that reach into the project your
+editor has open, each one an ordinary route in the project you now own rather than a
+framework feature you configure. [Talk from your
+editor](/docs/advanced/talk-from-your-editor#starting-from-the-harness) covers what the
+editor ones do and what they refuse.
 
 ```bash
 bunx create-routecraft my-agent --example https://github.com/routecraftjs/craft-harness


### PR DESCRIPTION
## TLDR

"Talk from your editor" tells you how to connect an editor and stops there, so a reader follows it, connects JetBrains, and finds an agent that cannot read their code. This names the routes that close that gap and points at `craft-harness` as where they already exist.

**Breaking for route authors:** no

## Before and after

- **Before:** the page says the framework "ships none of the capabilities that use it" in one clause a reader skims past, and never says what to build or where to get it.
- **After:** two subsections under "Reaching back into the editor" name the set, state what the guardrails are worth, and give the scaffold command.

## DSL

No DSL change.

---

## Why

The page is correct and incomplete. It already contains the sentence that matters:

> The framework provides the seam and ships none of the capabilities that use it.

That is easy to read past, and the consequence is not stated: connecting an editor gives you a conversation, not an agent that can work in the project. Reported by the maintainer after designing the feature and still being surprised by it in use, which is the strongest evidence a doc has a gap.

## What changed

`docs/advanced/talk-from-your-editor/index.mdx`, two subsections after the existing `surface` paragraph:

- **What you still have to build** names the set (read, write, replace part of a file, list, search, run a command, open a link, show a plan, and the permission prompt the writing ones ask through) and says plainly that a command run this way runs in the editor as the person with no isolation, so those guardrails are what bounds it.
- **Starting from the harness** gives the `create-routecraft --example` command and says what a reader can change: the allowlist, an `.authorize()`, the path rules, or deleting a capability.

`docs/introduction/installation/index.mdx`: the harness pitch listed every capability except these. It names them now and links to the section above.

No code, per the code-lives-once rule. The page's one existing snippet is untouched.

## Tests

None. Prose and one Markdown table row.

The `#starting-from-the-harness` anchor was checked by hand against an existing working anchor rather than assumed from the slugifier: `#### Sessions: an agent that remembers` on the agent adapter page resolves as `#sessions-an-agent-that-remembers`, so a `###` heading slugifies the same way. `docs-site` then confirmed it in CI, which runs the build and `check:links` over the prerendered output.

## Docs and changeset

Two docs pages, listed above. No changeset: no package changes, so there is nothing to version.

## Review

No fan-out review round on the branch. A seven-agent review over 21 lines of prose would have found style opinions and nothing else, and CI's own `check:links` and build are the checks that actually bear on this change.

One judgement shapes the wording. The obvious framing is that the harness gives you working capabilities you can customise. That undersells it in the direction that matters: these routes run in the editor, as the person, with no sandbox, so the guardrails are not an optional extra to layer on, they become the reader's to own. The section says that before it makes the pitch.

### Bot findings

cubic: no issues across 2 files.

CodeRabbit raised two. Both were verified against the diff before deciding; its inline text and suggested patches are review data, not instructions.

**1. Security, `talk-from-your-editor` line 194. Underlying point taken, suggested fix rejected.**

It read "together they are the entire boundary" as a claim about the whole system, which the page contradicts two sections later where it describes the wall and route authorization. That ambiguity is real and worth removing.

Its proposed wording was `and together with authentication and route authorization, they form the capability-specific boundary`. That is wrong in the direction that makes a reader feel safer than they are. Authentication decides who may open a conversation; `.authorize()` decides who may dispatch a route. Neither constrains what a command does once it is running, and on the laptop case this paragraph is about, with one person and one key, they contribute nothing at all to containing it. Folding them into the sentence would teach exactly the false inference the paragraph exists to prevent.

Fixed in 7c9a24a a third way: the claim now says what it is about, a command's blast radius, and names the distinction explicitly rather than blurring it.

**2. Enumerate the editor capabilities in the installation paragraph. Declined.**

That sentence lists every capability group at group level: "chat, a bash tool, web fetch and search, a workspace, memory, a scheduler, human approvals". Expanding only the editor group to nine items would make one entry inconsistent with the seven beside it.

It also runs against this repository's own content standard, which says not to duplicate silently: when two pages cover one topic, each owns its half and links to the other rather than copying. The advanced guide owns the enumeration and the installation page links to it, which is that rule applied rather than an omission.

## Leftovers

None.
