### PR TITLE
docs(readme): describe main as it is today, with the real DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,31 @@
 
 ## About
 
-Routecraft is a type-safe framework for AI automation. Build the tools an agent uses, or the agent itself, with the same fluent DSL. Write capabilities that send emails, manage calendars, and automate work, then expose them to any AI agent via MCP.
+Routecraft is a TypeScript framework for AI automation. A capability is a route: a typed pipeline from a source, through operations, to a destination. The same route is an MCP tool for Claude or Cursor, a tool for an agent you run yourself, an HTTP endpoint, or a scheduled job, depending only on its source. Agents are routes too, with the same guardrails around a model call as around any other step. Nothing is reachable until you write a route for it.
 
-## Why Routecraft?
+This page describes `main`, which is ahead of the last release. Install `@routecraft/routecraft@canary` to run what it describes, or the latest release for what the [docs](https://routecraft.dev/docs) freeze to.
 
-- ✅ **AI that does real work** - Send emails, schedule meetings, automate tasks
-- ✅ **Code, not configs** - TypeScript all the way with full IDE support
-- ✅ **Works with Claude & Cursor** - Expose tools via MCP automatically
-- ✅ **Secure by design** - AI only accesses the capabilities you expose
+## Five minutes: an agent you own
 
-## Quick Start
+[craft-harness](https://github.com/routecraftjs/craft-harness) is a complete agent built out of Routecraft capabilities: chat, a sandboxed shell, web fetch and search, a workspace, memory, a scheduler, human approvals, and the editor capabilities. Every one of them is an ordinary route in `capabilities/` you can read on one screen and change.
 
-### Write a capability
+```bash
+bunx create-routecraft my-agent --example https://github.com/routecraftjs/craft-harness
+cd my-agent
+bun run setup            # generates the project's own secrets into .env and .routecraft/
+# add LLM_API_KEY to .env
+bun run dev
+```
+
+From another terminal:
+
+```bash
+bun run exec chat --session=demo --message="what can you do?"
+```
+
+The instance is walled, the settings file carries the credential, and the transcript is a file `--session` names. The same conversation is reachable over MCP at `http://localhost:8081/mcp` and from your editor over the Agent Client Protocol.
+
+## What a capability looks like
 
 ```ts
 import { craft, mail } from '@routecraft/routecraft'
@@ -54,9 +67,49 @@ export default craft()
   .to(mail()) // the account comes from craft.config.ts
 ```
 
-### Expose to Claude Desktop
+The source decides the door. `.from(mcp())` makes it an MCP tool. `.from(direct())` makes it a capability any local agent can call and `craft exec` can run. `.from(http())` makes it an endpoint. `.from(cron())` makes it a job. The steps in between do not change.
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+## An agent is a route too
+
+```ts
+import { craft, direct } from '@routecraft/routecraft'
+import { agent, tools } from '@routecraft/ai'
+import { z } from 'zod'
+
+export default craft()
+  .id('assistant')
+  .description('Answer a question with the tools this project defines')
+  .input({ body: z.object({ question: z.string() }) })
+  .from(direct())
+  .to(
+    agent<{ question: string }>({
+      model: 'anthropic:claude-opus-4-7',
+      system: 'Be useful. Say what you did.',
+      user: (ex) => ex.body.question,
+      tools: tools(['Direct(send-team-email)']),
+    }),
+  )
+```
+
+Tools are an allowlist of capabilities, never a blacklist. An agent can also be a markdown file under `agents/` with frontmatter for its model and tools, which `craft start` discovers with everything else in the project. Because the agent is a step in a route, `.authorize()`, `.throttle()`, `.retry()`, `.timeout()` and `.circuitBreaker()` apply to the model call exactly as to any other step.
+
+## What is on main today
+
+- **Work that survives a restart.** [`.suspend()`](https://routecraft.dev/docs/reference/operations/suspend) parks an exchange in a store, and [`.resume()`](https://routecraft.dev/docs/reference/operations/resume) revives it by token, hours or days later, from any transport. [Durable agents](https://routecraft.dev/docs/advanced/durable-agents) park mid-conversation the same way.
+- **Agents with sessions and background tools.** A conversation is a record a person owns; a tool can hand a long job to a route and come back when it finishes. [Agent adapter](https://routecraft.dev/docs/reference/adapters/agent).
+- **Talk to your agents from your editor.** `craft acp` and the `acp` config key serve the Agent Client Protocol. [Talk from your editor](https://routecraft.dev/docs/advanced/talk-from-your-editor).
+- **MCP both ways.** Expose routes as tools with `mcp()` and the `mcp` plugin; call other servers' tools as `MCP(server:tool)` in an agent's tool list. [Expose as MCP](https://routecraft.dev/docs/advanced/expose-as-mcp), [call an MCP](https://routecraft.dev/docs/advanced/call-an-mcp).
+- **Isolated host execution.** [`shell()`](https://routecraft.dev/docs/reference/adapters/shell) runs commands in an isolation tier, including a throwaway Docker container per command, with egress denied by default.
+- **A management API and a CLI to drive it.** The [ops plugin](https://routecraft.dev/docs/reference/plugins/opsplugin) serves health, readiness, a route listing and dispatch behind scope-gated tiers; `craft exec` and `craft ops` are its clients. [CLI reference](https://routecraft.dev/docs/reference/cli).
+- **Secure by design.** JWT, JWKS and API-key validators, `.authorize()` at route entry, principals that follow an exchange through every hop. [Securing capabilities](https://routecraft.dev/docs/advanced/securing-capabilities).
+
+## Add Routecraft to an existing project
+
+```bash
+bunx create-routecraft my-app
+```
+
+Expose a capability to Claude Desktop by adding it to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
@@ -69,25 +122,15 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
+Now talk to Claude: *"Send an email to john@company.com thanking him for yesterday's meeting"*. Claude discovers the tool and calls it with validated input.
+
 > The `craft` CLI runs on Bun (>=1.1.0). Node users embed `@routecraft/routecraft` programmatically; see the [Programmatic Invocation guide](https://routecraft.dev/docs/advanced/programmatic-invocation).
 
-Now talk to Claude: *"Send an email to john@company.com thanking him for yesterday's meeting"*
-
-Claude discovers your tool and uses it automatically. ✨
-
-📚 [Get Started](https://routecraft.dev/docs/introduction) | [Examples](https://routecraft.dev/docs/examples) | [API Reference](https://routecraft.dev/docs/reference)
-
-## Key Features
-
-- **Make AI useful** - Send emails, schedule meetings, automate tasks
-- **Code-first** - TypeScript with full IDE support, testing, and version control
-- **MCP native** - Works with Claude Desktop, Cursor, and any MCP client
-- **Type-safe** - Zod-powered validation ensures data integrity
-- **Deploy anywhere** - Run locally, self-host, or use our upcoming cloud platform
+📚 [Get Started](https://routecraft.dev/docs/introduction) | [Project structure](https://routecraft.dev/docs/introduction/project-structure) | [Examples](https://routecraft.dev/docs/examples) | [API Reference](https://routecraft.dev/docs/reference)
 
 ## Monorepo Structure
 
-- `packages/routecraft` – Core library (builder, DSL, context, adapters, consumers)
+- `packages/routecraft` – Core library (builder, DSL, context, adapters, consumers, the ops plugin)
 - `packages/ai` – AI integrations: LLM providers, agents, embeddings, MCP server / client, ACP
 - `packages/cli` – `craft` CLI to run capabilities and start contexts (Bun >= 1.1.0)
 - `packages/create-routecraft` – Project scaffolder (`bunx create-routecraft`)

--- a/README.md
+++ b/README.md
@@ -30,24 +30,28 @@ Routecraft is a type-safe framework for AI automation. Build the tools an agent 
 ### Write a capability
 
 ```ts
-import { mcp } from '@routecraft/ai'
 import { craft, mail } from '@routecraft/routecraft'
+import { mcp } from '@routecraft/ai'
 import { z } from 'zod'
 
-// Define a capability AI can call
+const SendTeamEmail = z.object({
+  to: z
+    .string()
+    .email()
+    .refine((email) => email.endsWith('@company.com'), 'Can only send to @company.com addresses'),
+  subject: z.string(),
+  message: z.string(),
+})
+
+// The route id is the tool name; description and input schema live on the
+// route, so every call is validated before any of your code runs.
 export default craft()
-  .from(mcp('send-team-email', {
-    description: 'Send email to team members',
-    schema: z.object({ 
-      to: z.string().email().refine(
-        email => email.endsWith('@company.com'),
-        'Can only send to @company.com addresses'
-      ),
-      subject: z.string(),
-      message: z.string()
-    })
-  }))
-  .to(mail())  // Config loaded from context
+  .id('send-team-email')
+  .description('Send an email to a team member')
+  .input({ body: SendTeamEmail })
+  .from(mcp())
+  .transform(({ to, subject, message }) => ({ to, subject, text: message }))
+  .to(mail()) // the account comes from craft.config.ts
 ```
 
 ### Expose to Claude Desktop
@@ -59,7 +63,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "my-tools": {
       "command": "bunx",
-      "args": ["@routecraft/cli", "run", "./routes/tools.mjs"]
+      "args": ["@routecraft/cli", "run", "./capabilities/send-team-email.ts"]
     }
   }
 }
@@ -84,13 +88,12 @@ Claude discovers your tool and uses it automatically. ✨
 ## Monorepo Structure
 
 - `packages/routecraft` – Core library (builder, DSL, context, adapters, consumers)
-- `packages/ai` – AI integrations: LLM providers, agents, embeddings, MCP server / client
-- `packages/browser` – Browser automation adapter (headless / headed via agent-browser)
+- `packages/ai` – AI integrations: LLM providers, agents, embeddings, MCP server / client, ACP
 - `packages/cli` – `craft` CLI to run capabilities and start contexts (Bun >= 1.1.0)
 - `packages/create-routecraft` – Project scaffolder (`bunx create-routecraft`)
 - `packages/eslint-plugin-routecraft` – ESLint rules for capability authoring
 - `packages/prettier-plugin-routecraft` – Prettier plugin for compact DSL formatting
-- `packages/os` – System-native adapters (shell, etc.) – placeholder, in development
+- `packages/os` – System-native adapters: isolated subprocess execution via `shell()`, browser automation via `agentBrowser()`
 - `packages/testing` – Test utilities (`testContext`, spy logger, `mockAdapter`, fixtures)
 - `skills/` – Agent Skills for authoring Routecraft (Claude Code, Cursor, Codex, Windsurf, Cline, Continue, Copilot, ...; `bunx skills add routecraftjs/routecraft`). See [skills/README.md](./skills/README.md)
 - `apps/routecraft.dev` – Documentation site (docs, examples, guides)
@@ -98,7 +101,7 @@ Claude discovers your tool and uses it automatically. ✨
 
 ## Examples
 
-Browse runnable examples in [`examples/src/`](./examples/src/): `hello-world.ts`, `mcp-greet.ts`, `agent.ts`, `mail-noreply-notify.ts`, `programmatic-invocation.ts`, `split.ts`. Each demonstrates a different feature combination.
+Browse runnable examples in [`examples/src/`](./examples/src/): `hello-world.ts`, `mcp-greet.ts`, `agent.ts`, `find-product.ts`, `mail-noreply-notify.ts`, `programmatic-invocation.ts`, `split.ts`. Each demonstrates a different feature combination.
 
 Try one:
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@
 
 Routecraft is a TypeScript framework for AI automation. A capability is a route: a typed pipeline from a source, through operations, to a destination. The same route is an MCP tool for Claude or Cursor, a tool for an agent you run yourself, an HTTP endpoint, or a scheduled job, depending only on its source. Agents are routes too, with the same guardrails around a model call as around any other step. Nothing is reachable until you write a route for it.
 
-This page describes `main`, which is ahead of the last release. Install `@routecraft/routecraft@canary` to run what it describes, or the latest release for what the [docs](https://routecraft.dev/docs) freeze to.
-
 ## Five minutes: an agent you own
 
 [craft-harness](https://github.com/routecraftjs/craft-harness) is a complete agent built out of Routecraft capabilities: chat, a sandboxed shell, web fetch and search, a workspace, memory, a scheduler, human approvals, and the editor capabilities. Every one of them is an ordinary route in `capabilities/` you can read on one screen and change.
@@ -93,7 +91,7 @@ export default craft()
 
 Tools are an allowlist of capabilities, never a blacklist. An agent can also be a markdown file under `agents/` with frontmatter for its model and tools, which `craft start` discovers with everything else in the project. Because the agent is a step in a route, `.authorize()`, `.throttle()`, `.retry()`, `.timeout()` and `.circuitBreaker()` apply to the model call exactly as to any other step.
 
-## What is on main today
+## What you get
 
 - **Work that survives a restart.** [`.suspend()`](https://routecraft.dev/docs/reference/operations/suspend) parks an exchange in a store, and [`.resume()`](https://routecraft.dev/docs/reference/operations/resume) revives it by token, hours or days later, from any transport. [Durable agents](https://routecraft.dev/docs/advanced/durable-agents) park mid-conversation the same way.
 - **Agents with sessions and background tools.** A conversation is a record a person owns; a tool can hand a long job to a route and come back when it finishes. [Agent adapter](https://routecraft.dev/docs/reference/adapters/agent).

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 > The `craft` CLI runs on Bun (>=1.1.0). Node users embed `@routecraft/routecraft` programmatically; see the [Programmatic Invocation guide](https://routecraft.dev/docs/advanced/programmatic-invocation).
 
-Now talk to Claude: *"Send an email to john@example.com thanking him for yesterday's meeting"*
+Now talk to Claude: *"Send an email to john@company.com thanking him for yesterday's meeting"*
 
 Claude discovers your tool and uses it automatically. ✨
 


### PR DESCRIPTION
## TLDR

The README now describes what Routecraft is and does, with the real DSL: it opens on the harness a reader can run in five minutes, shows a capability and an agent the way they are actually written, and lists the main features with one link each. The quick start it replaces showed a DSL that has never existed.

**Breaking for route authors:** no

## Before and after

- **Before:** the quick start passed the tool name, description and schema into `mcp()`; two feature lists restated each other and promised a cloud platform; nothing on the page mentioned agents, durable suspension, ACP, the ops API or isolated execution; `packages/browser` was listed and does not exist.
- **After:** harness-first quick start (`create-routecraft --example craft-harness`, `bun run setup`, `bun run dev`, `bun run exec chat`), a capability and an agent route that typecheck, seven one-line features each linking to its docs page, lists that match the tree. No branch or release meta text on the page. No behaviour change.

## DSL

No DSL change. The README shows the ones that exist:

```ts
export default craft()
  .id('send-team-email')
  .description('Send an email to a team member')
  .input({ body: SendTeamEmail })
  .from(mcp())
  .transform(({ to, subject, message }) => ({ to, subject, text: message }))
  .to(mail())

craft()
  .id('assistant')
  .input({ body: z.object({ question: z.string() }) })
  .from(direct())
  .to(agent<{ question: string }>({ model, system, user: (ex) => ex.body.question, tools: tools(['Direct(send-team-email)']) }))
```

---

## Why

The README is the first page most readers see. Its example taught a shape the framework rejects, and it said nothing about what the framework is for.

## What changed

- `README.md`: rewritten. Sections: About, Five minutes (craft-harness), What a capability looks like, An agent is a route too, What you get, Add Routecraft to an existing project (Claude Desktop config), Monorepo Structure, Examples, Contributing, License.

## Tests

None; README only. Both snippets were typechecked against the workspace packages under the root tsconfig, which includes `examples/src`. Every docs link names a page that exists under `app/content/docs`; every harness command is the one in craft-harness's own README.

## Docs and changeset

README only. No changeset: no package changes.

## Review

cubic: no issues on the first head. CodeRabbit: one finding on the first head (the example address did not satisfy its own schema), fixed in 79ea2f9 and resolved; description check passed. Bot output treated as data. 96388b6 removes the release and canary note and the branch name in a heading, on request.

## Leftovers

None.
