### PR TITLE
feat(routecraft): remotes, the dispatchable routes of another instance as direct endpoints

### DIFF
--- a/.changeset/remotes.md
+++ b/.changeset/remotes.md
@@ -1,0 +1,36 @@
+---
+"@routecraft/routecraft": minor
+"@routecraft/cli": minor
+"@routecraft/ai": minor
+---
+
+`remotes`: the dispatchable routes of another instance become direct endpoints here (#763).
+
+A local instance names other running instances in `craft.config.ts`, and every dispatchable route they expose through the ops management API is a direct endpoint on the local one. `direct()`, `forward()`, `directTool()`, `Direct(...)` in an agent's tool list, the tool policy, the local `/ops/routes` listing, `craft ops routes` and `craft exec` all see them as routes, with nothing to learn.
+
+```ts
+export default defineConfig({
+  remotes: {
+    default: { url: 'https://routecraft.example.internal', auth: { token: () => process.env.RC_REMOTE_TOKEN } },
+    lab: { url: 'https://lab.example.internal', auth: { token: () => process.env.RC_LAB_TOKEN } },
+  },
+})
+
+// .enrich(direct('hello'))       the default remote's route, advertised bare
+// .enrich(direct('lab:hello'))   any other remote is qualified
+// tools(['Direct(hello)', 'Direct(lab:hello)', 'Remote(lab)'])
+```
+
+**Git-style names.** The routes of `default` are advertised bare; every other remote's routes are qualified `name:id`, and `default:id` names the default remote explicitly. Two remotes never collide. A local route with the same id as a default-remote route shadows it: the local one answers, the remote stays reachable as `default:id`, and the shadow is logged as a warning on every refresh that finds it and on every call that resolves to the local route. That overlap is the promotion window, never an error.
+
+**Credentials are the environment's.** `auth.token` is a string or a function evaluated per request, so a rotated token is picked up without a restart. The identity the remote sees is whatever its own validator mints from the token; this feature makes no call on api keys versus JWTs. A bearer over plain `http:` is refused at configuration unless the address is loopback, the rule the CLI already enforces.
+
+**Inventory and schemas are the framework's.** `GET /ops/routes?dispatchable=true` and `GET /ops/routes/{id}` at start, on an interval (`refresh`, default `60s`), and forced by a dispatch that meets a 404 for a route the inventory still lists. A remote unreachable at boot registers nothing, logs, and reports its `remote.<name>` health indicator down; its routes appear on the refresh that first reaches it.
+
+**Outcomes map onto the in-process ones.** Completed is the body; dropped is `RC5031`; suspended is the standard `Suspended` acknowledgment, with resume at the remote's door under its policy; a remote 500 is `RC5064` carrying the remote's code; a 401 or 403 from the door is `RC5063`; an unreachable remote or a timeout is `RC5062`.
+
+**The listing names the origin.** An imported route shows in the local `/ops/routes` as dispatchable with `sources: ["remote"]` and a `remote` field. The agent tool policy's `direct` rule sees `source.remote`, so a policy can keep an agent local-only. Re-exposure through the local door is intentional: a local instance with an open dispatch tier re-exports every imported route under its own door, exactly as a tool fronting an authenticated REST call does.
+
+**Agent tools.** `Direct(hello)` keeps its `direct__hello` wire name; `Direct(lab:hello)` and every expansion of `Remote(lab)` become `remote__lab__hello`, one separator per part, because a colon is outside the provider charset. A remote's name is constrained at configuration the way an MCP client's is.
+
+**The ops client lives in core.** `createOpsHttpClient` is exported from `@routecraft/routecraft` and `packages/cli` imports it; `craft exec`, `craft ops` and the refusal-hint behaviour are unchanged. A plugin can also contribute a health indicator without the app listing it (`contributeOpsIndicator`), which is how a remote reports.

--- a/apps/routecraft.dev/app/content/docs/_data/errors.json
+++ b/apps/routecraft.dev/app/content/docs/_data/errors.json
@@ -240,6 +240,24 @@
     "retryable": false
   },
   {
+    "code": "RC5062",
+    "category": "Runtime",
+    "message": "Remote instance unreachable",
+    "retryable": true
+  },
+  {
+    "code": "RC5063",
+    "category": "Runtime",
+    "message": "Remote instance refused the credential",
+    "retryable": false
+  },
+  {
+    "code": "RC5064",
+    "category": "Runtime",
+    "message": "Remote dispatch failed",
+    "retryable": false
+  },
+  {
     "code": "RC9901",
     "category": "Runtime",
     "message": "Unknown error",

--- a/apps/routecraft.dev/app/content/docs/_data/plugins.json
+++ b/apps/routecraft.dev/app/content/docs/_data/plugins.json
@@ -61,5 +61,12 @@
     "module": "@routecraft/os",
     "hint": "shell() context defaults.",
     "description": "Set context-wide defaults for shell(): isolation tier, timeout, and output cap. The lowest of the three precedence layers, under the ROUTECRAFT_SHELL_ISOLATION operator override and the call site."
+  },
+  {
+    "number": "10",
+    "name": "remotesPlugin",
+    "module": "@routecraft/routecraft",
+    "hint": "Routes of other instances.",
+    "description": "Name other running instances, and every dispatchable route they expose through the ops management API becomes a direct endpoint here, for direct(), forward(), agent tools and the local ops listing alike."
   }
 ]

--- a/apps/routecraft.dev/app/content/docs/reference/adapters/direct/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/adapters/direct/index.mdx
@@ -123,6 +123,7 @@ Route-level metadata lives on the builder: `.title('...')`, `.description('...')
 **Key characteristics:**
 - **Synchronous**: Calling route waits for response from the consuming route
 - **Endpoint = route id**: The direct source uses the route's `.id()` as its endpoint name. Callers reference the consumer by that id.
+- **Ids with a remote prefix**: with [`remotes`](/docs/reference/plugins/remotesplugin) configured, `direct('lab:hello')` reaches route `hello` on the remote named `lab`, and `direct('hello')` reaches the default remote's `hello` unless a local route of that id shadows it. Nothing about the enricher changes: the endpoint is a direct endpoint like any other, and the transport behind it is the remote's ops door.
 - **Agent-only capabilities**: Omit `.id()` to register under a UUID the builder generates; agents can still discover the route via the registry, but it cannot be addressed as a string from code.
 - **Framework-enforced validation**: `.input()` and `.output()` schemas are validated by the engine, not the adapter. A validation failure throws `RC5002` and routes to the consumer route's error handler (both directions); unrecovered, it fails the exchange and rejects the sender.
 - **Automatic endpoint name sanitization**: URL-unsafe characters in the route id are URL-encoded for collision-free registry keys.

--- a/apps/routecraft.dev/app/content/docs/reference/configuration/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/configuration/index.mdx
@@ -79,6 +79,7 @@ A disabled route is registered and known to the context, not started, not intaki
 | `servers` | `Record<string, HttpServerDefinition>` | Only when a surface mounts HTTP | -- | Named HTTP listeners that HTTP, MCP, ops, and custom plugins mount onto ([details](#servers-and-http)) |
 | `http` | `HttpPluginOptions` | No | -- | Serve routes over HTTP for the `http()` source ([details](#servers-and-http)) |
 | `ops` | `OpsConfig` | No | -- | Health, readiness, and liveness endpoints ([details](#ops)) |
+| `remotes` | `RemotesConfig` | No | -- | Other running instances whose dispatchable routes become direct endpoints here ([details](#remotes)) |
 | `mail` | `MailContextConfig` | No | -- | Mail adapter accounts (IMAP/SMTP) keyed by name |
 | `telemetry` | `TelemetryOptions` | No | -- | Telemetry plugin configuration (SQLite, OpenTelemetry) |
 | `suspension` | `SuspensionConfig` | Only when a route can reach `.suspend()` or `.resume()` | -- | Where parked exchanges are stored and how resume tokens are signed. A context with a suspendable route and no `suspension` block refuses to start with `RC5052`; the fields inside it are individually optional ([details](#suspension)) |
@@ -227,6 +228,38 @@ export const craftConfig = defineConfig({
 | `indicators` | `Indicator[]` | `[]` | Indicators to register, declared with [`defineIndicator`](/docs/reference/plugins/opsplugin#define-indicator). |
 
 Route lifecycle, circuit-breaker position, and the serving state are derived from events the framework already emits, so `ops: {}` alone gives a truthful surface. Indicators cover the dependencies the framework cannot see.
+
+### remotes
+
+Names other running instances, and every dispatchable route they expose through their [ops management API](/docs/reference/plugins/opsplugin#management-api) becomes a direct endpoint in this context. See [remotesPlugin](/docs/reference/plugins/remotesplugin) for the naming rule, the shadow rule, credentials, refresh and the outcome mapping.
+
+```ts
+import { defineConfig } from '@routecraft/routecraft'
+
+export default defineConfig({
+  remotes: {
+    default: {
+      url: 'https://routecraft.example.internal',
+      auth: { token: () => process.env.RC_REMOTE_TOKEN },
+    },
+    lab: {
+      url: 'https://lab.example.internal',
+      auth: { token: () => process.env.RC_LAB_TOKEN },
+    },
+  },
+})
+```
+
+Each entry is one remote, keyed by name. The routes of `default` are advertised bare (`direct('hello')`); every other remote's are qualified (`direct('lab:hello')`).
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | `string` | required | The instance's base URL |
+| `auth.token` | `string \| () => string \| undefined \| Promise<...>` | -- | Bearer for the remote's door, evaluated per request when a function |
+| `timeout` | `Duration` | `'30s'` | Per-request deadline against the remote |
+| `refresh` | `Duration \| false` | `'60s'` | How often the inventory is re-read; `false` disables the interval |
+
+The key applies after `ops`, whatever order the two are written in, so each remote's `remote.<name>` health indicator has a ledger to report into when the app carries an ops surface. The credential is read from the environment; the CLI's `.routecraft/settings.yaml` is for the local instance `craft` talks to and is never read here.
 
 Bind the server the surface sits on somewhere the probes can reach. A Kubernetes `httpGet` probe comes from the kubelet against the pod IP and a reverse-proxy check comes from the proxy, so neither reaches `127.0.0.1`; only a Docker `HEALTHCHECK`, which runs inside the container, does. Keep an internal-only port private at the network layer rather than by binding loopback.
 

--- a/apps/routecraft.dev/app/content/docs/reference/errors/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/errors/index.mdx
@@ -998,6 +998,33 @@ The cap applies to error responses too, so a 500 answering with a gigabyte is re
 **Suggestion**  
 Raise the ceiling on the call when the endpoint legitimately returns more than 10 MB: `http({ url, maxBodySize: 50_000_000 })`. Otherwise ask the endpoint for less, with a narrower query, a page, or a range request.
 
+## RC5062
+Remote instance unreachable
+
+**Why it happens**  
+A dispatch to a route imported through [`defineConfig({ remotes })`](/docs/reference/plugins/remotesplugin) never got an answer from the remote instance. The connection was refused, the name did not resolve, or the request timed out. The message names the remote and the route, and says which of the three it was.
+
+**Suggestion**  
+Check the remote's `url` and that the instance is running and serving its ops surface. A refused connection is safe to retry, and the code is marked retryable for it. A timeout is not: the remote may still be running the work it accepted, so a retry could run a non-idempotent route twice, and a timeout carries `retryable: false` on the error itself.
+
+## RC5063
+Remote instance refused the credential
+
+**Why it happens**  
+The remote's door answered 401 or 403 to a dispatch on an imported route, so the problem is the credential and not the route. The message carries the door's own reason: no credential was presented (`remotes.<name>.auth.token` is unset or resolved to nothing), the credential was rejected, or it is valid but lacks the dispatch tier's scope.
+
+**Suggestion**  
+A missing scope needs a token carrying it rather than a new sign-in; the message names the scope. When the remote advertises RFC 9728 metadata the message also names who issues acceptable tokens. The credential is read per request when `auth.token` is a function, so a rotated token takes effect on the next call without a restart.
+
+## RC5064
+Remote dispatch failed
+
+**Why it happens**  
+The remote instance answered a dispatch on an imported route with an error. Its own error code rides in the message and on `cause`, and is what to read first: the ops door sends the code and never the message, so the detail is in the remote's logs.
+
+**Suggestion**  
+A `RC5060` from the remote means the route stopped being dispatchable there (it declared `direct({ internal: true })`, or lost its direct source); anything else is the route's own failure, exactly as it would have surfaced to a caller on the remote. Read the remote's logs for the exchange, and fix the route where it lives.
+
 ## RC9901
 Unknown error
 

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/agentplugin/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/agentplugin/index.mdx
@@ -388,7 +388,7 @@ agentPlugin({
 
 Flat array of items. Each item is one of:
 
-- **Bare string**: name lookup. Plain ids resolve against the fn registry; `Direct(<routeId>)` wraps a direct route via `directTool` (the LLM-facing tool name becomes `direct__<routeId>`); `MCP(server:tool)` resolves against `MCP_TOOL_REGISTRY` (populated by `defineConfig.mcp` / `mcpPlugin({ clients })`), and `MCP(server)` (or the raw `mcp__server__tool` / `mcp__server` / `mcp__server__*` forms) expands at dispatch time to every tool the named server exposed. The raw `mcp__server__tool` form is the string Claude Code agent files carry, so they resolve unchanged, provided the server segment is unambiguous: the form is split at the first `__` after the prefix, so a client whose own name is empty, carries a `__`, or ends in `_` would misresolve. `mcpPlugin({ clients })` rejects such a name at startup, which is what makes the guarantee hold for any client it registered; see [client names](/docs/reference/plugins/mcpplugin).
+- **Bare string**: name lookup. Plain ids resolve against the fn registry; `Direct(<routeId>)` wraps a direct route via `directTool` (the LLM-facing tool name becomes `direct__<routeId>`), a route imported from another instance through [`remotes`](/docs/reference/plugins/remotesplugin) included: `Direct(hello)` reaches the default remote's route under its bare name, `Direct(lab:hello)` any other remote's under its qualified one, and `Remote(lab)` expands at dispatch time to every route imported from that remote; `MCP(server:tool)` resolves against `MCP_TOOL_REGISTRY` (populated by `defineConfig.mcp` / `mcpPlugin({ clients })`), and `MCP(server)` (or the raw `mcp__server__tool` / `mcp__server` / `mcp__server__*` forms) expands at dispatch time to every tool the named server exposed. The raw `mcp__server__tool` form is the string Claude Code agent files carry, so they resolve unchanged, provided the server segment is unambiguous: the form is split at the first `__` after the prefix, so a client whose own name is empty, carries a `__`, or ends in `_` would misresolve. `mcpPlugin({ clients })` rejects such a name at startup, which is what makes the guarantee hold for any client it registered; see [client names](/docs/reference/plugins/mcpplugin).
 - **`{ name, guard?, description? }`**: same name lookup, with optional per-binding overrides. The guard runs after schema validation and before the handler; throwing surfaces back to the LLM as a tool error so the model can self-correct. The `description` override applies only to this binding for fn-style names. MCP references reject `description` (the MCP server is the source of truth for description and schema; do not override).
 
 #### Authoring grammar vs wire names
@@ -399,6 +399,7 @@ Flat array of items. Each item is one of:
 |------|-----------|----------------|
 | fn | `fetchOrder` | `fetchOrder` |
 | capability | `Direct(cancel-order)` | `direct__cancel-order` |
+| imported capability, qualified | `Direct(lab:hello)`, or any `Remote(lab)` expansion | `remote__lab__hello` |
 | MCP client tool | `MCP(github:create_issue)` | `mcp__github__create_issue` |
 | block loader | (declared via `blocks`) | `_block__load__<name>` |
 
@@ -406,7 +407,7 @@ Flat array of items. Each item is one of:
 
 **An MCP client name may not be empty, contain `__`, or end in `_`**, which `mcpPlugin({ clients })` rejects with RC5003 at startup; see [client names](/docs/reference/plugins/mcpplugin) for why. Constraining the server half is what leaves the tool half free, so a remote may use `__` in its own tool names and `mcp__github__issues__create` resolves correctly.
 
-`Direct(<routeId>)` needs no equivalent rule. A direct wire name carries exactly one separator by construction, and everything after it is the route id, so there is nothing to disambiguate.
+`Direct(<routeId>)` needs no equivalent rule. A direct wire name carries exactly one separator by construction, and everything after it is the route id, so there is nothing to disambiguate. A qualified imported route is the one case with two: `remote__lab__hello` splits at the first separator into the remote and the id, and a remote's name is constrained at configuration exactly as an MCP client's is (no `__`, no trailing `_`), which is what leaves the id half free. The default remote's routes referenced bare keep the `direct__` form, because to the agent they are local.
 
 ### Disabled routes are not offered
 
@@ -590,7 +591,7 @@ agentPlugin({
 | Key | Governs |
 |-----|---------|
 | `fn` | In-process fns registered via `agentPlugin({ functions })` |
-| `direct` | Capabilities in the capability registry, reached via `Direct(<routeId>)` or a `directTool` alias |
+| `direct` | Capabilities in the capability registry, reached via `Direct(<routeId>)`, `Remote(<name>)` or a `directTool` alias. A capability imported from another instance carries `source.remote` (`'default'`, `'lab'`, absent for a local route), so `direct: (tool) => tool.source.remote === undefined` keeps an agent local-only |
 | `mcp` | Tools discovered from external MCP clients |
 
 Each value is `true`, `false`, or a predicate:

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/opsplugin/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/opsplugin/index.mdx
@@ -430,7 +430,7 @@ Source death and staleness stay independent on purpose. A dead scheduler takes t
 
 ### Contributed by a plugin
 
-`defineIndicator` is the app's API: a handle declared in source and named in `ops.indicators`. A plugin that watches a dependency the app never wrote a line for has no handle to give the app, so it contributes the declaration from its `apply()` and reports through the function the contribution returns. This plugin binds it at `start()`, whatever order the two were applied in; before that, or in a context with no ops plugin, a report is inert for the same reason a push through an unbound handle is. A name that is also listed in `ops.indicators` is refused at start, because indicator names are the keys of the report.
+`defineIndicator` is the app's API: a handle declared in source and named in `ops.indicators`. A plugin that watches a dependency the app never wrote a line for has no handle to give the app, so it contributes the declaration from its `apply()` and reports through the function the contribution returns. This plugin binds it at `start()`, whatever order the two were applied in, into every ops ledger on the context; a report made before that is kept and replayed at its own time when the ledger binds, so a `maxAge` window measures from the report. In a context with no ops plugin a report goes nowhere, for the same reason a push through an unbound handle is inert. A name that is also listed in `ops.indicators` is refused at start, because indicator names are the keys of the report.
 
 ```ts skip="fragment: ctx is illustrative"
 import { contributeOpsIndicator } from '@routecraft/routecraft'

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/opsplugin/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/opsplugin/index.mdx
@@ -267,6 +267,8 @@ curl -H "authorization: Bearer $TOKEN" 'http://127.0.0.1:8080/ops/routes'
 
 **Not every route is dispatchable.** A `direct()` ingress makes the route id into a door; a cron-, mail- or http-sourced route runs from its own trigger and has none. That is a fact about the route, so it rides on the representation rather than splitting the collection in two, and a dispatch against a route without a door is refused distinguishably with [`RC5060`](/docs/reference/errors#rc-5060).
 
+**An imported route names its origin.** A route another instance exposes and [`remotes`](/docs/reference/plugins/remotesplugin) made dispatchable here is listed beside the local ones, under its local endpoint (`lab:hello`, or bare for the default remote), as `dispatchable: true` with `sources: ["remote"]` and a `remote` field naming the instance it came from; `?source=remote` lists exactly those. Dispatching one through this door runs it on the remote, which is the intentional re-exposure the remotes page describes.
+
 **A route can close its door on purpose.** [`direct({ internal: true })`](/docs/reference/adapters/direct) keeps the in-process endpoint (other routes compose against it unchanged) and skips the capability registry, so the route shows `dispatchable: false` here and a dispatch refuses with `RC5060` naming the declaration rather than advising a direct source the route already has. It is the opt-out for a trusting subroutine whose boundary route carries `.input()`, `.description()` and `.authorize()`; dispatch the boundary route instead.
 
 Query parameters narrow the one collection:
@@ -275,7 +277,7 @@ Query parameters narrow the one collection:
 | --- | --- |
 | `dispatchable` | `true` or `false`. Only routes that do, or do not, have a dispatch door |
 | `id` | Exact route id. Not a prefix |
-| `source` | Routes carrying a source of this kind (`direct`, `cron`, `mail`, ...) |
+| `source` | Routes carrying a source of this kind (`direct`, `cron`, `mail`, ...); `remote` for routes imported from another instance |
 | `limit` | Page size. A positive integer, at most 200. Defaults to 50 |
 | `after` | The `nextCursor` from the previous page |
 
@@ -426,6 +428,19 @@ Three rows earn an explanation.
 
 Source death and staleness stay independent on purpose. A dead scheduler takes the route `down` at once and lets the indicator go stale on its own clock, so "the probe stopped running" and "the dependency is unreachable" never get confused for one another.
 
+### Contributed by a plugin
+
+`defineIndicator` is the app's API: a handle declared in source and named in `ops.indicators`. A plugin that watches a dependency the app never wrote a line for has no handle to give the app, so it contributes the declaration from its `apply()` and reports through the function the contribution returns. This plugin binds it at `start()`, whatever order the two were applied in; before that, or in a context with no ops plugin, a report is inert for the same reason a push through an unbound handle is. A name that is also listed in `ops.indicators` is refused at start, because indicator names are the keys of the report.
+
+```ts skip="fragment: ctx is illustrative"
+import { contributeOpsIndicator } from '@routecraft/routecraft'
+
+const report = contributeOpsIndicator(ctx, { name: 'remote.lab', domain: 'deployment' })
+report({ status: 'down', details: { routes: 0 } })
+```
+
+[`remotes`](/docs/reference/plugins/remotesplugin) is the one contributor shipped: each remote reports as `remote.<name>`, down while its inventory cannot be read and up once it has been, with the number of imported routes in `details`.
+
 ### Pushed by hand
 
 For a probe checking several subsystems, or a business route flagging a dependency mid-flight, push through the handle from any `.process()` or `.error()` step:
@@ -507,3 +522,4 @@ Point probes at the ops paths. The http built-ins cannot go red, including durin
 - [httpPlugin](/docs/reference/plugins/httpplugin) for the application's own HTTP surface
 - [`RC5053`](/docs/reference/errors#rc-5053), [`RC5059`](/docs/reference/errors#rc-5059), [`RC5060`](/docs/reference/errors#rc-5060)
 - [CLI reference](/docs/reference/cli#exec) for `craft exec` and the `craft ops` family
+- [remotesPlugin](/docs/reference/plugins/remotesplugin) for importing another instance's routes through this API

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/remotesplugin/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/remotesplugin/index.mdx
@@ -1,0 +1,118 @@
+---
+title: remotesPlugin
+---
+
+<Lead>
+[← All plugins](/docs/reference/plugins)
+</Lead>
+
+```ts
+import { remotesPlugin } from '@routecraft/routecraft'
+```
+
+Names other running instances, and every dispatchable route they expose through the [ops management API](/docs/reference/plugins/opsplugin#management-api) becomes a direct endpoint here. `direct()`, `forward()`, `directTool()`, `Direct(...)` in an agent's tool list, the [tool policy](/docs/reference/plugins/agentplugin#tool-policy), the local `/ops/routes` listing, `craft ops routes` and `craft exec` all see them as routes, with nothing to learn.
+
+The shape it exists for: one constrained instance hosts approved capabilities behind its own door, with its own service credentials and its own `.authorize()`, and every engineer runs a local instance with their own agents and their own routes. The local instance names the server, calls its routes as if they were local, and promotes a route to the server when it proves useful. The ops API is plain HTTPS and JSON, which is what makes it reachable where richer protocols are not.
+
+`remotes` is a first-class core config key, so the common path is `defineConfig({ remotes: {...} })` rather than `plugins: [remotesPlugin(...)]`. The factory is exported for programmatic composition.
+
+```ts
+import { defineConfig } from '@routecraft/routecraft'
+
+export default defineConfig({
+  remotes: {
+    default: {
+      url: 'https://routecraft.example.internal',
+      auth: { token: () => process.env.RC_REMOTE_TOKEN },
+    },
+    lab: {
+      url: 'https://lab.example.internal',
+      auth: { token: () => process.env.RC_LAB_TOKEN },
+    },
+  },
+})
+```
+
+```ts skip="fragment: the routes and the tools list are illustrative"
+craft()
+  .id('greet-twice')
+  .from(direct())
+  .enrich(direct('hello'))      // the default remote's route, advertised bare
+  .enrich(direct('lab:hello'))  // any other remote is qualified
+
+agent({
+  tools: tools(['Direct(hello)', 'Direct(lab:hello)', 'Remote(lab)']),
+})
+```
+
+## Options
+
+Each entry under `remotes` is one remote, keyed by name:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | `string` | required | The instance's base URL, the origin its ops surface is mounted on |
+| `auth.token` | `string \| () => string \| undefined \| Promise<...>` | none | Bearer for the remote's door. A function is evaluated per request, so a rotated token is picked up without a restart |
+| `timeout` | `Duration` | `'30s'` | Per-request deadline against the remote |
+| `refresh` | `Duration \| false` | `'60s'` | How often the inventory is re-read. `false` leaves only the boot read and the refresh a 404 forces |
+
+A remote's name becomes one segment of the tool name a model sees (`remote__lab__hello`) and the prefix of every qualified endpoint (`lab:hello`), so it must match `/^[A-Za-z0-9][A-Za-z0-9_-]*$/`, must not contain `__` and must not end in `_`, the same rule an [MCP client name](/docs/reference/plugins/mcpplugin) follows for the same reason. A bearer over plain `http:` is refused at configuration unless the address is loopback, the rule [`craft`](/docs/reference/cli) already enforces: every hop between here and the remote can read it.
+
+## Names
+
+Git-style. The routes of the remote called `default` are advertised bare, exactly as a local route would be, so `direct('hello')` and `Direct(hello)` reach them with nothing to learn. Every other remote's routes are qualified `name:id`, and `default:id` names the default remote explicitly. Two remotes therefore never collide.
+
+**Local wins.** A local route with the same id as a default-remote route shadows it: the local route answers `direct('hello')`, the remote route stays reachable as `default:hello`, and the shadow is logged as a warning on every refresh that finds it and on every call that resolves to the local route while it exists. That overlap is the promotion window, the moment a capability exists on a laptop and on the server at once, and it is never an error. A local route whose id is itself a qualified name (`lab:hello`) shadows the remote route entirely until one of them is renamed, and the warning says so.
+
+A route of `default` whose own id starts with another remote's name and a colon (`lab:x` on the default remote, beside a remote called `lab`) would be advertised under an endpoint that remote already holds. It is skipped with an error in the log, and stays reachable as `default:lab:x`.
+
+## Credentials and identity
+
+The credential is the environment's. `auth.token` is read from wherever the deployment keeps it, as a string or as a function evaluated per request. The CLI settings file (`.routecraft/settings.yaml`) is for the local instance the CLI talks to, and core never reads it. The identity the remote sees is whatever its own validator mints from the token, so this plugin makes no call on api keys versus JWTs, and its docs describe none: the remote's [ops surface](/docs/reference/plugins/opsplugin#securing-it) decides.
+
+The local caller's principal is never forwarded. A route imported from a remote runs there under the identity the bearer carries, whoever dispatched it here, which is the same two-boundary rule an [MCP client](/docs/reference/plugins/agentplugin#array-form) follows: the principal authenticates the caller into this instance, and the remote's credential authenticates this instance into the remote.
+
+## Inventory and schemas
+
+The inventory is the framework's. At start, `GET /ops/routes?dispatchable=true` and `GET /ops/routes/{id}` for each route are read from every remote, awaited, so an imported route is a local endpoint by the time the context reports ready; then on the `refresh` interval; and forced by a dispatch that meets a 404 for a route the inventory still lists. A remote unreachable at boot registers nothing, logs a warning, and reports its `remote.<name>` [indicator](/docs/reference/plugins/opsplugin#define-indicator) down on the local health endpoint; its routes appear on the refresh that first reaches it, and a remote that blinks keeps the last inventory rather than taking every endpoint with it.
+
+Each route's `input` and `output` arrive as the JSON Schema the remote rendered and become the endpoint's discovery bundle, so an agent tool advertises the remote's input schema to the model exactly as it would a local route's, and validation runs where the schema lives: at the remote's door.
+
+## Outcomes
+
+A dispatch through an imported endpoint maps the remote's outcome onto the in-process one:
+
+| The remote | Here |
+|------------|------|
+| completes | the body |
+| drops | [`RC5031`](/docs/reference/errors#rc-5031), as for a local drop |
+| parks on a `.suspend()` | the standard `Suspended` acknowledgment; resume is at the remote's door, under its policy |
+| fails (500 with a code) | [`RC5064`](/docs/reference/errors#rc-5064), carrying the remote's code as cause |
+| refuses the credential (401 or 403) | [`RC5063`](/docs/reference/errors#rc-5063), naming the door's own reason, so a credential problem is distinguishable from a broken route |
+| cannot be reached, or does not answer in time | [`RC5062`](/docs/reference/errors#rc-5062); a refused connection is retryable, a timeout is not |
+| answers 404 | the inventory is refreshed, then [`RC5004`](/docs/reference/errors#rc-5004): the route is gone from the remote or its dispatch tier is closed |
+
+## In the listing and the tool policy
+
+An imported route shows in the local [`/ops/routes`](/docs/reference/plugins/opsplugin#listing-routes) as dispatchable with `sources: ["remote"]` and a `remote` field naming its origin; `?source=remote` lists exactly the imported ones. The agent tool policy's `direct` rule sees `source.remote` (`'default'`, `'lab'`, or absent for a local route), so a policy can keep an agent local-only:
+
+```ts
+import { agentPlugin } from '@routecraft/ai'
+
+agentPlugin({
+  toolPolicy: {
+    fn: true,
+    direct: (tool) => tool.source.remote === undefined,
+    mcp: false,
+  },
+})
+```
+
+**Re-exposure is intentional.** A local instance with an open dispatch tier re-exports every imported route under its own door, exactly as a tool fronting an authenticated REST call re-exports that call; gate the local tiers the way you would gate that tool.
+
+## Related
+
+- [opsPlugin](/docs/reference/plugins/opsplugin) for the management API a remote is read through, and the health indicator a remote reports into
+- [agentPlugin](/docs/reference/plugins/agentplugin#array-form) for `Direct(name:id)` and `Remote(name)`
+- [direct adapter](/docs/reference/adapters/direct) for the endpoints imported routes become
+- [`RC5062`](/docs/reference/errors#rc-5062), [`RC5063`](/docs/reference/errors#rc-5063), [`RC5064`](/docs/reference/errors#rc-5064)

--- a/packages/ai/src/agent/tools/policy.ts
+++ b/packages/ai/src/agent/tools/policy.ts
@@ -14,7 +14,19 @@ import type { McpToolAnnotations } from "../../mcp/types.ts";
  */
 export type AgentToolSource =
   | { readonly kind: "fn"; readonly id: string }
-  | { readonly kind: "direct"; readonly routeId: string }
+  | {
+      readonly kind: "direct";
+      readonly routeId: string;
+      /**
+       * The remote the capability was imported from through
+       * `defineConfig({ remotes })`, absent for a local route. Still
+       * `direct`, because the tool reaches a capability in the capability
+       * registry exactly as a local one does; the field is what lets a
+       * rule keep an agent local-only, or admit one remote and not
+       * another.
+       */
+      readonly remote?: string;
+    }
   | {
       readonly kind: "mcp";
       readonly server: string;
@@ -224,12 +236,14 @@ export type AgentToolPolicy = {
    *
    * - `fn`: in-process fns registered via `agentPlugin({ functions })`.
    * - `direct`: capabilities in the capability registry, reached via
-   *   `Direct(<routeId>)` or a `directTool` alias. Named for the
-   *   capability registry rather than for routes, because that registry
-   *   is what the agent surface can actually reach: a route sourced
-   *   only from `http()` or `mcp()` never registers a capability, so it
-   *   is not addressable as an agent tool and a rule here would give a
-   *   false impression of governing it.
+   *   `Direct(<routeId>)`, `Remote(<name>)` or a `directTool` alias.
+   *   Named for the capability registry rather than for routes, because
+   *   that registry is what the agent surface can actually reach: a
+   *   route sourced only from `http()` or `mcp()` never registers a
+   *   capability, so it is not addressable as an agent tool and a rule
+   *   here would give a false impression of governing it. A capability
+   *   imported from another instance carries `source.remote`, so a rule
+   *   can keep an agent local-only.
    * - `mcp`: tools discovered from external MCP clients.
    */
   [K in AgentToolPolicyKind]: AgentToolRule<K>;

--- a/packages/ai/src/agent/tools/selection.ts
+++ b/packages/ai/src/agent/tools/selection.ts
@@ -48,6 +48,17 @@ export const DIRECT_TOOL_PREFIX = `direct${TOOL_NAME_SEPARATOR}`;
 export const MCP_TOOL_PREFIX = `mcp${TOOL_NAME_SEPARATOR}`;
 
 /**
+ * Wire-form prefix for a capability imported from another instance and
+ * referenced under its qualified endpoint: `Direct(lab:hello)` and every
+ * expansion of `Remote(lab)` become `remote__lab__hello`. The default
+ * remote's routes referenced bare keep the `direct__` form, because to
+ * the agent they are local.
+ *
+ * @internal
+ */
+export const REMOTE_TOOL_PREFIX = `remote${TOOL_NAME_SEPARATOR}`;
+
+/**
  * Reject a `Direct(<routeId>)` reference whose route id cannot survive
  * as a provider-facing tool name.
  *
@@ -96,7 +107,10 @@ export type { ToolGuard } from "../../fn/types.ts";
  * One entry in the agent's `tools([...])` list.
  *
  * - bare string: name lookup. Plain ids resolve against the fn registry;
- *   `Direct(<routeId>)` wraps a direct route via `directTool`;
+ *   `Direct(<routeId>)` wraps a direct route via `directTool`, a route
+ *   imported from another instance included (`Direct(hello)` for the
+ *   default remote, `Direct(lab:hello)` qualified); `Remote(<name>)`
+ *   expands to every route imported from that remote;
  *   `MCP(server:tool)` / `MCP(server)` and the raw `mcp__server__tool`
  *   / `mcp__server` / `mcp__server__*` forms resolve against
  *   `MCP_TOOL_REGISTRY` (populated by `defineConfig.mcp` /
@@ -140,12 +154,15 @@ export interface ToolsCatalog {
   }>;
   /**
    * Discoverable direct routes (see `CraftContext.capabilities()`).
-   * Reference them in a `ToolsItem` as `"Direct(<id>)"`.
+   * Reference them in a `ToolsItem` as `"Direct(<id>)"`. A route imported
+   * from another instance carries `remote`, and its id is the local
+   * endpoint (`lab:hello`, or bare for the default remote).
    */
   readonly routes: ReadonlyArray<{
     readonly id: string;
     readonly description?: string;
     readonly tags?: readonly Tag[];
+    readonly remote?: string;
   }>;
   /**
    * MCP tools populated by `mcpPlugin({ clients })`. Reference them in
@@ -327,6 +344,12 @@ export function tools(arg: ToolsItem[] | ToolsBuilder): ToolSelection {
             }
             continue;
           }
+          if (isRemoteRefName(item) && !fnRegistryHas(ctx, item)) {
+            for (const tool of resolveRemoteRefs(ctx, item, undefined)) {
+              record(out, tool);
+            }
+            continue;
+          }
           record(out, resolveByName(ctx, item, undefined));
           continue;
         }
@@ -350,6 +373,19 @@ export function tools(arg: ToolsItem[] | ToolsBuilder): ToolSelection {
             });
           }
           for (const tool of resolveMcpRefs(ctx, item.name, item.guard)) {
+            record(out, tool);
+          }
+          continue;
+        }
+        // A whole-remote ref expands to many tools, so one description
+        // cannot apply; name the route with Direct(<name>:<id>) instead.
+        if (isRemoteRefName(item.name) && !fnRegistryHas(ctx, item.name)) {
+          if (item.description !== undefined) {
+            throw rcError("RC5003", undefined, {
+              message: `tools(): { name: "${item.name}", description } is not supported for a whole-remote reference; it expands to every route of the remote. Reference one route with { name: "Direct(<name>:<id>)", description }.`,
+            });
+          }
+          for (const tool of resolveRemoteRefs(ctx, item.name, item.guard)) {
             record(out, tool);
           }
           continue;
@@ -429,6 +465,7 @@ function buildCatalog(ctx: CraftContext): ToolsCatalog {
         id: meta.endpoint,
         ...(meta.description ? { description: meta.description } : {}),
         ...(tags !== undefined ? { tags } : {}),
+        ...(meta.remote !== undefined ? { remote: meta.remote } : {}),
       }),
     );
   }
@@ -525,11 +562,7 @@ function resolveByName(
         message: `tools(): "${name}" has an empty route id; use "Direct(<routeId>)".`,
       });
     }
-    const toolName = `${DIRECT_TOOL_PREFIX}${routeId}`;
-    assertValidDirectToolName(name, routeId, toolName);
-    const wrapper = directTool(routeId);
-    const fn = wrapper.resolve(ctx, toolName);
-    return toResolvedTool(toolName, fn, guard, { kind: "direct", routeId });
+    return resolveDirect(ctx, name, routeId, guard);
   }
 
   const known = listKnownNames(ctx);
@@ -570,6 +603,144 @@ function combineGuards(
  *
  * @internal
  */
+/**
+ * Wrap one capability as a tool, under the wire name its origin decides.
+ *
+ * A local route, and the default remote's routes advertised bare, keep
+ * the `direct__<routeId>` form. A route referenced under a remote's
+ * qualified endpoint (`lab:hello`) cannot: the colon is outside the
+ * provider charset, so the wire name is `remote__<name>__<id>`, one
+ * separator per part, mirroring `mcp__<server>__<tool>`. The remote's
+ * name is constrained at configuration the way an MCP client's is, which
+ * is what leaves the id half free.
+ *
+ * @internal
+ */
+function resolveDirect(
+  ctx: CraftContext,
+  ref: string,
+  routeId: string,
+  guard: ToolGuard | undefined,
+): ResolvedTool {
+  const remote = remoteOf(ctx, routeId);
+  const qualifiedBy = `${remote ?? ""}:`;
+  const toolName =
+    remote !== undefined && routeId.startsWith(qualifiedBy)
+      ? `${REMOTE_TOOL_PREFIX}${remote}${TOOL_NAME_SEPARATOR}${routeId.slice(qualifiedBy.length)}`
+      : `${DIRECT_TOOL_PREFIX}${routeId}`;
+  assertValidDirectToolName(ref, routeId, toolName);
+  const wrapper = directTool(routeId);
+  const fn = wrapper.resolve(ctx, toolName);
+  return toResolvedTool(toolName, fn, guard, directSource(routeId, remote));
+}
+
+/** The remote a capability was imported from, or `undefined` for a local one. */
+function remoteOf(ctx: CraftContext, routeId: string): string | undefined {
+  return ctx.capabilities().find((c) => c.endpoint === routeId)?.remote;
+}
+
+function directSource(
+  routeId: string,
+  remote: string | undefined,
+): AgentToolSource {
+  return {
+    kind: "direct",
+    routeId,
+    ...(remote !== undefined ? { remote } : {}),
+  };
+}
+
+/**
+ * Recognise a `Remote(<name>)` reference: every route imported from one
+ * remote, the way `MCP(server)` is every tool on one client.
+ *
+ * @internal
+ */
+function isRemoteRefName(name: string): boolean {
+  return name.startsWith("Remote(") && name.endsWith(")");
+}
+
+/**
+ * Expand `Remote(<name>)` (also `Remote(<name>:*)`) to every capability
+ * the named remote imported, under their qualified endpoints. The
+ * default remote's bare aliases are skipped so its routes are not offered
+ * twice; `Direct(<id>)` is how the bare form is named.
+ *
+ * A route whose id cannot survive as a tool name is dropped with a
+ * warning rather than thrown, for the reason the MCP expansion gives:
+ * the name comes from the remote, `resolve` runs per dispatch, and a
+ * throw would let one route renamed on the remote fail every dispatch of
+ * every agent bound to it. Reported once per context and name.
+ *
+ * @internal
+ */
+function resolveRemoteRefs(
+  ctx: CraftContext,
+  ref: string,
+  guard: ToolGuard | undefined,
+): ResolvedTool[] {
+  const inner = ref.slice("Remote(".length, -1).trim();
+  const colon = inner.indexOf(":");
+  const remote = colon === -1 ? inner : inner.slice(0, colon).trim();
+  const selector = colon === -1 ? "*" : inner.slice(colon + 1).trim();
+  if (remote === "" || selector !== "*") {
+    throw rcError("RC5003", undefined, {
+      message: `tools(): remote reference "${ref}" must use "Remote(<name>)" for every route of a remote; name one route with "Direct(<name>:<id>)".`,
+    });
+  }
+  const prefix = `${remote}:`;
+  const imported = ctx
+    .capabilities()
+    .filter((c) => c.remote === remote && c.endpoint.startsWith(prefix));
+  if (imported.length === 0) {
+    const known = [
+      ...new Set(
+        ctx
+          .capabilities()
+          .map((c) => c.remote)
+          .filter((name): name is string => name !== undefined),
+      ),
+    ].sort();
+    throw rcError("RC5003", undefined, {
+      message:
+        `tools(): remote reference "${ref}" but remote "${remote}" has no imported routes. ` +
+        (known.length > 0
+          ? `Remotes with routes: ${known.map((k) => `"${k}"`).join(", ")}.`
+          : `No remote has imported routes in this context; configure defineConfig({ remotes }) and check the remote is reachable.`),
+    });
+  }
+  const out: ResolvedTool[] = [];
+  for (const capability of imported) {
+    const toolName = `${REMOTE_TOOL_PREFIX}${remote}${TOOL_NAME_SEPARATOR}${capability.endpoint.slice(prefix.length)}`;
+    const violation = describeToolNameViolation(toolName);
+    if (violation !== undefined) {
+      const reported = reportedRemoteNames.get(ctx) ?? new Set<string>();
+      reportedRemoteNames.set(ctx, reported);
+      if (!reported.has(toolName)) {
+        reported.add(toolName);
+        ctx.logger.warn(
+          { remote, routeId: capability.endpoint, toolName },
+          `Remote route id is not usable as a provider tool name (${violation}); dropping it from the agent's tool list. Expose it through a capability under a tool-safe name if the agent needs it.`,
+        );
+      }
+      continue;
+    }
+    const fn = directTool(capability.endpoint).resolve(ctx, toolName);
+    out.push(
+      toResolvedTool(
+        toolName,
+        fn,
+        guard,
+        directSource(capability.endpoint, remote),
+      ),
+    );
+  }
+  return out;
+}
+
+/** Unusable remote route names already warned about, per context. */
+const reportedRemoteNames = new WeakMap<CraftContext, Set<string>>();
+
 function record(out: Map<string, ResolvedTool>, tool: ResolvedTool): void {
   const existing = out.get(tool.name);
   if (!existing) {
@@ -607,10 +778,12 @@ function resolveFnEntry(
         // capability: it reaches the same route, only under a different
         // name. Reporting it as `fn` would let an alias slip past a
         // policy that denies `direct`.
-        return toResolvedTool(name, fn, guard, {
-          kind: "direct",
-          routeId: entry.targetId,
-        });
+        return toResolvedTool(
+          name,
+          fn,
+          guard,
+          directSource(entry.targetId, remoteOf(ctx, entry.targetId)),
+        );
       default: {
         const exhaustive: never = entry.kind;
         throw rcError("RC5003", undefined, {
@@ -924,6 +1097,14 @@ function listKnownNames(ctx: CraftContext): string[] {
   const fnNames = [
     ...(ctx.getStore(ADAPTER_FN_REGISTRY) ?? new Map<string, FnEntry>()).keys(),
   ];
-  const routeNames = ctx.capabilities().map((c) => `Direct(${c.endpoint})`);
-  return [...fnNames, ...routeNames].sort();
+  const capabilities = ctx.capabilities();
+  const routeNames = capabilities.map((c) => `Direct(${c.endpoint})`);
+  const remoteNames = [
+    ...new Set(
+      capabilities
+        .map((c) => c.remote)
+        .filter((name): name is string => name !== undefined),
+    ),
+  ].map((name) => `Remote(${name})`);
+  return [...fnNames, ...routeNames, ...remoteNames].sort();
 }

--- a/packages/ai/test/tools-selection-remote.bun.test.ts
+++ b/packages/ai/test/tools-selection-remote.bun.test.ts
@@ -35,10 +35,12 @@ mock.module("../src/llm/providers/index.ts", () => ({
  */
 
 const JWT_SECRET = "remote-tools-jwt-secret-please-change-me";
-const OPERATOR = signHs256({
-  secret: JWT_SECRET,
-  claims: { scope: "ops:introspection ops:dispatch" },
-});
+/** Minted per request so the suite never depends on finishing inside a token's minute. */
+const operator = (): string =>
+  signHs256({
+    secret: JWT_SECRET,
+    claims: { scope: "ops:introspection ops:dispatch" },
+  });
 
 async function startServer(): Promise<{ t: TestContext; url: string }> {
   const t = await testContext()
@@ -107,8 +109,8 @@ describe("tools() with imported routes", () => {
     local = await testContext()
       .with({
         remotes: {
-          default: { url, auth: { token: OPERATOR } },
-          lab: { url, auth: { token: OPERATOR } },
+          default: { url, auth: { token: operator } },
+          lab: { url, auth: { token: operator } },
         },
         plugins: [
           agentPlugin({ functions: { labHello: directTool("lab:hello") } }),
@@ -179,7 +181,7 @@ describe("tools() with imported routes", () => {
       const sink = spy();
       const t = await testContext()
         .with({
-          remotes: { lab: { url, auth: { token: OPERATOR } } },
+          remotes: { lab: { url, auth: { token: operator } } },
           plugins: [
             llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
             agentPlugin(

--- a/packages/ai/test/tools-selection-remote.bun.test.ts
+++ b/packages/ai/test/tools-selection-remote.bun.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { z } from "zod";
+import { craft, direct, jwt, noop, opsPlugin } from "@routecraft/routecraft";
+import {
+  signHs256,
+  spy,
+  testContext,
+  type TestContext,
+} from "@routecraft/testing";
+import {
+  agent,
+  agentPlugin,
+  directTool,
+  llmPlugin,
+  tools,
+  type AgentResult,
+} from "../src/index.ts";
+import { scriptedLlm } from "./helpers/scripted-llm.ts";
+import { MODEL } from "./helpers/suspend-fixtures.ts";
+
+const llm = scriptedLlm([]);
+mock.module("../src/llm/providers/index.ts", () => ({
+  callLlm: llm.callLlm,
+  streamLlm: llm.streamLlm,
+}));
+
+/**
+ * Imported routes on the agent tool surface.
+ *
+ * A second instance exposes two routes through a scope-gated ops door;
+ * the first imports it as `default` and as `lab`, and an agent on the
+ * first names them the three ways the grammar allows. The scripted model
+ * really calls the tools, so the second instance's answer is what the
+ * agent returns.
+ */
+
+const JWT_SECRET = "remote-tools-jwt-secret-please-change-me";
+const OPERATOR = signHs256({
+  secret: JWT_SECRET,
+  claims: { scope: "ops:introspection ops:dispatch" },
+});
+
+async function startServer(): Promise<{ t: TestContext; url: string }> {
+  const t = await testContext()
+    .with({
+      servers: { default: { port: 0, host: "127.0.0.1" } },
+      plugins: [
+        opsPlugin({
+          auth: jwt({
+            secret: JWT_SECRET,
+            issuer: "https://idp.test",
+            audience: "https://api.test",
+          }),
+          tiers: {
+            introspection: "ops:introspection",
+            dispatch: "ops:dispatch",
+          },
+        }),
+      ],
+    })
+    .routes([
+      craft()
+        .id("hello")
+        .description("Say hello to someone")
+        .input({ body: z.object({ name: z.string() }) })
+        .from(direct())
+        .transform((body) => ({ greeting: `hello ${body.name}` }))
+        .to(noop()),
+      craft()
+        .id("memory:get")
+        .description("A route whose id is not a tool name")
+        .input({ body: z.object({ key: z.string() }) })
+        .from(direct())
+        .transform((body) => ({ value: body.key }))
+        .to(noop()),
+    ])
+    .build();
+  let port: number | undefined;
+  t.ctx.on("server:listening", ({ details }) => {
+    port = details.port;
+  });
+  await t.startAndWaitReady();
+  if (port === undefined) throw new Error("no server reported a port");
+  return { t, url: `http://127.0.0.1:${String(port)}` };
+}
+
+describe("tools() with imported routes", () => {
+  let server: { t: TestContext; url: string } | undefined;
+  let local: TestContext | undefined;
+
+  afterEach(async () => {
+    llm.reset();
+    if (local) await local.stop();
+    if (server) await server.t.stop();
+    local = undefined;
+    server = undefined;
+  });
+
+  /**
+   * @case Direct(hello), Direct(lab:hello) and Remote(lab) resolve to tools whose provenance names the remote
+   * @preconditions Both remotes imported; an agentPlugin with a directTool alias of `lab:hello`
+   * @expectedResult The bare default route keeps the `direct__hello` wire name; the qualified reference and every Remote(lab) expansion carry `remote__lab__<id>`; every source is `direct` with `remote` set, the alias included; the remote route whose id is not a tool name is dropped from the expansion with a warning and refused by name when referenced explicitly. A colon is outside the provider charset, and the remote's name takes the MCP client's place as the constrained half
+   */
+  test("resolves the three reference forms and marks their provenance", async () => {
+    server = await startServer();
+    const { url } = server;
+    local = await testContext()
+      .with({
+        remotes: {
+          default: { url, auth: { token: OPERATOR } },
+          lab: { url, auth: { token: OPERATOR } },
+        },
+        plugins: [
+          agentPlugin({ functions: { labHello: directTool("lab:hello") } }),
+        ],
+      })
+      .routes([craft().id("keepalive").from(direct()).to(noop())])
+      .build();
+    const warnings: string[] = [];
+    const original = local.ctx.logger.warn.bind(local.ctx.logger);
+    local.ctx.logger.warn = ((first: unknown, second?: unknown) => {
+      warnings.push(typeof first === "string" ? first : String(second));
+      return original(first as never, second as never);
+    }) as typeof local.ctx.logger.warn;
+    await local.startAndWaitReady();
+
+    const resolved = tools([
+      "Direct(hello)",
+      "Direct(lab:hello)",
+      "Remote(lab)",
+      "labHello",
+    ]).resolve(local.ctx);
+    const byName = new Map(resolved.map((tool) => [tool.name, tool]));
+    expect([...byName.keys()].sort()).toEqual([
+      "direct__hello",
+      "labHello",
+      "remote__lab__hello",
+    ]);
+    expect(byName.get("direct__hello")?.source).toEqual({
+      kind: "direct",
+      routeId: "hello",
+      remote: "default",
+    });
+    expect(byName.get("remote__lab__hello")?.source).toEqual({
+      kind: "direct",
+      routeId: "lab:hello",
+      remote: "lab",
+    });
+    expect(byName.get("labHello")?.source).toEqual({
+      kind: "direct",
+      routeId: "lab:hello",
+      remote: "lab",
+    });
+    expect(byName.get("remote__lab__hello")?.description).toBe(
+      "Say hello to someone",
+    );
+    expect(
+      warnings.filter((line) =>
+        line.includes("Remote route id is not usable as a provider tool name"),
+      ),
+    ).toHaveLength(1);
+    expect(() => tools(["Direct(lab:memory:get)"]).resolve(local!.ctx)).toThrow(
+      /remote__lab__memory:get/,
+    );
+    expect(() => tools(["Remote(nowhere)"]).resolve(local!.ctx)).toThrow(
+      /Remotes with routes: "default", "lab"/,
+    );
+  });
+
+  /**
+   * @case An agent calls an imported route and gets the second instance's answer, and a local-only policy withholds it
+   * @preconditions A scripted model that calls `remote__lab__hello`; one context with no policy, one whose `direct` rule admits only local capabilities
+   * @expectedResult Without a policy the tool call's output is the remote's greeting; with the local-only rule the tool is dropped and the model is never offered it. `source.remote` is what makes the rule expressible
+   */
+  test("dispatches an imported route from an agent and lets a policy keep an agent local-only", async () => {
+    server = await startServer();
+    const { url } = server;
+    const run = async (localOnly: boolean): Promise<AgentResult> => {
+      const sink = spy();
+      const t = await testContext()
+        .with({
+          remotes: { lab: { url, auth: { token: OPERATOR } } },
+          plugins: [
+            llmPlugin({ providers: { anthropic: { apiKey: "sk-test" } } }),
+            agentPlugin(
+              localOnly
+                ? {
+                    toolPolicy: {
+                      fn: true,
+                      direct: (tool) => tool.source.remote === undefined,
+                      mcp: false,
+                    },
+                  }
+                : {},
+            ),
+          ],
+        })
+        .routes([
+          craft()
+            .id("ask")
+            .from(direct())
+            .to(
+              agent({
+                system: "be useful",
+                model: MODEL,
+                tools: tools(["Remote(lab)"]),
+              }),
+            )
+            .to(sink),
+        ])
+        .build();
+      local = t;
+      await t.startAndWaitReady();
+      llm.script.push(
+        {
+          toolCalls: [
+            { toolName: "remote__lab__hello", input: { name: "agent" } },
+          ],
+        },
+        { text: "done" },
+      );
+      await t.client.sendDirect("ask", "hi");
+      const result = sink.received[0]!.body as AgentResult;
+      await t.stop();
+      local = undefined;
+      return result;
+    };
+
+    const open = await run(false);
+    expect(open.toolCalls).toHaveLength(1);
+    expect(open.toolCalls![0]).toMatchObject({
+      toolName: "remote__lab__hello",
+      output: { greeting: "hello agent" },
+    });
+
+    llm.reset();
+    const closed = await run(true);
+    // The scripted model still asks for the tool; the agent was never offered
+    // it, so the call fails instead of reaching the remote.
+    const denied = closed.toolCalls ?? [];
+    expect(denied).toHaveLength(1);
+    expect(denied[0]!.output).toBeUndefined();
+    expect(denied[0]!.error).toBeInstanceOf(Error);
+  });
+});

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -127,6 +127,9 @@ export function renderRouteDetail(
     lines.push(`Dispatchable ${route.dispatchable ? "yes" : "no"}`);
     lines.push(`Enabled      ${route.enabled ? "yes" : "no"}`);
     lines.push(`Sources      ${route.sources.join(", ")}`);
+    if (route.remote !== undefined) {
+      lines.push(`Remote       ${route.remote}`);
+    }
     if (route.requiresPrincipal) {
       lines.push(`Authorize    route entry requires a principal`);
     }

--- a/packages/cli/src/ops-client.ts
+++ b/packages/cli/src/ops-client.ts
@@ -1,100 +1,29 @@
 /**
- * HTTP client for a running instance's ops server.
+ * The CLI's view of a running instance's ops server.
  *
- * Spans two surfaces that behave differently and must not be flattened.
- * `/health` never walls, so a probe with no credential works, and it
- * returns MORE when authenticated: per-component `details` are gated by
- * `health.details`. `/ops` answers by tier: 404 when a tier is off, open
- * when `true`, scope-checked when a scope string is configured.
- *
- * So this client presents a credential whenever the settings provide one,
- * on both surfaces, and degrades when none is. That is a correctness
- * requirement rather than a nicety: unauthenticated, a route component says
- * `degraded` and nothing else; authenticated, it says `degraded` because a
- * breaker is open. The bare status does not answer the question an operator
- * is asking.
+ * The client itself lives in core (`createOpsHttpClient`), beside the
+ * server it speaks to, because the remotes plugin drives the same wire
+ * from inside a running context. What stays here is what only the CLI
+ * knows: where the address and the token came from, and the remedies a
+ * person at a terminal can act on.
  */
 
-import type {
-  HealthComponent,
-  HealthReport,
-  OpsDispatchOutcome,
-  OpsPage,
-  OpsRouteDetail,
-  OpsRouteFilter,
-  OpsRouteSummary,
+import {
+  createOpsHttpClient,
+  isLoopbackHostname,
+  type OpsHttpClient,
 } from "@routecraft/routecraft";
 import {
   describeSource,
   SettingsError,
   type ResolvedSettings,
 } from "./settings.js";
-import { messageOf } from "./util.js";
 
-/**
- * How long one request may take before the client gives up.
- *
- * A connection the instance accepts and then never answers is otherwise
- * indistinguishable from work in progress, and a CLI that hangs with no
- * output is the worst way for a read to fail. The abort lands in the same
- * catch as a refused connection, so it is reported as unreachable with the
- * address named.
- */
-const REQUEST_TIMEOUT_MS = 30_000;
-
-/**
- * How long the follow-up fetch of an RFC 9728 metadata document may take.
- *
- * Much shorter than the request timeout: the refusal is already decided,
- * and this fetch only enriches the message. A caller must never wait
- * longer to be told no than they would have waited to be told yes.
- */
-const DISCOVERY_TIMEOUT_MS = 5_000;
-
-/** Why a call did not produce an answer. Each needs a different remedy. */
-export type OpsFailureKind =
-  /** The instance could not be reached at all. */
-  | "unreachable"
-  /** The door refused: no credential, a bad one, or a missing scope. */
-  | "refused"
-  /** The tier is disabled, or the thing asked for does not exist. */
-  | "absent"
-  /** The instance answered, and the answer was an error. */
-  | "error";
-
-/** A call that did not produce an answer, with what to do about it. */
-export class OpsClientError extends Error {
-  constructor(
-    readonly kind: OpsFailureKind,
-    message: string,
-    readonly status?: number,
-    readonly detail?: unknown,
-  ) {
-    super(message);
-    this.name = "OpsClientError";
-  }
-}
-
-/** A response body carrying the API's structured refusal or error. */
-interface WireError {
-  error?: string;
-  reason?: string;
-  scope?: string;
-  code?: string;
-  message?: string;
-}
-
-export interface OpsClient {
-  /** Whether a credential is being presented, for rendering the view. */
-  readonly authenticated: boolean;
-  health(): Promise<HealthReport>;
-  ready(): Promise<HealthReport>;
-  routeHealth(id: string): Promise<HealthComponent>;
-  indicatorHealth(name: string): Promise<HealthComponent>;
-  listRoutes(filter?: OpsRouteFilter): Promise<OpsRouteSummary[]>;
-  describeRoute(id: string): Promise<OpsRouteDetail>;
-  dispatch(id: string, body: unknown): Promise<OpsDispatchOutcome>;
-}
+export {
+  OpsClientError,
+  type OpsFailureKind,
+  type OpsHttpClient as OpsClient,
+} from "@routecraft/routecraft";
 
 /**
  * A bearer token over plain `http:` is readable by every hop between the
@@ -106,424 +35,26 @@ export interface OpsClient {
  */
 export function refuseClearTextBearer(settings: ResolvedSettings): void {
   const url = new URL(settings.url.value);
-  if (url.protocol !== "http:" || isLoopback(url.hostname)) return;
+  if (url.protocol !== "http:" || isLoopbackHostname(url.hostname)) return;
   throw new SettingsError(
     `The instance URL from the ${describeSource(settings.url)} is ${settings.url.value}, which is plain http, and the token from the ${describeSource(settings.token!)} would travel over it as clear text. ` +
       `Use an https URL, or a loopback address (localhost, 127.0.0.1, ::1) for an instance on this machine.`,
   );
 }
 
-/** localhost, 127.0.0.0/8 and ::1, as `URL.hostname` renders them. */
-function isLoopback(hostname: string): boolean {
-  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
-  return (
-    host === "localhost" || host === "::1" || /^127(?:\.\d{1,3}){3}$/.test(host)
-  );
-}
-
-export function createOpsClient(settings: ResolvedSettings): OpsClient {
-  const base = settings.url.value.replace(/\/+$/, "");
+export function createOpsClient(settings: ResolvedSettings): OpsHttpClient {
   const token = settings.token?.value;
   if (token !== undefined) refuseClearTextBearer(settings);
-
-  /**
-   * Where the address came from, phrased for an error a reader must act
-   * on. A wrong pinned address is otherwise indistinguishable from a
-   * stopped instance.
-   */
-  const addressBlame = (): string =>
-    `${base} (from the ${describeSource(settings.url)})`;
-
-  async function call<T>(
-    path: string,
-    init: {
-      method?: string;
-      body?: unknown;
-      /**
-       * Statuses whose body is an answer rather than an error. The health
-       * surface replies 503 with a full report when a component is down, and
-       * that is precisely the report an operator is asking for.
-       */
-      answeredBy?: readonly number[];
-    } = {},
-  ): Promise<T> {
-    const headers: Record<string, string> = {};
-    if (token !== undefined) headers["authorization"] = `Bearer ${token}`;
-    if (init.body !== undefined) {
-      headers["content-type"] = "application/json";
-    }
-
-    let response: Response;
-    try {
-      response = await fetch(`${base}${path}`, {
-        method: init.method ?? "GET",
-        headers,
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-        ...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
-      });
-    } catch (error: unknown) {
-      throw classifyTransportFailure(error, addressBlame());
-    }
-
-    // Inside its own guard: an abort part-way through the body is the same
-    // class of failure as one during the request, and leaving it outside
-    // turned a timeout into an unhandled rejection with a stack trace.
-    let text: string;
-    try {
-      text = await response.text();
-    } catch (error: unknown) {
-      throw classifyTransportFailure(error, addressBlame());
-    }
-    const parsed: unknown = text.length === 0 ? undefined : parseJson(text);
-
-    if (response.ok || (init.answeredBy?.includes(response.status) ?? false)) {
-      // A 200 from something that is not this API (a wrong port, a proxy's
-      // error page) would otherwise be cast to the caller's type and crash
-      // in the renderer rather than here, where the address can be named.
-      if (parsed === null || typeof parsed !== "object") {
-        throw new OpsClientError(
-          "error",
-          `The instance at ${addressBlame()} answered ${String(response.status)} with a body this client does not recognise. Check that the address is a routecraft ops server.`,
-          response.status,
-        );
-      }
-      return parsed as T;
-    }
-
-    // A body that is not JSON still carries the reason on the error path: a
-    // proxy's plain-text refusal names the thing that refused.
-    const wire: WireError =
-      parsed === null || typeof parsed !== "object"
-        ? textAsWireError(text)
-        : (parsed as WireError);
-    if (response.status === 401 || response.status === 403) {
-      const challenge = parseBearerChallenge(
-        response.headers.get("www-authenticate"),
-      );
-      const discovery = await fetchDiscovery(challenge.resourceMetadata, base);
-      throw new OpsClientError(
-        "refused",
-        refusalMessage(
-          response.status,
-          wire,
-          token !== undefined,
-          challenge,
-          discovery,
-        ),
-        response.status,
-        wire,
-      );
-    }
-    if (response.status === 404) {
-      throw new OpsClientError(
-        "absent",
-        wire.message ?? "not found",
-        404,
-        wire,
-      );
-    }
-    throw new OpsClientError(
-      "error",
-      wire.message ?? describeWireError(wire, response.status),
-      response.status,
-      wire,
-    );
-  }
-
-  /**
-   * Render the door's own refusal rather than a summary of it. A missing
-   * scope and a missing credential need opposite actions, and the server
-   * already distinguishes them on the wire.
-   *
-   * When the challenge carried an RFC 9728 `resource_metadata` hint and the
-   * document resolved, the refusal also says who issues acceptable tokens
-   * and which scopes the surface understands. One message path for every
-   * refusal: the discovery lines append to the existing text, they never
-   * replace it.
-   */
-  function refusalMessage(
-    status: number,
-    wire: WireError,
-    presented: boolean,
-    challenge: BearerChallenge,
-    discovery: Discovery | undefined,
-  ): string {
-    const lines: string[] = [];
-    if (status === 403 && wire.reason === "insufficient_scope") {
-      lines.push(
-        `Refused: the credential does not carry the scope "${
-          wire.scope ?? challenge.scope ?? "(unnamed)"
-        }". The identity is valid and the credential is not, so this needs a token carrying that scope rather than signing in again.`,
-      );
-    } else if (!presented) {
-      lines.push(
-        `Refused: this surface requires a credential and none was presented. Put a token in .routecraft/settings.yaml, set CRAFT_TOKEN, or pass --token.`,
-      );
-    } else {
-      lines.push(
-        `Refused: the instance rejected the credential${
-          wire.reason === undefined ? "" : ` (${wire.reason})`
-        }.`,
-      );
-    }
-    if (discovery !== undefined) {
-      lines.push(
-        discovery.issuers !== undefined && discovery.issuers.length > 0
-          ? `Tokens are issued by ${discovery.issuers.join(", ")}.`
-          : "The instance advertises no authorization server, so discovery cannot say who issues. Ask whoever operates the instance how to obtain a credential.",
-      );
-      if (discovery.scopes !== undefined && discovery.scopes.length > 0) {
-        lines.push(
-          `Scopes this surface understands: ${discovery.scopes.join(", ")}.`,
-        );
-      }
-    }
-    return lines.join("\n");
-  }
-
-  // The health surface answers 503 with a complete report when something is
-  // down. Treating that as a failure would blank the output at the one moment
-  // the command exists for.
-  const DOWN_IS_AN_ANSWER = { answeredBy: [503] } as const;
-
-  return {
-    authenticated: token !== undefined,
-
-    health: () => call<HealthReport>("/health", DOWN_IS_AN_ANSWER),
-    ready: () => call<HealthReport>("/health/ready", DOWN_IS_AN_ANSWER),
-    routeHealth: (id: string) =>
-      call<HealthComponent>(
-        `/health/routes/${encodeURIComponent(id)}`,
-        DOWN_IS_AN_ANSWER,
-      ),
-    indicatorHealth: (name: string) =>
-      call<HealthComponent>(
-        `/health/indicators/${encodeURIComponent(name)}`,
-        DOWN_IS_AN_ANSWER,
-      ),
-
-    /**
-     * Walk the whole collection rather than showing page one and stopping.
-     *
-     * The envelope's contract is that a present cursor means there is more,
-     * and a client that ignores it silently reports a partial inventory as
-     * a complete one. The cursor is replayed under the same filter it was
-     * minted with, which is the only way the server will honour it.
-     */
-    async listRoutes(filter: OpsRouteFilter = {}): Promise<OpsRouteSummary[]> {
-      // Serialised here, the one place that knows the wire, so no caller has
-      // to spell a filter name as a string the compiler does not own.
-      const query: Record<string, string> = {
-        ...(filter.dispatchable !== undefined
-          ? { dispatchable: String(filter.dispatchable) }
-          : {}),
-        ...(filter.id !== undefined ? { id: filter.id } : {}),
-        ...(filter.source !== undefined ? { source: filter.source } : {}),
-      };
-      const items: OpsRouteSummary[] = [];
-      const seen = new Set<string>();
-      let cursor: string | undefined;
-      do {
-        const params = new URLSearchParams(query);
-        if (cursor !== undefined) params.set("after", cursor);
-        const suffix = params.toString();
-        const page = await call<OpsPage<OpsRouteSummary>>(
-          `/ops/routes${suffix.length > 0 ? `?${suffix}` : ""}`,
-        );
-        items.push(...page.items);
-        cursor = page.nextCursor;
-        // The loop trusts the instance to advance, and this client talks to
-        // instances it did not build: a repeated cursor would page forever and
-        // grow `items` without bound. Refusing beats hanging, and beats
-        // silently returning a listing with the same rows in it many times.
-        if (cursor !== undefined && !seen.add(cursor)) {
-          throw new OpsClientError(
-            "error",
-            "The instance repeated a pagination cursor, so the route listing cannot be completed. This is a fault in the instance rather than in the request.",
-          );
-        }
-      } while (cursor !== undefined);
-      return items;
+  const base = settings.url.value.replace(/\/+$/, "");
+  return createOpsHttpClient({
+    url: settings.url.value,
+    ...(token !== undefined ? { token } : {}),
+    describeAddress: () => `${base} (from the ${describeSource(settings.url)})`,
+    advice: {
+      missingCredential:
+        "Put a token in .routecraft/settings.yaml, set CRAFT_TOKEN, or pass --token.",
+      unreachable:
+        "Start one with 'craft start', or point at another instance with --url.",
     },
-
-    describeRoute: (id: string) =>
-      call<OpsRouteDetail>(`/ops/routes/${encodeURIComponent(id)}`),
-
-    dispatch: (id: string, body: unknown) =>
-      call<OpsDispatchOutcome>(
-        `/ops/routes/${encodeURIComponent(id)}/exchanges`,
-        { method: "POST", body: body ?? {} },
-      ),
-  };
-}
-
-/** What a refusal's `WWW-Authenticate` header said, reduced to what is used. */
-interface BearerChallenge {
-  scope?: string;
-  resourceMetadata?: string;
-}
-
-/**
- * Read the RFC 6750 challenge parameters off a refusal.
- *
- * Quoted `key="value"` pairs only, which is what every routecraft surface
- * emits and what RFC 9728 prescribes for `resource_metadata`. A header
- * that is absent, not a Bearer challenge, or otherwise unparseable yields
- * an empty result rather than an error: the challenge only enriches a
- * refusal that already stands on its own.
- */
-function parseBearerChallenge(header: string | null): BearerChallenge {
-  if (header === null || !/^\s*bearer[\s,]/i.test(header)) return {};
-  const result: BearerChallenge = {};
-  for (const match of header.matchAll(/([a-z_]+)\s*=\s*"([^"]*)"/gi)) {
-    const key = match[1]!.toLowerCase();
-    if (key === "scope") result.scope = match[2]!;
-    if (key === "resource_metadata") result.resourceMetadata = match[2]!;
-  }
-  return result;
-}
-
-/** What the RFC 9728 document said, reduced to what a refusal can report. */
-interface Discovery {
-  issuers?: string[];
-  scopes?: string[];
-}
-
-/**
- * Follow a challenge's `resource_metadata` hint.
- *
- * Best-effort by design: the hint names the instance's own document, but a
- * proxy can strip it, the fetch can time out, and a non-routecraft server
- * can answer nonsense. Every failure resolves to `undefined` so the
- * refusal degrades to what the status line already proves, never to a
- * second error about the enrichment.
- *
- * The hint is followed only to the origin the operator addressed
- * (RFC 9728 section 3.3): a `WWW-Authenticate` header is unvalidated
- * input, and a refusing server that could point this process anywhere
- * would hold an SSRF primitive aimed from the operator's network.
- * Redirects are refused for the same reason: a 302 on the first hop
- * would carry the fetch past the origin check.
- */
-async function fetchDiscovery(
-  url: string | undefined,
-  base: string,
-): Promise<Discovery | undefined> {
-  if (url === undefined) return undefined;
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return undefined;
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    return undefined;
-  }
-  try {
-    if (parsed.origin !== new URL(base).origin) return undefined;
-  } catch {
-    return undefined;
-  }
-  try {
-    const response = await fetch(url, {
-      redirect: "error",
-      signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
-    });
-    if (!response.ok) return undefined;
-    const doc = (await response.json()) as {
-      authorization_servers?: unknown;
-      scopes_supported?: unknown;
-    };
-    const strings = (value: unknown): string[] | undefined =>
-      Array.isArray(value) && value.every((entry) => typeof entry === "string")
-        ? (value as string[]).map(printable)
-        : undefined;
-    const issuers = strings(doc.authorization_servers);
-    const scopes = strings(doc.scopes_supported);
-    return {
-      ...(issuers !== undefined ? { issuers } : {}),
-      ...(scopes !== undefined ? { scopes } : {}),
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Strip control characters from a server-supplied string before it reaches
- * the terminal, so a hostile document cannot smuggle ANSI escapes or fake
- * extra lines into the refusal message. Bounded too: an issuer is a URL,
- * not a page.
- */
-function printable(value: string): string {
-  // eslint-disable-next-line no-control-regex -- removing control chars is the point
-  return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, "").slice(0, 256);
-}
-
-/**
- * Parse a response body, or `undefined` when it is not JSON.
- *
- * Wrapping unparseable text in an object would let it through the
- * success guard, which only checks that the body is an object: a proxy
- * answering 200 with an HTML error page would then be handed to the caller
- * as a page whose `items` is missing, and the crash would land in the
- * renderer rather than here, where the address can be named.
- */
-function parseJson(text: string): unknown {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Tell a request that never got an answer from one the instance refused to
- * answer in time.
- *
- * They need opposite reactions. "Could not reach it, start one" invites a
- * retry, which for a dispatch means running a possibly non-idempotent route a
- * second time while the first is still going.
- */
-function classifyTransportFailure(
-  error: unknown,
-  address: string,
-): OpsClientError {
-  const aborted =
-    error instanceof Error &&
-    (error.name === "TimeoutError" || error.name === "AbortError");
-  if (aborted) {
-    return new OpsClientError(
-      "error",
-      `The instance at ${address} accepted the request but did not answer within ${String(REQUEST_TIMEOUT_MS / 1000)}s. Any work it started is still running there, so do not simply re-run this.`,
-    );
-  }
-  return new OpsClientError(
-    "unreachable",
-    `Could not reach a running instance at ${address}: ${messageOf(error)}\nStart one with 'craft start', or point at another instance with --url.`,
-  );
-}
-
-/**
- * Describe an error body that carries no message.
- *
- * The framework's error code belongs to a bounded, documented vocabulary and
- * is safe to show, so it is shown: without it a route that refused the
- * caller's own credential (`RC5038`) is indistinguishable from one that
- * crashed, and the operator is told only that the instance answered 500.
- */
-function describeWireError(wire: WireError, status: number): string {
-  const answered = `The instance answered ${String(status)}`;
-  if (wire.error === undefined && wire.code === undefined)
-    return `${answered}.`;
-  const parts = [wire.error, wire.code].filter(
-    (part): part is string => part !== undefined,
-  );
-  return `${answered}: ${parts.join(" ")}. See https://routecraft.dev/docs/reference/errors for what the code means.`;
-}
-
-/** A non-JSON error body, carried as the reason so it still reaches the reader. */
-function textAsWireError(text: string): WireError {
-  const message = text.trim();
-  return message.length > 0 ? { message } : {};
+  });
 }

--- a/packages/routecraft/src/adapters/direct/shared.ts
+++ b/packages/routecraft/src/adapters/direct/shared.ts
@@ -140,8 +140,13 @@ export function sanitizeEndpoint(endpoint: string): string {
  * IMPORTANT: This implements single-consumer semantics where only the
  * last route to subscribe to an endpoint will receive messages.
  * Previous subscribers are automatically replaced (last one wins).
+ *
+ * Exported for the remotes plugin, which hands one to a local route that
+ * subscribes onto an endpoint a remote already holds.
+ *
+ * @internal
  */
-class InMemoryDirectChannel<T> implements DirectChannel<T> {
+export class InMemoryDirectChannel<T> implements DirectChannel<T> {
   private handler: ((message: T) => Promise<T>) | null = null;
 
   async send(endpoint: string, message: T): Promise<T> {

--- a/packages/routecraft/src/adapters/direct/shared.ts
+++ b/packages/routecraft/src/adapters/direct/shared.ts
@@ -149,6 +149,11 @@ export function sanitizeEndpoint(endpoint: string): string {
 export class InMemoryDirectChannel<T> implements DirectChannel<T> {
   private handler: ((message: T) => Promise<T>) | null = null;
 
+  /** Whether a route currently answers on this channel. */
+  get subscribed(): boolean {
+    return this.handler !== null;
+  }
+
   async send(endpoint: string, message: T): Promise<T> {
     if (this.handler) {
       // Synchronous behavior - single consumer gets the message and we wait for result

--- a/packages/routecraft/src/capabilities.ts
+++ b/packages/routecraft/src/capabilities.ts
@@ -13,6 +13,13 @@ import type { RouteDiscovery } from "./route.ts";
 export interface Capability extends RouteDiscovery {
   /** Raw endpoint / route id, exactly as passed to `.id(...)` / `direct(...)`. */
   endpoint: string;
+  /**
+   * The remote this capability was imported from (`defineConfig({ remotes })`),
+   * absent for a capability a local route registered. Read by the ops
+   * listing to name the origin and by the agent tool policy so a rule can
+   * keep an agent local-only.
+   */
+  remote?: string;
 }
 
 /**

--- a/packages/routecraft/src/error.ts
+++ b/packages/routecraft/src/error.ts
@@ -105,6 +105,9 @@ export interface ErrorCodeRegistry {
   RC5059: RCMeta;
   RC5060: RCMeta;
   RC5061: RCMeta;
+  RC5062: RCMeta;
+  RC5063: RCMeta;
+  RC5064: RCMeta;
   RC9901: RCMeta;
 }
 
@@ -616,6 +619,30 @@ export const RC: { [K in CoreErrorCode]: RCMeta } = {
     suggestion:
       "The response to an `http({ url })` call is larger than the route allows, so it was refused rather than read. The cap defaults to 10 MB, matching the http plugin's inbound `maxBodySize`; raise it with `http({ url, maxBodySize })` when the endpoint genuinely returns more, or ask the endpoint for less (a narrower query, a page, a range request). The body is never truncated to fit: half a JSON document parses as though it were whole, and a route acting on it would be wrong rather than failed. A declared `Content-Length` over the cap is refused before any byte is read; a body that declares nothing is abandoned mid-stream the moment the count crosses the ceiling, so the message names whichever number was seen.",
     docs: `${DOCS_BASE}#rc-5061`,
+    retryable: false,
+  },
+  RC5062: {
+    category: "Runtime",
+    message: "Remote instance unreachable",
+    suggestion:
+      "A dispatch to a route imported through `defineConfig({ remotes })` never got an answer from the remote instance: the connection was refused, the name did not resolve, or the request timed out. Check the remote's `url` and that the instance is running and serving its ops surface. A refused connection is safe to retry; a timeout is not, because the remote may still be running the work it accepted, and the message says which of the two it was.",
+    docs: `${DOCS_BASE}#rc-5062`,
+    retryable: true,
+  },
+  RC5063: {
+    category: "Runtime",
+    message: "Remote instance refused the credential",
+    suggestion:
+      "The remote's door answered 401 or 403 to a dispatch on an imported route, so the problem is the credential and not the route. The message carries the door's own reason: no credential was presented (`remotes.<name>.auth.token` is unset or resolved to nothing), the credential was rejected, or it is valid but lacks the dispatch tier's scope, which needs a token carrying that scope rather than a new sign-in. When the remote advertises RFC 9728 metadata the message also names who issues acceptable tokens.",
+    docs: `${DOCS_BASE}#rc-5063`,
+    retryable: false,
+  },
+  RC5064: {
+    category: "Runtime",
+    message: "Remote dispatch failed",
+    suggestion:
+      "The remote instance answered a dispatch on an imported route with an error. Its own error code rides in the message and on `cause`, and is what to read first: the ops door sends the code and never the message, so the remote's logs hold the detail. A `RC5060` from the remote means the route stopped being dispatchable there (it declared `direct({ internal: true })`, or lost its direct source); anything else is the route's own failure, exactly as it would have surfaced to a caller on the remote.",
+    docs: `${DOCS_BASE}#rc-5064`,
     retryable: false,
   },
   RC9901: {

--- a/packages/routecraft/src/index.ts
+++ b/packages/routecraft/src/index.ts
@@ -93,6 +93,7 @@ export { type HttpConfig } from "./adapters/http/types.ts";
 import "./plugins/server/config.ts";
 import "./plugins/http/config.ts";
 import "./plugins/ops/config.ts";
+import "./plugins/remotes/config.ts";
 import "./adapters/cron/config.ts";
 import "./adapters/direct/config.ts";
 import "./adapters/mail/config.ts";
@@ -189,6 +190,23 @@ export {
   OPS_SCOPE_EVENTS,
   OPS_SCOPE_INTROSPECTION,
 } from "./plugins/ops/types.ts";
+// The client of that API, shared with the CLI and the remotes plugin so the
+// wire is spoken in one place.
+export {
+  createOpsHttpClient,
+  isLoopbackHostname,
+  OpsClientError,
+  type OpsBearerToken,
+  type OpsFailureKind,
+  type OpsHttpClient,
+  type OpsHttpClientOptions,
+} from "./plugins/ops/client.ts";
+export { remotesPlugin } from "./plugins/remotes/plugin.ts";
+export type {
+  RemoteDefinition,
+  RemotesConfig,
+  RemotesPluginOptions,
+} from "./plugins/remotes/types.ts";
 /** @deprecated Use `CraftConfig.direct` instead. Will be removed in next major version. */
 export { type DirectConfig } from "./adapters/direct/types.ts";
 

--- a/packages/routecraft/src/plugins/ops/client.ts
+++ b/packages/routecraft/src/plugins/ops/client.ts
@@ -1,0 +1,573 @@
+/**
+ * HTTP client for a running instance's ops server.
+ *
+ * Spans two surfaces that behave differently and must not be flattened.
+ * `/health` never walls, so a probe with no credential works, and it
+ * returns MORE when authenticated: per-component `details` are gated by
+ * `health.details`. `/ops` answers by tier: 404 when a tier is off, open
+ * when `true`, scope-checked when a scope string is configured.
+ *
+ * So this client presents a credential whenever one is configured, on both
+ * surfaces, and degrades when none is. That is a correctness requirement
+ * rather than a nicety: unauthenticated, a route component says `degraded`
+ * and nothing else; authenticated, it says `degraded` because a breaker is
+ * open. The bare status does not answer the question an operator is asking.
+ *
+ * Two callers share it. The `craft` CLI drives one instance from a
+ * terminal, and the remotes plugin imports another instance's dispatchable
+ * routes into a running context. Neither knows anything the other does
+ * not about the wire, so the client lives in core beside the server it
+ * speaks to, and each caller supplies only the words its own reader needs
+ * (where the address came from, and what to do when refused).
+ */
+
+import type { Duration } from "../../shared/duration.ts";
+import { parseDuration } from "../../shared/duration.ts";
+import type {
+  HealthComponent,
+  HealthReport,
+  OpsDispatchOutcome,
+  OpsPage,
+  OpsRouteDetail,
+  OpsRouteFilter,
+  OpsRouteSummary,
+} from "./types";
+
+/**
+ * How long one request may take before the client gives up.
+ *
+ * A connection the instance accepts and then never answers is otherwise
+ * indistinguishable from work in progress, and a caller that hangs with no
+ * output is the worst way for a read to fail. The abort lands in the same
+ * catch as a refused connection, so it is reported with the address named.
+ */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * How long the follow-up fetch of an RFC 9728 metadata document may take.
+ *
+ * Much shorter than the request timeout: the refusal is already decided,
+ * and this fetch only enriches the message. A caller must never wait
+ * longer to be told no than they would have waited to be told yes.
+ */
+const DISCOVERY_TIMEOUT_MS = 5_000;
+
+/** Why a call did not produce an answer. Each needs a different remedy. */
+export type OpsFailureKind =
+  /** The instance could not be reached at all. */
+  | "unreachable"
+  /** The door refused: no credential, a bad one, or a missing scope. */
+  | "refused"
+  /** The tier is disabled, or the thing asked for does not exist. */
+  | "absent"
+  /** The instance answered, and the answer was an error. */
+  | "error";
+
+/** A call that did not produce an answer, with what to do about it. */
+export class OpsClientError extends Error {
+  constructor(
+    readonly kind: OpsFailureKind,
+    message: string,
+    readonly status?: number,
+    readonly detail?: unknown,
+  ) {
+    super(message);
+    this.name = "OpsClientError";
+  }
+}
+
+/** A response body carrying the API's structured refusal or error. */
+interface WireError {
+  error?: string;
+  reason?: string;
+  scope?: string;
+  code?: string;
+  message?: string;
+}
+
+/**
+ * The bearer presented on every call: a string, or a function evaluated
+ * per request so a rotated token is picked up without a restart. A
+ * function returning `undefined` presents no credential for that call.
+ */
+export type OpsBearerToken =
+  string | (() => string | undefined | Promise<string | undefined>);
+
+/** What a caller supplies to build a client. */
+export interface OpsHttpClientOptions {
+  /** The instance's base URL. A trailing slash is tolerated. */
+  url: string;
+  /** Credential for both surfaces. Absent means every call is unauthenticated. */
+  token?: OpsBearerToken;
+  /** Per-request deadline. Defaults to 30 seconds. */
+  timeout?: Duration;
+  /**
+   * How the address is named in an error a reader must act on. A wrong
+   * pinned address is otherwise indistinguishable from a stopped instance,
+   * so the CLI says where it read the address from and the remotes plugin
+   * says which remote it is.
+   */
+  describeAddress?: () => string;
+  /** Sentences appended to a refusal or a transport failure, naming the caller's own remedy. */
+  advice?: {
+    /** What to do when the door wants a credential and none was presented. */
+    missingCredential?: string;
+    /** What to do when nothing answered at the address. */
+    unreachable?: string;
+  };
+}
+
+export interface OpsHttpClient {
+  /** Whether a credential is configured, for rendering the view. */
+  readonly authenticated: boolean;
+  health(): Promise<HealthReport>;
+  ready(): Promise<HealthReport>;
+  routeHealth(id: string): Promise<HealthComponent>;
+  indicatorHealth(name: string): Promise<HealthComponent>;
+  listRoutes(filter?: OpsRouteFilter): Promise<OpsRouteSummary[]>;
+  describeRoute(id: string): Promise<OpsRouteDetail>;
+  dispatch(id: string, body: unknown): Promise<OpsDispatchOutcome>;
+}
+
+/**
+ * localhost, 127.0.0.0/8 and ::1, as `URL.hostname` renders them.
+ *
+ * The one place a bearer may travel over plain `http:`: the bytes never
+ * leave the machine. Every caller that refuses clear-text bearers decides
+ * with this predicate so the exception cannot drift between them.
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  return (
+    host === "localhost" || host === "::1" || /^127(?:\.\d{1,3}){3}$/.test(host)
+  );
+}
+
+export function createOpsHttpClient(
+  options: OpsHttpClientOptions,
+): OpsHttpClient {
+  const base = options.url.replace(/\/+$/, "");
+  const token = options.token;
+  const timeoutMs =
+    options.timeout === undefined
+      ? DEFAULT_TIMEOUT_MS
+      : parseDuration(options.timeout, "timeout");
+  const addressBlame = options.describeAddress ?? (() => base);
+  const advice = options.advice ?? {};
+
+  async function resolveToken(): Promise<string | undefined> {
+    if (typeof token !== "function") return token;
+    const resolved = await token();
+    return resolved === undefined || resolved.length === 0
+      ? undefined
+      : resolved;
+  }
+
+  async function call<T>(
+    path: string,
+    init: {
+      method?: string;
+      body?: unknown;
+      /**
+       * Statuses whose body is an answer rather than an error. The health
+       * surface replies 503 with a full report when a component is down, and
+       * that is precisely the report an operator is asking for.
+       */
+      answeredBy?: readonly number[];
+    } = {},
+  ): Promise<T> {
+    const headers: Record<string, string> = {};
+    const bearer = await resolveToken();
+    if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
+    if (init.body !== undefined) {
+      headers["content-type"] = "application/json";
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(`${base}${path}`, {
+        method: init.method ?? "GET",
+        headers,
+        signal: AbortSignal.timeout(timeoutMs),
+        ...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
+      });
+    } catch (error: unknown) {
+      throw classifyTransportFailure(error, addressBlame());
+    }
+
+    // Inside its own guard: an abort part-way through the body is the same
+    // class of failure as one during the request, and leaving it outside
+    // turned a timeout into an unhandled rejection with a stack trace.
+    let text: string;
+    try {
+      text = await response.text();
+    } catch (error: unknown) {
+      throw classifyTransportFailure(error, addressBlame());
+    }
+    const parsed: unknown = text.length === 0 ? undefined : parseJson(text);
+
+    if (response.ok || (init.answeredBy?.includes(response.status) ?? false)) {
+      // A 200 from something that is not this API (a wrong port, a proxy's
+      // error page) would otherwise be cast to the caller's type and crash
+      // in the renderer rather than here, where the address can be named.
+      if (parsed === null || typeof parsed !== "object") {
+        throw new OpsClientError(
+          "error",
+          `The instance at ${addressBlame()} answered ${String(response.status)} with a body this client does not recognise. Check that the address is a routecraft ops server.`,
+          response.status,
+        );
+      }
+      return parsed as T;
+    }
+
+    // A body that is not JSON still carries the reason on the error path: a
+    // proxy's plain-text refusal names the thing that refused.
+    const wire: WireError =
+      parsed === null || typeof parsed !== "object"
+        ? textAsWireError(text)
+        : (parsed as WireError);
+    if (response.status === 401 || response.status === 403) {
+      const challenge = parseBearerChallenge(
+        response.headers.get("www-authenticate"),
+      );
+      const discovery = await fetchDiscovery(challenge.resourceMetadata, base);
+      throw new OpsClientError(
+        "refused",
+        refusalMessage(
+          response.status,
+          wire,
+          bearer !== undefined,
+          challenge,
+          discovery,
+        ),
+        response.status,
+        wire,
+      );
+    }
+    if (response.status === 404) {
+      throw new OpsClientError(
+        "absent",
+        wire.message ?? "not found",
+        404,
+        wire,
+      );
+    }
+    throw new OpsClientError(
+      "error",
+      wire.message ?? describeWireError(wire, response.status),
+      response.status,
+      wire,
+    );
+  }
+
+  /**
+   * Render the door's own refusal rather than a summary of it. A missing
+   * scope and a missing credential need opposite actions, and the server
+   * already distinguishes them on the wire.
+   *
+   * When the challenge carried an RFC 9728 `resource_metadata` hint and the
+   * document resolved, the refusal also says who issues acceptable tokens
+   * and which scopes the surface understands. One message path for every
+   * refusal: the discovery lines append to the existing text, they never
+   * replace it.
+   */
+  function refusalMessage(
+    status: number,
+    wire: WireError,
+    presented: boolean,
+    challenge: BearerChallenge,
+    discovery: Discovery | undefined,
+  ): string {
+    const lines: string[] = [];
+    if (status === 403 && wire.reason === "insufficient_scope") {
+      lines.push(
+        `Refused: the credential does not carry the scope "${
+          wire.scope ?? challenge.scope ?? "(unnamed)"
+        }". The identity is valid and the credential is not, so this needs a token carrying that scope rather than signing in again.`,
+      );
+    } else if (!presented) {
+      lines.push(
+        `Refused: this surface requires a credential and none was presented.${
+          advice.missingCredential === undefined
+            ? ""
+            : ` ${advice.missingCredential}`
+        }`,
+      );
+    } else {
+      lines.push(
+        `Refused: the instance rejected the credential${
+          wire.reason === undefined ? "" : ` (${wire.reason})`
+        }.`,
+      );
+    }
+    if (discovery !== undefined) {
+      lines.push(
+        discovery.issuers !== undefined && discovery.issuers.length > 0
+          ? `Tokens are issued by ${discovery.issuers.join(", ")}.`
+          : "The instance advertises no authorization server, so discovery cannot say who issues. Ask whoever operates the instance how to obtain a credential.",
+      );
+      if (discovery.scopes !== undefined && discovery.scopes.length > 0) {
+        lines.push(
+          `Scopes this surface understands: ${discovery.scopes.join(", ")}.`,
+        );
+      }
+    }
+    return lines.join("\n");
+  }
+
+  /**
+   * Tell a request that never got an answer from one the instance refused
+   * to answer in time.
+   *
+   * They need opposite reactions. "Could not reach it, start one" invites a
+   * retry, which for a dispatch means running a possibly non-idempotent
+   * route a second time while the first is still going.
+   */
+  function classifyTransportFailure(
+    error: unknown,
+    address: string,
+  ): OpsClientError {
+    const aborted =
+      error instanceof Error &&
+      (error.name === "TimeoutError" || error.name === "AbortError");
+    if (aborted) {
+      return new OpsClientError(
+        "error",
+        `The instance at ${address} accepted the request but did not answer within ${String(timeoutMs / 1000)}s. Any work it started is still running there, so do not simply re-run this.`,
+      );
+    }
+    return new OpsClientError(
+      "unreachable",
+      `Could not reach a running instance at ${address}: ${messageOf(error)}${
+        advice.unreachable === undefined ? "" : `\n${advice.unreachable}`
+      }`,
+    );
+  }
+
+  // The health surface answers 503 with a complete report when something is
+  // down. Treating that as a failure would blank the output at the one moment
+  // the command exists for.
+  const DOWN_IS_AN_ANSWER = { answeredBy: [503] } as const;
+
+  return {
+    authenticated: token !== undefined,
+
+    health: () => call<HealthReport>("/health", DOWN_IS_AN_ANSWER),
+    ready: () => call<HealthReport>("/health/ready", DOWN_IS_AN_ANSWER),
+    routeHealth: (id: string) =>
+      call<HealthComponent>(
+        `/health/routes/${encodeURIComponent(id)}`,
+        DOWN_IS_AN_ANSWER,
+      ),
+    indicatorHealth: (name: string) =>
+      call<HealthComponent>(
+        `/health/indicators/${encodeURIComponent(name)}`,
+        DOWN_IS_AN_ANSWER,
+      ),
+
+    /**
+     * Walk the whole collection rather than showing page one and stopping.
+     *
+     * The envelope's contract is that a present cursor means there is more,
+     * and a client that ignores it silently reports a partial inventory as
+     * a complete one. The cursor is replayed under the same filter it was
+     * minted with, which is the only way the server will honour it.
+     */
+    async listRoutes(filter: OpsRouteFilter = {}): Promise<OpsRouteSummary[]> {
+      // Serialised here, the one place that knows the wire, so no caller has
+      // to spell a filter name as a string the compiler does not own.
+      const query: Record<string, string> = {
+        ...(filter.dispatchable !== undefined
+          ? { dispatchable: String(filter.dispatchable) }
+          : {}),
+        ...(filter.id !== undefined ? { id: filter.id } : {}),
+        ...(filter.source !== undefined ? { source: filter.source } : {}),
+      };
+      const items: OpsRouteSummary[] = [];
+      const seen = new Set<string>();
+      let cursor: string | undefined;
+      do {
+        const params = new URLSearchParams(query);
+        if (cursor !== undefined) params.set("after", cursor);
+        const suffix = params.toString();
+        const page = await call<OpsPage<OpsRouteSummary>>(
+          `/ops/routes${suffix.length > 0 ? `?${suffix}` : ""}`,
+        );
+        items.push(...page.items);
+        cursor = page.nextCursor;
+        // The loop trusts the instance to advance, and this client talks to
+        // instances it did not build: a repeated cursor would page forever and
+        // grow `items` without bound. Refusing beats hanging, and beats
+        // silently returning a listing with the same rows in it many times.
+        if (cursor !== undefined && !seen.add(cursor)) {
+          throw new OpsClientError(
+            "error",
+            "The instance repeated a pagination cursor, so the route listing cannot be completed. This is a fault in the instance rather than in the request.",
+          );
+        }
+      } while (cursor !== undefined);
+      return items;
+    },
+
+    describeRoute: (id: string) =>
+      call<OpsRouteDetail>(`/ops/routes/${encodeURIComponent(id)}`),
+
+    dispatch: (id: string, body: unknown) =>
+      call<OpsDispatchOutcome>(
+        `/ops/routes/${encodeURIComponent(id)}/exchanges`,
+        { method: "POST", body: body ?? {} },
+      ),
+  };
+}
+
+/** What a refusal's `WWW-Authenticate` header said, reduced to what is used. */
+interface BearerChallenge {
+  scope?: string;
+  resourceMetadata?: string;
+}
+
+/**
+ * Read the RFC 6750 challenge parameters off a refusal.
+ *
+ * Quoted `key="value"` pairs only, which is what every routecraft surface
+ * emits and what RFC 9728 prescribes for `resource_metadata`. A header
+ * that is absent, not a Bearer challenge, or otherwise unparseable yields
+ * an empty result rather than an error: the challenge only enriches a
+ * refusal that already stands on its own.
+ */
+function parseBearerChallenge(header: string | null): BearerChallenge {
+  if (header === null || !/^\s*bearer[\s,]/i.test(header)) return {};
+  const result: BearerChallenge = {};
+  for (const match of header.matchAll(/([a-z_]+)\s*=\s*"([^"]*)"/gi)) {
+    const key = match[1]!.toLowerCase();
+    if (key === "scope") result.scope = match[2]!;
+    if (key === "resource_metadata") result.resourceMetadata = match[2]!;
+  }
+  return result;
+}
+
+/** What the RFC 9728 document said, reduced to what a refusal can report. */
+interface Discovery {
+  issuers?: string[];
+  scopes?: string[];
+}
+
+/**
+ * Follow a challenge's `resource_metadata` hint.
+ *
+ * Best-effort by design: the hint names the instance's own document, but a
+ * proxy can strip it, the fetch can time out, and a non-routecraft server
+ * can answer nonsense. Every failure resolves to `undefined` so the
+ * refusal degrades to what the status line already proves, never to a
+ * second error about the enrichment.
+ *
+ * The hint is followed only to the origin the caller addressed
+ * (RFC 9728 section 3.3): a `WWW-Authenticate` header is unvalidated
+ * input, and a refusing server that could point this process anywhere
+ * would hold an SSRF primitive aimed from the caller's network.
+ * Redirects are refused for the same reason: a 302 on the first hop
+ * would carry the fetch past the origin check.
+ */
+async function fetchDiscovery(
+  url: string | undefined,
+  base: string,
+): Promise<Discovery | undefined> {
+  if (url === undefined) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return undefined;
+  }
+  try {
+    if (parsed.origin !== new URL(base).origin) return undefined;
+  } catch {
+    return undefined;
+  }
+  try {
+    const response = await fetch(url, {
+      redirect: "error",
+      signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+    });
+    if (!response.ok) return undefined;
+    const doc = (await response.json()) as {
+      authorization_servers?: unknown;
+      scopes_supported?: unknown;
+    };
+    const strings = (value: unknown): string[] | undefined =>
+      Array.isArray(value) && value.every((entry) => typeof entry === "string")
+        ? (value as string[]).map(printable)
+        : undefined;
+    const issuers = strings(doc.authorization_servers);
+    const scopes = strings(doc.scopes_supported);
+    return {
+      ...(issuers !== undefined ? { issuers } : {}),
+      ...(scopes !== undefined ? { scopes } : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Strip control characters from a server-supplied string before it reaches
+ * a terminal or a log, so a hostile document cannot smuggle ANSI escapes or
+ * fake extra lines into the refusal message. Bounded too: an issuer is a
+ * URL, not a page.
+ */
+function printable(value: string): string {
+  // eslint-disable-next-line no-control-regex -- removing control chars is the point
+  return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, "").slice(0, 256);
+}
+
+/**
+ * Parse a response body, or `undefined` when it is not JSON.
+ *
+ * Wrapping unparseable text in an object would let it through the
+ * success guard, which only checks that the body is an object: a proxy
+ * answering 200 with an HTML error page would then be handed to the caller
+ * as a page whose `items` is missing, and the crash would land in the
+ * renderer rather than here, where the address can be named.
+ */
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Describe an error body that carries no message.
+ *
+ * The framework's error code belongs to a bounded, documented vocabulary and
+ * is safe to show, so it is shown: without it a route that refused the
+ * caller's own credential (`RC5038`) is indistinguishable from one that
+ * crashed, and the operator is told only that the instance answered 500.
+ */
+function describeWireError(wire: WireError, status: number): string {
+  const answered = `The instance answered ${String(status)}`;
+  if (wire.error === undefined && wire.code === undefined)
+    return `${answered}.`;
+  const parts = [wire.error, wire.code].filter(
+    (part): part is string => part !== undefined,
+  );
+  return `${answered}: ${parts.join(" ")}. See https://routecraft.dev/docs/reference/errors for what the code means.`;
+}
+
+/** A non-JSON error body, carried as the reason so it still reaches the reader. */
+function textAsWireError(text: string): WireError {
+  const message = text.trim();
+  return message.length > 0 ? { message } : {};
+}
+
+/** A thrown value's message; non-Error throws (a `ResolveMessage`) still carry one. */
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return typeof error === "object" && error !== null && "message" in error
+    ? String((error as { message: unknown }).message)
+    : String(error);
+}

--- a/packages/routecraft/src/plugins/ops/client.ts
+++ b/packages/routecraft/src/plugins/ops/client.ts
@@ -210,7 +210,11 @@ export function createOpsHttpClient(
       // A 200 from something that is not this API (a wrong port, a proxy's
       // error page) would otherwise be cast to the caller's type and crash
       // in the renderer rather than here, where the address can be named.
-      if (parsed === null || typeof parsed !== "object") {
+      if (
+        parsed === null ||
+        typeof parsed !== "object" ||
+        Array.isArray(parsed)
+      ) {
         throw new OpsClientError(
           "error",
           `The instance at ${addressBlame()} answered ${String(response.status)} with a body this client does not recognise. Check that the address is a routecraft ops server.`,
@@ -222,10 +226,11 @@ export function createOpsHttpClient(
 
     // A body that is not JSON still carries the reason on the error path: a
     // proxy's plain-text refusal names the thing that refused.
-    const wire: WireError =
+    const wire = sanitizeWire(
       parsed === null || typeof parsed !== "object"
         ? textAsWireError(text)
-        : (parsed as WireError);
+        : (parsed as WireError),
+    );
     if (response.status === 401 || response.status === 403) {
       const challenge = parseBearerChallenge(
         response.headers.get("www-authenticate"),
@@ -415,7 +420,7 @@ export function createOpsHttpClient(
     dispatch: (id: string, body: unknown) =>
       call<OpsDispatchOutcome>(
         `/ops/routes/${encodeURIComponent(id)}/exchanges`,
-        { method: "POST", body: body ?? {} },
+        { method: "POST", body },
       ),
   };
 }
@@ -562,6 +567,20 @@ function describeWireError(wire: WireError, status: number): string {
 function textAsWireError(text: string): WireError {
   const message = text.trim();
   return message.length > 0 ? { message } : {};
+}
+
+/**
+ * Strip and bound every string the wire supplied before it reaches an error
+ * message. The body came from whatever answered at the address, which may
+ * be a proxy or a stranger, and an error message reaches terminals and logs.
+ */
+function sanitizeWire(wire: WireError): WireError {
+  const out: WireError = {};
+  for (const key of ["error", "reason", "scope", "code", "message"] as const) {
+    const value = wire[key];
+    if (typeof value === "string") out[key] = printable(value);
+  }
+  return out;
 }
 
 /** A thrown value's message; non-Error throws (a `ResolveMessage`) still carry one. */

--- a/packages/routecraft/src/plugins/ops/indicator.ts
+++ b/packages/routecraft/src/plugins/ops/indicator.ts
@@ -84,6 +84,30 @@ export function isIndicator(value: unknown): value is Indicator {
 }
 
 /**
+ * Refuse a name that cannot be an indicator's.
+ *
+ * The name is the report key and one path segment of
+ * `/health/indicators/<name>`. A slash would split that segment, and `.` or
+ * `..` are eaten by URL normalisation before the handler ever sees them, so
+ * either way the component is unreachable at its own path: a typo that
+ * would otherwise present as an endpoint that is simply missing.
+ *
+ * @internal
+ */
+export function assertIndicatorName(name: string, surface: string): void {
+  if (name.trim() === "") {
+    throw rcError("RC5053", undefined, {
+      message: `${surface}: name must not be empty.`,
+    });
+  }
+  if (name === "." || name === ".." || name !== encodeURIComponent(name)) {
+    throw rcError("RC5053", undefined, {
+      message: `${surface}("${name}"): name must be usable as a single URL path segment. It is the key in the health report and the last segment of /health/indicators/<name>, so it cannot contain a slash, a space, or any character needing percent-encoding.`,
+    });
+  }
+}
+
+/**
  * Declare an indicator: a named dependency whose health the app reports.
  *
  * The returned handle is both the declaration and the push surface, and it is
@@ -122,25 +146,7 @@ export function isIndicator(value: unknown): value is Indicator {
  * @returns A handle to register in `ops.indicators` and push through.
  */
 export function defineIndicator(definition: IndicatorDefinition): Indicator {
-  if (definition.name.trim() === "") {
-    throw rcError("RC5053", undefined, {
-      message: "defineIndicator: name must not be empty.",
-    });
-  }
-  // The name is the report key and one path segment of
-  // `/health/indicators/<name>`. A slash would split that segment, and `.` or
-  // `..` are eaten by URL normalisation before the handler ever sees them, so
-  // either way the component is unreachable at its own path: a typo that
-  // would otherwise present as an endpoint that is simply missing.
-  if (
-    definition.name === "." ||
-    definition.name === ".." ||
-    definition.name !== encodeURIComponent(definition.name)
-  ) {
-    throw rcError("RC5053", undefined, {
-      message: `defineIndicator("${definition.name}"): name must be usable as a single URL path segment. It is the key in the health report and the last segment of /health/indicators/<name>, so it cannot contain a slash, a space, or any character needing percent-encoding.`,
-    });
-  }
+  assertIndicatorName(definition.name, "defineIndicator");
   // Parsed for its refusal, not its value: the resolved milliseconds are
   // computed again where the indicator registers. Validating here is what
   // makes a malformed duration fail at definition rather than at boot.

--- a/packages/routecraft/src/plugins/ops/management.ts
+++ b/packages/routecraft/src/plugins/ops/management.ts
@@ -31,6 +31,7 @@ import { decodeCursor, takePage } from "./pagination";
 import { safeStringify } from "../../shared/safe-json.ts";
 import { compareCodeUnits } from "../../shared/compare";
 import { OPS_RESOURCES } from "./store";
+import { REMOTE_ROUTES, type RemoteRoute } from "../remotes/store";
 import type {
   OpsDispatchOutcome,
   OpsEventTailItem,
@@ -138,12 +139,29 @@ export function createManagementApi(ctx: CraftContext): ManagementApi {
   const capabilityIndex = (): Map<string, Capability> =>
     new Map(ctx.capabilities().map((entry) => [entry.endpoint, entry]));
 
+  /**
+   * Routes imported from other instances, keyed by local endpoint.
+   *
+   * Listed beside the local routes as dispatchable, with `remote` naming
+   * the origin. A local route with the same id wins (the remotes plugin
+   * never lists a shadowed endpoint), and the id check here covers the
+   * moment between a local route subscribing and the next refresh.
+   */
+  const remoteIndex = (): Map<string, RemoteRoute> =>
+    ctx.getStore(REMOTE_ROUTES) ?? new Map<string, RemoteRoute>();
+
   const summaries = (): OpsRouteSummary[] => {
     const capabilities = capabilityIndex();
-    return ctx
+    const local = ctx
       .getRoutes()
-      .map((route) => summarise(ctx, route.definition, capabilities))
-      .sort((left, right) => compareCodeUnits(left.id, right.id));
+      .map((route) => summarise(ctx, route.definition, capabilities));
+    const localIds = new Set(local.map((route) => route.id));
+    const imported = [...remoteIndex().values()]
+      .filter((route) => !localIds.has(route.endpoint))
+      .map(summariseRemote);
+    return [...local, ...imported].sort((left, right) =>
+      compareCodeUnits(left.id, right.id),
+    );
   };
 
   return {
@@ -270,8 +288,9 @@ export function createManagementApi(ctx: CraftContext): ManagementApi {
       const route = ctx
         .getRoutes()
         .find((candidate) => candidate.definition.id === id);
-      if (!route) return undefined;
-      return detail(ctx, route.definition, capabilities);
+      if (route) return detail(ctx, route.definition, capabilities);
+      const imported = remoteIndex().get(id);
+      return imported === undefined ? undefined : detailRemote(imported);
     },
 
     async dispatch(
@@ -283,12 +302,17 @@ export function createManagementApi(ctx: CraftContext): ManagementApi {
       const route = ctx
         .getRoutes()
         .find((candidate) => candidate.definition.id === id);
-      if (!route) {
+      // An imported route has no definition here and needs none: its
+      // capability is its door, and the channel behind it carries the
+      // exchange to the instance that defines it. Re-exposing it through
+      // this door is intentional, exactly as a tool fronting an
+      // authenticated REST call re-exposes that call.
+      if (!route && !remoteIndex().has(id)) {
         throw rcError("RC5004", undefined, {
           message: `No route "${id}" is registered in this instance.`,
         });
       }
-      if (!capabilities.has(id)) {
+      if (route && !capabilities.has(id)) {
         // Two different refusals behind one absence: a route that declared
         // `direct({ internal: true })` HAS a direct source, so telling its
         // caller to add one would be wrong advice. The internal registry is
@@ -334,6 +358,40 @@ export function createManagementApi(ctx: CraftContext): ManagementApi {
         throw error;
       }
     },
+  };
+}
+
+/**
+ * An imported route as the listing presents it: what the remote said about
+ * its route, under the local endpoint, with the origin named. Always
+ * dispatchable and enabled, because the remote only lists routes that are,
+ * and the JSON Schema renderings pass through as the remote rendered them.
+ */
+function summariseRemote(route: RemoteRoute): OpsRouteSummary {
+  const { detail } = route;
+  return {
+    id: route.endpoint,
+    dispatchable: true,
+    enabled: true,
+    sources: ["remote"],
+    requiresPrincipal: detail.requiresPrincipal,
+    ...(detail.title !== undefined ? { title: detail.title } : {}),
+    ...(detail.description !== undefined
+      ? { description: detail.description }
+      : {}),
+    ...(detail.tags !== undefined && detail.tags.length > 0
+      ? { tags: [...detail.tags] }
+      : {}),
+    remote: route.remote,
+  };
+}
+
+function detailRemote(route: RemoteRoute): OpsRouteDetail {
+  const { detail } = route;
+  return {
+    ...summariseRemote(route),
+    ...(detail.input !== undefined ? { input: detail.input } : {}),
+    ...(detail.output !== undefined ? { output: detail.output } : {}),
   };
 }
 

--- a/packages/routecraft/src/plugins/ops/plugin.ts
+++ b/packages/routecraft/src/plugins/ops/plugin.ts
@@ -32,7 +32,7 @@ import {
   type ContributedIndicator,
 } from "./store";
 import { enforcesWall } from "./tier";
-import type { Indicator, OpsPluginOptions, OpsTiers } from "./types";
+import type { Health, Indicator, OpsPluginOptions, OpsTiers } from "./types";
 
 /**
  * Everything the mount answers. Claimed exhaustively so the server's
@@ -56,8 +56,11 @@ interface Runtime {
   authConfigured: boolean;
   /** Every indicator name registered on the ledger, from options and contributions. */
   indicatorNames: Set<string>;
-  /** Contributed indicators bound at start, released at teardown. */
-  contributed: ContributedIndicator[];
+  /** Contributed indicators bound at start, with this ledger's sink, released at teardown. */
+  contributed: Array<{
+    entry: ContributedIndicator;
+    sink: (health: Health) => void;
+  }>;
   unmount?: () => void;
 }
 
@@ -387,8 +390,14 @@ export function opsPlugin(options: OpsPluginOptions = {}): CraftPlugin {
           ...(entry.domain !== undefined ? { domain: entry.domain } : {}),
         });
         const { state } = runtime;
-        entry.report = (health) => state.reportIndicator(entry.name, health);
-        runtime.contributed.push(entry);
+        const sink = (health: Health): void => {
+          state.reportIndicator(entry.name, health);
+        };
+        entry.sinks.add(sink);
+        // A contributor whose start() already ran reported into nothing; its
+        // last verdict is what the ledger should open with.
+        if (entry.last !== undefined) sink(entry.last);
+        runtime.contributed.push({ entry, sink });
       }
 
       const unbound = unboundIndicators();
@@ -422,7 +431,9 @@ export function opsPlugin(options: OpsPluginOptions = {}): CraftPlugin {
         runtime.state.contextStopped();
         for (const unsubscribe of runtime.unsubscribes) unsubscribe();
         for (const indicator of indicators) unbindIndicator(indicator, ctx);
-        for (const entry of runtime.contributed) delete entry.report;
+        for (const { entry, sink } of runtime.contributed) {
+          entry.sinks.delete(sink);
+        }
         runtimes.delete(ctx);
       }
     },

--- a/packages/routecraft/src/plugins/ops/plugin.ts
+++ b/packages/routecraft/src/plugins/ops/plugin.ts
@@ -59,7 +59,7 @@ interface Runtime {
   /** Contributed indicators bound at start, with this ledger's sink, released at teardown. */
   contributed: Array<{
     entry: ContributedIndicator;
-    sink: (health: Health) => void;
+    sink: (health: Health, reportedAt: number) => void;
   }>;
   unmount?: () => void;
 }
@@ -390,13 +390,15 @@ export function opsPlugin(options: OpsPluginOptions = {}): CraftPlugin {
           ...(entry.domain !== undefined ? { domain: entry.domain } : {}),
         });
         const { state } = runtime;
-        const sink = (health: Health): void => {
-          state.reportIndicator(entry.name, health);
+        const sink = (health: Health, reportedAt: number): void => {
+          state.reportIndicator(entry.name, health, reportedAt);
         };
         entry.sinks.add(sink);
         // A contributor whose start() already ran reported into nothing; its
-        // last verdict is what the ledger should open with.
-        if (entry.last !== undefined) sink(entry.last);
+        // last verdict is what the ledger should open with, at the time it
+        // was made, so a maxAge window is measured from the report and not
+        // from this binding.
+        if (entry.last !== undefined) sink(entry.last.health, entry.last.at);
         runtime.contributed.push({ entry, sink });
       }
 

--- a/packages/routecraft/src/plugins/ops/plugin.ts
+++ b/packages/routecraft/src/plugins/ops/plugin.ts
@@ -26,7 +26,11 @@ import { createManagementApi } from "./management";
 import { createManagementHandler } from "./mount";
 import { createHealthHandler } from "./report";
 import { HealthState } from "./state";
-import { OPS_HEALTH_STATE } from "./store";
+import {
+  OPS_CONTRIBUTED_INDICATORS,
+  OPS_HEALTH_STATE,
+  type ContributedIndicator,
+} from "./store";
 import { enforcesWall } from "./tier";
 import type { Indicator, OpsPluginOptions, OpsTiers } from "./types";
 
@@ -50,6 +54,10 @@ interface Runtime {
   unsubscribes: (() => void)[];
   /** The mount's effective validator exists (its own auth, or the server's). */
   authConfigured: boolean;
+  /** Every indicator name registered on the ledger, from options and contributions. */
+  indicatorNames: Set<string>;
+  /** Contributed indicators bound at start, released at teardown. */
+  contributed: ContributedIndicator[];
   unmount?: () => void;
 }
 
@@ -142,15 +150,17 @@ export function opsPlugin(options: OpsPluginOptions = {}): CraftPlugin {
           ctx.emit("plugin:ops:health:changed", change);
         },
       });
+      const names = new Set<string>();
       const runtime: Runtime = {
         state,
         unsubscribes: [],
         authConfigured: mountAuth.configured,
+        indicatorNames: names,
+        contributed: [],
       };
       runtimes.set(ctx, runtime);
       ctx.setStore(OPS_HEALTH_STATE, state);
 
-      const names = new Set<string>();
       for (const indicator of indicators) {
         if (!isIndicator(indicator)) {
           throw rcError("RC5053", undefined, {
@@ -356,6 +366,31 @@ export function opsPlugin(options: OpsPluginOptions = {}): CraftPlugin {
         );
       }
 
+      // Indicators other plugins contributed from their apply(), bound here
+      // because a contributor may have applied after this plugin did. Names
+      // share one report with ops.indicators, so a clash is refused rather
+      // than letting whichever registered last own the key.
+      for (const entry of ctx.getStore(OPS_CONTRIBUTED_INDICATORS)?.values() ??
+        []) {
+        if (runtime.indicatorNames.has(entry.name)) {
+          throw rcError("RC5053", undefined, {
+            message: `Indicator "${entry.name}" is both listed in ops.indicators and contributed by a plugin. Indicator names are the keys of the health report, so they must be unique.`,
+          });
+        }
+        runtime.indicatorNames.add(entry.name);
+        const maxAgeMs =
+          entry.maxAge === undefined
+            ? undefined
+            : parseDuration(entry.maxAge, "maxAge");
+        runtime.state.registerIndicator(entry.name, {
+          ...(maxAgeMs !== undefined ? { maxAgeMs } : {}),
+          ...(entry.domain !== undefined ? { domain: entry.domain } : {}),
+        });
+        const { state } = runtime;
+        entry.report = (health) => state.reportIndicator(entry.name, health);
+        runtime.contributed.push(entry);
+      }
+
       const unbound = unboundIndicators();
       if (unbound.length > 0) {
         ctx.logger.warn(
@@ -387,6 +422,7 @@ export function opsPlugin(options: OpsPluginOptions = {}): CraftPlugin {
         runtime.state.contextStopped();
         for (const unsubscribe of runtime.unsubscribes) unsubscribe();
         for (const indicator of indicators) unbindIndicator(indicator, ctx);
+        for (const entry of runtime.contributed) delete entry.report;
         runtimes.delete(ctx);
       }
     },

--- a/packages/routecraft/src/plugins/ops/state.ts
+++ b/packages/routecraft/src/plugins/ops/state.ts
@@ -471,10 +471,16 @@ export class HealthState implements HealthLedger {
   }
 
   /** Record an indicator report. Any report clears a prior `inactive` marker. */
-  reportIndicator(name: string, health: Health): void {
+  reportIndicator(
+    name: string,
+    health: Health,
+    reportedAt: number = this.now(),
+  ): void {
     const record = this.indicators.get(name);
     if (!record) return;
-    record.lastReportAt = this.now();
+    // A report replayed from before this ledger existed keeps its own time,
+    // so a maxAge window measures from the report and not from the binding.
+    record.lastReportAt = reportedAt;
     // Copied, not referenced: this object came from the caller and is handed
     // back in every subsequent report, so sharing it would let either side
     // rewrite a verdict after the fact. Values are structural scalars, so a

--- a/packages/routecraft/src/plugins/ops/store.ts
+++ b/packages/routecraft/src/plugins/ops/store.ts
@@ -98,14 +98,14 @@ export interface ContributedIndicator {
    * context carrying two ops mounts reports into both. Empty until an ops
    * plugin binds it, and empty again after teardown.
    */
-  readonly sinks: Set<(health: Health) => void>;
+  readonly sinks: Set<(health: Health, reportedAt: number) => void>;
   /**
    * The most recent report, replayed to a ledger that binds after it was
    * made. A contributor whose start() ran before the ops plugin's would
    * otherwise have its first verdict lost, and a remote unreachable at boot
    * would read as up until its next refresh.
    */
-  last?: Health;
+  last?: { health: Health; at: number };
 }
 
 /**
@@ -129,8 +129,10 @@ declare module "@routecraft/routecraft" {
 /**
  * Contribute an indicator to the health report from a plugin's `apply()`.
  *
- * Returns the function to report through. Reports before the ops plugin
- * binds the indicator, or in a context with no ops plugin, are dropped.
+ * Returns the function to report through. A report made before an ops
+ * plugin binds the indicator is kept and replayed into the ledger when it
+ * binds, at the time it was made; in a context with no ops plugin a report
+ * goes nowhere.
  *
  * @throws RC5053 on a malformed name, or a name another contributor took
  */
@@ -151,7 +153,8 @@ export function contributeOpsIndicator(
   registry.set(definition.name, entry);
   ctx.setStore(OPS_CONTRIBUTED_INDICATORS, registry);
   return (health) => {
-    entry.last = health;
-    for (const sink of entry.sinks) sink(health);
+    const at = Date.now();
+    entry.last = { health, at };
+    for (const sink of entry.sinks) sink(health, at);
   };
 }

--- a/packages/routecraft/src/plugins/ops/store.ts
+++ b/packages/routecraft/src/plugins/ops/store.ts
@@ -1,7 +1,9 @@
 import type { HealthLedger } from "./state";
 import type { CraftContext } from "../../context";
 import { rcError } from "../../error";
-import type { OpsResource } from "./types";
+import type { Duration } from "../../shared/duration.ts";
+import { assertIndicatorName } from "./indicator";
+import type { FailureDomain, Health, OpsResource } from "./types";
 
 /**
  * Symbol key the ops plugin publishes its per-context ledger under.
@@ -72,4 +74,70 @@ export function registerOpsResource<TItem>(
   }
   registry.set(resource.name, resource as OpsResource);
   ctx.setStore(OPS_RESOURCES, registry);
+}
+
+/**
+ * An indicator another plugin contributes, without the app listing it.
+ *
+ * `defineIndicator` is the app's API: a handle declared in source and named
+ * in `ops.indicators`. A plugin that watches a dependency the app never
+ * wrote a line for (the remotes plugin and the instances it imports from)
+ * has no such handle to hand the app, so it contributes the declaration
+ * here and reports through the function the contribution returns. The
+ * ops plugin binds it to its ledger at start, and before that, or without
+ * an ops plugin at all, a report is inert for the same reason a push
+ * through an unbound handle is: health instrumentation must not be able
+ * to fail the code it instruments.
+ */
+export interface ContributedIndicator {
+  readonly name: string;
+  readonly domain?: FailureDomain;
+  readonly maxAge?: Duration;
+  /** Installed by the ops plugin when it binds the indicator; absent until then. */
+  report?: (health: Health) => void;
+}
+
+/**
+ * Symbol key for the indicators other plugins contribute, keyed by name.
+ * Written by {@link contributeOpsIndicator}, bound by the ops plugin's
+ * `start()`, so a contribution made from any plugin's `apply()` is served
+ * whatever order the plugins were applied in.
+ *
+ * @internal
+ */
+export const OPS_CONTRIBUTED_INDICATORS: unique symbol = Symbol.for(
+  "routecraft.plugin.ops.contributed-indicators",
+);
+
+declare module "@routecraft/routecraft" {
+  interface StoreRegistry {
+    [OPS_CONTRIBUTED_INDICATORS]: Map<string, ContributedIndicator>;
+  }
+}
+
+/**
+ * Contribute an indicator to the health report from a plugin's `apply()`.
+ *
+ * Returns the function to report through. Reports before the ops plugin
+ * binds the indicator, or in a context with no ops plugin, are dropped.
+ *
+ * @throws RC5053 on a malformed name, or a name another contributor took
+ */
+export function contributeOpsIndicator(
+  ctx: CraftContext,
+  definition: Omit<ContributedIndicator, "report">,
+): (health: Health) => void {
+  assertIndicatorName(definition.name, "contributeOpsIndicator");
+  const registry =
+    ctx.getStore(OPS_CONTRIBUTED_INDICATORS) ??
+    new Map<string, ContributedIndicator>();
+  if (registry.has(definition.name)) {
+    throw rcError("RC5053", undefined, {
+      message: `Indicator "${definition.name}" is already contributed on this context. One contributor per name.`,
+    });
+  }
+  const entry: ContributedIndicator = { ...definition };
+  registry.set(definition.name, entry);
+  ctx.setStore(OPS_CONTRIBUTED_INDICATORS, registry);
+  return (health) => entry.report?.(health);
 }

--- a/packages/routecraft/src/plugins/ops/store.ts
+++ b/packages/routecraft/src/plugins/ops/store.ts
@@ -93,8 +93,19 @@ export interface ContributedIndicator {
   readonly name: string;
   readonly domain?: FailureDomain;
   readonly maxAge?: Duration;
-  /** Installed by the ops plugin when it binds the indicator; absent until then. */
-  report?: (health: Health) => void;
+  /**
+   * Where reports go: one sink per ops ledger that bound the indicator, so a
+   * context carrying two ops mounts reports into both. Empty until an ops
+   * plugin binds it, and empty again after teardown.
+   */
+  readonly sinks: Set<(health: Health) => void>;
+  /**
+   * The most recent report, replayed to a ledger that binds after it was
+   * made. A contributor whose start() ran before the ops plugin's would
+   * otherwise have its first verdict lost, and a remote unreachable at boot
+   * would read as up until its next refresh.
+   */
+  last?: Health;
 }
 
 /**
@@ -125,7 +136,7 @@ declare module "@routecraft/routecraft" {
  */
 export function contributeOpsIndicator(
   ctx: CraftContext,
-  definition: Omit<ContributedIndicator, "report">,
+  definition: Omit<ContributedIndicator, "sinks" | "last">,
 ): (health: Health) => void {
   assertIndicatorName(definition.name, "contributeOpsIndicator");
   const registry =
@@ -136,8 +147,11 @@ export function contributeOpsIndicator(
       message: `Indicator "${definition.name}" is already contributed on this context. One contributor per name.`,
     });
   }
-  const entry: ContributedIndicator = { ...definition };
+  const entry: ContributedIndicator = { ...definition, sinks: new Set() };
   registry.set(definition.name, entry);
   ctx.setStore(OPS_CONTRIBUTED_INDICATORS, registry);
-  return (health) => entry.report?.(health);
+  return (health) => {
+    entry.last = health;
+    for (const sink of entry.sinks) sink(health);
+  };
 }

--- a/packages/routecraft/src/plugins/ops/types.ts
+++ b/packages/routecraft/src/plugins/ops/types.ts
@@ -458,6 +458,13 @@ export interface OpsRouteSummary {
   title?: string;
   description?: string;
   tags?: string[];
+  /**
+   * The remote this route was imported from, for a route another instance
+   * exposes and `defineConfig({ remotes })` made dispatchable here. Absent
+   * for a route this instance defines. Additive: an existing consumer that
+   * never reads it sees the listing it always saw.
+   */
+  remote?: string;
 }
 
 /** One route in full. Adds the schema renderings to the summary. */

--- a/packages/routecraft/src/plugins/remotes/channel.ts
+++ b/packages/routecraft/src/plugins/remotes/channel.ts
@@ -1,0 +1,176 @@
+/**
+ * The direct channel behind an imported route.
+ *
+ * Registered in the direct store under the route's local endpoint, so
+ * `direct('lab:hello')`, `forward('lab:hello', ...)`, `CraftClient.sendDirect`
+ * and a `directTool` all reach it through the code paths they already use.
+ * A send becomes `POST /ops/routes/{id}/exchanges` on the remote, and the
+ * remote's outcome is mapped onto the in-process one: a completed exchange
+ * is the body, a drop is `RC5031`, a park is the standard `Suspended`
+ * acknowledgment, and the door's own refusals and failures become codes a
+ * caller can tell apart.
+ */
+
+import type { CraftContext } from "../../context";
+import { rcError } from "../../error";
+import { DefaultExchange, type Exchange } from "../../exchange";
+import type { DirectChannel } from "../../adapters/direct/types";
+import { InMemoryDirectChannel } from "../../adapters/direct/shared";
+import { createSuspended } from "../../suspension/suspended";
+import { OpsClientError, type OpsHttpClient } from "../ops/client";
+
+/** What a channel needs to know about the route it fronts. */
+export interface RemoteTarget {
+  ctx: CraftContext;
+  /** The remote's name in `defineConfig({ remotes })`. */
+  remote: string;
+  /** The route id on the remote. */
+  id: string;
+  /** The local endpoint, for log lines and messages. */
+  endpoint: string;
+  client: OpsHttpClient;
+  /** The remote named for a reader, without the credential. */
+  describe(): string;
+  /**
+   * Called when the remote answers 404 for this route, which means the
+   * inventory is stale: the route is gone, or the dispatch tier closed.
+   * Awaited before the failure is thrown, so the next call sees the truth.
+   */
+  onMissing(): Promise<void>;
+}
+
+/**
+ * A direct channel that dispatches to another instance.
+ *
+ * It also carries the shadow rule. A local route may subscribe onto an
+ * endpoint this channel holds, or may already hold the endpoint when the
+ * remote's inventory arrives; either way `local` is set and the local
+ * route answers every send, with a warning naming the remote route that is
+ * being shadowed, because a shadow is the promotion window and a caller
+ * reading the logs should be able to see which of the two ran.
+ */
+export class RemoteDirectChannel implements DirectChannel<Exchange> {
+  /** The local route's channel when one shadows this endpoint. */
+  local: DirectChannel<Exchange> | undefined;
+
+  constructor(
+    private readonly target: RemoteTarget,
+    local?: DirectChannel<Exchange>,
+  ) {
+    this.local = local;
+  }
+
+  async send(endpoint: string, exchange: Exchange): Promise<Exchange> {
+    if (this.local !== undefined) {
+      const { ctx, remote, id, endpoint: local } = this.target;
+      ctx.logger.warn(
+        { endpoint: local, remote, remoteRouteId: id },
+        `Direct endpoint "${local}" is answered by the local route; the route "${id}" of remote "${remote}" is shadowed and stays reachable as "${remote}:${id}"`,
+      );
+      return this.local.send(endpoint, exchange);
+    }
+    return this.dispatch(exchange);
+  }
+
+  async subscribe(
+    context: CraftContext,
+    endpoint: string,
+    handler: (message: Exchange) => Promise<Exchange>,
+  ): Promise<void> {
+    this.local ??= new InMemoryDirectChannel<Exchange>();
+    await this.local.subscribe(context, endpoint, handler);
+  }
+
+  async unsubscribe(context: CraftContext, endpoint: string): Promise<void> {
+    if (this.local === undefined) return;
+    await this.local.unsubscribe(context, endpoint);
+    // The local route left, so the remote answers again: a capability
+    // demoted from the laptop still exists on the server.
+    this.local = undefined;
+  }
+
+  private async dispatch(exchange: Exchange): Promise<Exchange> {
+    const { ctx, remote, id, client } = this.target;
+    let outcome: Awaited<ReturnType<OpsHttpClient["dispatch"]>>;
+    try {
+      outcome = await client.dispatch(id, exchange.body);
+    } catch (error: unknown) {
+      throw await this.translate(error);
+    }
+    switch (outcome.outcome) {
+      case "completed":
+        return new DefaultExchange(ctx, {
+          body: outcome.body,
+          headers: exchange.headers,
+        });
+      case "suspended": {
+        // Re-branded so the local transports recognise the park the way they
+        // recognise one of their own: the ops door answers 202, an agent
+        // tool reports it, and a route with `.suspend()` downstream is not
+        // fooled by a body that merely looks parked. Resume stays at the
+        // remote's door, under the remote's policy.
+        const { suspensionId, token, schema, expiresAt } = outcome.suspension;
+        return new DefaultExchange(ctx, {
+          body: createSuspended({
+            suspensionId,
+            token,
+            ...(schema !== undefined ? { schema } : {}),
+            ...(expiresAt !== undefined ? { expiresAt } : {}),
+          }),
+          headers: exchange.headers,
+        });
+      }
+      case "dropped":
+        throw rcError("RC5031", undefined, {
+          message: `Route "${id}" on remote "${remote}" dropped the exchange instead of completing it; there is no response body. ${outcome.message}`,
+        });
+    }
+  }
+
+  /**
+   * Map the client's failure onto the codes a caller branches on.
+   *
+   * Every message names the remote and the route and never the bearer:
+   * the client's own messages already hold that line, and this layer only
+   * adds which remote it was.
+   */
+  private async translate(error: unknown): Promise<Error> {
+    const { remote, id } = this.target;
+    const where = `route "${id}" on remote "${remote}" (${this.target.describe()})`;
+    if (!(error instanceof OpsClientError)) {
+      return rcError("RC5062", error, {
+        message: `Dispatching ${where} failed before an answer arrived: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      });
+    }
+    switch (error.kind) {
+      case "unreachable":
+        return rcError("RC5062", error, {
+          message: `Dispatching ${where}: ${error.message}`,
+        });
+      case "refused":
+        return rcError("RC5063", error, {
+          message: `Dispatching ${where}: ${error.message}`,
+        });
+      case "absent":
+        await this.target.onMissing();
+        return rcError("RC5004", error, {
+          message: `Dispatching ${where}: the remote answered 404, so the route is gone from the remote or its dispatch tier is closed. The inventory has been refreshed; a route the remote no longer lists is no longer a direct endpoint here.`,
+        });
+      case "error":
+        // No status means the request never completed: a timeout, where
+        // the work may still be running on the remote. Not retryable, for
+        // the reason the client's own message gives.
+        if (error.status === undefined) {
+          return rcError("RC5062", error, {
+            message: `Dispatching ${where}: ${error.message}`,
+            retryable: false,
+          });
+        }
+        return rcError("RC5064", error, {
+          message: `Dispatching ${where}: ${error.message}`,
+        });
+    }
+  }
+}

--- a/packages/routecraft/src/plugins/remotes/channel.ts
+++ b/packages/routecraft/src/plugins/remotes/channel.ts
@@ -17,6 +17,7 @@ import { DefaultExchange, type Exchange } from "../../exchange";
 import type { DirectChannel } from "../../adapters/direct/types";
 import { InMemoryDirectChannel } from "../../adapters/direct/shared";
 import { createSuspended } from "../../suspension/suspended";
+import { rcCodeOf } from "../../brand";
 import { OpsClientError, type OpsHttpClient } from "../ops/client";
 
 /** What a channel needs to know about the route it fronts. */
@@ -67,7 +68,20 @@ export class RemoteDirectChannel implements DirectChannel<Exchange> {
         { endpoint: local, remote, remoteRouteId: id },
         `Direct endpoint "${local}" is answered by the local route; the route "${id}" of remote "${remote}" is shadowed and stays reachable as "${remote}:${id}"`,
       );
-      return this.local.send(endpoint, exchange);
+      try {
+        return await this.local.send(endpoint, exchange);
+      } catch (error: unknown) {
+        // A local route that stops unsubscribes the channel it captured at
+        // start, not this wrapper, and the in-memory channel answers RC5004
+        // from then on. That is the one signal the wrapper gets that the
+        // shadow has lifted, so the remote takes over from here.
+        if (rcCodeOf(error) !== "RC5004") throw error;
+        this.local = undefined;
+        ctx.logger.info(
+          { endpoint: local, remote, remoteRouteId: id },
+          `The local route on "${local}" has stopped; the route "${id}" of remote "${remote}" answers it from now on`,
+        );
+      }
     }
     return this.dispatch(exchange);
   }
@@ -123,6 +137,14 @@ export class RemoteDirectChannel implements DirectChannel<Exchange> {
       case "dropped":
         throw rcError("RC5031", undefined, {
           message: `Route "${id}" on remote "${remote}" dropped the exchange instead of completing it; there is no response body. ${outcome.message}`,
+        });
+      default:
+        // The client only guarantees an object came back. Anything that is
+        // not one of the three outcomes is an instance this side does not
+        // understand, and it fails as a remote failure rather than as a
+        // TypeError in whoever reads the result.
+        throw rcError("RC5064", undefined, {
+          message: `Dispatching route "${id}" on remote "${remote}" (${this.target.describe()}): the remote answered with an envelope this instance does not recognise (outcome ${JSON.stringify((outcome as { outcome?: unknown }).outcome)}). Check that the address is a routecraft ops server of a compatible version.`,
         });
     }
   }

--- a/packages/routecraft/src/plugins/remotes/channel.ts
+++ b/packages/routecraft/src/plugins/remotes/channel.ts
@@ -17,7 +17,6 @@ import { DefaultExchange, type Exchange } from "../../exchange";
 import type { DirectChannel } from "../../adapters/direct/types";
 import { InMemoryDirectChannel } from "../../adapters/direct/shared";
 import { createSuspended } from "../../suspension/suspended";
-import { rcCodeOf } from "../../brand";
 import { OpsClientError, type OpsHttpClient } from "../ops/client";
 
 /** What a channel needs to know about the route it fronts. */
@@ -62,28 +61,40 @@ export class RemoteDirectChannel implements DirectChannel<Exchange> {
   }
 
   async send(endpoint: string, exchange: Exchange): Promise<Exchange> {
-    if (this.local !== undefined) {
+    if (this.local !== undefined && !this.shadowLifted()) {
       const { ctx, remote, id, endpoint: local } = this.target;
       ctx.logger.warn(
         { endpoint: local, remote, remoteRouteId: id },
         `Direct endpoint "${local}" is answered by the local route; the route "${id}" of remote "${remote}" is shadowed and stays reachable as "${remote}:${id}"`,
       );
-      try {
-        return await this.local.send(endpoint, exchange);
-      } catch (error: unknown) {
-        // A local route that stops unsubscribes the channel it captured at
-        // start, not this wrapper, and the in-memory channel answers RC5004
-        // from then on. That is the one signal the wrapper gets that the
-        // shadow has lifted, so the remote takes over from here.
-        if (rcCodeOf(error) !== "RC5004") throw error;
-        this.local = undefined;
-        ctx.logger.info(
-          { endpoint: local, remote, remoteRouteId: id },
-          `The local route on "${local}" has stopped; the route "${id}" of remote "${remote}" answers it from now on`,
-        );
-      }
+      return this.local.send(endpoint, exchange);
     }
     return this.dispatch(exchange);
+  }
+
+  /**
+   * Whether the shadowing local route has stopped since the wrapper was
+   * installed. A stopping route unsubscribes the channel it captured at
+   * start, not this wrapper, so the wrapper reads that channel's own
+   * subscription state rather than guessing from an error a route may
+   * legitimately throw. Only the in-memory channel exposes it; under a
+   * custom channel type the shadow holds until the inventory drops the
+   * endpoint.
+   */
+  private shadowLifted(): boolean {
+    if (
+      !(this.local instanceof InMemoryDirectChannel) ||
+      this.local.subscribed
+    ) {
+      return false;
+    }
+    const { ctx, remote, id, endpoint: local } = this.target;
+    this.local = undefined;
+    ctx.logger.info(
+      { endpoint: local, remote, remoteRouteId: id },
+      `The local route on "${local}" has stopped; the route "${id}" of remote "${remote}" answers it from now on`,
+    );
+    return true;
   }
 
   async subscribe(

--- a/packages/routecraft/src/plugins/remotes/config.ts
+++ b/packages/routecraft/src/plugins/remotes/config.ts
@@ -1,0 +1,19 @@
+import { registerConfigApplier } from "../../config-applier";
+import { remotesPlugin } from "./plugin";
+import type { RemotesConfig } from "./types";
+
+declare module "@routecraft/routecraft" {
+  interface CraftConfig {
+    /** Other running instances whose dispatchable routes become direct endpoints here. */
+    remotes?: RemotesConfig;
+  }
+}
+
+/**
+ * Register the `remotes` config key so `defineConfig({ remotes: {...} })`
+ * is equivalent to `defineConfig({ plugins: [remotesPlugin({...})] })`.
+ * Loaded as a side-effect import from `packages/routecraft/src/index.ts`,
+ * after the `ops` key, so an imported route's indicator has a ledger to
+ * report into when the app carries an ops surface.
+ */
+registerConfigApplier("remotes", (options) => remotesPlugin(options));

--- a/packages/routecraft/src/plugins/remotes/plugin.ts
+++ b/packages/routecraft/src/plugins/remotes/plugin.ts
@@ -1,0 +1,484 @@
+/**
+ * Remotes plugin: the dispatchable routes of other instances become direct
+ * endpoints here.
+ *
+ * The consumer is a deployment where one constrained instance hosts
+ * approved capabilities behind its own door and every engineer runs a
+ * local instance with their own agents. The local instance names the
+ * server under `remotes`, reads its route inventory through the ops
+ * management API, and registers each route in the direct store and the
+ * capability registry under a local endpoint. From then on nothing else
+ * in the framework knows the route is elsewhere: `direct()`, `forward()`,
+ * `directTool()`, `Direct(...)` in an agent's tool list, the tool policy
+ * and the local ops listing all see a capability.
+ *
+ * The server keeps its service credentials and its `.authorize()`; this
+ * side holds only a bearer for the server's door, and the local caller's
+ * principal is never forwarded. What the server's validator mints from the
+ * bearer is the identity every imported route runs under.
+ */
+
+import type { CraftContext, CraftPlugin } from "../../context";
+import { rcError } from "../../error";
+import {
+  CAPABILITY_REGISTRY,
+  isInternalEndpoint,
+  registerCapability,
+  type Capability,
+} from "../../capabilities";
+import {
+  ADAPTER_DIRECT_STORE,
+  sanitizeEndpoint,
+} from "../../adapters/direct/shared";
+import type { DirectChannel } from "../../adapters/direct/types";
+import type { Exchange } from "../../exchange";
+import { parseDuration } from "../../shared/duration.ts";
+import {
+  createOpsHttpClient,
+  isLoopbackHostname,
+  type OpsHttpClient,
+} from "../ops/client";
+import { contributeOpsIndicator } from "../ops/store";
+import type { Health, OpsRouteDetail } from "../ops/types";
+import { RemoteDirectChannel, type RemoteTarget } from "./channel";
+import { standardSchemaFromJsonSchema } from "./schema";
+import { REMOTE_ROUTES, type RemoteRoute } from "./store";
+import type { RemoteDefinition, RemotesPluginOptions } from "./types";
+
+/** The remote whose routes are advertised bare. */
+const DEFAULT_REMOTE = "default";
+
+const DEFAULT_REFRESH = "60s";
+const DEFAULT_TIMEOUT = "30s";
+
+/**
+ * A remote's name is one segment of a tool wire name (`remote__lab__hello`)
+ * and one half of a qualified endpoint (`lab:hello`), so it carries the
+ * charset a model provider accepts and never the `__` separator that
+ * would make the wire name ambiguous to split.
+ */
+const REMOTE_NAME = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+/** One remote's live state on one context. */
+interface RemoteRuntime {
+  name: string;
+  definition: RemoteDefinition;
+  client: OpsHttpClient;
+  report: (health: Health) => void;
+  refreshMs: number | undefined;
+  /** The channels this remote installed, by local endpoint. */
+  channels: Map<string, RemoteDirectChannel>;
+  timer?: ReturnType<typeof setInterval>;
+  inflight?: Promise<void>;
+  /** Whether the last refresh failed, so a repeat is logged quietly. */
+  down: boolean;
+  /** Whether an inventory has ever landed, so the first one is logged at info. */
+  seen: boolean;
+}
+
+/** Per-context state. One plugin instance may serve several contexts. */
+interface Runtime {
+  remotes: RemoteRuntime[];
+}
+
+/** The health indicator an imported remote reports through. */
+function indicatorName(remote: string): string {
+  return `remote.${remote}`;
+}
+
+/** The local endpoint a remote route answers on when qualified. */
+function qualified(remote: string, id: string): string {
+  return `${remote}:${id}`;
+}
+
+/**
+ * Validate the config key once, at construction, so a typo fails
+ * `defineConfig` rather than the first refresh.
+ */
+function validate(options: RemotesPluginOptions): void {
+  if (
+    typeof options !== "object" ||
+    options === null ||
+    Array.isArray(options)
+  ) {
+    throw rcError("RC5003", undefined, {
+      message: `remotes must be an object of remotes by name, e.g. { default: { url } }.`,
+    });
+  }
+  for (const [name, definition] of Object.entries(options)) {
+    if (!REMOTE_NAME.test(name) || name.includes("__") || name.endsWith("_")) {
+      throw rcError("RC5003", undefined, {
+        message: `remotes.${name}: a remote name must match ${REMOTE_NAME.source}, must not contain "__" and must not end in "_". It becomes one segment of the tool name a model sees (remote__${name}__<route>) and the prefix of every qualified endpoint (${name}:<route>).`,
+      });
+    }
+    if (typeof definition !== "object" || definition === null) {
+      throw rcError("RC5003", undefined, {
+        message: `remotes.${name} must be an object with at least a url.`,
+      });
+    }
+    let url: URL;
+    try {
+      url = new URL(definition.url);
+    } catch {
+      throw rcError("RC5003", undefined, {
+        message: `remotes.${name}.url must be an absolute URL; got ${JSON.stringify(definition.url)}.`,
+      });
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw rcError("RC5003", undefined, {
+        message: `remotes.${name}.url must be an http or https URL; got ${url.protocol}.`,
+      });
+    }
+    const token = definition.auth?.token;
+    if (
+      token !== undefined &&
+      typeof token !== "function" &&
+      (typeof token !== "string" || token.length === 0)
+    ) {
+      throw rcError("RC5003", undefined, {
+        message: `remotes.${name}.auth.token must be a non-empty string or a function returning one.`,
+      });
+    }
+    // The same rule the CLI enforces, for the same reason: a bearer over
+    // plain http is readable by every hop, and loopback is the one address
+    // where there are none.
+    if (
+      token !== undefined &&
+      url.protocol === "http:" &&
+      !isLoopbackHostname(url.hostname)
+    ) {
+      throw rcError("RC5003", undefined, {
+        message: `remotes.${name}.url is ${definition.url}, which is plain http, and auth.token would travel over it as clear text. Use an https URL, or a loopback address (localhost, 127.0.0.1, ::1) for an instance on this machine.`,
+      });
+    }
+    if (definition.timeout !== undefined) {
+      parseDuration(definition.timeout, `remotes.${name}.timeout`);
+    }
+    if (definition.refresh !== undefined && definition.refresh !== false) {
+      parseDuration(definition.refresh, `remotes.${name}.refresh`);
+    }
+  }
+}
+
+/**
+ * Another instance's dispatchable routes as direct endpoints here.
+ *
+ * Materialised by the config applier, so apps normally write
+ * `defineConfig({ remotes: { default: { url, auth } } })` rather than
+ * pushing it onto `config.plugins`.
+ *
+ * `apply` validates, builds a client per remote and contributes an
+ * indicator per remote to the health report. `start` reads every
+ * inventory once, awaited, so a route the remote exposes is a local
+ * endpoint by the time the context reports ready, and a remote that is
+ * unreachable registers nothing, logs, and reports its indicator down;
+ * its routes appear on the refresh that first reaches it. `teardown`
+ * clears the timers and removes every endpoint this plugin installed.
+ */
+export function remotesPlugin(options: RemotesPluginOptions): CraftPlugin {
+  validate(options);
+  const runtimes = new WeakMap<CraftContext, Runtime>();
+
+  return {
+    name: "remotes",
+
+    apply(ctx: CraftContext) {
+      const remotes: RemoteRuntime[] = Object.entries(options).map(
+        ([name, definition]) => {
+          const client = createOpsHttpClient({
+            url: definition.url,
+            ...(definition.auth?.token !== undefined
+              ? { token: definition.auth.token }
+              : {}),
+            timeout: definition.timeout ?? DEFAULT_TIMEOUT,
+            describeAddress: () => `remote "${name}" at ${definition.url}`,
+            advice: {
+              missingCredential: `Set remotes.${name}.auth.token to a credential the remote's door accepts.`,
+              unreachable: `Check remotes.${name}.url and that the instance is running.`,
+            },
+          });
+          const refreshMs =
+            definition.refresh === false
+              ? undefined
+              : parseDuration(
+                  definition.refresh ?? DEFAULT_REFRESH,
+                  `remotes.${name}.refresh`,
+                );
+          // Deployment domain: every replica reaches the remote with the same
+          // credential over the same network, so one failing means all do,
+          // and moving traffic between replicas would not help.
+          const report = contributeOpsIndicator(ctx, {
+            name: indicatorName(name),
+            domain: "deployment",
+          });
+          return {
+            name,
+            definition,
+            client,
+            report,
+            refreshMs,
+            channels: new Map(),
+            down: false,
+            seen: false,
+          };
+        },
+      );
+      runtimes.set(ctx, { remotes });
+      if (!ctx.getStore(REMOTE_ROUTES)) {
+        ctx.setStore(REMOTE_ROUTES, new Map<string, RemoteRoute>());
+      }
+    },
+
+    async start(ctx: CraftContext) {
+      const runtime = runtimes.get(ctx);
+      if (!runtime) return;
+      await Promise.all(runtime.remotes.map((remote) => refresh(ctx, remote)));
+      for (const remote of runtime.remotes) {
+        if (remote.refreshMs === undefined) continue;
+        const timer = setInterval(() => {
+          void refresh(ctx, remote);
+        }, remote.refreshMs);
+        timer.unref?.();
+        remote.timer = timer;
+      }
+    },
+
+    async teardown(ctx: CraftContext) {
+      const runtime = runtimes.get(ctx);
+      if (!runtime) return;
+      runtimes.delete(ctx);
+      for (const remote of runtime.remotes) {
+        if (remote.timer !== undefined) clearInterval(remote.timer);
+        delete remote.timer;
+        // A refresh in flight would otherwise re-install what is removed
+        // below on a context that is going away.
+        await remote.inflight?.catch(() => undefined);
+        for (const endpoint of [...remote.channels.keys()]) {
+          release(ctx, remote, endpoint);
+        }
+      }
+    },
+  };
+}
+
+/**
+ * Re-read one remote's inventory and reconcile the local endpoints.
+ *
+ * Serialised per remote: the interval can fire while a forced refresh is
+ * still running, and two reconciliations interleaving would install and
+ * release the same endpoints against each other. A caller that finds one
+ * in flight joins it, which is also the right answer for a dispatch that
+ * met a 404 while the interval was already asking.
+ */
+function refresh(ctx: CraftContext, remote: RemoteRuntime): Promise<void> {
+  if (remote.inflight !== undefined) return remote.inflight;
+  remote.inflight = reconcile(ctx, remote).finally(() => {
+    delete remote.inflight;
+  });
+  return remote.inflight;
+}
+
+async function reconcile(
+  ctx: CraftContext,
+  remote: RemoteRuntime,
+): Promise<void> {
+  const { name, client } = remote;
+  let details: OpsRouteDetail[];
+  try {
+    const summaries = await client.listRoutes({ dispatchable: true });
+    details = await Promise.all(
+      summaries.map((summary) => client.describeRoute(summary.id)),
+    );
+  } catch (error: unknown) {
+    // The last inventory stays: a remote that blinks must not take every
+    // imported endpoint with it, and a dispatch against a route that is
+    // truly gone finds out at the door and forces the next refresh.
+    const log = remote.down ? ctx.logger.debug : ctx.logger.warn;
+    log.call(
+      ctx.logger,
+      { remote: name, url: remote.definition.url, err: error },
+      `Remote "${name}" inventory could not be read; keeping the last inventory (${String(remote.channels.size)} routes)`,
+    );
+    remote.down = true;
+    remote.report({
+      status: "down",
+      details: { routes: remote.channels.size },
+    });
+    return;
+  }
+
+  const wanted = new Map<string, OpsRouteDetail>();
+  for (const detail of details) {
+    wanted.set(qualified(name, detail.id), detail);
+    if (name === DEFAULT_REMOTE) wanted.set(detail.id, detail);
+  }
+  for (const endpoint of [...remote.channels.keys()]) {
+    if (!wanted.has(endpoint)) release(ctx, remote, endpoint);
+  }
+  for (const [endpoint, detail] of wanted) {
+    install(ctx, remote, endpoint, detail);
+  }
+
+  const log = remote.seen ? ctx.logger.debug : ctx.logger.info;
+  log.call(
+    ctx.logger,
+    { remote: name, url: remote.definition.url, routes: details.length },
+    `Remote "${name}" inventory read: ${String(details.length)} dispatchable routes`,
+  );
+  remote.seen = true;
+  remote.down = false;
+  remote.report({ status: "up", details: { routes: details.length } });
+}
+
+/**
+ * Register one remote route under one local endpoint, or find out why not.
+ *
+ * Local wins. A capability the registry holds without a `remote` is a
+ * local route, and an endpoint declared internal is one too; either
+ * shadows the remote route. The remote's channel is still installed
+ * around the local one so every call through the shadow says so, and the
+ * route stays reachable under its qualified name, which this function is
+ * also called for.
+ */
+function install(
+  ctx: CraftContext,
+  remote: RemoteRuntime,
+  endpoint: string,
+  detail: OpsRouteDetail,
+): void {
+  const { name } = remote;
+  const registry = ctx.getStore(CAPABILITY_REGISTRY);
+  const existing = registry?.get(endpoint);
+  const routes = ctx.getStore(REMOTE_ROUTES)!;
+
+  if (
+    isInternalEndpoint(ctx, endpoint) ||
+    (existing !== undefined && existing.remote === undefined)
+  ) {
+    ctx.logger.warn(
+      { endpoint, remote: name, remoteRouteId: detail.id },
+      endpoint === qualified(name, detail.id)
+        ? `Local route "${endpoint}" shadows route "${detail.id}" of remote "${name}", which is unreachable until the local route is renamed`
+        : `Local route "${endpoint}" shadows route "${detail.id}" of remote "${name}"; the local route answers direct("${endpoint}") and the remote route stays reachable as "${qualified(name, detail.id)}"`,
+    );
+    routes.delete(endpoint);
+    if (!remote.channels.has(endpoint)) {
+      const store = directStore(ctx);
+      const key = sanitizeEndpoint(endpoint);
+      const local = store.get(key);
+      // No channel means an internal route that never subscribed, or a
+      // route whose channel comes later; there is nothing to warn through.
+      if (local === undefined) return;
+      const channel = new RemoteDirectChannel(
+        target(ctx, remote, endpoint, detail.id),
+        local,
+      );
+      store.set(key, channel);
+      remote.channels.set(endpoint, channel);
+    }
+    return;
+  }
+
+  if (existing !== undefined && existing.remote !== name) {
+    ctx.logger.error(
+      {
+        endpoint,
+        remote: name,
+        remoteRouteId: detail.id,
+        heldBy: existing.remote,
+      },
+      `Route "${detail.id}" of remote "${name}" would be advertised as "${endpoint}", which remote "${existing.remote}" already holds; skipping it. Rename the route on one of the remotes`,
+    );
+    return;
+  }
+
+  const capability: Capability = { endpoint, remote: name };
+  if (detail.title !== undefined) capability.title = detail.title;
+  if (detail.description !== undefined) {
+    capability.description = detail.description;
+  }
+  if (detail.tags !== undefined && detail.tags.length > 0) {
+    capability.tags = [...detail.tags];
+  }
+  if (detail.input?.body !== undefined) {
+    capability.input = {
+      body: standardSchemaFromJsonSchema(detail.input.body),
+    };
+  }
+  if (detail.output?.body !== undefined) {
+    capability.output = {
+      body: standardSchemaFromJsonSchema(detail.output.body),
+    };
+  }
+  registerCapability(ctx, capability);
+  routes.set(endpoint, { remote: name, id: detail.id, endpoint, detail });
+
+  if (!remote.channels.has(endpoint)) {
+    const store = directStore(ctx);
+    // Whatever the store holds here is a placeholder an enricher created
+    // on demand before this inventory landed (a subscribed local route
+    // would have registered a capability and returned above), so replacing
+    // it is what makes that enricher's next fetch reach the remote.
+    const channel = new RemoteDirectChannel(
+      target(ctx, remote, endpoint, detail.id),
+    );
+    store.set(sanitizeEndpoint(endpoint), channel);
+    remote.channels.set(endpoint, channel);
+  }
+}
+
+/** Remove one endpoint this remote installed, restoring a shadowed local channel. */
+function release(
+  ctx: CraftContext,
+  remote: RemoteRuntime,
+  endpoint: string,
+): void {
+  const channel = remote.channels.get(endpoint);
+  remote.channels.delete(endpoint);
+  const registry = ctx.getStore(CAPABILITY_REGISTRY);
+  if (registry?.get(endpoint)?.remote === remote.name) {
+    registry.delete(endpoint);
+  }
+  const routes = ctx.getStore(REMOTE_ROUTES);
+  if (routes?.get(endpoint)?.remote === remote.name) routes.delete(endpoint);
+  const store = ctx.getStore(ADAPTER_DIRECT_STORE);
+  const key = sanitizeEndpoint(endpoint);
+  if (
+    store === undefined ||
+    channel === undefined ||
+    store.get(key) !== channel
+  ) {
+    return;
+  }
+  if (channel.local !== undefined) {
+    store.set(key, channel.local);
+  } else {
+    store.delete(key);
+  }
+}
+
+function directStore(ctx: CraftContext): Map<string, DirectChannel<Exchange>> {
+  let store = ctx.getStore(ADAPTER_DIRECT_STORE);
+  if (!store) {
+    store = new Map<string, DirectChannel<Exchange>>();
+    ctx.setStore(ADAPTER_DIRECT_STORE, store);
+  }
+  return store;
+}
+
+function target(
+  ctx: CraftContext,
+  remote: RemoteRuntime,
+  endpoint: string,
+  id: string,
+): RemoteTarget {
+  return {
+    ctx,
+    remote: remote.name,
+    id,
+    endpoint,
+    client: remote.client,
+    describe: () => remote.definition.url,
+    onMissing: () => refresh(ctx, remote),
+  };
+}

--- a/packages/routecraft/src/plugins/remotes/schema.ts
+++ b/packages/routecraft/src/plugins/remotes/schema.ts
@@ -1,0 +1,33 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
+/**
+ * Wrap a JSON Schema the remote rendered as a Standard Schema.
+ *
+ * The result is the discovery bundle a local route would have declared,
+ * so nothing downstream learns that the schema came from a remote: the
+ * ops listing renders it back through the same `~standard.jsonSchema`
+ * arms it reads for a Zod schema, and the agent tool bridge hands it to
+ * the model provider the way it hands an MCP tool's.
+ *
+ * Validation is a pass-through on purpose. The remote validates at its
+ * own door against the live schema, and a second validation here against
+ * a rendering would add latency and, the day the two disagree, refuse
+ * what the remote accepts.
+ */
+export function standardSchemaFromJsonSchema(
+  schema: unknown,
+): StandardSchemaV1<unknown, unknown> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "routecraft",
+      validate(value) {
+        return { value };
+      },
+      jsonSchema: {
+        input: () => schema,
+        output: () => schema,
+      },
+    } as StandardSchemaV1<unknown, unknown>["~standard"],
+  };
+}

--- a/packages/routecraft/src/plugins/remotes/store.ts
+++ b/packages/routecraft/src/plugins/remotes/store.ts
@@ -1,0 +1,41 @@
+import type { OpsRouteDetail } from "../ops/types";
+
+/**
+ * One imported route, as the ops listing presents it.
+ *
+ * The capability registry carries what the agent surface needs (a schema
+ * per arm, a description, tags); this record carries the rest of what the
+ * remote said about the route, so the local listing can describe an
+ * imported route exactly as the remote's own listing would, with the
+ * JSON Schema renderings passed through rather than re-rendered.
+ */
+export interface RemoteRoute {
+  /** The remote's name in `defineConfig({ remotes })`. */
+  remote: string;
+  /** The route id on the remote. */
+  id: string;
+  /** The local endpoint the route answers on (`id` for the default remote, else `remote:id`). */
+  endpoint: string;
+  /** The remote's own description of the route. */
+  detail: OpsRouteDetail;
+}
+
+/**
+ * Symbol key the remotes plugin publishes imported routes under, keyed by
+ * local endpoint. Read by the ops management API so an imported route is
+ * listed, described and dispatched through the local door like any other.
+ *
+ * `Symbol.for` so the key is shared across duplicate package copies in a
+ * workspace, matching every other plugin's convention.
+ *
+ * @internal
+ */
+export const REMOTE_ROUTES: unique symbol = Symbol.for(
+  "routecraft.plugin.remotes.routes",
+);
+
+declare module "@routecraft/routecraft" {
+  interface StoreRegistry {
+    [REMOTE_ROUTES]: Map<string, RemoteRoute>;
+  }
+}

--- a/packages/routecraft/src/plugins/remotes/types.ts
+++ b/packages/routecraft/src/plugins/remotes/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Public types for the remotes plugin.
+ *
+ * A remote is another running instance whose dispatchable routes become
+ * direct endpoints here. The options are deliberately small: an address,
+ * a credential for that instance's door, and two cadences. Everything
+ * about what the remote exposes is the remote's own configuration, read
+ * through its ops management API, and nothing here restates it.
+ */
+
+import type { Duration } from "../../shared/duration.ts";
+import type { OpsBearerToken } from "../ops/client.ts";
+
+/** One remote instance, keyed by name in `defineConfig({ remotes })`. */
+export interface RemoteDefinition {
+  /**
+   * The instance's base URL, the origin its ops surface is mounted on.
+   * A bearer travels over plain `http:` only to a loopback address, for
+   * the same reason the CLI refuses it: every hop in between can read it.
+   */
+  url: string;
+  /**
+   * Credential for the remote's door. Read from the environment, as a
+   * string or as a function evaluated per request so a rotated token is
+   * picked up without a restart. The identity the remote sees is whatever
+   * its own validator mints from it; this plugin makes no call on api keys
+   * versus JWTs.
+   */
+  auth?: {
+    token?: OpsBearerToken;
+  };
+  /** Per-request deadline against the remote. Defaults to `"30s"`. */
+  timeout?: Duration;
+  /**
+   * How often the inventory is re-read. Defaults to `"60s"`; `false`
+   * disables the interval, leaving the boot read and the refresh a
+   * dispatch forces when it meets a 404 for a route the inventory still
+   * lists.
+   */
+  refresh?: Duration | false;
+}
+
+/**
+ * The `remotes` config key: remotes by name.
+ *
+ * Git-style naming. The routes of `default` are advertised bare, exactly
+ * as a local route would be, so `direct('hello')` and `Direct(hello)` reach
+ * them with nothing to learn; every other remote's routes are qualified
+ * `name:id`, and `default:id` names the default remote explicitly. Two
+ * remotes therefore never collide, and a local route with the same id as
+ * a default-remote route shadows it: the local one answers, the remote
+ * stays reachable as `default:id`, and the overlap is logged as a warning
+ * rather than refused, because it is the window in which a capability is
+ * being promoted from a laptop to the server.
+ */
+export type RemotesConfig = Record<string, RemoteDefinition>;
+
+/** Options for {@link remotesPlugin}; the same shape as the config key. */
+export type RemotesPluginOptions = RemotesConfig;

--- a/packages/routecraft/test/remotes.bun.test.ts
+++ b/packages/routecraft/test/remotes.bun.test.ts
@@ -37,16 +37,20 @@ const JWT_ISSUER = "https://idp.test";
 const JWT_AUDIENCE = "https://api.test";
 const SUSPENSION_SECRET = "remotes-suspension-secret-0123456789";
 
-/** A credential admitted to both tiers. */
-const OPERATOR = signHs256({
-  secret: JWT_SECRET,
-  claims: { scope: "ops:introspection ops:dispatch" },
-});
+/**
+ * A credential admitted to both tiers, minted per request: the helper's
+ * tokens live for a minute, and a suite must not depend on finishing in one.
+ */
+const operator = (): string =>
+  signHs256({
+    secret: JWT_SECRET,
+    claims: { scope: "ops:introspection ops:dispatch" },
+  });
 /** A credential admitted to the listing and refused at dispatch. */
-const READER = signHs256({
-  secret: JWT_SECRET,
-  claims: { scope: "ops:introspection" },
-});
+const reader = (): string =>
+  signHs256({ secret: JWT_SECRET, claims: { scope: "ops:introspection" } });
+/** The base64url head every HS256 JWT starts with, which no log line may carry. */
+const JWT_HEAD = "eyJhbGciOi";
 /** Not a credential at all; distinctive so a log line carrying it is findable. */
 const FORGED = "forged-bearer-0f3a9c1e-never-log-me";
 
@@ -296,8 +300,8 @@ describe("remotes", () => {
     const url = `http://127.0.0.1:${String(server.port)}`;
     local = await startLocal({
       remotes: {
-        default: { url, auth: { token: OPERATOR } },
-        lab: { url, auth: { token: () => OPERATOR } },
+        default: { url, auth: { token: operator } },
+        lab: { url, auth: { token: operator } },
       },
       routes: [
         craft()
@@ -340,8 +344,8 @@ describe("remotes", () => {
     const url = `http://127.0.0.1:${String(server.port)}`;
     local = await startLocal({
       remotes: {
-        default: { url, auth: { token: OPERATOR } },
-        lab: { url, auth: { token: OPERATOR } },
+        default: { url, auth: { token: operator } },
+        lab: { url, auth: { token: operator } },
       },
     });
 
@@ -395,7 +399,7 @@ describe("remotes", () => {
     const url = `http://127.0.0.1:${String(server.port)}`;
     let warnings: string[] = [];
     local = await startLocal({
-      remotes: { default: { url, auth: { token: OPERATOR } } },
+      remotes: { default: { url, auth: { token: operator } } },
       routes: [
         craft()
           .id("hello")
@@ -455,8 +459,8 @@ describe("remotes", () => {
     const url = `http://127.0.0.1:${String(server.port)}`;
     local = await startLocal({
       remotes: {
-        lab: { url, auth: { token: OPERATOR } },
-        reader: { url, auth: { token: READER } },
+        lab: { url, auth: { token: operator } },
+        reader: { url, auth: { token: reader } },
       },
     });
 
@@ -500,7 +504,7 @@ describe("remotes", () => {
           auth: {
             token: () => {
               reads += 1;
-              return OPERATOR;
+              return operator();
             },
           },
         },
@@ -527,7 +531,7 @@ describe("remotes", () => {
       ),
     ).toBe(true);
     expect(logs!.everything.some((line) => line.includes(FORGED))).toBe(false);
-    expect(logs!.everything.some((line) => line.includes(OPERATOR))).toBe(
+    expect(logs!.everything.some((line) => line.includes(JWT_HEAD))).toBe(
       false,
     );
   });
@@ -598,7 +602,7 @@ describe("remotes", () => {
       remotes: {
         lab: {
           url: `http://127.0.0.1:${String(port)}`,
-          auth: { token: OPERATOR },
+          auth: { token: operator },
           refresh: "100ms",
         },
       },

--- a/packages/routecraft/test/remotes.bun.test.ts
+++ b/packages/routecraft/test/remotes.bun.test.ts
@@ -1,0 +1,649 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { z } from "zod";
+import { signHs256, testContext, type TestContext } from "@routecraft/testing";
+import {
+  MemorySuspensionStore,
+  OpsClientError,
+  craft,
+  direct,
+  isSuspended,
+  jwt,
+  noop,
+  opsPlugin,
+  remotesPlugin,
+  type HealthReport,
+  type OpsPage,
+  type OpsRouteDetail,
+  type OpsRouteSummary,
+  type RemotesConfig,
+} from "../src/index.ts";
+import { rcCodeOf } from "../src/brand.ts";
+
+/**
+ * The remotes plugin against a real second instance in the same process.
+ *
+ * The second instance carries the ops management API behind a JWT wall
+ * with scope-gated tiers, exactly as the constrained server this feature
+ * exists for would. The first names it twice, as `default` and as `lab`,
+ * and every case below drives the imported endpoints through the code
+ * paths a local route would use: `CraftClient.sendDirect`, a `direct()`
+ * enricher, and the first instance's own ops door.
+ */
+
+const JWT_SECRET = "remotes-jwt-secret-please-change-me";
+const JWT_ISSUER = "https://idp.test";
+const JWT_AUDIENCE = "https://api.test";
+const SUSPENSION_SECRET = "remotes-suspension-secret-0123456789";
+
+/** A credential admitted to both tiers. */
+const OPERATOR = signHs256({
+  secret: JWT_SECRET,
+  claims: { scope: "ops:introspection ops:dispatch" },
+});
+/** A credential admitted to the listing and refused at dispatch. */
+const READER = signHs256({
+  secret: JWT_SECRET,
+  claims: { scope: "ops:introspection" },
+});
+/** Not a credential at all; distinctive so a log line carrying it is findable. */
+const FORGED = "forged-bearer-0f3a9c1e-never-log-me";
+
+/** Whatever the test harness accepts as a route list. */
+type Routes = Parameters<ReturnType<typeof testContext>["routes"]>[0];
+
+interface Instance {
+  t: TestContext;
+  port: number;
+}
+
+/** The four route shapes an outcome mapping has to cover. */
+function serverRoutes(): Routes {
+  return [
+    craft()
+      .id("hello")
+      .description("Say hello")
+      .input({ body: z.object({ name: z.string() }) })
+      .output({ body: z.object({ greeting: z.string() }) })
+      .from(direct())
+      .transform((body) => ({ greeting: `hello ${body.name}` }))
+      .to(noop()),
+    craft()
+      .id("boom")
+      .description("Always fails")
+      .input({ body: z.object({}) })
+      .from(direct())
+      .process(() => {
+        throw new Error("kaboom");
+      })
+      .to(noop()),
+    craft()
+      .id("picky")
+      .description("Drops everything")
+      .input({ body: z.object({}) })
+      .from(direct())
+      .filter(() => false)
+      .to(noop()),
+    craft()
+      .id("payout")
+      .description("Parks until approved")
+      .input({ body: z.object({}) })
+      .from(direct())
+      .suspend({ schema: z.object({ approved: z.boolean() }) })
+      .to(noop()),
+  ];
+}
+
+/**
+ * The instance whose routes are imported: an ops surface behind a JWT
+ * wall, both tiers scope-gated. Port 0 asks the OS for a free one unless
+ * the test needs a port it reserved earlier.
+ */
+async function startServer(options: { port?: number } = {}): Promise<Instance> {
+  const t = await testContext()
+    .with({
+      servers: { default: { port: options.port ?? 0, host: "127.0.0.1" } },
+      suspension: {
+        store: new MemorySuspensionStore(),
+        secret: SUSPENSION_SECRET,
+      },
+      plugins: [
+        opsPlugin({
+          auth: jwt({
+            secret: JWT_SECRET,
+            issuer: JWT_ISSUER,
+            audience: JWT_AUDIENCE,
+          }),
+          tiers: {
+            introspection: "ops:introspection",
+            dispatch: "ops:dispatch",
+          },
+        }),
+      ],
+    })
+    .routes(serverRoutes())
+    .build();
+  return { t, port: await listen(t) };
+}
+
+/**
+ * The instance that imports. Carries an open ops door of its own so the
+ * re-exposure of imported routes can be read and dispatched through it.
+ */
+async function startLocal(options: {
+  remotes: RemotesConfig;
+  routes?: Routes;
+  onBuilt?: (t: TestContext) => void;
+}): Promise<Instance> {
+  const t = await testContext()
+    .with({
+      servers: { default: { port: 0, host: "127.0.0.1" } },
+      ops: { tiers: { introspection: true, dispatch: true } },
+      remotes: options.remotes,
+    })
+    .routes(options.routes ?? [])
+    .build();
+  options.onBuilt?.(t);
+  return { t, port: await listen(t) };
+}
+
+async function listen(t: TestContext): Promise<number> {
+  let port: number | undefined;
+  t.ctx.on("server:listening", ({ details }) => {
+    port = details.port;
+  });
+  await t.startAndWaitReady();
+  if (port === undefined) throw new Error("no server reported a port");
+  return port;
+}
+
+/** A port nothing listens on right now, for an instance that comes up later. */
+async function reservePort(): Promise<number> {
+  const probe = createServer();
+  await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+  const { port } = probe.address() as AddressInfo;
+  await new Promise<void>((resolve, reject) => {
+    probe.close((error) => (error ? reject(error) : resolve()));
+  });
+  return port;
+}
+
+/** A stand-in ops server, for the one case a real instance cannot stage. */
+async function serveFake(
+  handle: (pathname: string) => { status: number; body?: unknown },
+): Promise<{ port: number; close(): Promise<void> }> {
+  const fake = createServer((req, res) => {
+    const { pathname } = new URL(req.url ?? "/", "http://127.0.0.1");
+    const answer = handle(pathname);
+    if (answer.body === undefined) {
+      res.writeHead(answer.status);
+      res.end();
+      return;
+    }
+    res.writeHead(answer.status, { "content-type": "application/json" });
+    res.end(JSON.stringify(answer.body));
+  });
+  await new Promise<void>((resolve) => fake.listen(0, "127.0.0.1", resolve));
+  return {
+    port: (fake.address() as AddressInfo).port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        fake.closeAllConnections();
+        fake.close(() => resolve());
+      }),
+  };
+}
+
+interface Fetched<T> {
+  status: number;
+  body: T;
+}
+
+async function call<T>(
+  port: number,
+  path: string,
+  init: { method?: string; body?: unknown } = {},
+): Promise<Fetched<T>> {
+  const res = await fetch(`http://127.0.0.1:${String(port)}${path}`, {
+    method: init.method ?? "GET",
+    ...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
+  });
+  const text = await res.text();
+  return {
+    status: res.status,
+    body: (text.length === 0 ? undefined : JSON.parse(text)) as T,
+  };
+}
+
+/** Capture every line the context logs, at every level, rendered to text. */
+function captureLogs(ctx: TestContext["ctx"]): {
+  warnings: string[];
+  everything: string[];
+} {
+  const warnings: string[] = [];
+  const everything: string[] = [];
+  for (const level of ["debug", "info", "warn", "error"] as const) {
+    const original = ctx.logger[level].bind(ctx.logger);
+    ctx.logger[level] = ((first: unknown, second?: unknown) => {
+      const rendered = [renderLogArgument(first), renderLogArgument(second)]
+        .filter((part) => part !== undefined)
+        .join(" ");
+      everything.push(rendered);
+      if (level === "warn") warnings.push(rendered);
+      return original(first as never, second as never);
+    }) as (typeof ctx.logger)[typeof level];
+  }
+  return { warnings, everything };
+}
+
+function renderLogArgument(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  return JSON.stringify(value, (_key, entry: unknown) =>
+    entry instanceof Error
+      ? { message: entry.message, cause: entry.cause }
+      : entry,
+  );
+}
+
+async function rejection(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error: unknown) {
+    return error as Error;
+  }
+  throw new Error("expected a rejection");
+}
+
+async function until(
+  predicate: () => boolean,
+  what: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+describe("remotes", () => {
+  let server: Instance | undefined;
+  let local: Instance | undefined;
+
+  // Typed loosely on purpose: the endpoints under test are the imported
+  // ones, which no local registry declares.
+  const send = (endpoint: string, body: unknown): Promise<unknown> =>
+    local!.t.client.sendDirect(endpoint, body);
+
+  afterEach(async () => {
+    // The importer stops first so its teardown releases the endpoints while
+    // the remote is still there to have been imported from.
+    if (local) await local.t.stop();
+    if (server) await server.t.stop();
+    local = undefined;
+    server = undefined;
+  });
+
+  /**
+   * @case The remote's dispatchable routes become direct endpoints, bare for `default` and qualified for every other remote
+   * @preconditions A second instance with a scope-gated ops surface; the first names it as `default` and as `lab`, and carries a local route that enriches from `lab:hello`
+   * @expectedResult `hello`, `default:hello` and `lab:hello` are capabilities carrying their remote's name; `sendDirect` on each and the enricher on the local route return the second instance's result. Git-style naming is what lets `direct('hello')` reach the server with nothing to learn while two remotes never collide
+   */
+  test("imports routes as direct endpoints under git-style names", async () => {
+    server = await startServer();
+    const url = `http://127.0.0.1:${String(server.port)}`;
+    local = await startLocal({
+      remotes: {
+        default: { url, auth: { token: OPERATOR } },
+        lab: { url, auth: { token: () => OPERATOR } },
+      },
+      routes: [
+        craft()
+          .id("caller")
+          .from(direct())
+          .enrich(direct("lab:hello"))
+          .to(noop()),
+      ],
+    });
+
+    const capabilities = local.t.ctx.capabilities();
+    const byEndpoint = new Map(capabilities.map((c) => [c.endpoint, c]));
+    expect(byEndpoint.get("hello")?.remote).toBe("default");
+    expect(byEndpoint.get("default:hello")?.remote).toBe("default");
+    expect(byEndpoint.get("lab:hello")?.remote).toBe("lab");
+    expect(byEndpoint.get("lab:hello")?.description).toBe("Say hello");
+    expect(byEndpoint.get("caller")?.remote).toBeUndefined();
+
+    expect(await send("hello", { name: "bare" })).toEqual({
+      greeting: "hello bare",
+    });
+    expect(await send("default:hello", { name: "qualified" })).toEqual({
+      greeting: "hello qualified",
+    });
+    expect(await send("lab:hello", { name: "lab" })).toEqual({
+      greeting: "hello lab",
+    });
+    expect(await send("caller", { name: "enrich" })).toEqual({
+      greeting: "hello enrich",
+    });
+  });
+
+  /**
+   * @case The local ops door lists imported routes with their origin and dispatches one
+   * @preconditions Both remotes imported; the first instance's introspection and dispatch tiers open
+   * @expectedResult `GET /ops/routes?source=remote` lists every imported endpoint as dispatchable with `sources: ["remote"]` and a `remote` field; the detail carries the remote's JSON Schema; a POST to the exchanges path returns the second instance's result. This is what `craft ops routes` and `craft exec` read, and it is the intentional re-exposure: an open dispatch tier re-exports every imported route under the local door
+   */
+  test("lists and dispatches imported routes through the local door", async () => {
+    server = await startServer();
+    const url = `http://127.0.0.1:${String(server.port)}`;
+    local = await startLocal({
+      remotes: {
+        default: { url, auth: { token: OPERATOR } },
+        lab: { url, auth: { token: OPERATOR } },
+      },
+    });
+
+    const listing = await call<OpsPage<OpsRouteSummary>>(
+      local.port,
+      "/ops/routes?source=remote",
+    );
+    expect(listing.status).toBe(200);
+    const ids = listing.body.items.map((route) => route.id);
+    expect(ids).toEqual([...ids].sort());
+    expect(ids).toEqual(
+      expect.arrayContaining(["hello", "default:hello", "lab:hello"]),
+    );
+    for (const route of listing.body.items) {
+      expect(route.dispatchable).toBe(true);
+      expect(route.sources).toEqual(["remote"]);
+      expect(route.remote).toBe(
+        route.id.startsWith("lab:") ? "lab" : "default",
+      );
+    }
+
+    const detail = await call<OpsRouteDetail>(
+      local.port,
+      `/ops/routes/${encodeURIComponent("lab:hello")}`,
+    );
+    expect(detail.status).toBe(200);
+    expect(detail.body.remote).toBe("lab");
+    expect(detail.body.input?.body).toMatchObject({
+      properties: { name: { type: "string" } },
+    });
+
+    const dispatched = await call<{ outcome: string; body: unknown }>(
+      local.port,
+      `/ops/routes/${encodeURIComponent("lab:hello")}/exchanges`,
+      { method: "POST", body: { name: "door" } },
+    );
+    expect(dispatched.status).toBe(200);
+    expect(dispatched.body).toEqual({
+      outcome: "completed",
+      body: { greeting: "hello door" },
+    });
+  });
+
+  /**
+   * @case A local route with the same id as a default-remote route wins, loudly
+   * @preconditions A local `hello` beside the default remote's `hello`
+   * @expectedResult The local route answers `hello`; `default:hello` reaches the remote; a warning names the shadow when the inventory is read and again on every call that resolves to the local route; the local listing carries one `hello`, the local one. The overlap is the promotion window, so it is never an error
+   */
+  test("lets a local route shadow a default-remote route with a warning on refresh and on call", async () => {
+    server = await startServer();
+    const url = `http://127.0.0.1:${String(server.port)}`;
+    let warnings: string[] = [];
+    local = await startLocal({
+      remotes: { default: { url, auth: { token: OPERATOR } } },
+      routes: [
+        craft()
+          .id("hello")
+          .description("The local greeter")
+          .input({ body: z.object({ name: z.string() }) })
+          .from(direct())
+          .transform(() => ({ greeting: "local" }))
+          .to(noop()),
+      ],
+      onBuilt: (t) => {
+        warnings = captureLogs(t.ctx).warnings;
+      },
+    });
+
+    expect(
+      warnings.filter((line) =>
+        line.includes(
+          'Local route "hello" shadows route "hello" of remote "default"',
+        ),
+      ),
+    ).toHaveLength(1);
+
+    const seen = warnings.length;
+    expect(await send("hello", { name: "x" })).toEqual({
+      greeting: "local",
+    });
+    expect(
+      warnings
+        .slice(seen)
+        .filter((line) =>
+          line.includes('"hello" is answered by the local route'),
+        ),
+    ).toHaveLength(1);
+    expect(await send("default:hello", { name: "x" })).toEqual({
+      greeting: "hello x",
+    });
+
+    const listing = await call<OpsPage<OpsRouteSummary>>(
+      local.port,
+      "/ops/routes?id=hello",
+    );
+    expect(listing.body.items).toHaveLength(1);
+    expect(listing.body.items[0]).toMatchObject({
+      id: "hello",
+      sources: ["direct"],
+    });
+    expect(listing.body.items[0]!.remote).toBeUndefined();
+  });
+
+  /**
+   * @case Every dispatch outcome maps onto the in-process one, against the real door
+   * @preconditions Routes on the remote that complete, drop, park and fail; one remote named with a credential admitted to the listing but not to dispatch
+   * @expectedResult completed is the body; dropped is `RC5031`; suspended is the branded `Suspended` acknowledgment; a remote failure is `RC5064` carrying the remote's code with the client's error as cause; the refused dispatch is `RC5063` naming the missing scope. A caller can tell a credential problem from a broken route
+   */
+  test("maps completed, dropped, suspended, failed and refused onto local outcomes", async () => {
+    server = await startServer();
+    const url = `http://127.0.0.1:${String(server.port)}`;
+    local = await startLocal({
+      remotes: {
+        lab: { url, auth: { token: OPERATOR } },
+        reader: { url, auth: { token: READER } },
+      },
+    });
+
+    expect(await send("lab:hello", { name: "ok" })).toEqual({
+      greeting: "hello ok",
+    });
+
+    const dropped = await rejection(send("lab:picky", {}));
+    expect(rcCodeOf(dropped)).toBe("RC5031");
+
+    const parked = await send("lab:payout", {});
+    expect(isSuspended(parked)).toBe(true);
+    expect((parked as { suspensionId: string }).suspensionId).toBeTruthy();
+
+    const failed = await rejection(send("lab:boom", {}));
+    expect(rcCodeOf(failed)).toBe("RC5064");
+    expect(failed.message).toMatch(/route "boom" on remote "lab"/);
+    expect(failed.message).toMatch(/RC\d{4}/);
+    expect(failed.cause).toBeInstanceOf(OpsClientError);
+    expect((failed.cause as OpsClientError).status).toBe(500);
+
+    const refused = await rejection(send("reader:hello", { name: "no" }));
+    expect(rcCodeOf(refused)).toBe("RC5063");
+    expect(refused.message).toMatch(/ops:dispatch/);
+  });
+
+  /**
+   * @case The credential is read per request and never written anywhere a reader could see it
+   * @preconditions One remote whose token is a counting function; one remote configured with a forged bearer the door rejects
+   * @expectedResult The function is called once per request the inventory needs and once more per dispatch; the forged remote imports nothing, its inventory failure is logged as a warning, and no log line or error message carries the bearer
+   */
+  test("evaluates the token per request and keeps it out of logs and errors", async () => {
+    server = await startServer();
+    const url = `http://127.0.0.1:${String(server.port)}`;
+    let reads = 0;
+    let logs: ReturnType<typeof captureLogs> | undefined;
+    local = await startLocal({
+      remotes: {
+        lab: {
+          url,
+          auth: {
+            token: () => {
+              reads += 1;
+              return OPERATOR;
+            },
+          },
+        },
+        bad: { url, auth: { token: FORGED } },
+      },
+      onBuilt: (t) => {
+        logs = captureLogs(t.ctx);
+      },
+    });
+
+    // One listing plus one description per route the listing returned.
+    const routes = (serverRoutes() as readonly unknown[]).length;
+    expect(reads).toBe(1 + routes);
+    await send("lab:hello", { name: "count" });
+    expect(reads).toBe(2 + routes);
+
+    const endpoints = local.t.ctx.capabilities().map((c) => c.endpoint);
+    expect(endpoints.some((endpoint) => endpoint.startsWith("bad:"))).toBe(
+      false,
+    );
+    expect(
+      logs!.warnings.some((line) =>
+        line.includes('Remote "bad" inventory could not be read'),
+      ),
+    ).toBe(true);
+    expect(logs!.everything.some((line) => line.includes(FORGED))).toBe(false);
+    expect(logs!.everything.some((line) => line.includes(OPERATOR))).toBe(
+      false,
+    );
+  });
+
+  /**
+   * @case A dispatch that meets a 404 forces a refresh, and a route the remote no longer lists stops being an endpoint
+   * @preconditions A stand-in ops server that lists `ghost` at boot, answers 404 to its dispatch, and no longer lists it by then; the interval refresh disabled
+   * @expectedResult The dispatch fails with `RC5004` after the inventory was re-read; `lab:ghost` is gone from the capabilities and a second dispatch finds no channel at all. The inventory is the framework's to keep true, and the door is where a stale entry is found out
+   */
+  test("refreshes the inventory when a dispatch meets a 404", async () => {
+    let listed = ["ghost"];
+    const summary = (id: string): OpsRouteSummary => ({
+      id,
+      dispatchable: true,
+      enabled: true,
+      sources: ["direct"],
+      requiresPrincipal: false,
+      description: "A route that will vanish",
+    });
+    const fake = await serveFake((pathname) => {
+      if (pathname === "/ops/routes") {
+        return { status: 200, body: { items: listed.map(summary) } };
+      }
+      const one = /^\/ops\/routes\/([^/]+)$/.exec(pathname);
+      if (one !== null && listed.includes(decodeURIComponent(one[1]!))) {
+        return {
+          status: 200,
+          body: {
+            ...summary(decodeURIComponent(one[1]!)),
+            input: { body: { type: "object" } },
+          },
+        };
+      }
+      return { status: 404 };
+    });
+    try {
+      local = await startLocal({
+        remotes: {
+          lab: { url: `http://127.0.0.1:${String(fake.port)}`, refresh: false },
+        },
+      });
+      const has = (endpoint: string): boolean =>
+        local!.t.ctx.capabilities().some((c) => c.endpoint === endpoint);
+      expect(has("lab:ghost")).toBe(true);
+
+      listed = [];
+      const missing = await rejection(send("lab:ghost", {}));
+      expect(rcCodeOf(missing)).toBe("RC5004");
+      expect(missing.message).toMatch(/inventory has been refreshed/);
+      expect(has("lab:ghost")).toBe(false);
+
+      const gone = await rejection(send("lab:ghost", {}));
+      expect(rcCodeOf(gone)).toBe("RC5004");
+      expect(gone.message).toMatch(/No direct channel/);
+    } finally {
+      await fake.close();
+    }
+  });
+
+  /**
+   * @case A remote unreachable at boot registers nothing and its routes appear when it answers
+   * @preconditions The first instance names a port nothing listens on, with a short refresh interval; the second instance is started on that port afterwards
+   * @expectedResult The first instance starts, imports nothing for the remote and reports the `remote.lab` indicator down on its own health endpoint; after the second comes up a refresh imports its routes and the indicator reports up. An unreachable remote must not fail the boot, and must not need a restart to be found
+   */
+  test("starts without an unreachable remote and imports it once it answers", async () => {
+    const port = await reservePort();
+    local = await startLocal({
+      remotes: {
+        lab: {
+          url: `http://127.0.0.1:${String(port)}`,
+          auth: { token: OPERATOR },
+          refresh: "100ms",
+        },
+      },
+    });
+    const has = (endpoint: string): boolean =>
+      local!.t.ctx.capabilities().some((c) => c.endpoint === endpoint);
+    expect(has("lab:hello")).toBe(false);
+
+    const down = await call<HealthReport>(local.port, "/health");
+    expect(down.body.indicators["remote.lab"]?.status).toBe("down");
+
+    server = await startServer({ port });
+    await until(() => has("lab:hello"), "the remote's routes to be imported");
+    const up = await call<HealthReport>(local.port, "/health");
+    expect(up.body.indicators["remote.lab"]?.status).toBe("up");
+    expect(await send("lab:hello", { name: "late" })).toEqual({
+      greeting: "hello late",
+    });
+  });
+
+  /**
+   * @case Configuration mistakes fail at definition, not at the first refresh
+   * @preconditions A remote name that would break the tool wire name; a bearer over plain http to a non-loopback host; a malformed url
+   * @expectedResult Each is refused with `RC5003` naming the key. The clear-text rule is the CLI's, for the same reason: every hop between here and the remote could read the token
+   */
+  test("refuses a bad remote name, a clear-text bearer and a malformed url", () => {
+    const attempt = (remotes: RemotesConfig): string | undefined => {
+      try {
+        remotesPlugin(remotes);
+        return undefined;
+      } catch (error: unknown) {
+        return `${rcCodeOf(error) ?? "?"} ${(error as Error).message}`;
+      }
+    };
+    expect(attempt({ my__lab: { url: "https://lab.test" } })).toMatch(
+      /^RC5003 remotes\.my__lab/,
+    );
+    expect(
+      attempt({ lab: { url: "http://lab.test", auth: { token: "t" } } }),
+    ).toMatch(/^RC5003 .*clear text/);
+    expect(attempt({ lab: { url: "not a url" } })).toMatch(
+      /^RC5003 remotes\.lab\.url/,
+    );
+    expect(
+      attempt({ lab: { url: "http://127.0.0.1:1", auth: { token: "t" } } }),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## TLDR

A local instance names other running instances under `remotes`, and every dispatchable route they expose through the ops management API becomes a direct endpoint here: `direct()`, `forward()`, `directTool()`, `Direct(...)` in an agent's tool list, the tool policy, the local `/ops/routes` listing, `craft ops routes` and `craft exec` all see them as routes, with nothing to learn. The server keeps its credentials and its `.authorize()`; the local instance holds only a bearer for the server's door.

Closes #763

**Breaking for route authors:** no. Additive: a new config key, a `remote` field on the ops route summary and on the `direct` tool source, three error codes.

## Before and after

- **Before:** a route on another instance is reachable only by hand-written HTTP against its ops door, and an agent cannot list it as a tool.
- **After:** `direct('lab:hello')` and `Direct(lab:hello)` reach it as a local capability; the local listing shows it with `remote: "lab"`; a local route with the same id as a `default` remote route wins, with a warning on every refresh and every call.

## DSL

```ts
export default defineConfig({
  remotes: {
    default: { url: 'https://routecraft.example.internal', auth: { token: () => process.env.RC_REMOTE_TOKEN } },
    lab:     { url: 'https://lab.example.internal',        auth: { token: () => process.env.RC_LAB_TOKEN } },
  },
})

craft()
  .id('greet-twice')
  .from(direct())
  .enrich(direct('hello'))        // the default remote's route, advertised bare
  .enrich(direct('lab:hello'))    // any other remote is qualified

agent({ tools: tools(['Direct(hello)', 'Direct(lab:hello)', 'Remote(lab)']) })
```

New: `remotes.<name>.{ url, auth.token, timeout, refresh }`; `Remote(<name>)` in `tools()`; wire name `remote__<name>__<id>` for qualified references; `OpsRouteSummary.remote`; `AgentToolSource.remote` on the `direct` arm; error codes `RC5062` (unreachable or timeout), `RC5063` (credential refused), `RC5064` (remote dispatch failed); `createOpsHttpClient` and `contributeOpsIndicator` exported from core.

---

## Why

#763. A constrained server instance (no models, no agents, service credentials, approved routes behind per-person tokens) and engineers running local harnesses with their own agents. MCP is not available on that network; the ops API is plain HTTPS and JSON and is. The design (git-style names, local wins with the double warning, env-var credentials, framework-owned refresh, re-exposure intentional) was agreed on the issue.

## What changed

- `packages/routecraft/src/plugins/remotes/`: the plugin (inventory at start, on `refresh`, and forced by a 404 on dispatch; shadow rule; one indicator per remote), the direct channel that maps outcomes (completed is the body, dropped is `RC5031`, suspended is the branded `Suspended` acknowledgment, a remote 500 is `RC5064` with the remote's code as cause, 401/403 is `RC5063`, unreachable or timeout is `RC5062`, an envelope this side does not recognise is `RC5064`), a JSON Schema passthrough as the endpoint's discovery bundle, the `remotes` config applier.
- `packages/routecraft/src/plugins/ops/client.ts`: the ops HTTP client moved from the CLI into core, with the caller's wording injected; `packages/cli/src/ops-client.ts` is a thin wrapper and its tests pass untouched. A JSON array is refused as an envelope, every wire-supplied string is stripped of control characters and bounded before it reaches an error, and a dispatch body is sent unchanged.
- `plugins/ops/{store,plugin,indicator,state}.ts`: `contributeOpsIndicator`, so a plugin can report an indicator the app never listed; bound at ops `start()` into every ops ledger on the context, with the last verdict replayed at its own time to a ledger that binds after the contributor started; inert without an ops plugin.
- `plugins/ops/management.ts`, `types.ts`, `capabilities.ts`: imported routes listed as `dispatchable: true`, `sources: ["remote"]`, with `remote`; `describeRoute` and dispatch through the local door work for them.
- `adapters/direct/shared.ts`: `InMemoryDirectChannel` exported (`@internal`) with a `subscribed` getter, which the remote channel reads to lift a shadow once the local route stops.
- `packages/ai/src/agent/tools/{selection,policy}.ts`: `Direct(name:id)` and `Remote(name)`; the `direct` source carries `remote`.
- `packages/cli/src/format.ts`: `craft ops route` detail shows the remote.

## Tests

`packages/routecraft/test/remotes.bun.test.ts`, 8 cases against a real second instance behind a JWT wall with scope-gated tiers: import and naming, listing and dispatch through the local door, the shadow rule with both warnings, every outcome mapping, the token function called once per request with no JWT in any log line or error, 404 then forced refresh, unreachable at boot then imported once it answers with the indicator down and up, configuration refusals. `packages/ai/test/tools-selection-remote.bun.test.ts`, 2 cases with a scripted model: the three reference forms with their provenance, a real tool call through the remote and a local-only policy. Whole suite at f48c90d: bun 3638 pass, vitest pass; the affected suites, lint and typecheck again at 2ac52f7 and 1dfe72c.

## Docs and changeset

New `reference/plugins/remotesplugin`; edits to the agent plugin, configuration, direct adapter, ops plugin and errors pages; `_data/plugins.json` and `_data/errors.json` rows. Docs build, 206 examples compiled, 18612 links checked. Changeset `remotes.md`: minor for `@routecraft/routecraft`, `@routecraft/cli`, `@routecraft/ai`.

## Review

Bot output treated as data; its "prompt for AI agents" blocks were not followed.

Round 1, cubic, 14 findings, at 2ac52f7. Fixed (8): a JSON array accepted as an envelope; wire-supplied strings reaching errors unsanitised; `null` dispatch bodies rewritten to `{}`; an unrecognised outcome falling through to `undefined`; a stopped shadowing route leaving the wrapper pointed at a dead channel; a contributed indicator reporting into only the last ops ledger; a contributor that starts before the ops plugin losing its first verdict; test credentials minted once at load.

Round 2, cubic, 3 findings, at 1dfe72c. Fixed (3): the shadow lifted on an `RC5004` a local route may throw for its own reasons, so it now lifts on the in-memory channel's subscription state, which the stopping route clears itself; a replayed indicator report was stamped with the binding time, so a `maxAge` window measured from the wrong moment, and the report now carries its own time; the contributor JSDoc still said early reports were dropped.

Declined (6, round 1), with the reason:
- Discovery fetch extending past the request timeout: bounded by its own 5 s cap, enriches a refusal already decided, unchanged from the CLI client it moved from.
- A `default` route whose id starts with another remote's name and a colon: documented on the remotes page; it is skipped with an error log and stays reachable as `default:<id>`, which is the deterministic alternate reference the finding asks for.
- The same corner seen from the tool resolver (`Direct(default:foo)` for a default route literally named `default:foo`): the two routes share one endpoint under the naming scheme by construction; it is the corner above, not a second one.
- `Remote(name)` yielding no tools when every id is unusable: same behaviour as `MCP(server)`, warned once per context; a throw here would run per dispatch.
- The docs claim that `tool.source.remote === undefined` keeps an agent local-only: the finding has it backwards; default-remote routes carry `remote: 'default'` and are excluded by that predicate.
- `RC5062` registry default `retryable: true` while a timeout is not: the registry entry describes the refused-connection case and the timeout override is on the error itself, as the suggestion says.

Decisions taken under the delegated list: wire name `remote__<name>__<id>` mirroring `mcp__<server>__<tool>`, with the remote's name constrained at configuration; `Remote(name)` only, no raw wire grammar; per-remote `refresh` (60s) and `timeout` (30s); indicator `remote.<name>` in the deployment domain, contributed rather than listed by the app; a `default` route colliding with another remote's qualified name is skipped with an error log; a timeout is `RC5062` with `retryable: false`; the boot refresh is awaited in `start()`.

## Leftovers

- One `GET /ops/routes/{id}` per route per refresh; a detail-carrying listing would pair with #764.
- A custom `direct.channelType` is bypassed for imported endpoints, and under a custom channel type a shadow holds until the inventory drops the endpoint, because only the in-memory channel exposes its subscription state.
- The shadow lifting when a local route stops is covered by reasoning on the channel's subscription state and not by a test; stopping one route in the harness needs a helper that does not exist yet.
