### PR TITLE
fix(routecraft): a lifted shadow keeps its remote provenance, and a lost connection is not retried

### DIFF
--- a/apps/routecraft.dev/app/content/docs/reference/errors/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/errors/index.mdx
@@ -1002,10 +1002,10 @@ Raise the ceiling on the call when the endpoint legitimately returns more than 1
 Remote instance unreachable
 
 **Why it happens**  
-A dispatch to a route imported through [`defineConfig({ remotes })`](/docs/reference/plugins/remotesplugin) never got an answer from the remote instance. The connection was refused, the name did not resolve, or the request timed out. The message names the remote and the route, and says which of the three it was.
+A dispatch to a route imported through [`defineConfig({ remotes })`](/docs/reference/plugins/remotesplugin) never got an answer from the remote instance. The connection was refused or the name did not resolve, the connection was lost after the request was sent, or the request timed out. The message names the remote and the route, and says which it was.
 
 **Suggestion**  
-Check the remote's `url` and that the instance is running and serving its ops surface. A refused connection is safe to retry, and the code is marked retryable for it. A timeout is not: the remote may still be running the work it accepted, so a retry could run a non-idempotent route twice, and a timeout carries `retryable: false` on the error itself.
+Check the remote's `url` and that the instance is running and serving its ops surface. Only a connection that never opened is safe to retry, and the code is marked retryable for it. A connection lost after the request was sent, or a timeout, is not: the remote may still be running the work it accepted, so a retry could run a non-idempotent route twice, and those carry `retryable: false` on the error itself.
 
 ## RC5063
 Remote instance refused the credential

--- a/apps/routecraft.dev/app/content/docs/reference/plugins/remotesplugin/index.mdx
+++ b/apps/routecraft.dev/app/content/docs/reference/plugins/remotesplugin/index.mdx
@@ -62,7 +62,7 @@ A remote's name becomes one segment of the tool name a model sees (`remote__lab_
 
 Git-style. The routes of the remote called `default` are advertised bare, exactly as a local route would be, so `direct('hello')` and `Direct(hello)` reach them with nothing to learn. Every other remote's routes are qualified `name:id`, and `default:id` names the default remote explicitly. Two remotes therefore never collide.
 
-**Local wins.** A local route with the same id as a default-remote route shadows it: the local route answers `direct('hello')`, the remote route stays reachable as `default:hello`, and the shadow is logged as a warning on every refresh that finds it and on every call that resolves to the local route while it exists. That overlap is the promotion window, the moment a capability exists on a laptop and on the server at once, and it is never an error. A local route whose id is itself a qualified name (`lab:hello`) shadows the remote route entirely until one of them is renamed, and the warning says so.
+**Local wins.** A local route with the same id as a default-remote route shadows it: the local route answers `direct('hello')`, the remote route stays reachable as `default:hello`, and the shadow is logged as a warning on every refresh that finds it and on every call that resolves to the local route while it exists. That overlap is the promotion window, the moment a capability exists on a laptop and on the server at once, and it is never an error. When the local route stops, the remote route takes the endpoint back: the listing and the tool policy see it as the remote's from that moment, and the handover is logged. A local route whose id is itself a qualified name (`lab:hello`) shadows the remote route entirely until one of them is renamed, and the warning says so.
 
 A route of `default` whose own id starts with another remote's name and a colon (`lab:x` on the default remote, beside a remote called `lab`) would be advertised under an endpoint that remote already holds. It is skipped with an error in the log, and stays reachable as `default:lab:x`.
 
@@ -89,7 +89,7 @@ A dispatch through an imported endpoint maps the remote's outcome onto the in-pr
 | parks on a `.suspend()` | the standard `Suspended` acknowledgment; resume is at the remote's door, under its policy |
 | fails (500 with a code) | [`RC5064`](/docs/reference/errors#rc-5064), carrying the remote's code as cause |
 | refuses the credential (401 or 403) | [`RC5063`](/docs/reference/errors#rc-5063), naming the door's own reason, so a credential problem is distinguishable from a broken route |
-| cannot be reached, or does not answer in time | [`RC5062`](/docs/reference/errors#rc-5062); a refused connection is retryable, a timeout is not |
+| cannot be reached, loses the connection, or does not answer in time | [`RC5062`](/docs/reference/errors#rc-5062); a connection that never opened is retryable, a lost connection or a timeout is not |
 | answers 404 | the inventory is refreshed, then [`RC5004`](/docs/reference/errors#rc-5004): the route is gone from the remote or its dispatch tier is closed |
 
 ## In the listing and the tool policy

--- a/packages/ai/test/tools-selection-remote.bun.test.ts
+++ b/packages/ai/test/tools-selection-remote.bun.test.ts
@@ -244,4 +244,65 @@ describe("tools() with imported routes", () => {
     expect(denied[0]!.output).toBeUndefined();
     expect(denied[0]!.error).toBeInstanceOf(Error);
   });
+
+  /**
+   * @case A shadowing local route that stops makes `Direct(hello)` a remote-backed tool, and a local-only rule then withholds it
+   * @preconditions A local `hello` shadowing the default remote's `hello`; `Direct(hello)` resolved before and after the local route stops
+   * @expectedResult Before the stop the tool's source carries no `remote` and is admitted by the local-only rule. After the stop the same reference resolves with `remote: "default"`, the rule drops it, and a call through the tool that is admitted reaches the remote. A tool must never be labelled local while its dispatch leaves the instance
+   */
+  test("relabels Direct(hello) as remote-backed once the shadowing local route stops", async () => {
+    server = await startServer();
+    const { url } = server;
+    local = await testContext()
+      .with({
+        remotes: { default: { url, auth: { token: operator } } },
+        plugins: [agentPlugin()],
+      })
+      .routes([
+        craft()
+          .id("hello")
+          .description("The local greeter")
+          .input({ body: z.object({ name: z.string() }) })
+          .from(direct())
+          .transform(() => ({ greeting: "local" }))
+          .to(noop()),
+        craft().id("keepalive").from(direct()).to(noop()),
+      ])
+      .build();
+    await local.startAndWaitReady();
+    const resolveHello = () => tools(["Direct(hello)"]).resolve(local!.ctx)[0]!;
+    const localOnly = (tool: ReturnType<typeof resolveHello>): boolean =>
+      tool.source.kind === "direct" && tool.source.remote === undefined;
+
+    const before = resolveHello();
+    expect(before.source).toEqual({ kind: "direct", routeId: "hello" });
+    expect(localOnly(before)).toBe(true);
+
+    const route = local.ctx
+      .getRoutes()
+      .find((candidate) => candidate.definition.id === "hello");
+    if (route === undefined) throw new Error("the local route is missing");
+    route.stop();
+    const deadline = Date.now() + 5_000;
+    while (
+      local.ctx.capabilities().find((c) => c.endpoint === "hello")?.remote !==
+      "default"
+    ) {
+      if (Date.now() > deadline) throw new Error("the shadow never lifted");
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    const after = resolveHello();
+    expect(after.name).toBe("direct__hello");
+    expect(after.source).toEqual({
+      kind: "direct",
+      routeId: "hello",
+      remote: "default",
+    });
+    expect(localOnly(after)).toBe(false);
+    const answer: unknown = await local.client.sendDirect("hello", {
+      name: "agent",
+    });
+    expect(answer).toEqual({ greeting: "hello agent" });
+  });
 });

--- a/packages/routecraft/src/adapters/direct/shared.ts
+++ b/packages/routecraft/src/adapters/direct/shared.ts
@@ -149,11 +149,6 @@ export function sanitizeEndpoint(endpoint: string): string {
 export class InMemoryDirectChannel<T> implements DirectChannel<T> {
   private handler: ((message: T) => Promise<T>) | null = null;
 
-  /** Whether a route currently answers on this channel. */
-  get subscribed(): boolean {
-    return this.handler !== null;
-  }
-
   async send(endpoint: string, message: T): Promise<T> {
     if (this.handler) {
       // Synchronous behavior - single consumer gets the message and we wait for result

--- a/packages/routecraft/src/context.ts
+++ b/packages/routecraft/src/context.ts
@@ -1146,9 +1146,17 @@ export class CraftContext {
     // offered to the model rather than being offered and failing on call.
     // A route disabled at boot never subscribed and so never registered
     // here at all; this covers the route disabled AFTER it started, whose
-    // registry entry outlives the transition.
+    // registry entry outlives the transition. A capability imported from
+    // another instance is that instance's to enable: it shares an id with
+    // a local route only while it holds the endpoint the local route gave
+    // up, and filtering it on the local predicate would hide the one that
+    // answers.
     return [...registry.values()]
-      .filter((capability) => this.enablement.isEnabled(capability.endpoint))
+      .filter(
+        (capability) =>
+          capability.remote !== undefined ||
+          this.enablement.isEnabled(capability.endpoint),
+      )
       .map(snapshotCapability);
   }
 

--- a/packages/routecraft/src/error.ts
+++ b/packages/routecraft/src/error.ts
@@ -625,7 +625,7 @@ export const RC: { [K in CoreErrorCode]: RCMeta } = {
     category: "Runtime",
     message: "Remote instance unreachable",
     suggestion:
-      "A dispatch to a route imported through `defineConfig({ remotes })` never got an answer from the remote instance: the connection was refused, the name did not resolve, or the request timed out. Check the remote's `url` and that the instance is running and serving its ops surface. A refused connection is safe to retry; a timeout is not, because the remote may still be running the work it accepted, and the message says which of the two it was.",
+      "A dispatch to a route imported through `defineConfig({ remotes })` never got an answer from the remote instance: the connection was refused or the name did not resolve, the connection was lost after the request was sent, or the request timed out. Check the remote's `url` and that the instance is running and serving its ops surface. Only a connection that never opened is safe to retry; a lost connection or a timeout is not, because the remote may still be running the work it accepted, and the error carries `retryable: false` for those. The message says which it was.",
     docs: `${DOCS_BASE}#rc-5062`,
     retryable: true,
   },

--- a/packages/routecraft/src/plugins/ops/client.ts
+++ b/packages/routecraft/src/plugins/ops/client.ts
@@ -605,12 +605,18 @@ function sanitizeWire(wire: WireError): WireError {
  * resolve. Node reports them on the cause of `fetch failed`, Bun on the
  * error itself under its own names. Anything else is treated as possibly
  * delivered, which is the safe reading for a request that may run work.
+ *
+ * `ETIMEDOUT` is deliberately absent: Node raises it for a connect that
+ * never completed and for a socket that went quiet after the request was
+ * written, and the code alone cannot tell the two apart. undici's own
+ * connect timeout has its own code and is listed.
  */
 const NEVER_CONNECTED = new Set([
   "ECONNREFUSED",
   "EHOSTUNREACH",
   "ENETUNREACH",
   "EADDRNOTAVAIL",
+  "UND_ERR_CONNECT_TIMEOUT",
   "ENOTFOUND",
   "EAI_AGAIN",
   "EAI_NONAME",

--- a/packages/routecraft/src/plugins/ops/client.ts
+++ b/packages/routecraft/src/plugins/ops/client.ts
@@ -54,8 +54,14 @@ const DISCOVERY_TIMEOUT_MS = 5_000;
 
 /** Why a call did not produce an answer. Each needs a different remedy. */
 export type OpsFailureKind =
-  /** The instance could not be reached at all. */
+  /** The instance could not be reached at all; the request never left. */
   | "unreachable"
+  /**
+   * The request may have reached the instance: the connection was lost
+   * after it was sent, or while the answer was being read. Whatever it
+   * asked for may have run.
+   */
+  | "interrupted"
   /** The door refused: no credential, a bad one, or a missing scope. */
   | "refused"
   /** The tier is disabled, or the thing asked for does not exist. */
@@ -192,7 +198,7 @@ export function createOpsHttpClient(
         ...(init.body === undefined ? {} : { body: JSON.stringify(init.body) }),
       });
     } catch (error: unknown) {
-      throw classifyTransportFailure(error, addressBlame());
+      throw classifyTransportFailure(error, addressBlame(), "request");
     }
 
     // Inside its own guard: an abort part-way through the body is the same
@@ -202,7 +208,7 @@ export function createOpsHttpClient(
     try {
       text = await response.text();
     } catch (error: unknown) {
-      throw classifyTransportFailure(error, addressBlame());
+      throw classifyTransportFailure(error, addressBlame(), "response");
     }
     const parsed: unknown = text.length === 0 ? undefined : parseJson(text);
 
@@ -321,16 +327,19 @@ export function createOpsHttpClient(
   }
 
   /**
-   * Tell a request that never got an answer from one the instance refused
-   * to answer in time.
+   * Tell a request that never left from one the instance may have received.
    *
    * They need opposite reactions. "Could not reach it, start one" invites a
    * retry, which for a dispatch means running a possibly non-idempotent
-   * route a second time while the first is still going.
+   * route a second time while the first is still going. So a failure is
+   * `unreachable` only when the connection provably never opened; a
+   * connection lost after that, a timeout, or a failure while reading the
+   * answer all mean the request may have run.
    */
   function classifyTransportFailure(
     error: unknown,
     address: string,
+    phase: "request" | "response",
   ): OpsClientError {
     const aborted =
       error instanceof Error &&
@@ -341,11 +350,17 @@ export function createOpsHttpClient(
         `The instance at ${address} accepted the request but did not answer within ${String(timeoutMs / 1000)}s. Any work it started is still running there, so do not simply re-run this.`,
       );
     }
+    if (phase === "request" && neverConnected(error)) {
+      return new OpsClientError(
+        "unreachable",
+        `Could not reach a running instance at ${address}: ${messageOf(error)}${
+          advice.unreachable === undefined ? "" : `\n${advice.unreachable}`
+        }`,
+      );
+    }
     return new OpsClientError(
-      "unreachable",
-      `Could not reach a running instance at ${address}: ${messageOf(error)}${
-        advice.unreachable === undefined ? "" : `\n${advice.unreachable}`
-      }`,
+      "interrupted",
+      `The instance at ${address} may have received the request, but the connection was lost before it answered: ${messageOf(error)}. Any work it started may still be running there, so do not simply re-run this.`,
     );
   }
 
@@ -584,6 +599,38 @@ function sanitizeWire(wire: WireError): WireError {
 }
 
 /** A thrown value's message; non-Error throws (a `ResolveMessage`) still carry one. */
+/**
+ * The codes a runtime raises when no connection was ever established, so
+ * nothing was sent: refused, no route to the host, or a name that did not
+ * resolve. Node reports them on the cause of `fetch failed`, Bun on the
+ * error itself under its own names. Anything else is treated as possibly
+ * delivered, which is the safe reading for a request that may run work.
+ */
+const NEVER_CONNECTED = new Set([
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EADDRNOTAVAIL",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EAI_NONAME",
+  "EAI_FAIL",
+  "ConnectionRefused",
+  "FailedToOpenSocket",
+  "DNSException",
+]);
+
+function neverConnected(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 4 && current !== undefined; depth += 1) {
+    if (typeof current !== "object" || current === null) return false;
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && NEVER_CONNECTED.has(code)) return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
 function messageOf(error: unknown): string {
   if (error instanceof Error) return error.message;
   return typeof error === "object" && error !== null && "message" in error

--- a/packages/routecraft/src/plugins/ops/management.ts
+++ b/packages/routecraft/src/plugins/ops/management.ts
@@ -143,17 +143,26 @@ export function createManagementApi(ctx: CraftContext): ManagementApi {
    * Routes imported from other instances, keyed by local endpoint.
    *
    * Listed beside the local routes as dispatchable, with `remote` naming
-   * the origin. A local route with the same id wins (the remotes plugin
-   * never lists a shadowed endpoint), and the id check here covers the
-   * moment between a local route subscribing and the next refresh.
+   * the origin. A local route with the same id wins while it shadows the
+   * remote route, and the capability registry is what says so: `direct()`
+   * writes a local capability when the route subscribes, and the remotes
+   * plugin writes the remote's back when that route stops. A stopped
+   * route stays in `getRoutes()`, so the id alone cannot decide.
    */
   const remoteIndex = (): Map<string, RemoteRoute> =>
     ctx.getStore(REMOTE_ROUTES) ?? new Map<string, RemoteRoute>();
+
+  const remoteAnswers = (
+    id: string,
+    capabilities: Map<string, Capability>,
+  ): boolean =>
+    remoteIndex().has(id) && capabilities.get(id)?.remote !== undefined;
 
   const summaries = (): OpsRouteSummary[] => {
     const capabilities = capabilityIndex();
     const local = ctx
       .getRoutes()
+      .filter((route) => !remoteAnswers(route.definition.id, capabilities))
       .map((route) => summarise(ctx, route.definition, capabilities));
     const localIds = new Set(local.map((route) => route.id));
     const imported = [...remoteIndex().values()]
@@ -285,9 +294,9 @@ export function createManagementApi(ctx: CraftContext): ManagementApi {
 
     describeRoute(id: string): OpsRouteDetail | undefined {
       const capabilities = capabilityIndex();
-      const route = ctx
-        .getRoutes()
-        .find((candidate) => candidate.definition.id === id);
+      const route = remoteAnswers(id, capabilities)
+        ? undefined
+        : ctx.getRoutes().find((candidate) => candidate.definition.id === id);
       if (route) return detail(ctx, route.definition, capabilities);
       const imported = remoteIndex().get(id);
       return imported === undefined ? undefined : detailRemote(imported);
@@ -299,9 +308,9 @@ export function createManagementApi(ctx: CraftContext): ManagementApi {
       principal: Principal | undefined,
     ): Promise<OpsDispatchOutcome> {
       const capabilities = capabilityIndex();
-      const route = ctx
-        .getRoutes()
-        .find((candidate) => candidate.definition.id === id);
+      const route = remoteAnswers(id, capabilities)
+        ? undefined
+        : ctx.getRoutes().find((candidate) => candidate.definition.id === id);
       // An imported route has no definition here and needs none: its
       // capability is its door, and the channel behind it carries the
       // exchange to the instance that defines it. Re-exposing it through

--- a/packages/routecraft/src/plugins/remotes/channel.ts
+++ b/packages/routecraft/src/plugins/remotes/channel.ts
@@ -47,7 +47,9 @@ export interface RemoteTarget {
  * remote's inventory arrives; either way `local` is set and the local
  * route answers every send, with a warning naming the remote route that is
  * being shadowed, because a shadow is the promotion window and a caller
- * reading the logs should be able to see which of the two ran.
+ * reading the logs should be able to see which of the two ran. The plugin
+ * lifts the shadow when the local route stops, together with the
+ * capability's provenance, so the channel never decides that on its own.
  */
 export class RemoteDirectChannel implements DirectChannel<Exchange> {
   /** The local route's channel when one shadows this endpoint. */
@@ -61,7 +63,7 @@ export class RemoteDirectChannel implements DirectChannel<Exchange> {
   }
 
   async send(endpoint: string, exchange: Exchange): Promise<Exchange> {
-    if (this.local !== undefined && !this.shadowLifted()) {
+    if (this.local !== undefined) {
       const { ctx, remote, id, endpoint: local } = this.target;
       ctx.logger.warn(
         { endpoint: local, remote, remoteRouteId: id },
@@ -70,31 +72,6 @@ export class RemoteDirectChannel implements DirectChannel<Exchange> {
       return this.local.send(endpoint, exchange);
     }
     return this.dispatch(exchange);
-  }
-
-  /**
-   * Whether the shadowing local route has stopped since the wrapper was
-   * installed. A stopping route unsubscribes the channel it captured at
-   * start, not this wrapper, so the wrapper reads that channel's own
-   * subscription state rather than guessing from an error a route may
-   * legitimately throw. Only the in-memory channel exposes it; under a
-   * custom channel type the shadow holds until the inventory drops the
-   * endpoint.
-   */
-  private shadowLifted(): boolean {
-    if (
-      !(this.local instanceof InMemoryDirectChannel) ||
-      this.local.subscribed
-    ) {
-      return false;
-    }
-    const { ctx, remote, id, endpoint: local } = this.target;
-    this.local = undefined;
-    ctx.logger.info(
-      { endpoint: local, remote, remoteRouteId: id },
-      `The local route on "${local}" has stopped; the route "${id}" of remote "${remote}" answers it from now on`,
-    );
-    return true;
   }
 
   async subscribe(
@@ -181,6 +158,14 @@ export class RemoteDirectChannel implements DirectChannel<Exchange> {
       case "unreachable":
         return rcError("RC5062", error, {
           message: `Dispatching ${where}: ${error.message}`,
+        });
+      case "interrupted":
+        // The request may have run on the remote, so a retry could run a
+        // non-idempotent route twice, for the reason the timeout is not
+        // retryable either.
+        return rcError("RC5062", error, {
+          message: `Dispatching ${where}: ${error.message}`,
+          retryable: false,
         });
       case "refused":
         return rcError("RC5063", error, {

--- a/packages/routecraft/src/plugins/remotes/plugin.ts
+++ b/packages/routecraft/src/plugins/remotes/plugin.ts
@@ -70,6 +70,8 @@ interface RemoteRuntime {
   channels: Map<string, RemoteDirectChannel>;
   /** The last inventory's detail per local endpoint, shadowed ones included. */
   details: Map<string, OpsRouteDetail>;
+  /** Ids of local routes that have stopped, shared by every remote on the context. */
+  stopped: Set<string>;
   timer?: ReturnType<typeof setInterval>;
   inflight?: Promise<void>;
   /** Whether the last refresh failed, so a repeat is logged quietly. */
@@ -81,8 +83,8 @@ interface RemoteRuntime {
 /** Per-context state. One plugin instance may serve several contexts. */
 interface Runtime {
   remotes: RemoteRuntime[];
-  /** Stops listening for local routes stopping. */
-  off?: () => void;
+  /** Stops listening for local routes starting and stopping. */
+  off: Array<() => void>;
 }
 
 /** The health indicator an imported remote reports through. */
@@ -187,6 +189,7 @@ export function remotesPlugin(options: RemotesPluginOptions): CraftPlugin {
     name: "remotes",
 
     apply(ctx: CraftContext) {
+      const stopped = new Set<string>();
       const remotes: RemoteRuntime[] = Object.entries(options).map(
         ([name, definition]) => {
           const client = createOpsHttpClient({
@@ -223,12 +226,29 @@ export function remotesPlugin(options: RemotesPluginOptions): CraftPlugin {
             refreshMs,
             channels: new Map(),
             details: new Map(),
+            stopped,
             down: false,
             seen: false,
           };
         },
       );
-      runtimes.set(ctx, { remotes });
+      // A local route that stops hands its endpoint to the remote route it
+      // shadowed. The direct source registers the capability at subscribe
+      // and nothing removes it at stop, so this plugin keeps the lifecycle
+      // itself: a stop rewrites the provenance and the channel at once, and
+      // an inventory that arrives after the stop must not read the stale
+      // capability as a live shadow. Listening from apply, not start, so no
+      // route can stop unseen.
+      const off = [
+        ctx.on("route:started", ({ details }) => {
+          stopped.delete(details.routeId);
+        }),
+        ctx.on("route:stopped", ({ details }) => {
+          stopped.add(details.routeId);
+          for (const remote of remotes) lift(ctx, remote, details.routeId);
+        }),
+      ];
+      runtimes.set(ctx, { remotes, off });
       if (!ctx.getStore(REMOTE_ROUTES)) {
         ctx.setStore(REMOTE_ROUTES, new Map<string, RemoteRoute>());
       }
@@ -237,16 +257,6 @@ export function remotesPlugin(options: RemotesPluginOptions): CraftPlugin {
     async start(ctx: CraftContext) {
       const runtime = runtimes.get(ctx);
       if (!runtime) return;
-      // A local route that stops hands its endpoint to the remote route it
-      // shadowed. The direct source registers the capability at subscribe
-      // and nothing removes it at stop, so the transition has to rewrite
-      // the provenance as well as the channel, and this is the one place
-      // that knows both.
-      runtime.off = ctx.on("route:stopped", ({ details }) => {
-        for (const remote of runtime.remotes) {
-          lift(ctx, remote, details.routeId);
-        }
-      });
       await Promise.all(runtime.remotes.map((remote) => refresh(ctx, remote)));
       for (const remote of runtime.remotes) {
         if (remote.refreshMs === undefined) continue;
@@ -262,7 +272,7 @@ export function remotesPlugin(options: RemotesPluginOptions): CraftPlugin {
       const runtime = runtimes.get(ctx);
       if (!runtime) return;
       runtimes.delete(ctx);
-      runtime.off?.();
+      for (const off of runtime.off) off();
       for (const remote of runtime.remotes) {
         if (remote.timer !== undefined) clearInterval(remote.timer);
         delete remote.timer;
@@ -354,7 +364,9 @@ async function reconcile(
  * shadows the remote route. The remote's channel is still installed
  * around the local one so every call through the shadow says so, and the
  * route stays reachable under its qualified name, which this function is
- * also called for.
+ * also called for. A local capability whose route has already stopped is
+ * not a shadow: its registry entry outlived the route, and the remote
+ * route takes the endpoint as if the entry were not there.
  */
 function install(
   ctx: CraftContext,
@@ -370,7 +382,9 @@ function install(
 
   if (
     isInternalEndpoint(ctx, endpoint) ||
-    (existing !== undefined && existing.remote === undefined)
+    (existing !== undefined &&
+      existing.remote === undefined &&
+      !remote.stopped.has(endpoint))
   ) {
     ctx.logger.warn(
       { endpoint, remote: name, remoteRouteId: detail.id },
@@ -396,7 +410,11 @@ function install(
     return;
   }
 
-  if (existing !== undefined && existing.remote !== name) {
+  if (
+    existing !== undefined &&
+    existing.remote !== undefined &&
+    existing.remote !== name
+  ) {
     ctx.logger.error(
       {
         endpoint,

--- a/packages/routecraft/src/plugins/remotes/plugin.ts
+++ b/packages/routecraft/src/plugins/remotes/plugin.ts
@@ -68,6 +68,8 @@ interface RemoteRuntime {
   refreshMs: number | undefined;
   /** The channels this remote installed, by local endpoint. */
   channels: Map<string, RemoteDirectChannel>;
+  /** The last inventory's detail per local endpoint, shadowed ones included. */
+  details: Map<string, OpsRouteDetail>;
   timer?: ReturnType<typeof setInterval>;
   inflight?: Promise<void>;
   /** Whether the last refresh failed, so a repeat is logged quietly. */
@@ -79,6 +81,8 @@ interface RemoteRuntime {
 /** Per-context state. One plugin instance may serve several contexts. */
 interface Runtime {
   remotes: RemoteRuntime[];
+  /** Stops listening for local routes stopping. */
+  off?: () => void;
 }
 
 /** The health indicator an imported remote reports through. */
@@ -218,6 +222,7 @@ export function remotesPlugin(options: RemotesPluginOptions): CraftPlugin {
             report,
             refreshMs,
             channels: new Map(),
+            details: new Map(),
             down: false,
             seen: false,
           };
@@ -232,6 +237,16 @@ export function remotesPlugin(options: RemotesPluginOptions): CraftPlugin {
     async start(ctx: CraftContext) {
       const runtime = runtimes.get(ctx);
       if (!runtime) return;
+      // A local route that stops hands its endpoint to the remote route it
+      // shadowed. The direct source registers the capability at subscribe
+      // and nothing removes it at stop, so the transition has to rewrite
+      // the provenance as well as the channel, and this is the one place
+      // that knows both.
+      runtime.off = ctx.on("route:stopped", ({ details }) => {
+        for (const remote of runtime.remotes) {
+          lift(ctx, remote, details.routeId);
+        }
+      });
       await Promise.all(runtime.remotes.map((remote) => refresh(ctx, remote)));
       for (const remote of runtime.remotes) {
         if (remote.refreshMs === undefined) continue;
@@ -247,6 +262,7 @@ export function remotesPlugin(options: RemotesPluginOptions): CraftPlugin {
       const runtime = runtimes.get(ctx);
       if (!runtime) return;
       runtimes.delete(ctx);
+      runtime.off?.();
       for (const remote of runtime.remotes) {
         if (remote.timer !== undefined) clearInterval(remote.timer);
         delete remote.timer;
@@ -350,6 +366,7 @@ function install(
   const registry = ctx.getStore(CAPABILITY_REGISTRY);
   const existing = registry?.get(endpoint);
   const routes = ctx.getStore(REMOTE_ROUTES)!;
+  remote.details.set(endpoint, detail);
 
   if (
     isInternalEndpoint(ctx, endpoint) ||
@@ -392,6 +409,30 @@ function install(
     return;
   }
 
+  advertise(ctx, remote, endpoint, detail);
+
+  if (!remote.channels.has(endpoint)) {
+    const store = directStore(ctx);
+    // Whatever the store holds here is a placeholder an enricher created
+    // on demand before this inventory landed (a subscribed local route
+    // would have registered a capability and returned above), so replacing
+    // it is what makes that enricher's next fetch reach the remote.
+    const channel = new RemoteDirectChannel(
+      target(ctx, remote, endpoint, detail.id),
+    );
+    store.set(sanitizeEndpoint(endpoint), channel);
+    remote.channels.set(endpoint, channel);
+  }
+}
+
+/** Register the remote route as the capability behind a local endpoint. */
+function advertise(
+  ctx: CraftContext,
+  remote: RemoteRuntime,
+  endpoint: string,
+  detail: OpsRouteDetail,
+): void {
+  const { name } = remote;
   const capability: Capability = { endpoint, remote: name };
   if (detail.title !== undefined) capability.title = detail.title;
   if (detail.description !== undefined) {
@@ -411,20 +452,45 @@ function install(
     };
   }
   registerCapability(ctx, capability);
+  const routes = ctx.getStore(REMOTE_ROUTES)!;
   routes.set(endpoint, { remote: name, id: detail.id, endpoint, detail });
+}
 
-  if (!remote.channels.has(endpoint)) {
-    const store = directStore(ctx);
-    // Whatever the store holds here is a placeholder an enricher created
-    // on demand before this inventory landed (a subscribed local route
-    // would have registered a capability and returned above), so replacing
-    // it is what makes that enricher's next fetch reach the remote.
-    const channel = new RemoteDirectChannel(
-      target(ctx, remote, endpoint, detail.id),
-    );
-    store.set(sanitizeEndpoint(endpoint), channel);
-    remote.channels.set(endpoint, channel);
+/**
+ * Hand a shadowed endpoint to the remote route once the local route that
+ * shadowed it has stopped.
+ *
+ * A shadow is a channel this remote installed for an endpoint that is not
+ * listed as one of its routes. The transition rewrites both halves at
+ * once: the channel stops answering from the local route, and the
+ * capability registry says the endpoint is the remote's, so the listing
+ * and an agent's tool policy see a remote-backed endpoint and never a
+ * local one that quietly dispatches elsewhere. An internal endpoint is
+ * left alone: the app declared it is not a capability, and a remote route
+ * behind it would open the door the declaration closed.
+ */
+function lift(
+  ctx: CraftContext,
+  remote: RemoteRuntime,
+  endpoint: string,
+): void {
+  const channel = remote.channels.get(endpoint);
+  const detail = remote.details.get(endpoint);
+  const routes = ctx.getStore(REMOTE_ROUTES);
+  if (
+    channel === undefined ||
+    detail === undefined ||
+    routes?.has(endpoint) === true ||
+    isInternalEndpoint(ctx, endpoint)
+  ) {
+    return;
   }
+  channel.local = undefined;
+  advertise(ctx, remote, endpoint, detail);
+  ctx.logger.info(
+    { endpoint, remote: remote.name, remoteRouteId: detail.id },
+    `The local route on "${endpoint}" has stopped; the route "${detail.id}" of remote "${remote.name}" answers it from now on`,
+  );
 }
 
 /** Remove one endpoint this remote installed, restoring a shadowed local channel. */
@@ -435,6 +501,7 @@ function release(
 ): void {
   const channel = remote.channels.get(endpoint);
   remote.channels.delete(endpoint);
+  remote.details.delete(endpoint);
   const registry = ctx.getStore(CAPABILITY_REGISTRY);
   if (registry?.get(endpoint)?.remote === remote.name) {
     registry.delete(endpoint);

--- a/packages/routecraft/test/remotes.bun.test.ts
+++ b/packages/routecraft/test/remotes.bun.test.ts
@@ -579,6 +579,62 @@ describe("remotes", () => {
   });
 
   /**
+   * @case A shadowing local route disabled by `.enabled()` hands the endpoint to the remote route, and takes it back when re-enabled
+   * @preconditions A local `hello` with an `.enabled()` predicate beside the default remote's `hello`
+   * @expectedResult Enabled, the local route answers and the capability is local. Disabled through `reevaluateEnablement`, the capability carries `remote: "default"`, the listing shows the imported route, and a send reaches the remote: a disabled local route must not hide the remote route that shares its id, on the tool surface or at the door. Re-enabled, the local route wins again
+   */
+  test("hands a shadowed endpoint to the remote route while the local route is disabled", async () => {
+    server = await startServer();
+    const url = `http://127.0.0.1:${String(server.port)}`;
+    let on = true;
+    local = await startLocal({
+      remotes: { default: { url, auth: { token: operator } } },
+      routes: [
+        craft()
+          .id("hello")
+          .description("The local greeter")
+          .enabled(() => (on ? true : "switched off"))
+          .input({ body: z.object({ name: z.string() }) })
+          .from(direct())
+          .transform(() => ({ greeting: "local" }))
+          .to(noop()),
+      ],
+    });
+    const capability = () =>
+      local!.t.ctx.capabilities().find((c) => c.endpoint === "hello");
+    expect(capability()?.remote).toBeUndefined();
+    expect(await send("hello", { name: "x" })).toEqual({ greeting: "local" });
+
+    on = false;
+    await local.t.ctx.reevaluateEnablement("hello");
+    await until(
+      () => capability()?.remote === "default",
+      "the remote route to take the endpoint",
+    );
+    expect(await send("hello", { name: "x" })).toEqual({
+      greeting: "hello x",
+    });
+    const listing = await call<OpsPage<OpsRouteSummary>>(
+      local.port,
+      "/ops/routes?id=hello",
+    );
+    expect(listing.body.items).toHaveLength(1);
+    expect(listing.body.items[0]).toMatchObject({
+      id: "hello",
+      sources: ["remote"],
+      remote: "default",
+    });
+
+    on = true;
+    await local.t.ctx.reevaluateEnablement("hello");
+    await until(
+      () => capability()?.remote === undefined,
+      "the local route to take the endpoint back",
+    );
+    expect(await send("hello", { name: "x" })).toEqual({ greeting: "local" });
+  });
+
+  /**
    * @case A connection lost after the request was sent is not retryable; one that never opened is
    * @preconditions A stand-in remote that lists one route and, on dispatch, reads the body and drops the socket without answering; then the same remote gone entirely
    * @expectedResult The dropped dispatch is `RC5062` with `retryable: false` and a message saying the remote may have received the request; the dispatch against the closed port is `RC5062` with `retryable: true`. A route that may already have run must not be retried by the framework's default policy

--- a/packages/routecraft/test/remotes.bun.test.ts
+++ b/packages/routecraft/test/remotes.bun.test.ts
@@ -521,6 +521,64 @@ describe("remotes", () => {
   });
 
   /**
+   * @case A local route that stopped before the first inventory arrived does not shadow the remote route
+   * @preconditions A local `hello` beside a default remote that is unreachable at boot; the local route is stopped, then the remote comes up and is imported
+   * @expectedResult The inventory finds the stale local capability and a dead channel, and installs the remote route over both: `hello` carries `remote: "default"`, dispatches to the remote, and is listed as imported. A registry entry that outlived its route must never be read as a live shadow
+   */
+  test("does not let a route stopped before the inventory shadow the remote route", async () => {
+    const port = await reservePort();
+    local = await startLocal({
+      remotes: {
+        default: {
+          url: `http://127.0.0.1:${String(port)}`,
+          auth: { token: operator },
+          refresh: "100ms",
+        },
+      },
+      routes: [
+        craft()
+          .id("hello")
+          .description("The local greeter")
+          .input({ body: z.object({ name: z.string() }) })
+          .from(direct())
+          .transform(() => ({ greeting: "local" }))
+          .to(noop()),
+      ],
+    });
+    const capability = () =>
+      local!.t.ctx.capabilities().find((c) => c.endpoint === "hello");
+    expect(capability()?.remote).toBeUndefined();
+
+    const route = local.t.ctx
+      .getRoutes()
+      .find((r) => r.definition.id === "hello");
+    if (route === undefined) throw new Error("the local route is missing");
+    route.stop();
+    expect(rcCodeOf(await rejection(send("hello", { name: "x" })))).toBe(
+      "RC5004",
+    );
+
+    server = await startServer({ port });
+    await until(
+      () => capability()?.remote === "default",
+      "the remote route to take the endpoint",
+    );
+    expect(await send("hello", { name: "late" })).toEqual({
+      greeting: "hello late",
+    });
+    const listing = await call<OpsPage<OpsRouteSummary>>(
+      local.port,
+      "/ops/routes?id=hello",
+    );
+    expect(listing.body.items).toHaveLength(1);
+    expect(listing.body.items[0]).toMatchObject({
+      id: "hello",
+      sources: ["remote"],
+      remote: "default",
+    });
+  });
+
+  /**
    * @case A connection lost after the request was sent is not retryable; one that never opened is
    * @preconditions A stand-in remote that lists one route and, on dispatch, reads the body and drops the socket without answering; then the same remote gone entirely
    * @expectedResult The dropped dispatch is `RC5062` with `retryable: false` and a message saying the remote may have received the request; the dispatch against the closed port is `RC5062` with `retryable: true`. A route that may already have run must not be retried by the framework's default policy

--- a/packages/routecraft/test/remotes.bun.test.ts
+++ b/packages/routecraft/test/remotes.bun.test.ts
@@ -450,6 +450,143 @@ describe("remotes", () => {
   });
 
   /**
+   * @case A shadowing local route that stops hands the endpoint to the remote route, provenance included
+   * @preconditions A local `hello` shadowing the default remote's `hello`, with the remote refreshing every 100ms
+   * @expectedResult While the local route runs, `hello` is a local capability and answers locally. After `route.stop()` the capability carries `remote: "default"`, the local listing shows it as imported, a send reaches the remote, and the next inventory refresh keeps it that way. A tool policy reading `source.remote` must never see a local endpoint that dispatches elsewhere
+   */
+  test("hands a shadowed endpoint to the remote route when the local route stops", async () => {
+    server = await startServer();
+    const url = `http://127.0.0.1:${String(server.port)}`;
+    let everything: string[] = [];
+    local = await startLocal({
+      remotes: {
+        default: { url, auth: { token: operator }, refresh: "100ms" },
+      },
+      routes: [
+        craft()
+          .id("hello")
+          .description("The local greeter")
+          .input({ body: z.object({ name: z.string() }) })
+          .from(direct())
+          .transform(() => ({ greeting: "local" }))
+          .to(noop()),
+      ],
+      onBuilt: (t) => {
+        everything = captureLogs(t.ctx).everything;
+      },
+    });
+    const capability = () =>
+      local!.t.ctx.capabilities().find((c) => c.endpoint === "hello");
+
+    expect(capability()?.remote).toBeUndefined();
+    expect(await send("hello", { name: "x" })).toEqual({ greeting: "local" });
+
+    const route = local.t.ctx
+      .getRoutes()
+      .find((r) => r.definition.id === "hello");
+    if (route === undefined) throw new Error("the local route is missing");
+    route.stop();
+    await until(
+      () => capability()?.remote === "default",
+      "the endpoint to become the remote's",
+    );
+
+    expect(capability()?.description).toBe("Say hello");
+    expect(await send("hello", { name: "x" })).toEqual({
+      greeting: "hello x",
+    });
+    expect(
+      everything.filter((line) =>
+        line.includes('The local route on "hello" has stopped'),
+      ),
+    ).toHaveLength(1);
+    const listing = await call<OpsPage<OpsRouteSummary>>(
+      local.port,
+      "/ops/routes?id=hello",
+    );
+    expect(listing.body.items).toHaveLength(1);
+    expect(listing.body.items[0]).toMatchObject({
+      id: "hello",
+      sources: ["remote"],
+      remote: "default",
+    });
+
+    // Two refresh intervals later the inventory has been reconciled against
+    // the new provenance at least once and must not have re-shadowed it.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(capability()?.remote).toBe("default");
+    expect(await send("hello", { name: "again" })).toEqual({
+      greeting: "hello again",
+    });
+  });
+
+  /**
+   * @case A connection lost after the request was sent is not retryable; one that never opened is
+   * @preconditions A stand-in remote that lists one route and, on dispatch, reads the body and drops the socket without answering; then the same remote gone entirely
+   * @expectedResult The dropped dispatch is `RC5062` with `retryable: false` and a message saying the remote may have received the request; the dispatch against the closed port is `RC5062` with `retryable: true`. A route that may already have run must not be retried by the framework's default policy
+   */
+  test("marks a connection lost after dispatch as not retryable", async () => {
+    let executions = 0;
+    const detail: OpsRouteDetail = {
+      id: "hello",
+      description: "Say hello",
+      sources: ["direct"],
+      dispatchable: true,
+    } as OpsRouteDetail;
+    const fake = createServer((req, res) => {
+      const { pathname } = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (req.method === "POST") {
+        req.on("data", () => undefined);
+        req.on("end", () => {
+          executions += 1;
+          res.destroy();
+        });
+        return;
+      }
+      const body =
+        pathname === "/ops/routes"
+          ? { items: [detail] }
+          : pathname === "/ops/routes/hello"
+            ? detail
+            : undefined;
+      if (body === undefined) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      // Each request on its own connection: a socket dropped mid-reuse reads
+      // as a stale keep-alive to the client, which then retries on a fresh
+      // one, and this case is about a request that provably ran once.
+      res.writeHead(200, {
+        "content-type": "application/json",
+        connection: "close",
+      });
+      res.end(JSON.stringify(body));
+    });
+    await new Promise<void>((resolve) => fake.listen(0, "127.0.0.1", resolve));
+    const port = (fake.address() as AddressInfo).port;
+    local = await startLocal({
+      remotes: { lab: { url: `http://127.0.0.1:${String(port)}` } },
+    });
+
+    const dropped = await rejection(send("lab:hello", { name: "x" }));
+    expect(rcCodeOf(dropped)).toBe("RC5062");
+    expect((dropped as { retryable?: boolean }).retryable).toBe(false);
+    expect(dropped.message).toContain("may have received the request");
+    expect(executions).toBe(1);
+
+    await new Promise<void>((resolve) => {
+      fake.closeAllConnections();
+      fake.close(() => resolve());
+    });
+    const refused = await rejection(send("lab:hello", { name: "x" }));
+    expect(rcCodeOf(refused)).toBe("RC5062");
+    expect((refused as { retryable?: boolean }).retryable).toBe(true);
+    expect(refused.message).toContain("Could not reach a running instance");
+    expect(executions).toBe(1);
+  });
+
+  /**
    * @case Every dispatch outcome maps onto the in-process one, against the real door
    * @preconditions Routes on the remote that complete, drop, park and fail; one remote named with a credential admitted to the listing but not to dispatch
    * @expectedResult completed is the body; dropped is `RC5031`; suspended is the branded `Suspended` acknowledgment; a remote failure is `RC5064` carrying the remote's code with the client's error as cause; the refused dispatch is `RC5063` naming the missing scope. A caller can tell a credential problem from a broken route


### PR DESCRIPTION
## TLDR

Two defects in the remotes plugin found on the merged head of #767. When a local route that shadowed a remote route stops, the endpoint now hands over to the remote route with its provenance: the capability registry, the ops listing and an agent's tool policy all see a remote-backed endpoint from that moment, instead of a "local" one that dispatches elsewhere. And a connection lost after a dispatch was sent is `RC5062` with `retryable: false`, the way a timeout already is, so the framework's default retry policy no longer re-runs work that may have executed.

**Breaking for route authors:** no. `OpsFailureKind` gains an `interrupted` member; a caller switching on it exhaustively sees a new arm.

## Before and after

- **Before:** after `route.stop()` on a shadowing local `hello`, `ctx.capabilities()` still said local, `/ops/routes` listed the stopped route as `sources: ["direct"]`, `tools(['Direct(hello)'])` resolved with no `remote`, and the local-only policy `tool.source.remote === undefined` admitted a tool whose calls left the instance. A local route stopped before the first inventory arrived, or disabled by `.enabled()`, left a stale capability that hid the remote route. A dispatch whose socket dropped after the body was sent came back `RC5062` with `retryable: true` although the remote had already run it.
- **After:** the remotes plugin lifts the shadow on `route:stopped`, re-registers the capability as the remote's, and the ops surface reads that provenance; a capability whose route has already stopped is not a shadow when the inventory arrives; an imported capability is exempt from the local enablement filter. A lost connection is `interrupted` in the client and `RC5062` with `retryable: false` at the channel; only a connection that never opened stays retryable.

## DSL

No DSL change.

---

## Why

Both findings came from a focused reproduction against the merged head, posted on #767. The first is a policy bypass: a rule written to keep an agent local-only could be satisfied by an endpoint that dispatches to another instance. The second is duplicated side effects: `classifyTransportFailure` called every non-abort failure "unreachable", which inherits `RC5062`'s retryable default, so `defaultRetryOn()` would admit a second attempt for a route that may have completed. The bot rounds on this PR found the same root cause from two more sides: the direct source's capability outlives its route, so a stop before the inventory and a disable through `.enabled()` each left an entry the plugin or the registry trusted.

## What changed

- `plugins/remotes/plugin.ts`: `apply()` listens for `route:started` and `route:stopped` and keeps the set of stopped route ids; a stop hands a shadowed endpoint to the remote route through `lift()`, which clears the channel's local reference and re-registers the capability through the new `advertise()`, also used by `install()`. `install()` treats a local capability whose route has stopped as absent, so the remote route takes the endpoint over the stale entry and the dead channel. Details are kept per endpoint, shadowed ones included. Internal endpoints are never lifted. The listeners are removed at teardown.
- `context.ts`: `capabilities()` no longer filters an imported capability on the local enablement predicate. A disabled local route stops the way a stopped one does and hands its endpoint over, but the two share an id, so the filter hid the remote route from the tool surface and the listing and turned a dispatch into `RC5060`.
- `plugins/remotes/channel.ts`: the channel no longer decides on its own that a shadow lifted; `send()` answers from the local route while `local` is set and dispatches otherwise. `interrupted` maps to `RC5062` with `retryable: false`.
- `plugins/ops/management.ts`: listing, describe and dispatch read the capability registry to decide whether the remote answers an id, because a stopped route stays in `getRoutes()` and the id alone cannot decide.
- `plugins/ops/client.ts`: `OpsFailureKind` gains `interrupted`. `classifyTransportFailure` takes the phase; a failure while reading the answer is always interrupted, and a failure during the request is `unreachable` only when the error carries a connect-phase code Node or Bun raises (refused, unreachable host or network, name resolution, undici's connect timeout). Anything else, `ETIMEDOUT` included, is treated as possibly delivered.
- `adapters/direct/shared.ts`: the `subscribed` getter added in round 2 is removed; nothing reads it now.
- `error.ts`: the `RC5062` registry text names the lost-connection case.

## Tests

`packages/routecraft/test/remotes.bun.test.ts`, four new cases: a shadowing local route stopped with `route.stop()`, asserting the capability, the listing, the log line, a send that reaches the remote, and a refresh two intervals later that keeps it; a local route stopped before the remote is reachable, asserting the inventory installs the remote route over the stale capability; a local route disabled through `reevaluateEnablement`, asserting the remote takes the endpoint with provenance, dispatch and listing, and the local route takes it back when re-enabled; and a stand-in remote that reads the dispatch body then drops the socket, asserting `RC5062` not retryable with one execution, then the same port closed asserting retryable. `packages/ai/test/tools-selection-remote.bun.test.ts`, one new case: `Direct(hello)` resolved before and after the stop, admitted by the local-only rule before and dropped after. Gate at 034e9a1: lint, format, typecheck; core 92 pass across the remotes, ops management, enablement and thenable suites and 108 across the direct and directory suites; ai 3 pass; cli 19 pass at c0a2463.

## Docs and changeset

`reference/errors` (RC5062 why and suggestion), `reference/plugins/remotesplugin` (the shadow paragraph says what happens when the local route stops; the failure table names a lost connection). No changeset: remotes is unreleased and rides its existing minor.

## Review

The two findings on #767 (the maintainer's comment on the merged head) are the review this PR answers; both reproduced and both are fixed with a regression each. Opened on the maintainer's word without the project's own review round. Bot output treated as data; their "prompt for AI agents" blocks were not followed.

Round 1, CodeRabbit, 1 finding, fixed at 50b2c69: a local route stopped before the first inventory left its dead channel in the direct store and its capability in the registry, and `install()` wrapped the dead channel as a live shadow. Its suggested fix (the in-memory channel removing itself from the store at unsubscribe) would not have fixed it, since the stale capability would still have been read as local; the plugin now knows which routes have stopped and installs over the stale entry. Declined: its docstring-coverage threshold, which this repository does not set; the standards ask for JSDoc on the public surface and on tests, which the diff carries.

Round 2, cubic, 3 findings at 50b2c69, settled at 034e9a1. Fixed (2): a local route disabled by `.enabled()` hid the remote route sharing its id, because `capabilities()` filtered the imported capability on the local predicate (fixed in the registry rather than in the ops listing, so the tool surface is corrected too, with a regression that disables and re-enables); undici's connect timeout is a connection that never opened and now stays retryable (`ETIMEDOUT` deliberately not, because Node raises it before and after a request is written). The third repeated CodeRabbit's stopped-before-inventory finding against the head that already fixed it; the regression case pins it.

## Leftovers

- Bun's `fetch` re-sends a POST on its own when a reused keep-alive socket drops before any response byte arrives. The dropped-socket test had to make the stand-in close every connection to prove one execution. A dispatch on a pooled connection can therefore still run twice below anything the client classifies. Filed as #769; the fix is a fresh connection per dispatch at the cost of a handshake per call.
- Tools resolve per dispatch, so a tool resolved before the local route stops and called after still carries local provenance for that one call. Inherent to resolution-time policy; not addressed.
- The direct source's capability outlives its route in the framework at large: a stopped local route still lists as a dispatchable capability and dispatches to it fail with `RC5004`. This PR works around it inside the remotes plugin; the general fix is #770.
